### PR TITLE
Dedupe jsonableTreeFromForest

### DIFF
--- a/packages/dds/tree/src/test/feature-libraries/default-field-kinds/defaultChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/default-field-kinds/defaultChangeFamily.spec.ts
@@ -15,8 +15,6 @@ import {
 	type UpPath,
 	applyDelta,
 	makeDetachedFieldIndex,
-	mapCursorField,
-	moveToDetachedField,
 	rootFieldKey,
 } from "../../../core/index.js";
 import {
@@ -25,7 +23,7 @@ import {
 	DefaultEditBuilder,
 	cursorForJsonableTreeField,
 	intoDelta,
-	jsonableTreeFromCursor,
+	jsonableTreeFromForest,
 } from "../../../feature-libraries/index.js";
 import { FluidClientVersion, FormatValidatorBasic } from "../../../index.js";
 import { JsonAsTree } from "../../../jsonDomainSchema.js";
@@ -160,10 +158,7 @@ function expectForest(
 	actual: IForestSubscription,
 	expected: JsonableTree | JsonableTree[],
 ): void {
-	const reader = actual.allocateCursor();
-	moveToDetachedField(actual, reader);
-	const copy = mapCursorField(reader, jsonableTreeFromCursor);
-	reader.free();
+	const copy = jsonableTreeFromForest(actual);
 	const expectedArray = Array.isArray(expected) ? expected : [expected];
 	assert.deepEqual(copy, expectedArray);
 }
@@ -447,7 +442,7 @@ describe("DefaultEditBuilder", () => {
 				},
 			});
 			builder.move({ parent: root, field: fooKey }, 0, 3, { parent: root, field: fooKey }, 4);
-			const treeView = toJsonableTreeFromForest(forest);
+			const treeView = jsonableTreeFromForest(forest);
 			const expected: JsonableTree = {
 				type: brand(JsonAsTree.JsonObject.identifier),
 				fields: {
@@ -475,7 +470,7 @@ describe("DefaultEditBuilder", () => {
 				},
 			});
 			builder.move({ parent: root, field: fooKey }, 1, 3, { parent: root, field: fooKey }, 0);
-			const treeView = toJsonableTreeFromForest(forest);
+			const treeView = jsonableTreeFromForest(forest);
 			const expected: JsonableTree = {
 				type: brand(JsonAsTree.JsonObject.identifier),
 				fields: {
@@ -503,7 +498,7 @@ describe("DefaultEditBuilder", () => {
 				},
 			});
 			builder.move({ parent: root, field: fooKey }, 1, 2, { parent: root, field: fooKey }, 2);
-			const treeView = toJsonableTreeFromForest(forest);
+			const treeView = jsonableTreeFromForest(forest);
 			const expected: JsonableTree = {
 				type: brand(JsonAsTree.JsonObject.identifier),
 				fields: {
@@ -532,7 +527,7 @@ describe("DefaultEditBuilder", () => {
 				},
 			});
 			builder.move({ parent: root, field: fooKey }, 1, 3, { parent: root, field: barKey }, 1);
-			const treeView = toJsonableTreeFromForest(forest);
+			const treeView = jsonableTreeFromForest(forest);
 			const expected: JsonableTree = {
 				type: brand(JsonAsTree.JsonObject.identifier),
 				fields: {
@@ -580,7 +575,7 @@ describe("DefaultEditBuilder", () => {
 				{ parent: root_foo1, field: fooKey },
 				1,
 			);
-			const treeView = toJsonableTreeFromForest(forest);
+			const treeView = jsonableTreeFromForest(forest);
 			const expected: JsonableTree = {
 				type: brand(JsonAsTree.JsonObject.identifier),
 				fields: {
@@ -640,7 +635,7 @@ describe("DefaultEditBuilder", () => {
 				{ parent: root_foo0, field: fooKey },
 				1,
 			);
-			const treeView = toJsonableTreeFromForest(forest);
+			const treeView = jsonableTreeFromForest(forest);
 			const expected: JsonableTree = {
 				type: brand(JsonAsTree.JsonObject.identifier),
 				fields: {
@@ -702,7 +697,7 @@ describe("DefaultEditBuilder", () => {
 				{ parent: root_bar0, field: barKey },
 				1,
 			);
-			const treeView = toJsonableTreeFromForest(forest);
+			const treeView = jsonableTreeFromForest(forest);
 			const expected: JsonableTree = {
 				type: brand(JsonAsTree.JsonObject.identifier),
 				fields: {
@@ -759,7 +754,7 @@ describe("DefaultEditBuilder", () => {
 				{ parent: root_bar0, field: barKey },
 				1,
 			);
-			const treeView = toJsonableTreeFromForest(forest);
+			const treeView = jsonableTreeFromForest(forest);
 			const expected: JsonableTree = {
 				type: brand(JsonAsTree.JsonObject.identifier),
 				fields: {
@@ -808,7 +803,7 @@ describe("DefaultEditBuilder", () => {
 				{ parent: root, field: fooKey },
 				0,
 			);
-			const treeView = toJsonableTreeFromForest(forest);
+			const treeView = jsonableTreeFromForest(forest);
 			const expected: JsonableTree = {
 				type: brand(JsonAsTree.JsonObject.identifier),
 				fields: {
@@ -854,7 +849,7 @@ describe("DefaultEditBuilder", () => {
 				{ parent: root, field: fooKey },
 				1,
 			);
-			const treeView = toJsonableTreeFromForest(forest);
+			const treeView = jsonableTreeFromForest(forest);
 			const expected: JsonableTree = {
 				type: brand(JsonAsTree.JsonObject.identifier),
 				fields: {
@@ -908,7 +903,7 @@ describe("DefaultEditBuilder", () => {
 				},
 				1,
 			);
-			const treeView = toJsonableTreeFromForest(forest);
+			const treeView = jsonableTreeFromForest(forest);
 			const expected: JsonableTree = {
 				type: brand(JsonAsTree.JsonObject.identifier),
 				fields: {
@@ -957,7 +952,7 @@ describe("DefaultEditBuilder", () => {
 				{ parent: root_foo0, field: fooKey },
 				1,
 			);
-			const treeView = toJsonableTreeFromForest(forest);
+			const treeView = jsonableTreeFromForest(forest);
 			const expected: JsonableTree = {
 				type: brand(JsonAsTree.JsonObject.identifier),
 				fields: {
@@ -1000,7 +995,7 @@ describe("DefaultEditBuilder", () => {
 					0,
 				),
 			);
-			const treeView = toJsonableTreeFromForest(forest);
+			const treeView = jsonableTreeFromForest(forest);
 			assert.deepEqual(treeView, [statingState]);
 		});
 
@@ -1052,7 +1047,7 @@ describe("DefaultEditBuilder", () => {
 				{ parent: root_bar0_bar0, field: barKey },
 				1,
 			);
-			const treeView = toJsonableTreeFromForest(forest);
+			const treeView = jsonableTreeFromForest(forest);
 			const expected: JsonableTree = {
 				type: brand(JsonAsTree.JsonObject.identifier),
 				fields: {
@@ -1109,7 +1104,7 @@ describe("DefaultEditBuilder", () => {
 				},
 			});
 			builder.move({ parent: root, field: fooKey }, 0, 3, { parent: root, field: barKey }, 1);
-			const treeView = toJsonableTreeFromForest(forest);
+			const treeView = jsonableTreeFromForest(forest);
 			const expected: JsonableTree = {
 				type: brand(JsonAsTree.JsonObject.identifier),
 				fields: {
@@ -1130,7 +1125,7 @@ describe("DefaultEditBuilder", () => {
 			});
 			const sequencePath = { parent: root, field: EmptyKey };
 			builder.move(sequencePath, 0, 0, sequencePath, 0);
-			const treeView = toJsonableTreeFromForest(forest);
+			const treeView = jsonableTreeFromForest(forest);
 			const expected: JsonableTree = {
 				type: brand(JsonAsTree.Array.identifier),
 			};
@@ -1138,11 +1133,3 @@ describe("DefaultEditBuilder", () => {
 		});
 	});
 });
-
-function toJsonableTreeFromForest(forest: IForestSubscription): JsonableTree[] {
-	const readCursor = forest.allocateCursor();
-	moveToDetachedField(forest, readCursor);
-	const jsonable = mapCursorField(readCursor, jsonableTreeFromCursor);
-	readCursor.free();
-	return jsonable;
-}


### PR DESCRIPTION
## Description

defaultChangeFamily.spec.ts reimplements jsonableTreeFromForest twice, and this deduplicates it replacing both copies of the logic with jsonableTreeFromForest.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
