### PR TITLE
Remove unreachable branch in getCreateDetailsForChild FromAttach case

### DIFF
--- a/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNode.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNode.ts
@@ -570,13 +570,6 @@ export class SummarizerNode implements IRootSummarizerNode {
 		const parentLastSummaryReferenceSequenceNumber = this._lastSummaryReferenceSequenceNumber;
 		switch (createParam.type) {
 			case CreateSummarizerNodeSource.FromAttach: {
-				if (
-					parentLastSummaryReferenceSequenceNumber !== undefined &&
-					createParam.sequenceNumber <= parentLastSummaryReferenceSequenceNumber
-				) {
-					// Prioritize latest summary if it was after this node was attached.
-					childLastSummaryReferenceSequenceNumber = parentLastSummaryReferenceSequenceNumber;
-				}
 				changeSequenceNumber = createParam.sequenceNumber;
 				break;
 			}

--- a/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNode.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNode.ts
@@ -570,6 +570,15 @@ export class SummarizerNode implements IRootSummarizerNode {
 		const parentLastSummaryReferenceSequenceNumber = this._lastSummaryReferenceSequenceNumber;
 		switch (createParam.type) {
 			case CreateSummarizerNodeSource.FromAttach: {
+				// A FromAttach node is created synchronously while processing the attach op, and ops are processed
+				// in order. So the parent's last summary reference sequence number must be less than the attach op's
+				// sequence number - the summary ack that would raise it to >= the attach sequence number is itself a
+				// later op in the stream. This assert tracks in telemetry if that invariant is ever violated.
+				assert(
+					parentLastSummaryReferenceSequenceNumber === undefined ||
+						createParam.sequenceNumber > parentLastSummaryReferenceSequenceNumber,
+					"Attach sequence number should be greater than the parent's last summary reference sequence number",
+				);
 				changeSequenceNumber = createParam.sequenceNumber;
 				break;
 			}

--- a/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNode.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNode.ts
@@ -570,10 +570,15 @@ export class SummarizerNode implements IRootSummarizerNode {
 		const parentLastSummaryReferenceSequenceNumber = this._lastSummaryReferenceSequenceNumber;
 		switch (createParam.type) {
 			case CreateSummarizerNodeSource.FromAttach: {
-				// A FromAttach node is created synchronously while processing the attach op, and ops are processed
-				// in order. So the parent's last summary reference sequence number must be less than the attach op's
-				// sequence number - the summary ack that would raise it to >= the attach sequence number is itself a
-				// later op in the stream. This assert tracks in telemetry if that invariant is ever violated.
+				// `parentLastSummaryReferenceSequenceNumber` is the latest sequence number processed in the last
+				// successful summary. So, for `createParam.sequenceNumber <= parentLastSummaryReferenceSequenceNumber`
+				// to be true, the attach message would have to have been sequenced before the last summary and somehow
+				// not be part of that summary, which is not possible.
+				// This check used to exist because of a legacy "failure summaries" feature where a data store that
+				// failed to summarize would include its previous summary + pending ops in the current summary. In the
+				// next summary, those pending ops (which could include a DDS attach op) would be processed and the above
+				// condition could be true. That feature was deleted years ago, so this is now converted to an assert to
+				// validate the invariant - if it ever does happen, we would see the assert.
 				assert(
 					parentLastSummaryReferenceSequenceNumber === undefined ||
 						createParam.sequenceNumber > parentLastSummaryReferenceSequenceNumber,

--- a/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNode.ts
+++ b/packages/runtime/container-runtime/src/summary/summarizerNode/summarizerNode.ts
@@ -574,11 +574,6 @@ export class SummarizerNode implements IRootSummarizerNode {
 				// successful summary. So, for `createParam.sequenceNumber <= parentLastSummaryReferenceSequenceNumber`
 				// to be true, the attach message would have to have been sequenced before the last summary and somehow
 				// not be part of that summary, which is not possible.
-				// This check used to exist because of a legacy "failure summaries" feature where a data store that
-				// failed to summarize would include its previous summary + pending ops in the current summary. In the
-				// next summary, those pending ops (which could include a DDS attach op) would be processed and the above
-				// condition could be true. That feature was deleted years ago, so this is now converted to an assert to
-				// validate the invariant - if it ever does happen, we would see the assert.
 				assert(
 					parentLastSummaryReferenceSequenceNumber === undefined ||
 						createParam.sequenceNumber > parentLastSummaryReferenceSequenceNumber,


### PR DESCRIPTION
## Description

Removes a dead `if` block in `SummarizerNode.getCreateDetailsForChild` for the
`CreateSummarizerNodeSource.FromAttach` case. The assignment to
`childLastSummaryReferenceSequenceNumber` inside that block is unreachable.

`parentLastSummaryReferenceSequenceNumber` refers to the latest sequence number that was processed in the last successful summary. So, for `createParam.sequenceNumber <= parentLastSummaryReferenceSequenceNumber` to be true, the attach message would have to have been sequenced before the last summary and somehow not be part of that summary. This is not possible.

The reason this check exists is because of a legacy feature called "failure summaries" where if a data store failed to summarize, the summarize node would include its previous summary + pending ops into the current summary. In the next summary, when this data store was being summarized, the pending ops would be processed and the above condition could be true if there was an attach op for a DDS in that data store.

That feature was deleted years ago, so this check is no longer needed and only adds to confusion. Converted that check to as assert to validate the same. If this condition does happen somehow, we would see the assert.

