### PR TITLE
Deprecate mixinSummaryHandler

### DIFF
--- a/.changeset/major-rabbits-check.md
+++ b/.changeset/major-rabbits-check.md
@@ -1,0 +1,7 @@
+---
+"@fluidframework/datastore": minor
+"__section": deprecation
+---
+Deprecate mixinSummaryHandler
+
+The `mixinSummaryHandler` function from `@fluidframework/datastore` is now deprecated and will be removed in a future release. There is no replacement for it.

--- a/packages/runtime/datastore/api-report/datastore.legacy.beta.api.md
+++ b/packages/runtime/datastore/api-report/datastore.legacy.beta.api.md
@@ -132,7 +132,7 @@ export interface ISharedObjectRegistry {
 // @beta @legacy
 export const mixinRequestHandler: (requestHandler: (request: IRequest, runtime: FluidDataStoreRuntime) => Promise<IResponse>, Base?: typeof FluidDataStoreRuntime) => typeof FluidDataStoreRuntime;
 
-// @beta @legacy
+// @beta @deprecated @legacy
 export const mixinSummaryHandler: (handler: (runtime: FluidDataStoreRuntime, setCurrentSummarizeStep: (currentStep: string) => void) => Promise<{
     path: string[];
     content: string;

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -1636,6 +1636,7 @@ export const mixinRequestHandler = (
  * Or undefined not to add anything to summary.
  * @param Base - base class, inherits from FluidDataStoreRuntime
  * @legacy @beta
+ * @deprecated This API is deprecated and will be removed in a future release. There is no replacement for it.
  */
 export const mixinSummaryHandler = (
 	handler: (

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -1637,6 +1637,7 @@ export const mixinRequestHandler = (
  * @param Base - base class, inherits from FluidDataStoreRuntime
  * @legacy @beta
  * @deprecated This API is deprecated and will be removed in a future release. There is no replacement for it.
+ * @privateRemarks
  * This should not be removed until all consumers are migrated off using it. See AB#78575.
  */
 export const mixinSummaryHandler = (

--- a/packages/runtime/datastore/src/dataStoreRuntime.ts
+++ b/packages/runtime/datastore/src/dataStoreRuntime.ts
@@ -1637,6 +1637,7 @@ export const mixinRequestHandler = (
  * @param Base - base class, inherits from FluidDataStoreRuntime
  * @legacy @beta
  * @deprecated This API is deprecated and will be removed in a future release. There is no replacement for it.
+ * This should not be removed until all consumers are migrated off using it. See AB#78575.
  */
 export const mixinSummaryHandler = (
 	handler: (


### PR DESCRIPTION
## Description

Marks the `mixinSummaryHandler` export from `@fluidframework/datastore` (a `@legacy @beta` API) as deprecated. It will be removed in a future release and has no replacement.

Changes:
- Added an `@deprecated` TSDoc tag to `mixinSummaryHandler` in `dataStoreRuntime.ts`.
- Regenerated the legacy API report to reflect the tag.
- Added a changeset under the "Deprecations" section.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).