### PR TITLE
docs(tree): add schema upgrade walkthrough guides for testing and feature flags

### DIFF
--- a/website/docs/data-structures/tree/schema-evolution/allowed-types-rollout.mdx
+++ b/website/docs/data-structures/tree/schema-evolution/allowed-types-rollout.mdx
@@ -82,4 +82,6 @@ If you have a [`snapshotSchemaCompatibility`](../../../api/fluid-framework/#snap
 ## See Also
 
 - [`SchemaFactoryBeta.staged()` API](../../../api/fluid-framework/schemafactorybeta-class#staged-property) - API documentation
+- [Enabling Schema Upgrades with Feature Flags](./feature-flag-schema-upgrades.mdx) - Using runtime upgrades in production
+- [Testing Schema Upgrades](./testing-schema-upgrades.mdx) - Create test documents that simulate future schema states
 - [Schema Definition](../schema-definition/index.mdx) - How to define schemas

--- a/website/docs/data-structures/tree/schema-evolution/feature-flag-schema-upgrades.mdx
+++ b/website/docs/data-structures/tree/schema-evolution/feature-flag-schema-upgrades.mdx
@@ -5,10 +5,6 @@ sidebar\_position: 6
 
 # How to Enable Staged Schema Upgrades with Feature Flags
 
-:::warning[Important]
-Only use schema configurations in production that are covered by your [`snapshotSchemaCompatibility`](../../../api/fluid-framework/#snapshotschemacompatibility-function) tests.
-:::
-
 The standard [staged rollout](./index.mdx#staged-rollouts) strategy requires two separate code deployments: one to add reading support, and another to enable writing.
 **Runtime schema upgrades** let you ship both in a single deployment and control when the upgrade takes effect using a feature flag or other runtime control.
 
@@ -175,7 +171,7 @@ This means:
 
 - **Clients running the staged code** (Step 1 and above) can still open and read upgraded documents — their view schema is compatible.
 - **Clients running older code** (before the staged type was added) **cannot** open upgraded documents. This is why [client saturation](./index.mdx#staged-rollouts) of the staged code is important before enabling the flag.
-- There is currently no API to query whether a particular document has already been upgraded (this capability is in progress). This means there is no built-in mechanism to selectively target only un-upgraded documents when disabling the flag.
+- There is currently no API to query whether a particular document has already been upgraded (this capability is in progress). This means there is no built-in mechanism to selectively target only non-upgraded documents when disabling the flag.
 
 Plan your rollout with this in mind: ensure that all active clients have the staged code before turning on the flag.
 
@@ -191,7 +187,10 @@ Plan your rollout with this in mind: ensure that all active clients have the sta
   Use [testing schema upgrades](./testing-schema-upgrades.mdx) to verify your code handles the upgraded schema correctly before turning on the flag in production.
 
 - **Use `snapshotSchemaCompatibility` tests.**
-  Write [`snapshotSchemaCompatibility`](../../../api/fluid-framework/#snapshotschemacompatibility-function) tests to verify compatibility across all schema states in your rollout.
+  Write [`snapshotSchemaCompatibility`](../../../api/fluid-framework/#snapshotschemacompatibility-function) tests to verify compatibility across all schema states in your rollout. Only use schema configurations in production that are covered by these tests.
+
+- **Avoid diverging upgrade paths.**
+  `snapshotSchemaCompatibility` assumes a linear version history and cannot model branching upgrade paths. If different documents enable different combinations of staged upgrades (e.g., one enables A+C while another enables B+C), the resulting schema states diverge and cannot be validated in a single snapshot test. Keep your rollout linear — enable staged upgrades in the same order for all documents — so that every schema state you encounter in production is covered by your compatibility tests.
 
 ## See Also
 

--- a/website/docs/data-structures/tree/schema-evolution/feature-flag-schema-upgrades.mdx
+++ b/website/docs/data-structures/tree/schema-evolution/feature-flag-schema-upgrades.mdx
@@ -1,0 +1,201 @@
+---
+title: How to Enable Staged Schema Upgrades with Feature Flags
+sidebar\_position: 6
+---
+
+# How to Enable Staged Schema Upgrades with Feature Flags
+
+:::warning[Important]
+Only use schema configurations in production that are covered by your [`snapshotSchemaCompatibility`](../../../api/fluid-framework/#snapshotschemacompatibility-function) tests.
+:::
+
+The standard [staged rollout](./index.mdx#staged-rollouts) strategy requires two separate code deployments: one to add reading support, and another to enable writing.
+**Runtime schema upgrades** let you ship both in a single deployment and control when the upgrade takes effect using a feature flag or other runtime control.
+
+This decouples *code deployment* from *feature rollout*, giving you:
+- **Gradual rollout** — enable the upgrade for a subset of users or documents first
+- **Simpler deployment** — one code version handles both the "before" and "after" schema states
+
+:::note
+The APIs described here are currently **alpha**.
+Import them from `@fluidframework/tree/alpha`.
+:::
+
+## How It Works
+
+When you define a [staged schema upgrade](./index.mdx#staged-schema-upgrades) (using [`staged()`](../../../api/fluid-framework/schemafactorybeta-class#staged-property) for allowed types or [`stagedOptional()`](../../../api/tree/schemafactoryalpha-class#stagedoptional-property) for field optionality), the staged parts are excluded from stored schema by default.
+
+With `TreeViewConfigurationAlpha`, you can selectively enable specific staged upgrades at view construction time:
+
+```typescript
+import {
+    SchemaFactoryAlpha,
+    StagedSchemaUpgradePolicy,
+    TreeViewConfigurationAlpha,
+} from "@fluidframework/tree/alpha";
+
+const sf = new SchemaFactoryAlpha("MyApp");
+
+// Create a staged type and extract its upgrade token
+const stagedNewType = sf.staged(MyNewType);
+const myUpgradeToken = stagedNewType.metadata.stagedSchemaUpgrade;
+
+const view = tree.viewWith(
+    new TreeViewConfigurationAlpha({
+        schema: MySchema,
+        stagedUpgradePolicy:
+            StagedSchemaUpgradePolicy.enabledStagedUpgrades(myUpgradeToken),
+    }),
+);
+```
+
+When a view is constructed with enabled staged upgrades:
+- `initialize()` includes the enabled staged changes in the new document's stored schema.
+- `upgradeSchema()` includes them when upgrading an existing document.
+- `compatibility` reflects the enabled upgrades when determining what actions are possible.
+
+The upgrade set is fixed at view construction time and cannot be changed afterwards.
+
+## Walkthrough: Adding RGB Colors to a Whiteboard App
+
+You have a collaborative whiteboard app where users place sticky notes.
+Currently, the `color` field on each note stores a plain string (e.g. `"red"`, `"#ff0000"`).
+You want to add a new `RgbColor` type as an additional allowed type for the `color` field — a change that is [backwards compatible but not forwards compatible](./index.mdx#schema-change-examples).
+
+### Step 1: Define the Staged Schema
+
+Add the new type as a [staged allowed type](./allowed-types-rollout.mdx) and capture its upgrade token:
+
+```typescript
+import { SchemaFactoryAlpha, TreeViewConfigurationAlpha } from "@fluidframework/tree/alpha";
+
+const sf = new SchemaFactoryAlpha("WhiteboardApp");
+
+class RgbColor extends sf.object("RgbColor", {
+    r: sf.number,
+    g: sf.number,
+    b: sf.number,
+}) {}
+
+const stagedRgbColor = sf.staged(RgbColor);
+const rgbUpgrade = stagedRgbColor.metadata.stagedSchemaUpgrade;
+
+class Note extends sf.objectAlpha("Note", {
+    text: sf.string,
+    x: sf.number,
+    y: sf.number,
+    color: sf.required([sf.string, stagedRgbColor]),
+}) {}
+
+class Board extends sf.object("Board", {
+    notes: sf.array(Note),
+}) {}
+```
+
+Your application code must handle `RgbColor` nodes correctly — rendering them, converting to CSS values, etc. — because once the upgrade is enabled, documents will contain them.
+
+### Step 2: Wire Up the Feature Flag
+
+Derive the `stagedUpgradePolicy` from your feature flag system when constructing the view:
+
+```typescript
+import { StagedSchemaUpgradePolicy } from "@fluidframework/tree/alpha";
+
+function openDocument(tree, featureFlags) {
+    const stagedUpgradePolicy = featureFlags.enableRgbColors
+        ? StagedSchemaUpgradePolicy.enabledStagedUpgrades(rgbUpgrade)
+        : undefined; // undefined = restrictive (default, no staged upgrades)
+
+    const view = tree.viewWith(
+        new TreeViewConfigurationAlpha({
+            schema: Board,
+            stagedUpgradePolicy,
+        }),
+    );
+
+    if (view.compatibility.canInitialize) {
+        view.initialize(new Board({ notes: [] }));
+    } else if (view.compatibility.canUpgrade) {
+        view.upgradeSchema();
+    }
+
+    return view;
+}
+```
+
+### Step 3: Deploy and Enable
+
+1. **Deploy** the new code. With the feature flag **off**, the app behaves identically to before — `RgbColor` is excluded from stored schema, and `upgradeSchema()` is a no-op for the staged type.
+
+2. **Turn on the feature flag.** New views are constructed with `rgbUpgrade` enabled:
+    - **New documents** are initialized with stored schema that includes `RgbColor`.
+    - **Existing documents** are upgraded to include `RgbColor` when `upgradeSchema()` is called.
+    - Users can now assign RGB colors to notes.
+
+3. **Clients without the flag** (or clients who haven't picked up the flag yet) can still **read** upgraded documents because their view schema already includes `RgbColor` as a staged type.
+
+### Step 4: Clean Up After Full Rollout
+
+Once the upgrade is complete and all documents have been migrated, remove the staged wrappers:
+
+```typescript
+import { SchemaFactory, TreeViewConfiguration } from "@fluidframework/tree";
+
+const sf = new SchemaFactory("WhiteboardApp");
+
+class RgbColor extends sf.object("RgbColor", {
+    r: sf.number,
+    g: sf.number,
+    b: sf.number,
+}) {}
+
+class Note extends sf.object("Note", {
+    text: sf.string,
+    x: sf.number,
+    y: sf.number,
+    color: sf.required([sf.string, RgbColor]),
+}) {}
+
+class Board extends sf.object("Board", {
+    notes: sf.array(Note),
+}) {}
+
+// No more alpha config or feature flags needed
+const config = new TreeViewConfiguration({ schema: Board });
+```
+
+## Understanding Irreversibility
+
+:::warning
+Once a document's stored schema has been upgraded, it cannot be downgraded. Do not disable a feature flag that has already been enabled in production — there is currently no API to determine which documents have been upgraded, so you cannot safely roll back without risking incompatibility for clients that encounter already-upgraded documents. An API for querying per-document upgrade status is in progress.
+:::
+
+Disabling the feature flag prevents **new** documents from being upgraded, but documents that have already been upgraded retain the new schema.
+This means:
+
+- **Clients running the staged code** (Step 1 and above) can still open and read upgraded documents — their view schema is compatible.
+- **Clients running older code** (before the staged type was added) **cannot** open upgraded documents. This is why [client saturation](./index.mdx#staged-rollouts) of the staged code is important before enabling the flag.
+- There is currently no API to query whether a particular document has already been upgraded (this capability is in progress). This means there is no built-in mechanism to selectively target only un-upgraded documents when disabling the flag.
+
+Plan your rollout with this in mind: ensure that all active clients have the staged code before turning on the flag.
+
+## Best Practices
+
+- **Wait for client saturation before enabling.**
+  Monitor your client version distribution to ensure all (or tolerably most) users have deployed the code with the staged schema before enabling the flag.
+
+- **One upgrade token per feature.**
+  Each `staged()` or `stagedOptional()` call creates a separate upgrade token. Group related schema changes under the same feature flag by enabling all their tokens together.
+
+- **Test before enabling.**
+  Use [testing schema upgrades](./testing-schema-upgrades.mdx) to verify your code handles the upgraded schema correctly before turning on the flag in production.
+
+- **Use `snapshotSchemaCompatibility` tests.**
+  Write [`snapshotSchemaCompatibility`](../../../api/fluid-framework/#snapshotschemacompatibility-function) tests to verify compatibility across all schema states in your rollout.
+
+## See Also
+
+- [Schema Evolution](./index.mdx) — Overview of schema changes and compatibility
+- [Rolling Out New Allowed Types](./allowed-types-rollout.mdx) — Staged allowed type rollout process
+- [Testing Schema Upgrades](./testing-schema-upgrades.mdx) — Creating test documents with future schema states
+- [Types of Schema Changes](./types-of-changes.mdx) — Which changes are safe vs breaking

--- a/website/docs/data-structures/tree/schema-evolution/index.mdx
+++ b/website/docs/data-structures/tree/schema-evolution/index.mdx
@@ -162,6 +162,17 @@ view.root.color = "#FF0000";
 
 For detailed information about which types of changes are safe versus breaking, see [Types of Schema Changes](./types-of-changes.mdx).
 
+### Staged Schema Upgrades
+
+A **staged schema upgrade** is a schema change that is declared in the view schema but excluded from stored schema until explicitly enabled.
+This allows your application code to understand and handle the new schema shape (reading documents that contain it) before the upgrade is activated for writes.
+
+SharedTree provides two mechanisms for defining staged schema upgrades:
+- [`staged()`](../../../api/fluid-framework/schemafactorybeta-class#staged-property) -- marks a new allowed type as staged
+- [`stagedOptional()`](../../../api/tree/schemafactoryalpha-class#stagedoptional-property) -- marks a field as optionally present during migration from required to optional
+
+Staged schema upgrades are the building blocks of [staged rollouts](#staged-rollouts) and [feature-flag-driven upgrades](./feature-flag-schema-upgrades.mdx).
+
 ### Staged Rollouts
 
 When deploying schema changes in production, use staged rollouts to ensure compatibility between clients running different application versions.
@@ -182,6 +193,8 @@ If a client upgrades a document to a new schema that older clients cannot read, 
 - Deploy code that automatically upgrades documents to the new schema.
 - Monitor for any compatibility issues.
 
+Alternatively, you can use [feature flags](./feature-flag-schema-upgrades.mdx) to combine both phases into a single deployment and control when upgrades are enabled at runtime.
+
 Changes that are both [backwards compatible](./index.mdx#backwards-compatibility) and [forwards compatible](./index.mdx#forwards-compatibility) are capable of cross-version collaboration without requiring a staged rollout.
 In that case, new clients can read and write to the same document as old clients without either one being fundamentally incompatible.
 However, staged rollouts are not easily avoidable.
@@ -190,11 +203,13 @@ Even seemingly simple schema changes (for example, adding a new type of node to 
 **Best Practices:**
 - Allow appropriate amount of time between release cycles to ensure client version adoption
 - Monitor client version distribution before enabling upgrades
-- Test compatibility scenarios with mixed client versions
+- [Test compatibility scenarios](./testing-schema-upgrades.mdx) with mixed client versions
 
 ## See Also
 
 - [Types of Schema Changes](./types-of-changes.mdx) - Detailed guide on safe vs breaking changes
 - [Rolling Out New Allowed Types](./allowed-types-rollout.mdx) - Guide on using staged to safely add new allowed types
+- [Enabling Schema Upgrades with Feature Flags](./feature-flag-schema-upgrades.mdx) - Use feature flags to control when staged upgrades take effect in production
+- [Testing Schema Upgrades](./testing-schema-upgrades.mdx) - Create test documents that simulate future schema states
 - [Schema Definition](../schema-definition/index.mdx) - How to define schemas
 - [Node Types](../node-types.mdx) - Understanding different node types

--- a/website/docs/data-structures/tree/schema-evolution/testing-schema-upgrades.mdx
+++ b/website/docs/data-structures/tree/schema-evolution/testing-schema-upgrades.mdx
@@ -1,0 +1,180 @@
+---
+title: Testing Schema Upgrades
+sidebar\_position: 5
+---
+
+# Testing Schema Upgrades
+
+When you define a [staged schema upgrade](./index.mdx#staged-schema-upgrades) (using [`staged()`](../../../api/fluid-framework/schemafactorybeta-class#staged-property) or [`stagedOptional()`](../../../api/tree/schemafactoryalpha-class#stagedoptional-property)), you need to verify that your current code works correctly with documents that a *future* version will produce.
+
+Runtime schema upgrades let you create test documents whose stored schema matches a future state.
+
+:::note
+The testing APIs described here are currently **alpha**.
+Import them from `@fluidframework/tree/alpha`.
+:::
+
+## The Problem
+
+Consider a staged rollout where you're [adding a new allowed type](./allowed-types-rollout.mdx) — say, adding an `RgbColor` type to a sticky note's `color` field.
+During the rollout, there are three schema states:
+
+1. **Before**: The original schema (`color` only accepts strings).
+2. **Staged**: `RgbColor` is in the view schema but excluded from stored schema.
+3. **Upgraded**: `RgbColor` is fully included in the stored schema.
+
+Your Phase 1 code (the "staged" state) needs to handle documents created in the "upgraded" state.
+But how do you create such a document in a test?
+
+Normally, staged types are excluded from stored schema, so `initialize()` and `upgradeSchema()` won't include them.
+**Runtime schema upgrades** solve this by letting you explicitly enable staged upgrades at view construction time.
+
+## Creating Test Documents with Future Schema
+
+Use `TreeViewConfigurationAlpha` with `stagedUpgradePolicy` to construct a view that includes staged changes in the stored schema:
+
+```typescript
+import {
+    SchemaFactoryAlpha,
+    StagedSchemaUpgradePolicy,
+    TreeViewConfigurationAlpha,
+} from "@fluidframework/tree/alpha";
+import { independentView } from "@fluidframework/tree/alpha";
+
+const sf = new SchemaFactoryAlpha("WhiteboardApp");
+
+class RgbColor extends sf.object("RgbColor", {
+    r: sf.number,
+    g: sf.number,
+    b: sf.number,
+}) {}
+
+// staged() marks RgbColor as a staged allowed type
+const stagedRgbColor = sf.staged(RgbColor);
+const rgbUpgrade = stagedRgbColor.metadata.stagedSchemaUpgrade;
+
+class Note extends sf.objectAlpha("Note", {
+    text: sf.string,
+    color: sf.required([sf.string, stagedRgbColor]),
+}) {}
+```
+
+### Test: Verifying Your Code Reads Future Documents
+
+```typescript
+it("can read documents with RgbColor enabled", () => {
+    // Create a view with the RGB upgrade enabled — simulates a future client
+    const futureView = independentView(
+        new TreeViewConfigurationAlpha({
+            schema: Note,
+            stagedUpgradePolicy:
+                StagedSchemaUpgradePolicy.enabledStagedUpgrades(rgbUpgrade),
+        }),
+    );
+
+    // Initialize a document as a future client would
+    futureView.initialize(new Note({
+        text: "Hello",
+        color: new RgbColor({ r: 255, g: 0, b: 0 }),
+    }));
+
+    // Verify your code can read the data
+    assert.equal(futureView.root.text, "Hello");
+    assert(futureView.root.color instanceof RgbColor);
+});
+```
+
+### Test: Verifying Writes Are Rejected Without the Upgrade
+
+```typescript
+it("rejects staged content when upgrades are not enabled", () => {
+    const view = independentView(
+        new TreeViewConfigurationAlpha({
+            schema: Note,
+            // No stagedUpgradePolicy — staged types stay excluded
+        }),
+    );
+
+    view.initialize(new Note({ text: "Hello", color: "red" }));
+
+    // Writing an RgbColor should fail because it's staged
+    assert.throws(() => {
+        view.root.color = new RgbColor({ r: 255, g: 0, b: 0 });
+    });
+});
+```
+
+## Testing Staged Optional Fields
+
+The same pattern works for `stagedOptional()` fields.
+For example, if you're migrating a required field to optional:
+
+```typescript
+const sf = new SchemaFactoryAlpha("MyApp");
+
+// During the rollout: field is staged optional
+const description = sf.stagedOptional(sf.string);
+const optionalUpgrade = description.isStagedOptional;
+
+class Item extends sf.objectAlpha("Item", {
+    name: sf.string,
+    description,
+}) {}
+```
+
+```typescript
+it("can read documents where the field was cleared", () => {
+    const futureView = independentView(
+        new TreeViewConfigurationAlpha({
+            schema: Item,
+            stagedUpgradePolicy:
+                StagedSchemaUpgradePolicy.enabledStagedUpgrades(optionalUpgrade),
+        }),
+    );
+
+    futureView.initialize(new Item({ name: "Test" }));
+    // The field is absent — verify your code handles this
+    assert.equal(futureView.root.description, undefined);
+});
+```
+
+## Checking Schema Compatibility in Tests
+
+Use `view.compatibility` to verify compatibility after constructing a view against a document:
+
+```typescript
+it("staged schema is compatible with the original stored schema", () => {
+    const view = tree.viewWith(
+        new TreeViewConfigurationAlpha({ schema: StagedSchema }),
+    );
+
+    assert.equal(view.compatibility.canView, true);
+    assert.equal(view.compatibility.isEquivalent, true);
+});
+```
+
+For comparing against serialized schemas without a live document, use `comparePersistedSchema`:
+
+```typescript
+import { comparePersistedSchema } from "@fluidframework/tree/alpha";
+
+const result = comparePersistedSchema(persistedSchemaJson, StagedSchema, { jsonValidator: ... });
+assert.equal(result.canView, true);
+```
+
+This is useful for verifying that each phase of your rollout maintains the expected compatibility relationships.
+
+## Tips
+
+- **Use `independentView`** for isolated tests that don't require a Fluid service connection.
+- **Use `StagedSchemaUpgradePolicy.permissive`** to enable *all* staged upgrades at once — useful for broad integration tests that exercise the fully-upgraded schema without listing individual tokens.
+- **Test all schema states**: original → staged → upgraded → cleanup (staged wrappers removed). Each transition should maintain compatibility.
+- **Combine with** [**`snapshotSchemaCompatibility`**](../../../api/fluid-framework/#snapshotschemacompatibility-function) tests to catch regressions when your schema changes across releases.
+- **Test edge cases**: What happens when a staged field is absent? When a staged type appears in a sequence? Ensure your application logic handles these gracefully.
+
+## See Also
+
+- [Schema Evolution](./index.mdx) — Overview of schema changes and compatibility
+- [Rolling Out New Allowed Types](./allowed-types-rollout.mdx) — Staged allowed type rollout process
+- [Enabling Schema Upgrades with Feature Flags](./feature-flag-schema-upgrades.mdx) — Using runtime upgrades in production
+- [Test suite](https://github.com/microsoft/FluidFramework/blob/main/packages/dds/tree/src/test/simple-tree/api/stagedSchemaUpgrade.spec.ts) — Full code examples

--- a/website/docs/data-structures/tree/schema-evolution/types-of-changes.mdx
+++ b/website/docs/data-structures/tree/schema-evolution/types-of-changes.mdx
@@ -161,5 +161,8 @@ because those documents will only use the `string` type for the `id` field, whic
 ## See Also
 
 - [Schema Evolution](./index.mdx) - Overview and upgrade process
+- [Rolling Out New Allowed Types](./allowed-types-rollout.mdx) - Staged allowed type rollout
+- [Enabling Schema Upgrades with Feature Flags](./feature-flag-schema-upgrades.mdx) - Feature-flag-driven staged rollouts
+- [Testing Schema Upgrades](./testing-schema-upgrades.mdx) - Testing with future schema states
 - [Schema Definition](../schema-definition/index.mdx) - How to define schemas
 - [Node Types](../node-types.mdx) - Understanding different node types


### PR DESCRIPTION
## Description

Adds two new user-facing walkthrough guides to the schema-evolution documentation. These guides show how to use the runtime schema upgrade mechanism (`StagedSchemaUpgradePolicy` + `TreeViewConfigurationAlpha`) for:

1. **Testing** (`testing-schema-upgrades.mdx`) -- how to create test documents that simulate future schema states using `independentView` with `StagedSchemaUpgradePolicy.enabledStagedUpgrades(...)`, so you can verify your code handles upgraded documents before deploying.

2. **Production rollouts** (`feature-flag-schema-upgrades.mdx`) -- how to use feature flags to control when staged upgrades take effect, decoupling code deployment from feature rollout. Walks through a realistic whiteboard app scenario end-to-end.

Also adds cross-links from the existing schema-evolution pages (index, allowed-types-rollout, types-of-changes) to the new guides.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

- These are purely documentation additions -- no source code changes.
- The code examples reference the `StagedSchemaUpgradePolicy` API shape as merged in #27542. Please verify the examples are accurate and match the intended usage patterns.