### PR TITLE
feat(publish): Removed public publishing from pipeline (#27707) [2.112]

### DIFF
--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -35,6 +35,10 @@ parameters:
     - default
     - skip
     - force
+- name: allowPublishingToNpmjs
+  displayName: Allow publishing to npmjs.org
+  type: boolean
+  default: false
 - name: interdependencyRange
   displayName: Range to use for interdependencies (only affects releases) (default = ~)
   type: string
@@ -193,6 +197,7 @@ extends:
   template: /tools/pipelines/templates/build-npm-client-package.yml@self
   parameters:
     publish: ${{ variables.publish }}
+    allowPublishingToNpmjs: ${{ parameters.allowPublishingToNpmjs }}
     publishOverride: ${{ parameters.publishOverride }}
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     packageTypesOverride: ${{ parameters.packageTypesOverride }}

--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -115,6 +115,11 @@ parameters:
 - name: publish
   type: boolean
 
+# Indicates if publishing to the public npmjs.org registry is allowed.
+- name: allowPublishingToNpmjs
+  type: boolean
+  default: false
+
 # Indicates if tests should be run with code coverage analysis.
 - name: testCoverage
   type: boolean
@@ -898,6 +903,7 @@ extends:
           parameters:
             tagName: ${{ parameters.tagName }}
             isReleaseGroup: ${{ parameters.isReleaseGroup }}
+            allowPublishingToNpmjs: ${{ parameters.allowPublishingToNpmjs }}
             buildDirectory: ${{ parameters.buildDirectory }}
 
       # Capture pipeline stage results

--- a/tools/pipelines/templates/include-publish-npm-package.yml
+++ b/tools/pipelines/templates/include-publish-npm-package.yml
@@ -15,6 +15,10 @@ parameters:
   type: boolean
   default: false
 
+- name: allowPublishingToNpmjs
+  type: boolean
+  default: false
+
 - name: buildDirectory
   type: string
 
@@ -75,7 +79,7 @@ stages:
 - stage: publish_npm_public
   dependsOn: build
   displayName: Publish to public npmjs.org
-  condition: and(succeeded(), or(eq(variables['release'], 'release'), eq(variables['release'], 'prerelease')))
+  condition: and(succeeded(), eq(${{ parameters.allowPublishingToNpmjs }}, true), or(eq(variables['release'], 'release'), eq(variables['release'], 'prerelease')))
   variables:
   - group: ado-feeds
   jobs:


### PR DESCRIPTION
## Description

Cherry-picks [PR #27707](https://github.com/microsoft/FluidFramework/pull/27707) (`feat(publish): Removed public publishing from pipeline`) onto the `release/client/2.112` release branch.

Policy changes block registry.npmjs.org in various contexts, so the publishing process needed to be updated to unblock build pipelines. This backports that change to the 2.112 release.

Cherry-picked from upstream commit 92c8d24ed1c2933a18e5a8386293bea95fa19947.

## Note

Only the client pipeline can publish to registry.npmjs.org, and only when the corresponding option is set. No other pipeline run from this branch can publish to registry.npmjs.org. That is acceptable because this branch is intended for client releases only.