### PR TITLE
feat(tree): emit telemetry when healing unresolvable identifiers on decode

### DIFF
--- a/.changeset/heal-identifier-decode-telemetry.md
+++ b/.changeset/heal-identifier-decode-telemetry.md
@@ -5,6 +5,6 @@
 ---
 SharedTree now emits telemetry when it heals an unresolvable identifier on decode
 
-When [`SharedTreeOptionsBeta.healUnresolvableIdentifiersOnDecode`](https://fluidframework.com/docs/api/tree/sharedtreeoptionsbeta-interface#healunresolvableidentifiersondecode-propertysignature) is enabled and an unresolvable identifier is healed while loading a summary, SharedTree now records a `HealUnresolvableIdentifierOnDecode` telemetry event (at `LogLevel.info`). This lets applications relying on the healing workaround detect which documents actually required healing.
+When [`SharedTreeOptionsBeta.healUnresolvableIdentifiersOnDecode`](https://fluidframework.com/docs/api/tree/sharedtreeoptionsbeta-interface#healunresolvableidentifiersondecode-propertysignature) is enabled and an unresolvable identifier is healed while loading a summary, SharedTree now records a `HealUnresolvableIdentifierOnDecode` telemetry event (at `LogLevel.essential`). This lets applications relying on the healing workaround detect which documents actually required healing.
 
 This only affects applications that have opted into `healUnresolvableIdentifiersOnDecode`; the telemetry is emitted through the same logger the DDS already uses, and no behavior other than the added telemetry has changed.

--- a/.changeset/heal-identifier-decode-telemetry.md
+++ b/.changeset/heal-identifier-decode-telemetry.md
@@ -1,0 +1,10 @@
+---
+"@fluidframework/tree": minor
+"fluid-framework": minor
+"__section": tree
+---
+SharedTree now emits telemetry when it heals an unresolvable identifier on decode
+
+When [`SharedTreeOptionsBeta.healUnresolvableIdentifiersOnDecode`](https://fluidframework.com/docs/api/tree/sharedtreeoptionsbeta-interface#healunresolvableidentifiersondecode-propertysignature) is enabled and an unresolvable identifier is healed while loading a summary, SharedTree now records a `HealUnresolvableIdentifierOnDecode` telemetry event (at `LogLevel.info`). This lets applications relying on the healing workaround detect which documents actually required healing.
+
+This only affects applications that have opted into `healUnresolvableIdentifiersOnDecode`; the telemetry is emitted through the same logger the DDS already uses, and no behavior other than the added telemetry has changed.

--- a/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
+++ b/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
@@ -207,7 +207,7 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange>
 				options.minVersionForCollab,
 				this.schemaAndPolicy,
 				options.healUnresolvableIdentifiersOnDecode === true
-					? { sharedObjectId: sharedObject.id }
+					? { sharedObjectId: sharedObject.id, logger }
 					: undefined,
 			),
 			...summarizables,

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -252,7 +252,7 @@ export class SharedTreeKernel
 			idCompressor,
 			healing:
 				options.healUnresolvableIdentifiersOnDecode === true
-					? { sharedObjectId: sharedObject.id }
+					? { sharedObjectId: sharedObject.id, logger }
 					: undefined,
 		});
 		const forestSummarizer = new ForestSummarizer(
@@ -595,6 +595,11 @@ export interface SharedTreeOptionsBeta extends ForestOptions, Partial<CodecWrite
 	 * so every reader of the same blob (other than the originator) agrees on the resulting in-memory id.
 	 * Healed identifiers are written back out at the next summary in their stable UUID form,
 	 * so the inconsistency does not need to be re-healed on every load.
+	 *
+	 * When this flag is enabled, each time an unresolvable identifier is healed a
+	 * `HealUnresolvableIdentifierOnDecode` telemetry event is emitted (at
+	 * {@link @fluidframework/core-interfaces#LogLevelConst.info | LogLevel.info}) through the shared
+	 * object's logger, allowing applications to detect which documents actually required healing.
 	 *
 	 * Off by default because enabling it for documents that are not actually corrupt
 	 * would mask genuine bugs that otherwise surface as decode failures.

--- a/packages/dds/tree/src/test/util/compressedIds.spec.ts
+++ b/packages/dds/tree/src/test/util/compressedIds.spec.ts
@@ -267,7 +267,7 @@ describe("compressedIds", () => {
 				);
 			});
 
-			it("does not log when the id is resolvable", () => {
+			it("does not log when the ID is resolvable", () => {
 				const compressedId = testIdCompressor.generateCompressedId();
 				const opSpaceId = testIdCompressor.normalizeToOpSpace(compressedId);
 				const logger = new MockLogger();

--- a/packages/dds/tree/src/test/util/compressedIds.spec.ts
+++ b/packages/dds/tree/src/test/util/compressedIds.spec.ts
@@ -7,6 +7,7 @@ import { strict as assert } from "node:assert";
 
 import type { OpSpaceCompressedId, SessionId } from "@fluidframework/id-compressor";
 import { createIdCompressor, createSessionId } from "@fluidframework/id-compressor/internal";
+import { MockLogger } from "@fluidframework/telemetry-utils/internal";
 import { validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
 
 import {
@@ -251,6 +252,31 @@ describe("compressedIds", () => {
 			// The id is final, so the result is a session-space id (numeric), not a v5 UUID string.
 			assert.equal(result, compressedId);
 			assert.equal(typeof result, "number");
+		});
+
+		describe("telemetry", () => {
+			it("records a recovery event on the heal path via the healing config logger", () => {
+				const { opSpaceId } = makeUnresolvableOpSpaceId();
+				const logger = new MockLogger();
+				forceDecodeEncodedIdWithoutSession(opSpaceId, testIdCompressor, {
+					sharedObjectId,
+					logger,
+				});
+				assert(
+					logger.events.some((e) => e.eventName === "HealUnresolvableIdentifierOnDecode"),
+				);
+			});
+
+			it("does not log when the id is resolvable", () => {
+				const compressedId = testIdCompressor.generateCompressedId();
+				const opSpaceId = testIdCompressor.normalizeToOpSpace(compressedId);
+				const logger = new MockLogger();
+				forceDecodeEncodedIdWithoutSession(opSpaceId, testIdCompressor, {
+					sharedObjectId,
+					logger,
+				});
+				assert.equal(logger.events.length, 0);
+			});
 		});
 	});
 

--- a/packages/dds/tree/src/util/compressedIds.ts
+++ b/packages/dds/tree/src/util/compressedIds.ts
@@ -212,7 +212,11 @@ export function forceDecodeEncodedIdWithoutSession(
 				category: "generic",
 				eventName: "HealUnresolvableIdentifierOnDecode",
 			},
-			LogLevel.info,
+			// This telemetry should be very low-volume (and possibly never happen at all),
+			// as should only occur when loading documents that were corrupted by a now fixed bug and have not been re-summarized since healing was added.
+			// It is useful for monitoring and diagnosing for this to be reported in the same cases in which the error case would be reported,
+			// which is the essential level.
+			LogLevel.essential,
 		);
 		return healed;
 	}

--- a/packages/dds/tree/src/util/compressedIds.ts
+++ b/packages/dds/tree/src/util/compressedIds.ts
@@ -191,9 +191,9 @@ export interface IdentifierHealingConfig {
  * not instrumented here: the thrown exception is expected to surface via the application's own error
  * telemetry, and should never be silently swallowed.
  *
- * @param id - The op-space compressed id to decode.
- * @param idCompressor - The ID compressor used to normalize the id.
- * @param healing - Heal-on-decode configuration. Presence enables healing of non-final ids.
+ * @param id - The op-space compressed ID to decode.
+ * @param idCompressor - The ID compressor used to normalize the ID.
+ * @param healing - Heal-on-decode configuration. Presence enables healing of non-final IDs.
  */
 export function forceDecodeEncodedIdWithoutSession(
 	id: OpSpaceCompressedId,

--- a/packages/dds/tree/src/util/compressedIds.ts
+++ b/packages/dds/tree/src/util/compressedIds.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { LogLevel, type ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils/internal";
 import type {
 	IIdCompressor,
@@ -166,6 +167,12 @@ export interface IdentifierHealingConfig {
 	 * same session offsets.
 	 */
 	readonly sharedObjectId: string;
+
+	/**
+	 * Optional logger used by {@link forceDecodeEncodedIdWithoutSession} to record telemetry
+	 * when the heal-on-decode recovery path is taken (a non-final identifier is healed).
+	 */
+	readonly logger?: ITelemetryBaseLogger;
 }
 
 /**
@@ -177,6 +184,16 @@ export interface IdentifierHealingConfig {
  * deterministic v5 UUID string — *not* a `StableId`, since that brand requires
  * v4, but still a valid identifier value; the `string` arm of the return type
  * covers this case.
+ *
+ * The recovery (heal) path only occurs because of a prior bug where non-finalized identifiers were
+ * written into summaries. When {@link IdentifierHealingConfig.logger} is supplied, a telemetry event
+ * is recorded on that path so heals can be observed in the wild. The error/throw path is intentionally
+ * not instrumented here: the thrown exception is expected to surface via the application's own error
+ * telemetry, and should never be silently swallowed.
+ *
+ * @param id - The op-space compressed id to decode.
+ * @param idCompressor - The ID compressor used to normalize the id.
+ * @param healing - Heal-on-decode configuration. Presence enables healing of non-final ids.
  */
 export function forceDecodeEncodedIdWithoutSession(
 	id: OpSpaceCompressedId,
@@ -189,7 +206,15 @@ export function forceDecodeEncodedIdWithoutSession(
 	}
 	// `id` is a non-final op-space compressed id.
 	if (healing !== undefined) {
-		return uuidV5(`${healing.sharedObjectId}|${id}`, healingNamespace);
+		const healed = uuidV5(`${healing.sharedObjectId}|${id}`, healingNamespace);
+		healing.logger?.send(
+			{
+				category: "generic",
+				eventName: "HealUnresolvableIdentifierOnDecode",
+			},
+			LogLevel.info,
+		);
+		return healed;
 	}
 	throw new Error(
 		"Summary could not be loaded due to an incorrectly encoded identifier. See SharedTreeOptionsBeta.healUnresolvableIdentifiersOnDecode for mitigation.",


### PR DESCRIPTION
## Description

When `SharedTreeOptionsBeta.healUnresolvableIdentifiersOnDecode` is enabled, SharedTree now records a `HealUnresolvableIdentifierOnDecode` telemetry event (at `LogLevel.info`) each time a non-final identifier is healed while loading a summary. This lets applications relying on the healing workaround observe which documents actually required healing.

This is a follow-up to the identifier-healing work: the heal and throw paths only exist because of a prior bug where non-finalized identifiers could be written into summaries. Instrumenting the recovery path makes those occurrences visible in the wild. The error/throw path is intentionally left un-instrumented — the thrown exception already surfaces via the application's own error telemetry and must not be silently swallowed.

Changes:
- Add an optional `logger` to the internal `IdentifierHealingConfig`; `forceDecodeEncodedIdWithoutSession` sends the event directly via `logger?.send(..., LogLevel.essential)`.
- Thread the shared object's logger into the healing config in `SharedTreeKernel` and `SharedTreeCore`.
- Document the telemetry event and level on `healUnresolvableIdentifiersOnDecode`.
- Add unit tests and a changeset.

Because it changes observable behavior for consumers who opted into the healing feature (they now get telemetry), this ships with a changeset.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

- The logger lives on `IdentifierHealingConfig` (recovery path only) rather than being threaded independently; the throw path is deliberately not instrumented. Confirm that split is acceptable.