### PR TITLE
ci: skip pnpm version switch on unsigned mirror registries

### DIFF
--- a/tools/pipelines/templates/include-install-pnpm.yml
+++ b/tools/pipelines/templates/include-install-pnpm.yml
@@ -143,3 +143,10 @@ steps:
       # Disable minimum release age checks in CI to avoid false positives.
       echo "Disabling pnpm minimumReleaseAge check as workaround for npm mirror publish time issues"
       echo "##vso[task.setvariable variable=PNPM_CONFIG_MINIMUM_RELEASE_AGE]0"
+      # When pnpm runs in a project whose "packageManager" field pins a different pnpm version
+      # (e.g. the ff_pipeline_host repo), pnpm tries to self-switch to that version and verifies
+      # its npm registry signature. Our mirrored registries do not carry pnpm's signatures, so the
+      # switch is refused and the install fails. Set pmOnFail=ignore so pnpm skips the failed
+      # version switch and runs with the already-installed version instead of erroring out.
+      echo "Setting pnpm pmOnFail=ignore as workaround for npm mirror missing package-manager signatures"
+      echo "##vso[task.setvariable variable=PNPM_CONFIG_PM_ON_FAIL]ignore"


### PR DESCRIPTION
## Description

The stress test pipeline installs pnpm from the FluidFramework packageManager pin, then runs pnpm i  in the ff_pipeline_host checkout. When the two repos pin different pnpm versions (e.g. ff_pipeline_host at 11.15.1 vs release branch 2.112 at 11.12.0), pnpm tries to self-switch to the pinned version and verify its npm registry signature. Our CI mirror registries don't carry pnpm's signatures, so the switch is refused and the install fails (causing the stress pipeline failures on release/client/2.112 ).

This sets pmOnFail=ignore alongside the existing mirror workarounds, so pnpm skips the failed version switch and runs with the already-installed pnpm instead.
