### PR TITLE
refactor(tree): split encode/decode contexts for change and field codecs

### DIFF
--- a/packages/dds/tree/src/core/change-family/changeFamily.ts
+++ b/packages/dds/tree/src/core/change-family/changeFamily.ts
@@ -17,7 +17,7 @@ export interface ChangeFamily<TEditor extends ChangeFamilyEditor, TChange> {
 	): TEditor;
 
 	readonly rebaser: ChangeRebaser<TChange>;
-	readonly codecs: ICodecFamily<TChange, ChangeEncodingContext>;
+	readonly codecs: ICodecFamily<TChange, ChangeEncodingContext, ChangeDecodingContext>;
 }
 
 export interface ChangeEncodingContext {
@@ -43,11 +43,23 @@ export interface ChangeEncodingContext {
 	readonly healing?: IdentifierHealingConfig;
 }
 
+/**
+ * Context provided to change codecs when decoding.
+ * @remarks
+ * Currently identical to {@link ChangeEncodingContext}; it exists as a distinct name so that the
+ * decode side of change codecs can be given a decode-specific shape independently of the encode
+ * side in a later step (for example, to carry an {@link IdDecodingContext} instead of the raw
+ * session-id fields). Keeping it a separate type now lets that migration happen without re-threading
+ * every codec type declaration.
+ */
+export type ChangeDecodingContext = ChangeEncodingContext;
+
 export type ChangeFamilyCodec<TChange> = IJsonCodec<
 	TChange,
 	JsonCompatibleReadOnly,
 	JsonCompatibleReadOnly,
-	ChangeEncodingContext
+	ChangeEncodingContext,
+	ChangeDecodingContext
 >;
 
 export interface ChangeFamilyEditor {

--- a/packages/dds/tree/src/core/change-family/changeFamily.ts
+++ b/packages/dds/tree/src/core/change-family/changeFamily.ts
@@ -46,13 +46,18 @@ export interface ChangeEncodingContext {
 /**
  * Context provided to change codecs when decoding.
  * @remarks
- * Currently identical to {@link ChangeEncodingContext}; it exists as a distinct name so that the
- * decode side of change codecs can be given a decode-specific shape independently of the encode
- * side in a later step (for example, to carry an {@link IdDecodingContext} instead of the raw
- * session-id fields). Keeping it a separate type now lets that migration happen without re-threading
- * every codec type declaration.
+ * The same as {@link ChangeEncodingContext} except that it omits `schema`: that field is only
+ * consulted when *encoding* (for schema-aware compression), whereas decoding relies on the
+ * self-describing encoded format and never reads it. Keeping decode-irrelevant fields off this
+ * type documents the decode-side contract and lets the two contexts diverge further in the future.
+ *
+ * @privateRemarks
+ * `healing` is only meaningful on the decode side, but it is retained on {@link ChangeEncodingContext}
+ * (rather than moved here) because the EditManager and Message codecs still use a single
+ * `ChangeEncodingContext` for both encode and decode; moving it would require splitting those codecs
+ * first.
  */
-export type ChangeDecodingContext = ChangeEncodingContext;
+export type ChangeDecodingContext = Omit<ChangeEncodingContext, "schema">;
 
 export type ChangeFamilyCodec<TChange> = IJsonCodec<
 	TChange,

--- a/packages/dds/tree/src/core/change-family/index.ts
+++ b/packages/dds/tree/src/core/change-family/index.ts
@@ -7,6 +7,7 @@ export type {
 	ChangeFamily,
 	ChangeFamilyEditor,
 	ChangeEncodingContext,
+	ChangeDecodingContext,
 	ChangeFamilyCodec,
 } from "./changeFamily.js";
 export { EditBuilder } from "./editBuilder.js";

--- a/packages/dds/tree/src/core/index.ts
+++ b/packages/dds/tree/src/core/index.ts
@@ -164,6 +164,7 @@ export {
 	type ChangeFamily,
 	type ChangeFamilyCodec,
 	type ChangeEncodingContext,
+	type ChangeDecodingContext,
 	type ChangeFamilyEditor,
 	EditBuilder,
 } from "./change-family/index.js";

--- a/packages/dds/tree/src/feature-libraries/default-schema/defaultEditBuilder.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/defaultEditBuilder.ts
@@ -10,6 +10,7 @@ import type { CodecWriteOptions, ICodecFamily } from "../../codec/index.js";
 import {
 	type ChangeAtomId,
 	type ChangeEncodingContext,
+	type ChangeDecodingContext,
 	type ChangeFamily,
 	type ChangeFamilyEditor,
 	type ChangeRebaser,
@@ -54,7 +55,7 @@ export class DefaultChangeFamily
 	private readonly modularFamily: ModularChangeFamily;
 
 	public constructor(
-		codecs: ICodecFamily<ModularChangeset, ChangeEncodingContext>,
+		codecs: ICodecFamily<ModularChangeset, ChangeEncodingContext, ChangeDecodingContext>,
 		codecOptions: CodecWriteOptions,
 	) {
 		this.modularFamily = new ModularChangeFamily(fieldKinds, codecs, codecOptions);
@@ -64,7 +65,11 @@ export class DefaultChangeFamily
 		return this.modularFamily.rebaser;
 	}
 
-	public get codecs(): ICodecFamily<DefaultChangeset, ChangeEncodingContext> {
+	public get codecs(): ICodecFamily<
+		DefaultChangeset,
+		ChangeEncodingContext,
+		ChangeDecodingContext
+	> {
 		return this.modularFamily.codecs;
 	}
 

--- a/packages/dds/tree/src/feature-libraries/default-schema/noChangeCodecs.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/noChangeCodecs.ts
@@ -4,7 +4,13 @@
  */
 
 import { type ICodecFamily, makeCodecFamily, unitCodec } from "../../codec/index.js";
-import type { FieldChangeEncodingContext } from "../modular-schema/index.js";
+import type {
+	FieldChangeEncodingContext,
+	FieldChangeDecodingContext,
+} from "../modular-schema/index.js";
 
-export const noChangeCodecFamily: ICodecFamily<0, FieldChangeEncodingContext> =
-	makeCodecFamily<0, FieldChangeEncodingContext>([[1, unitCodec]]);
+export const noChangeCodecFamily: ICodecFamily<
+	0,
+	FieldChangeEncodingContext,
+	FieldChangeDecodingContext
+> = makeCodecFamily<0, FieldChangeEncodingContext>([[1, unitCodec]]);

--- a/packages/dds/tree/src/feature-libraries/default-schema/noChangeCodecs.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/noChangeCodecs.ts
@@ -13,4 +13,6 @@ export const noChangeCodecFamily: ICodecFamily<
 	0,
 	FieldChangeEncodingContext,
 	FieldChangeDecodingContext
-> = makeCodecFamily<0, FieldChangeEncodingContext>([[1, unitCodec]]);
+> = makeCodecFamily<0, FieldChangeEncodingContext, FieldChangeDecodingContext>([
+	[1, unitCodec],
+]);

--- a/packages/dds/tree/src/feature-libraries/index.ts
+++ b/packages/dds/tree/src/feature-libraries/index.ts
@@ -88,6 +88,7 @@ export {
 	updateRefreshers,
 	type NodeId,
 	type FieldChangeEncodingContext,
+	type FieldChangeDecodingContext,
 	type FieldKindConfiguration,
 	type FieldKindConfigurationEntry,
 	isNeverTree,

--- a/packages/dds/tree/src/feature-libraries/modular-schema/fieldChangeHandler.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/fieldChangeHandler.ts
@@ -63,7 +63,7 @@ export interface FieldChangeHandler<
 			typeof RevisionTagSchema,
 			ChangeEncodingContext
 		>,
-	) => ICodecFamily<TChangeset, FieldChangeEncodingContext>;
+	) => ICodecFamily<TChangeset, FieldChangeEncodingContext, FieldChangeDecodingContext>;
 	readonly editor: TEditor;
 	intoDelta(change: TChangeset, deltaFromChild: ToDelta): FieldChangeDelta;
 	/**
@@ -304,3 +304,12 @@ export interface FieldChangeEncodingContext {
 	encodeNode(nodeId: NodeId): EncodedNodeChangeset;
 	decodeNode(encodedNode: EncodedNodeChangeset): NodeId;
 }
+
+/**
+ * Context provided to field change codecs when decoding.
+ * @remarks
+ * Currently identical to {@link FieldChangeEncodingContext}; it exists as a distinct name so the
+ * decode side of field codecs can diverge from the encode side in a later step (for example, to
+ * carry a {@link ChangeDecodingContext} as its `baseContext`). See {@link ChangeDecodingContext}.
+ */
+export type FieldChangeDecodingContext = FieldChangeEncodingContext;

--- a/packages/dds/tree/src/feature-libraries/modular-schema/fieldChangeHandler.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/fieldChangeHandler.ts
@@ -302,14 +302,14 @@ export interface RebaseRevisionMetadata extends RevisionMetadataSource {
 export interface FieldChangeEncodingContext {
 	readonly baseContext: ChangeEncodingContext;
 	encodeNode(nodeId: NodeId): EncodedNodeChangeset;
-	decodeNode(encodedNode: EncodedNodeChangeset): NodeId;
 }
 
 /**
  * Context provided to field change codecs when decoding.
  * @remarks
- * Currently identical to {@link FieldChangeEncodingContext}; it exists as a distinct name so the
- * decode side of field codecs can diverge from the encode side in a later step (for example, to
- * carry a {@link ChangeDecodingContext} as its `baseContext`). See {@link ChangeDecodingContext}.
+ * The decode-side counterpart of {@link FieldChangeEncodingContext}.
  */
-export type FieldChangeDecodingContext = FieldChangeEncodingContext;
+export interface FieldChangeDecodingContext {
+	readonly baseContext: ChangeEncodingContext;
+	decodeNode(encodedNode: EncodedNodeChangeset): NodeId;
+}

--- a/packages/dds/tree/src/feature-libraries/modular-schema/genericFieldKindCodecs.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/genericFieldKindCodecs.ts
@@ -5,14 +5,18 @@
 
 import { type ICodecFamily, type IJsonCodec, makeCodecFamily } from "../../codec/index.js";
 
-import type { FieldChangeEncodingContext } from "./fieldChangeHandler.js";
+import type {
+	FieldChangeEncodingContext,
+	FieldChangeDecodingContext,
+} from "./fieldChangeHandler.js";
 import { EncodedGenericChangeset } from "./genericFieldKindFormat.js";
 import { newGenericChangeset, type GenericChangeset } from "./genericFieldKindTypes.js";
 import { EncodedNodeChangeset } from "./modularChangeFormatV1.js";
 
 export function makeGenericChangeCodec(): ICodecFamily<
 	GenericChangeset,
-	FieldChangeEncodingContext
+	FieldChangeEncodingContext,
+	FieldChangeDecodingContext
 > {
 	return makeCodecFamily([[1, makeV1Codec()]]);
 }

--- a/packages/dds/tree/src/feature-libraries/modular-schema/genericFieldKindCodecs.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/genericFieldKindCodecs.ts
@@ -25,7 +25,8 @@ function makeV1Codec(): IJsonCodec<
 	GenericChangeset,
 	EncodedGenericChangeset,
 	EncodedGenericChangeset,
-	FieldChangeEncodingContext
+	FieldChangeEncodingContext,
+	FieldChangeDecodingContext
 > {
 	return {
 		encode: (
@@ -39,7 +40,7 @@ function makeV1Codec(): IJsonCodec<
 		},
 		decode: (
 			encoded: EncodedGenericChangeset,
-			context: FieldChangeEncodingContext,
+			context: FieldChangeDecodingContext,
 		): GenericChangeset => {
 			return newGenericChangeset(
 				encoded.map(([index, nodeChange]) => [index, context.decodeNode(nodeChange)]),

--- a/packages/dds/tree/src/feature-libraries/modular-schema/index.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/index.ts
@@ -34,6 +34,7 @@ export {
 	type FieldChangeHandler,
 	type FieldChangeDelta,
 	type FieldChangeEncodingContext,
+	type FieldChangeDecodingContext,
 	type FieldChangeRebaser,
 	type FieldEditor,
 	type NestedChangesIndices,

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecV1.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecV1.ts
@@ -42,7 +42,11 @@ import {
 } from "../chunked-forest/index.js";
 import { TreeCompressionStrategy } from "../treeCompressionUtils.js";
 
-import type { FieldChangeEncodingContext, FieldChangeHandler } from "./fieldChangeHandler.js";
+import type {
+	FieldChangeEncodingContext,
+	FieldChangeDecodingContext,
+	FieldChangeHandler,
+} from "./fieldChangeHandler.js";
 import type {
 	FieldKindConfiguration,
 	FieldKindConfigurationEntry,
@@ -78,7 +82,8 @@ type FieldCodec = IJsonCodec<
 	FieldChangeset,
 	JsonCompatibleReadOnly,
 	JsonCompatibleReadOnly,
-	FieldChangeEncodingContext
+	FieldChangeEncodingContext,
+	FieldChangeDecodingContext
 >;
 
 type FieldChangesetCodecs = Map<
@@ -115,8 +120,6 @@ export function encodeFieldChangesForJson(
 			assert(node !== undefined, 0x92e /* Unknown node ID */);
 			return encodeNodeChangesForJson(node, fieldContext, fieldChangesetCodecs);
 		},
-
-		decodeNode: () => fail(0xb1e /* Should not decode nodes during field encoding */),
 	};
 
 	return encodeFieldChangesForJsonI(change, fieldContext, fieldChangesetCodecs);
@@ -200,10 +203,8 @@ export function decodeFieldChangesFromJson(
 			field: field.fieldKey,
 		};
 
-		const fieldContext: FieldChangeEncodingContext = {
+		const fieldContext: FieldChangeDecodingContext = {
 			baseContext: context,
-
-			encodeNode: () => fail(0xb21 /* Should not encode nodes during field decoding */),
 
 			decodeNode: (encodedNode: EncodedNodeChangeset): NodeId => {
 				const nodeId: NodeId = {

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecs.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecs.ts
@@ -13,6 +13,7 @@ import {
 } from "../../codec/index.js";
 import type {
 	ChangeEncodingContext,
+	ChangeDecodingContext,
 	RevisionTag,
 	RevisionTagSchema,
 } from "../../core/index.js";
@@ -35,7 +36,7 @@ export function makeModularChangeCodecFamily(
 	fieldsCodec: FieldBatchCodec,
 	codecOptions: ICodecOptions,
 	chunkCompressionStrategy: TreeCompressionStrategy = TreeCompressionStrategy.Compressed,
-): ICodecFamily<ModularChangeset, ChangeEncodingContext> {
+): ICodecFamily<ModularChangeset, ChangeEncodingContext, ChangeDecodingContext> {
 	return makeCodecFamily(
 		Array.from(fieldKindConfigurations.entries(), ([version, fieldKinds]) => {
 			switch (version) {

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -15,6 +15,7 @@ import {
 } from "../../codec/index.js";
 import {
 	type ChangeEncodingContext,
+	type ChangeDecodingContext,
 	type ChangeFamily,
 	type ChangeFamilyEditor,
 	type ChangeRebaser,
@@ -120,7 +121,11 @@ export class ModularChangeFamily
 
 	public constructor(
 		fieldKinds: ReadonlyMap<FieldKindIdentifier, FlexFieldKind>,
-		public readonly codecs: ICodecFamily<ModularChangeset, ChangeEncodingContext>,
+		public readonly codecs: ICodecFamily<
+			ModularChangeset,
+			ChangeEncodingContext,
+			ChangeDecodingContext
+		>,
 		public readonly codecOptions: CodecWriteOptions,
 	) {
 		this.fieldKinds = fieldKinds;

--- a/packages/dds/tree/src/feature-libraries/optional-field/optionalFieldCodecV2.ts
+++ b/packages/dds/tree/src/feature-libraries/optional-field/optionalFieldCodecV2.ts
@@ -16,6 +16,7 @@ import type { Mutable } from "../../util/index.js";
 import { makeChangeAtomIdCodec } from "../changeAtomIdCodec.js";
 import type {
 	FieldChangeEncodingContext,
+	FieldChangeDecodingContext,
 	EncodedChangeAtomId,
 } from "../modular-schema/index.js";
 import { EncodedNodeChangeset } from "../modular-schema/index.js";
@@ -57,7 +58,8 @@ export function makeOptionalFieldCodec(
 	OptionalChangeset,
 	EncodedOptionalChangeset<TAnySchema>,
 	EncodedOptionalChangeset<TAnySchema>,
-	FieldChangeEncodingContext
+	FieldChangeEncodingContext,
+	FieldChangeDecodingContext
 > {
 	const changeAtomIdCodec = makeChangeAtomIdCodec(revisionTagCodec);
 	const registerIdCodec = makeRegisterIdCodec(changeAtomIdCodec);
@@ -98,7 +100,7 @@ export function makeOptionalFieldCodec(
 
 		decode: (
 			encoded: EncodedOptionalChangeset<TAnySchema>,
-			context: FieldChangeEncodingContext,
+			context: FieldChangeDecodingContext,
 		) => {
 			const decoded: Mutable<OptionalChangeset> = {
 				moves:

--- a/packages/dds/tree/src/feature-libraries/optional-field/optionalFieldCodecs.ts
+++ b/packages/dds/tree/src/feature-libraries/optional-field/optionalFieldCodecs.ts
@@ -9,7 +9,10 @@ import type {
 	RevisionTag,
 	RevisionTagSchema,
 } from "../../core/index.js";
-import type { FieldChangeEncodingContext } from "../modular-schema/index.js";
+import type {
+	FieldChangeEncodingContext,
+	FieldChangeDecodingContext,
+} from "../modular-schema/index.js";
 
 import type { OptionalChangeset } from "./optionalFieldChangeTypes.js";
 import { makeOptionalFieldCodec as makeV2Codec } from "./optionalFieldCodecV2.js";
@@ -20,5 +23,5 @@ export const makeOptionalFieldCodecFamily = (
 		typeof RevisionTagSchema,
 		ChangeEncodingContext
 	>,
-): ICodecFamily<OptionalChangeset, FieldChangeEncodingContext> =>
+): ICodecFamily<OptionalChangeset, FieldChangeEncodingContext, FieldChangeDecodingContext> =>
 	makeCodecFamily([[2, makeV2Codec(revisionTagCodec)]]);

--- a/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldCodecV2.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldCodecV2.ts
@@ -24,6 +24,7 @@ import { makeChangeAtomIdCodec } from "../changeAtomIdCodec.js";
 import {
 	EncodedNodeChangeset,
 	type FieldChangeEncodingContext,
+	type FieldChangeDecodingContext,
 } from "../modular-schema/index.js";
 
 import { Changeset as ChangesetSchema, type Encoded } from "./formatV2.js";
@@ -271,7 +272,8 @@ export function makeV2Codec(
 	Changeset,
 	JsonCompatibleReadOnly,
 	JsonCompatibleReadOnly,
-	FieldChangeEncodingContext
+	FieldChangeEncodingContext,
+	FieldChangeDecodingContext
 > {
 	const { markEffectCodec, changeAtomIdCodec } = makeV2CodecHelpers(revisionTagCodec);
 	/**
@@ -305,7 +307,7 @@ export function makeV2Codec(
 		},
 		decode: (
 			changeset: Encoded.Changeset<NodeChangeSchema>,
-			context: FieldChangeEncodingContext,
+			context: FieldChangeDecodingContext,
 		): Changeset => {
 			const marks: Changeset = [];
 			for (const mark of changeset) {

--- a/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldCodecV3.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldCodecV3.ts
@@ -19,6 +19,7 @@ import type { JsonCompatibleReadOnly } from "../../util/index.js";
 import {
 	EncodedNodeChangeset,
 	type FieldChangeEncodingContext,
+	type FieldChangeDecodingContext,
 } from "../modular-schema/index.js";
 
 import { Changeset as ChangesetSchema, type Encoded } from "./formatV3.js";
@@ -36,7 +37,8 @@ export function makeV3Codec(
 	Changeset,
 	JsonCompatibleReadOnly,
 	JsonCompatibleReadOnly,
-	FieldChangeEncodingContext
+	FieldChangeEncodingContext,
+	FieldChangeDecodingContext
 > {
 	const {
 		changeAtomIdCodec: atomIdCodec,
@@ -115,7 +117,7 @@ export function makeV3Codec(
 		},
 		decode: (
 			changeset: Encoded.Changeset<NodeChangeSchema>,
-			context: FieldChangeEncodingContext,
+			context: FieldChangeDecodingContext,
 		): Changeset => {
 			const marks: Changeset = [];
 			for (const mark of changeset) {

--- a/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldCodecs.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldCodecs.ts
@@ -9,7 +9,10 @@ import type {
 	RevisionTag,
 	RevisionTagSchema,
 } from "../../core/index.js";
-import type { FieldChangeEncodingContext } from "../modular-schema/index.js";
+import type {
+	FieldChangeEncodingContext,
+	FieldChangeDecodingContext,
+} from "../modular-schema/index.js";
 
 import { makeV2Codec } from "./sequenceFieldCodecV2.js";
 import { makeV3Codec } from "./sequenceFieldCodecV3.js";
@@ -21,7 +24,7 @@ export const sequenceFieldChangeCodecFactory = (
 		typeof RevisionTagSchema,
 		ChangeEncodingContext
 	>,
-): ICodecFamily<MarkList, FieldChangeEncodingContext> =>
+): ICodecFamily<MarkList, FieldChangeEncodingContext, FieldChangeDecodingContext> =>
 	makeCodecFamily<Changeset, FieldChangeEncodingContext>([
 		[2, makeV2Codec(revisionTagCodec)],
 		[3, makeV3Codec(revisionTagCodec)],

--- a/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldCodecs.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldCodecs.ts
@@ -25,7 +25,7 @@ export const sequenceFieldChangeCodecFactory = (
 		ChangeEncodingContext
 	>,
 ): ICodecFamily<MarkList, FieldChangeEncodingContext, FieldChangeDecodingContext> =>
-	makeCodecFamily<Changeset, FieldChangeEncodingContext>([
+	makeCodecFamily<Changeset, FieldChangeEncodingContext, FieldChangeDecodingContext>([
 		[2, makeV2Codec(revisionTagCodec)],
 		[3, makeV3Codec(revisionTagCodec)],
 	]);

--- a/packages/dds/tree/src/shared-tree/sharedTreeChangeCodecs.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTreeChangeCodecs.ts
@@ -16,7 +16,11 @@ import {
 	makeCodecFamily,
 	withSchemaValidation,
 } from "../codec/index.js";
-import type { ChangeEncodingContext, TreeStoredSchema } from "../core/index.js";
+import type {
+	ChangeEncodingContext,
+	ChangeDecodingContext,
+	TreeStoredSchema,
+} from "../core/index.js";
 import {
 	ModularChangeFormatVersion,
 	type ModularChangeset,
@@ -39,9 +43,13 @@ import {
 import type { SharedTreeChange, SharedTreeInnerChange } from "./sharedTreeChangeTypes.js";
 
 export function makeSharedTreeChangeCodecFamily(
-	modularChangeCodecFamily: ICodecFamily<ModularChangeset, ChangeEncodingContext>,
+	modularChangeCodecFamily: ICodecFamily<
+		ModularChangeset,
+		ChangeEncodingContext,
+		ChangeDecodingContext
+	>,
 	options: CodecWriteOptions,
-): ICodecFamily<SharedTreeChange, ChangeEncodingContext> {
+): ICodecFamily<SharedTreeChange, ChangeEncodingContext, ChangeDecodingContext> {
 	const versions: [
 		FormatVersion,
 		IJsonCodec<

--- a/packages/dds/tree/src/shared-tree/sharedTreeChangeFamily.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTreeChangeFamily.ts
@@ -9,6 +9,7 @@ import type { IIdCompressor } from "@fluidframework/id-compressor";
 import type { CodecWriteOptions, ICodecFamily } from "../codec/index.js";
 import {
 	type ChangeEncodingContext,
+	type ChangeDecodingContext,
 	type ChangeFamily,
 	type ChangeRebaser,
 	type DeltaDetachedNodeId,
@@ -55,7 +56,11 @@ export class SharedTreeChangeFamily
 		changes: [],
 	};
 
-	public readonly codecs: ICodecFamily<SharedTreeChange, ChangeEncodingContext>;
+	public readonly codecs: ICodecFamily<
+		SharedTreeChange,
+		ChangeEncodingContext,
+		ChangeDecodingContext
+	>;
 	private readonly modularChangeFamily: ModularChangeFamily;
 
 	public constructor(

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/basicRebasers.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/basicRebasers.ts
@@ -16,6 +16,7 @@ import {
 import {
 	type FieldChangeDelta,
 	type FieldChangeEncodingContext,
+	type FieldChangeDecodingContext,
 	type FieldChangeHandler,
 	type FieldChangeRebaser,
 	FlexFieldKind,
@@ -91,7 +92,10 @@ export type ValueChangeset = ReplaceOp<number>;
 export const valueHandler = {
 	rebaser: replaceRebaser(),
 	codecsFactory: () => {
-		const inner = makeValueCodec<TUnsafe<ValueChangeset>, FieldChangeEncodingContext>(
+		const inner = makeValueCodec<
+			TUnsafe<ValueChangeset>,
+			FieldChangeEncodingContext | FieldChangeDecodingContext
+		>(
 			// As this is just a test rebaser, it is acceptable to not use a proper schema, and thus not detect invalid data here.
 			JsonCompatibleReadOnlySchema as TUnsafe<ValueChangeset>,
 		);

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/genericFieldKind.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/genericFieldKind.spec.ts
@@ -13,6 +13,7 @@ import { newGenericChangeset } from "../../../feature-libraries/modular-schema/g
 import {
 	type FieldChangeDelta,
 	type FieldChangeEncodingContext,
+	type FieldChangeDecodingContext,
 	type NodeId,
 	type RebaseRevisionMetadata,
 	genericChangeHandler,
@@ -212,7 +213,7 @@ describe("GenericField", () => {
 		const encodingTestData: EncodingTestData<
 			GenericChangeset,
 			unknown,
-			FieldChangeEncodingContext
+			FieldChangeEncodingContext & FieldChangeDecodingContext
 		> = {
 			successes: [
 				[

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/genericFieldSnapshots.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/genericFieldSnapshots.test.ts
@@ -46,7 +46,6 @@ export function testSnapshots(): void {
 						const encoded = codec.encode(change, {
 							baseContext,
 							encodeNode: (nodeId) => TestNodeId.encode(nodeId, baseContext),
-							decodeNode: (nodeId) => TestNodeId.decode(nodeId, baseContext),
 						});
 						takeJsonSnapshot(encoded);
 					});

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
@@ -66,6 +66,7 @@ import type {
 	EncodedNodeChangeset,
 	FieldChangeDelta,
 	FieldChangeEncodingContext,
+	FieldChangeDecodingContext,
 	// eslint-disable-next-line import-x/no-internal-modules
 } from "../../../feature-libraries/modular-schema/index.js";
 import {
@@ -136,7 +137,8 @@ const singleNodeCodec: IJsonCodec<
 	SingleNodeChangeset,
 	EncodedNodeChangeset | "",
 	EncodedNodeChangeset | "",
-	FieldChangeEncodingContext
+	FieldChangeEncodingContext,
+	FieldChangeDecodingContext
 > = {
 	encode: (change, context) => {
 		return change === undefined ? emptyEncodedChange : context.encodeNode(change);

--- a/packages/dds/tree/src/test/feature-libraries/optional-field/optionalFieldChangeCodecs.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/optional-field/optionalFieldChangeCodecs.test.ts
@@ -5,7 +5,10 @@
 
 import type { SessionId } from "@fluidframework/id-compressor";
 
-import type { FieldChangeEncodingContext } from "../../../feature-libraries/index.js";
+import type {
+	FieldChangeEncodingContext,
+	FieldChangeDecodingContext,
+} from "../../../feature-libraries/index.js";
 import {
 	optionalFieldEditor,
 	// eslint-disable-next-line import-x/no-internal-modules
@@ -81,7 +84,7 @@ export function testCodecs(): void {
 			revision: undefined,
 			idCompressor: testIdCompressor,
 		};
-		const context: FieldChangeEncodingContext = {
+		const context: FieldChangeEncodingContext & FieldChangeDecodingContext = {
 			baseContext,
 			encodeNode: (nodeId) => TestNodeId.encode(nodeId, baseContext),
 			decodeNode: (nodeId) => TestNodeId.decode(nodeId, baseContext),
@@ -90,7 +93,7 @@ export function testCodecs(): void {
 		const encodingTestData: EncodingTestData<
 			OptionalChangeset,
 			unknown,
-			FieldChangeEncodingContext
+			FieldChangeEncodingContext & FieldChangeDecodingContext
 		> = {
 			successes: [
 				["set from empty", change1, context],

--- a/packages/dds/tree/src/test/feature-libraries/optional-field/optionalFieldSnapshots.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/optional-field/optionalFieldSnapshots.test.ts
@@ -85,7 +85,6 @@ export function testSnapshots(): void {
 						const encoded = codec.encode(change, {
 							baseContext,
 							encodeNode: (node) => TestNodeId.encode(node, baseContext),
-							decodeNode: (node) => TestNodeId.decode(node, baseContext),
 						});
 						takeJsonSnapshot(encoded);
 					});

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldCodecs.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldCodecs.test.ts
@@ -7,7 +7,10 @@ import type { SessionId } from "@fluidframework/id-compressor";
 
 import { withSchemaValidation } from "../../../codec/index.js";
 import { FormatValidatorBasic } from "../../../external-utilities/index.js";
-import type { FieldChangeEncodingContext } from "../../../feature-libraries/index.js";
+import type {
+	FieldChangeEncodingContext,
+	FieldChangeDecodingContext,
+} from "../../../feature-libraries/index.js";
 // eslint-disable-next-line import-x/no-internal-modules
 import { sequenceFieldChangeCodecFactory } from "../../../feature-libraries/sequence-field/sequenceFieldCodecs.js";
 // eslint-disable-next-line import-x/no-internal-modules
@@ -27,7 +30,7 @@ import { generatePopulatedMarks } from "./populatedMarks.js";
 import { ChangeMaker as Change, cases, MarkMaker as Mark } from "./testEdits.js";
 import { assertChangesetsEqual, inlineRevision } from "./utils.js";
 
-type TestCase = [string, Changeset, FieldChangeEncodingContext];
+type TestCase = [string, Changeset, FieldChangeEncodingContext & FieldChangeDecodingContext];
 
 const tag1 = mintRevisionTag();
 const tag2 = mintRevisionTag();
@@ -39,7 +42,7 @@ const baseContext = {
 };
 const encodedTag1 = testRevisionTagCodec.encode(tag1);
 const encodedTag2 = testRevisionTagCodec.encode(tag2);
-const context: FieldChangeEncodingContext = {
+const context: FieldChangeEncodingContext & FieldChangeDecodingContext = {
 	baseContext,
 	encodeNode: (node) => TestNodeId.encode(node, baseContext),
 	decodeNode: (node) => TestNodeId.decode(node, baseContext),
@@ -47,7 +50,11 @@ const context: FieldChangeEncodingContext = {
 
 const changes = TestNodeId.create({ localId: brand(2) }, TestChange.mint([], 1));
 
-const encodingTestData: EncodingTestData<Changeset, unknown, FieldChangeEncodingContext> = {
+const encodingTestData: EncodingTestData<
+	Changeset,
+	unknown,
+	FieldChangeEncodingContext & FieldChangeDecodingContext
+> = {
 	successes: [
 		["with child change", inlineRevision(Change.modify(1, changes), tag1), context],
 		["without child change", inlineRevision(Change.remove(2, 2, tag1), tag1), context],

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldSnapshots.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldSnapshots.test.ts
@@ -37,7 +37,6 @@ export function testSnapshots(): void {
 						const encoded = codec.encode(changeset, {
 							baseContext,
 							encodeNode: (node) => TestNodeId.encode(node, baseContext),
-							decodeNode: (node) => TestNodeId.decode(node, baseContext),
 						});
 						takeJsonSnapshot(encoded);
 					});

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -1187,12 +1187,8 @@ export function makeEncodingTestSuite<
 				describe("rejects malformed data", () => {
 					for (const [name, encodedData, context] of failureCases) {
 						it(name, () => {
-							assert.throws(() =>
-								jsonCodec.decode(
-									encodedData as JsonCompatible,
-									context as TEncodeContext & TDecodeContext,
-								),
-							);
+							assert(context !== undefined);
+							assert.throws(() => jsonCodec.decode(encodedData as JsonCompatible, context));
 						});
 					}
 				});

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -1083,8 +1083,8 @@ const testedFamilies = new WeakSet<ICodecFamily<unknown, unknown>>();
  * Tracks tested versions and registers an after hook to validate that all supported
  * versions in the codec family have corresponding tests.
  */
-function registerValidationHook<TDecoded, TContext>(
-	family: ICodecFamily<TDecoded, TContext>,
+function registerValidationHook<TDecoded, TEncodeContext, TDecodeContext>(
+	family: ICodecFamily<TDecoded, TEncodeContext, TDecodeContext>,
 	versions: readonly FormatVersion[],
 ): void {
 	let tested = testedVersionsByFamily.get(family);
@@ -1130,17 +1130,22 @@ function registerValidationHook<TDecoded, TContext>(
  * Maybe generalize test cases to each have an optional encoded and optional decoded form (require at least one), for example via:
  * `{name: string, encoded?: JsonCompatibleReadOnly, decoded?: TDecoded}`.
  */
-export function makeEncodingTestSuite<TDecoded, TEncoded, TContext>(
-	family: ICodecFamily<TDecoded, TContext>,
-	encodingTestData: EncodingTestData<TDecoded, TEncoded, TContext>,
+export function makeEncodingTestSuite<
+	TDecoded,
+	TEncoded,
+	TEncodeContext,
+	TDecodeContext = TEncodeContext,
+>(
+	family: ICodecFamily<TDecoded, TEncodeContext, TDecodeContext>,
+	encodingTestData: EncodingTestData<TDecoded, TEncoded, TEncodeContext & TDecodeContext>,
 	assertEquivalent: (a: TDecoded, b: TDecoded) => void = assertDeepEqual,
 	supportedVersions?: FormatVersion[],
 ): void {
-	// Type cast away the conditional type: if TContext is void, indexing off the end of this will get undefined which works, making this safe.
+	// Type cast away the conditional type: if the context is void, indexing off the end of this will get undefined which works, making this safe.
 	const successes = encodingTestData.successes as [
 		name: string,
 		data: TDecoded,
-		context: TContext,
+		context: TEncodeContext & TDecodeContext,
 	][];
 	const supportedVersionsToTest = supportedVersions ?? [...family.getSupportedFormats()];
 	registerValidationHook(family, supportedVersionsToTest);
@@ -1183,7 +1188,10 @@ export function makeEncodingTestSuite<TDecoded, TEncoded, TContext>(
 					for (const [name, encodedData, context] of failureCases) {
 						it(name, () => {
 							assert.throws(() =>
-								jsonCodec.decode(encodedData as JsonCompatible, context as TContext),
+								jsonCodec.decode(
+									encodedData as JsonCompatible,
+									context as TEncodeContext & TDecodeContext,
+								),
 							);
 						});
 					}


### PR DESCRIPTION
## Description

Part of a set of changes for giving SharedTree's change codecs distinct encode-side and decode-side context types. Pure type-level refactor — **no runtime behavior change** — scoped to the change/field codecs.

### What changed

1. **Distinct decode contexts.** Add `ChangeDecodingContext` and `FieldChangeDecodingContext`, and thread `TDecodeContext` through the change/field codec family declarations (`ChangeFamily.codecs`, `ChangeFamilyCodec`, `FieldChangeHandler.codecsFactory`, the sequence/optional/generic field families, modular change, and shared-tree-change families). The codec infrastructure already supported a separate `TDecodeContext` defaulting to `TEncodeContext`, so this is mostly plumbing.

2. **Drop `schema` from `ChangeDecodingContext`** (`Omit<ChangeEncodingContext, "schema">`): it's only used for schema-aware compression on encode.

3. **Split `FieldChangeEncodingContext`/`FieldChangeDecodingContext`** into `encodeNode`-only and `decodeNode`-only interfaces, removing the `fail(...)` stubs `modularChangeCodecV1` previously used to guard against misuse.

`ChangeEncodingContext` keeps `healing`/`originatorId` for now because the EditManager/Message codecs still use one context type for both directions; splitting those (and dropping the decode-only fields) is a follow-up.

### Tests
- Round-trip contexts typed as `FieldChangeEncodingContext & FieldChangeDecodingContext`; encode-only snapshot contexts drop the unused `decodeNode`.
- `makeEncodingTestSuite`/`registerValidationHook` generalized to accept split encode/decode contexts (backward-compatible via `TDecodeContext = TEncodeContext`).

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
