### PR TITLE
Misc Formatted Text work

### DIFF
--- a/packages/dds/tree/src/simple-tree/api/eraseSchemaDetails.ts
+++ b/packages/dds/tree/src/simple-tree/api/eraseSchemaDetails.ts
@@ -103,6 +103,21 @@ export function eraseSchemaDetails<TNode, ExtraSchemaProperties = unknown>(): <
  * const square = Square.create(10);
  * assert.equal(square.area, 100);
  * ```
+ * @remarks
+ * Care must be taken to avoid subclass members colliding with internal members of the schema.
+ * This is mainly a problem when using the output from {@link eraseSchemaDetailsSubclassable} to type a class returned to third party code which can subclass it.
+ * This pattern mainly occurs when writing generic schema factory functions which generate a schema from some parameters and return it to third party code which can subclass it.
+ *
+ * For example if the schema has a field or method named `size` (from a field, like in the `Square` example, or otherwise),
+ * then a subclass should not define a member named `size` as it will collide with the internal field.
+ *
+ * In practice, this risk can be mitigated by doing one of:
+ * 1. Using JavaScript private properties
+ * 2. Use non exported symbols for the properties
+ * 3. Use a naming convention for internal properties which you document the subclasses must not use.
+ * 4. Documenting the specific internal properties keys as not to be used by subclasses.
+ * 5. Subclass the returned class and declaring uninitialized readonly private properties to protect them (`private readonly size!: unknown;`).
+ * 6. Include the properties in `TNode` or `ExtraSchemaProperties`. This can use readonly erased types (like unknown) if desired.
  * @privateRemarks
  * See "example" test for an executable version of this example.
  * @alpha

--- a/packages/dds/tree/src/test/text/textDomain.spec.ts
+++ b/packages/dds/tree/src/test/text/textDomain.spec.ts
@@ -37,7 +37,18 @@ describe("textDomain", () => {
 		>();
 	});
 
-	it("basic use", () => {
+	it("@Smoke basic use", () => {
+		const text = TextAsTree.Tree.fromString("hello");
+		assert.equal(text.fullString(), "hello");
+		assert.deepEqual([...text.characters()], ["h", "e", "l", "l", "o"]);
+		text.insertAt(5, " world");
+		assert.equal(text.fullString(), "hello world");
+		text.removeRange(0, 6);
+		assert.equal(text.fullString(), "world");
+	});
+
+	it("basic use without expensive DebugAsserts", () => {
+		setEnableExpensiveDebugAsserts(false);
 		const text = TextAsTree.Tree.fromString("hello");
 		assert.equal(text.fullString(), "hello");
 		assert.deepEqual([...text.characters()], ["h", "e", "l", "l", "o"]);

--- a/packages/dds/tree/src/test/text/textDomain.spec.ts
+++ b/packages/dds/tree/src/test/text/textDomain.spec.ts
@@ -11,12 +11,17 @@ import {
 	TreeViewConfiguration,
 	type NodeFromSchema,
 } from "../../simple-tree/index.js";
-// eslint-disable-next-line import-x/no-internal-modules -- Importing code being tested
-import { setEnableExpensiveDebugAsserts, TextAsTree } from "../../text/textDomain.js";
+import {
+	expensiveInternalValidationAssert,
+	setEnableExpensiveDebugAsserts,
+	TextAsTree,
+	// eslint-disable-next-line import-x/no-internal-modules -- Importing code being tested
+} from "../../text/textDomain.js";
 import type { requireTrue, areSafelyAssignable } from "../../util/index.js";
 import { describeHydration, hydrateNode } from "../simple-tree/index.js";
 import { testSchemaCompatibilitySnapshots } from "../snapshots/index.js";
 import { suitesWithAndWithoutProduction } from "../utils.js";
+import { nonProductionConditionalsIncluded } from "@fluidframework/core-utils/internal";
 
 describe("textDomain", () => {
 	beforeEach(() => {
@@ -37,25 +42,28 @@ describe("textDomain", () => {
 		>();
 	});
 
-	it("@Smoke basic use", () => {
-		const text = TextAsTree.Tree.fromString("hello");
-		assert.equal(text.fullString(), "hello");
-		assert.deepEqual([...text.characters()], ["h", "e", "l", "l", "o"]);
-		text.insertAt(5, " world");
-		assert.equal(text.fullString(), "hello world");
-		text.removeRange(0, 6);
-		assert.equal(text.fullString(), "world");
-	});
+	for (const expensiveAsserts of [false, true]) {
+		it(`@Smoke basic use with${expensiveAsserts ? "" : "out"} expensive asserts`, () => {
+			setEnableExpensiveDebugAsserts(expensiveAsserts);
+			const text = TextAsTree.Tree.fromString("hello");
+			assert.equal(text.fullString(), "hello");
+			assert.deepEqual([...text.characters()], ["h", "e", "l", "l", "o"]);
+			text.insertAt(5, " world");
+			assert.equal(text.fullString(), "hello world");
+			text.removeRange(0, 6);
+			assert.equal(text.fullString(), "world");
+		});
+	}
 
-	it("basic use without expensive DebugAsserts", () => {
+	it("@Smoke expensiveInternalValidationAssert", () => {
+		if (nonProductionConditionalsIncluded()) {
+			assert.throws(() => expensiveInternalValidationAssert(() => "fail"), /fail/);
+		} else {
+			expensiveInternalValidationAssert(() => "fail");
+		}
 		setEnableExpensiveDebugAsserts(false);
-		const text = TextAsTree.Tree.fromString("hello");
-		assert.equal(text.fullString(), "hello");
-		assert.deepEqual([...text.characters()], ["h", "e", "l", "l", "o"]);
-		text.insertAt(5, " world");
-		assert.equal(text.fullString(), "hello world");
-		text.removeRange(0, 6);
-		assert.equal(text.fullString(), "world");
+		// Disabled, so should not throw.
+		expensiveInternalValidationAssert(() => "error");
 	});
 
 	// Hydrated and unhydrated trees implement cursors differently which impacts observation tracking, so test both.

--- a/packages/dds/tree/src/test/text/textDomain.spec.ts
+++ b/packages/dds/tree/src/test/text/textDomain.spec.ts
@@ -11,15 +11,21 @@ import {
 	TreeViewConfiguration,
 	type NodeFromSchema,
 } from "../../simple-tree/index.js";
-// Allow importing file being tested
-// eslint-disable-next-line import-x/no-internal-modules
-import { TextAsTree } from "../../text/textDomain.js";
+// eslint-disable-next-line import-x/no-internal-modules -- Importing code being tested
+import { setEnableExpensiveDebugAsserts, TextAsTree } from "../../text/textDomain.js";
 import type { requireTrue, areSafelyAssignable } from "../../util/index.js";
 import { describeHydration, hydrateNode } from "../simple-tree/index.js";
 import { testSchemaCompatibilitySnapshots } from "../snapshots/index.js";
 import { suitesWithAndWithoutProduction } from "../utils.js";
 
 describe("textDomain", () => {
+	beforeEach(() => {
+		setEnableExpensiveDebugAsserts(true);
+	});
+	afterEach(() => {
+		setEnableExpensiveDebugAsserts(false);
+	});
+
 	it("compatibility", () => {
 		const currentViewSchema = new TreeViewConfiguration({ schema: TextAsTree.Tree });
 		testSchemaCompatibilitySnapshots(currentViewSchema, "2.81.0", "text");

--- a/packages/dds/tree/src/test/text/textDomainFormatted.spec.ts
+++ b/packages/dds/tree/src/test/text/textDomainFormatted.spec.ts
@@ -9,7 +9,11 @@ import { UsageError } from "@fluidframework/telemetry-utils/internal";
 import { validateUsageError } from "@fluidframework/test-runtime-utils/internal";
 
 import { TreeAlpha } from "../../shared-tree/index.js";
-import { SchemaFactory, SchemaFactoryBeta, TreeViewConfiguration } from "../../simple-tree/index.js";
+import {
+	SchemaFactory,
+	SchemaFactoryBeta,
+	TreeViewConfiguration,
+} from "../../simple-tree/index.js";
 // Allow importing file being tested
 // eslint-disable-next-line import-x/no-internal-modules -- Importing code being tested
 import type { TextAsTree } from "../../text/textDomain.js";

--- a/packages/dds/tree/src/test/text/textDomainFormatted.spec.ts
+++ b/packages/dds/tree/src/test/text/textDomainFormatted.spec.ts
@@ -222,6 +222,21 @@ describe("textDomainFormatted", () => {
 				],
 			);
 		});
+
+		it("replaces an object format with a non-object node format", () => {
+			// Unlike formatRange, reformat replaces the whole format, so it supports non-object (leaf) formats.
+			const text = UnionFormatText.fromString("ab");
+			text.reformat(0, 2, 5);
+			assert.deepEqual(
+				[...text.charactersWithFormatting()].map((atom) => atom.format),
+				[5, 5],
+			);
+			text.reformat(0, 2, 6);
+			assert.deepEqual(
+				[...text.charactersWithFormatting()].map((atom) => atom.format),
+				[6, 6],
+			);
+		});
 	});
 
 	it("insertWithFormattingAt", () => {

--- a/packages/dds/tree/src/test/text/textDomainFormatted.spec.ts
+++ b/packages/dds/tree/src/test/text/textDomainFormatted.spec.ts
@@ -14,11 +14,11 @@ import {
 	SchemaFactoryBeta,
 	TreeViewConfiguration,
 } from "../../simple-tree/index.js";
-// Allow importing file being tested
+// eslint-disable-next-line import-x/no-internal-modules -- Importing code being tested
+import { setEnableExpensiveDebugAsserts } from "../../text/textDomain.js";
 // eslint-disable-next-line import-x/no-internal-modules -- Importing code being tested
 import type { TextAsTree } from "../../text/textDomain.js";
 import {
-	setEnableExpensiveDebugAsserts,
 	FormattedTextAsTree,
 	// eslint-disable-next-line import-x/no-internal-modules -- Importing code being tested
 } from "../../text/textDomainFormatted.js";

--- a/packages/dds/tree/src/test/text/textDomainFormatted.spec.ts
+++ b/packages/dds/tree/src/test/text/textDomainFormatted.spec.ts
@@ -6,20 +6,59 @@
 import { strict as assert } from "node:assert";
 
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
+import { validateUsageError } from "@fluidframework/test-runtime-utils/internal";
 
 import { TreeAlpha } from "../../shared-tree/index.js";
-import { TreeViewConfiguration } from "../../simple-tree/index.js";
+import { SchemaFactory, SchemaFactoryBeta, TreeViewConfiguration } from "../../simple-tree/index.js";
 // Allow importing file being tested
-// eslint-disable-next-line import-x/no-internal-modules
+// eslint-disable-next-line import-x/no-internal-modules -- Importing code being tested
 import type { TextAsTree } from "../../text/textDomain.js";
-// eslint-disable-next-line import-x/no-internal-modules
-import { FormattedTextAsTree } from "../../text/textDomainFormatted.js";
+import {
+	setEnableExpensiveDebugAsserts,
+	FormattedTextAsTree,
+	// eslint-disable-next-line import-x/no-internal-modules -- Importing code being tested
+} from "../../text/textDomainFormatted.js";
 import { describeHydration, hydrateNode } from "../simple-tree/index.js";
 import { testSchemaCompatibilitySnapshots } from "../snapshots/index.js";
 import { suitesWithAndWithoutProduction } from "../utils.js";
 import { FormattedTextAsTreeDefault } from "../../text/index.js";
 
+// Custom formatted-text schemas used to exercise `formatRange` edge cases which the default schema cannot express.
+
+// A format with an optional field, used to test formatting of optional fields.
+const optionalFormatFactory = new SchemaFactoryBeta("test.formatted.optional");
+class OptionalFormat extends optionalFormatFactory.object("OptionalFormat", {
+	bold: SchemaFactory.boolean,
+	color: SchemaFactory.optional(SchemaFactory.string),
+}) {}
+class OptionalFormatText extends FormattedTextAsTree.createSchema(
+	optionalFormatFactory,
+	OptionalFormat,
+	[],
+	{ bold: false },
+) {}
+
+// A format which is a union of an object node and a non-object (leaf) node.
+// Used to test that `formatRange` rejects non-object node formats, including when they only occur partway through a range.
+const unionFormatFactory = new SchemaFactoryBeta("test.formatted.union");
+class UnionFormat extends unionFormatFactory.object("UnionFormat", {
+	bold: SchemaFactory.boolean,
+}) {}
+class UnionFormatText extends FormattedTextAsTree.createSchema(
+	unionFormatFactory,
+	[UnionFormat, SchemaFactory.number],
+	[],
+	new UnionFormat({ bold: false }),
+) {}
+
 describe("textDomainFormatted", () => {
+	beforeEach(() => {
+		setEnableExpensiveDebugAsserts(true);
+	});
+	afterEach(() => {
+		setEnableExpensiveDebugAsserts(false);
+	});
+
 	it("compatibility", () => {
 		const currentViewSchema = new TreeViewConfiguration({
 			schema: FormattedTextAsTreeDefault.Tree,
@@ -27,7 +66,7 @@ describe("textDomainFormatted", () => {
 		testSchemaCompatibilitySnapshots(currentViewSchema, "2.111.0", "formattedText");
 	});
 
-	it("basic unformatted use", () => {
+	it("@Smoke basic unformatted use", () => {
 		const text = FormattedTextAsTreeDefault.Tree.fromString("hello");
 		assert.equal(text.fullString(), "hello");
 		assert.deepEqual([...text.characters()], ["h", "e", "l", "l", "o"]);
@@ -37,23 +76,148 @@ describe("textDomainFormatted", () => {
 		assert.equal(text.fullString(), "world");
 	});
 
-	it("formatting", () => {
-		const text = FormattedTextAsTreeDefault.Tree.fromString("hello");
-		text.formatRange(1, 4, { bold: true });
-		assert.equal(text.fullString(), "hello");
-		assert.deepEqual(
-			[...text.charactersWithFormatting()].map((atom) => [
-				atom.content.content,
-				atom.format.bold,
-			]),
-			[
-				["h", false],
-				["e", true],
-				["l", true],
-				["l", true],
-				["o", false],
-			],
-		);
+	describe("formatRange", () => {
+		it("basic use", () => {
+			const text = FormattedTextAsTreeDefault.Tree.fromString("hello");
+			text.formatRange(1, 4, { bold: true });
+			assert.equal(text.fullString(), "hello");
+			assert.deepEqual(
+				[...text.charactersWithFormatting()].map((atom) => [
+					atom.content.content,
+					atom.format.bold,
+				]),
+				[
+					["h", false],
+					["e", true],
+					["l", true],
+					["l", true],
+					["o", false],
+				],
+			);
+		});
+
+		it("supports optional format fields", () => {
+			const text = OptionalFormatText.fromString("abc");
+			// Setting an optional field on a sub-range.
+			text.formatRange(0, 2, { color: "red" });
+			assert.deepEqual(
+				[...text.charactersWithFormatting()].map((atom) => atom.format.color),
+				["red", "red", undefined],
+			);
+			// Clearing an optional field by setting it to undefined.
+			text.formatRange(0, 1, { color: undefined });
+			assert.deepEqual(
+				[...text.charactersWithFormatting()].map((atom) => atom.format.color),
+				[undefined, "red", undefined],
+			);
+		});
+
+		it("throws when an atom's format is a non-object node", () => {
+			const text = UnionFormatText.fromString("b");
+			// Prepend an atom whose format is a non-object (number) node.
+			text.insertWithFormattingAt(0, [{ content: { content: "a" }, format: 5 }]);
+			assert.throws(
+				() => text.formatRange(0, 2, { bold: true }),
+				validateUsageError(/formatRange currently only supports object nodes for the format./),
+			);
+		});
+
+		it("throws when a non-object node format occurs in the middle of a range", () => {
+			const text = UnionFormatText.fromString("ac");
+			// Insert an atom with a non-object (number) format between the two object-formatted atoms.
+			text.insertWithFormattingAt(1, [{ content: { content: "b" }, format: 5 }]);
+			// The range spans object formats at either end with a non-object format in the middle.
+			assert.throws(
+				() => text.formatRange(0, 3, { bold: true }),
+				validateUsageError(/formatRange currently only supports object nodes for the format./),
+			);
+		});
+	});
+
+	describe("reformat", () => {
+		it("replaces formatting over a range", () => {
+			const text = FormattedTextAsTreeDefault.Tree.fromString("hello");
+			// Apply some formatting to the whole string first.
+			text.formatRange(0, 5, { bold: true });
+			// Reformat a sub-range, replacing all of its formatting.
+			text.reformat(
+				1,
+				4,
+				new FormattedTextAsTreeDefault.CharacterFormat({
+					bold: false,
+					italic: true,
+					underline: false,
+					size: 12,
+					font: "Arial",
+				}),
+			);
+			assert.equal(text.fullString(), "hello");
+			assert.deepEqual(
+				[...text.charactersWithFormatting()].map((atom) => [
+					atom.content.content,
+					atom.format.bold,
+					atom.format.italic,
+				]),
+				[
+					["h", true, false],
+					["e", false, true],
+					["l", false, true],
+					["l", false, true],
+					["o", true, false],
+				],
+			);
+		});
+
+		it("applies to the whole text when the range is omitted", () => {
+			const text = FormattedTextAsTreeDefault.Tree.fromString("abc");
+			text.formatRange(0, 3, { bold: true, italic: true });
+			text.reformat(
+				undefined,
+				undefined,
+				new FormattedTextAsTreeDefault.CharacterFormat({
+					bold: false,
+					italic: false,
+					underline: false,
+					size: 12,
+					font: "Arial",
+				}),
+			);
+			assert.deepEqual(
+				[...text.charactersWithFormatting()].map((atom) => [
+					atom.format.bold,
+					atom.format.italic,
+				]),
+				[
+					[false, false],
+					[false, false],
+					[false, false],
+				],
+			);
+		});
+
+		it("uses the default format when no format is provided", () => {
+			const text = FormattedTextAsTreeDefault.Tree.fromString("hello");
+			text.formatRange(0, 5, { bold: true, italic: true });
+			// Customize the default format so we can distinguish it from a fresh default.
+			text.defaultFormat.underline = true;
+			// Reformat a sub-range without providing a format: the default format should be used.
+			text.reformat(1, 4);
+			assert.deepEqual(
+				[...text.charactersWithFormatting()].map((atom) => [
+					atom.content.content,
+					atom.format.bold,
+					atom.format.italic,
+					atom.format.underline,
+				]),
+				[
+					["h", true, true, false],
+					["e", false, false, true],
+					["l", false, false, true],
+					["l", false, false, true],
+					["o", true, true, false],
+				],
+			);
+		});
 	});
 
 	it("insertWithFormattingAt", () => {

--- a/packages/dds/tree/src/text/textDomain.ts
+++ b/packages/dds/tree/src/text/textDomain.ts
@@ -34,6 +34,20 @@ import type {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars, unused-imports/no-unused-imports, import-x/no-duplicates
 import type { NodeKind, TreeNodeSchema } from "../simple-tree/index.js";
 
+/**
+ * Enables expensive debug assertions for formatted text.
+ */
+export let enableTextExpensiveDebugAsserts = false;
+
+/**
+ * Enables or disables expensive debug assertions for formatted text.
+ * @remarks
+ * These should remain disabled except when testing implementation details of this code.
+ */
+export function setEnableExpensiveDebugAsserts(value: boolean): void {
+	enableTextExpensiveDebugAsserts = value;
+}
+
 const sf = new SchemaFactoryAlpha("com.fluidframework.text");
 
 class TextNode
@@ -122,7 +136,8 @@ class TextNode
 		const result = this.content.charactersCopy();
 		debugAssert(
 			() =>
-				compareArrays(result, this.charactersCopy_reference()) ||
+				(enableTextExpensiveDebugAsserts &&
+					compareArrays(result, this.#charactersCopy_reference())) ||
 				"invalid charactersCopy optimizations",
 		);
 		return result;
@@ -131,7 +146,9 @@ class TextNode
 	public fullString(): string {
 		const result = this.content.fullString();
 		debugAssert(
-			() => result === this.fullString_reference() || "invalid fullString optimizations",
+			() =>
+				(enableTextExpensiveDebugAsserts && result === this.#fullString_reference()) ||
+				"invalid fullString optimizations",
 		);
 		return result;
 	}
@@ -139,14 +156,14 @@ class TextNode
 	/**
 	 * Unoptimized trivially correct implementation of fullString.
 	 */
-	public fullString_reference(): string {
+	#fullString_reference(): string {
 		return this.content.join("");
 	}
 
 	/**
 	 * Unoptimized trivially correct implementation of charactersCopy.
 	 */
-	public charactersCopy_reference(): string[] {
+	#charactersCopy_reference(): string[] {
 		return [...this.content];
 	}
 

--- a/packages/dds/tree/src/text/textDomain.ts
+++ b/packages/dds/tree/src/text/textDomain.ts
@@ -37,7 +37,7 @@ import type { NodeKind, TreeNodeSchema } from "../simple-tree/index.js";
 /**
  * Enables expensive debug assertions for formatted text.
  */
-export let enableTextExpensiveDebugAsserts = false;
+let enableTextExpensiveDebugAsserts = false;
 
 /**
  * Enables or disables expensive debug assertions for formatted text.
@@ -48,6 +48,11 @@ export function setEnableExpensiveDebugAsserts(value: boolean): void {
 	enableTextExpensiveDebugAsserts = value;
 }
 
+/**
+ * Runs `condition` as a {@link debugAssert} only when {@link enableTextExpensiveDebugAsserts} is enabled.
+ * @remarks
+ * Like all {@link debugAssert}s, this is compiled out of production builds, so `condition` is never evaluated there.
+ */
 export function expensiveInternalValidationAssert(condition: () => true | string): void {
 	debugAssert(() => !enableTextExpensiveDebugAsserts || condition());
 }

--- a/packages/dds/tree/src/text/textDomain.ts
+++ b/packages/dds/tree/src/text/textDomain.ts
@@ -48,6 +48,10 @@ export function setEnableExpensiveDebugAsserts(value: boolean): void {
 	enableTextExpensiveDebugAsserts = value;
 }
 
+export function expensiveInternalValidationAssert(condition: () => true | string): void {
+	debugAssert(() => !enableTextExpensiveDebugAsserts || condition());
+}
+
 const sf = new SchemaFactoryAlpha("com.fluidframework.text");
 
 class TextNode
@@ -134,10 +138,9 @@ class TextNode
 
 	public charactersCopy(): string[] {
 		const result = this.content.charactersCopy();
-		debugAssert(
+		expensiveInternalValidationAssert(
 			() =>
-				(enableTextExpensiveDebugAsserts &&
-					compareArrays(result, this.#charactersCopy_reference())) ||
+				compareArrays(result, this.#charactersCopy_reference()) ||
 				"invalid charactersCopy optimizations",
 		);
 		return result;
@@ -145,10 +148,8 @@ class TextNode
 
 	public fullString(): string {
 		const result = this.content.fullString();
-		debugAssert(
-			() =>
-				(enableTextExpensiveDebugAsserts && result === this.#fullString_reference()) ||
-				"invalid fullString optimizations",
+		expensiveInternalValidationAssert(
+			() => result === this.#fullString_reference() || "invalid fullString optimizations",
 		);
 		return result;
 	}

--- a/packages/dds/tree/src/text/textDomainFormatted.ts
+++ b/packages/dds/tree/src/text/textDomainFormatted.ts
@@ -236,7 +236,7 @@ export namespace FormattedTextAsTree {
 						}
 
 						// Ensures that if the input is a node, it is cloned before being inserted into the tree.
-						// Note that since this used field schema, `undefined` can pass through this if allowed by the schema.
+						// Note that since this uses field schema, `undefined` can pass through this if allowed by the schema.
 						const clonedValue = TreeBeta.clone(TreeBeta.create(field, value as never)) as
 							| TreeNode
 							| TreeValue;
@@ -618,7 +618,7 @@ export namespace FormattedTextAsTree {
 		 * This is not persisted in the tree, and observation of it is not tracked by the tree observation tracking.
 		 * @privateRemarks
 		 * Opt this into observation tracking.
-		 * TODO: This being an mutable instance property is not required, and might not be the best API design choice.
+		 * TODO: This being a mutable instance property is not required, and might not be the best API design choice.
 		 */
 		defaultFormat: TFormatTree;
 

--- a/packages/dds/tree/src/text/textDomainFormatted.ts
+++ b/packages/dds/tree/src/text/textDomainFormatted.ts
@@ -45,6 +45,7 @@ import { brand, mapIterable, validateIndex, validateIndexRange } from "../util/i
 
 import {
 	charactersFromString,
+	enableTextExpensiveDebugAsserts,
 	processCharactersChangedDelta,
 	type TextAsTree,
 } from "./textDomain.js";
@@ -66,20 +67,6 @@ function createFormattedScopedFactory<TUserScope extends string>(
 const sfStatic = new SchemaFactoryAlpha("com.fluidframework.text.formatted");
 
 const formatKey: FieldKey = brand("format");
-
-/**
- * Enables expensive debug assertions for formatted text.
- */
-let enableTextExpensiveDebugAsserts = false;
-
-/**
- * Enables or disables expensive debug assertions for formatted text.
- * @remarks
- * These should remain disabled except when testing implementation details of this code.
- */
-export function setEnableExpensiveDebugAsserts(value: boolean): void {
-	enableTextExpensiveDebugAsserts = value;
-}
 
 /**
  * A collection of text related types, schema and utilities for working with text beyond the basic {@link SchemaStatics.string}.
@@ -526,6 +513,12 @@ export namespace FormattedTextAsTree {
 		 * @remarks
 		 * See {@link FormattedTextAsTree.Members} for the API.
 		 * See {@link FormattedTextAsTree.Statics} for static APIs on this Schema, including construction.
+		 * @privateRemarks
+		 * eraseSchemaDetailsSubclassable risks user's defining subclass members which collide with internals.
+		 * Ideally we would generate private members for non-public properties, but TypeScript does not support this.
+		 * It is up to the user of eraseSchemaDetailsSubclassable to manage this risk.
+		 *
+		 * TODO: there is at least one collision prone member to worry about here: `content`.
 		 */
 		const Tree = eraseSchemaDetailsSubclassable<
 			FormattedTextMembers<FormatSchema, ExtraAtomsSchema>,

--- a/packages/dds/tree/src/text/textDomainFormatted.ts
+++ b/packages/dds/tree/src/text/textDomainFormatted.ts
@@ -45,7 +45,7 @@ import { brand, mapIterable, validateIndex, validateIndexRange } from "../util/i
 
 import {
 	charactersFromString,
-	enableTextExpensiveDebugAsserts,
+	expensiveInternalValidationAssert,
 	processCharactersChangedDelta,
 	type TextAsTree,
 } from "./textDomain.js";
@@ -141,10 +141,9 @@ export namespace FormattedTextAsTree {
 
 			public charactersCopy(): string[] {
 				const result = this.content.charactersCopy();
-				debugAssert(
+				expensiveInternalValidationAssert(
 					() =>
-						(enableTextExpensiveDebugAsserts &&
-							compareArrays(result, this.#charactersCopy_reference())) ||
+						compareArrays(result, this.#charactersCopy_reference()) ||
 						"invalid charactersCopy optimizations",
 				);
 				return result;
@@ -156,10 +155,8 @@ export namespace FormattedTextAsTree {
 
 			public fullString(): string {
 				const result = this.content.fullString();
-				debugAssert(
-					() =>
-						(enableTextExpensiveDebugAsserts && result === this.#fullString_reference()) ||
-						"invalid fullString optimizations",
+				expensiveInternalValidationAssert(
+					() => result === this.#fullString_reference() || "invalid fullString optimizations",
 				);
 				return result;
 			}

--- a/packages/dds/tree/src/text/textDomainFormatted.ts
+++ b/packages/dds/tree/src/text/textDomainFormatted.ts
@@ -689,7 +689,7 @@ export namespace FormattedTextAsTree {
 		 * @remarks
 		 * The start and end behave the same as in {@link (TreeArrayNode:interface).removeRange}.
 		 *
-		 * This is typically used to normalize formatting, like resetting formatting or a range to default settings.
+		 * This is typically used to normalize formatting, like resetting the formatting of a range to default settings.
 		 * @privateRemarks
 		 * See notes on {@link FormattedTextAsTree.Members.formatRange} for future optimization opportunities.
 		 */

--- a/packages/dds/tree/src/text/textDomainFormatted.ts
+++ b/packages/dds/tree/src/text/textDomainFormatted.ts
@@ -68,6 +68,20 @@ const sfStatic = new SchemaFactoryAlpha("com.fluidframework.text.formatted");
 const formatKey: FieldKey = brand("format");
 
 /**
+ * Enables expensive debug assertions for formatted text.
+ */
+let enableTextExpensiveDebugAsserts = false;
+
+/**
+ * Enables or disables expensive debug assertions for formatted text.
+ * @remarks
+ * These should remain disabled except when testing implementation details of this code.
+ */
+export function setEnableExpensiveDebugAsserts(value: boolean): void {
+	enableTextExpensiveDebugAsserts = value;
+}
+
+/**
  * A collection of text related types, schema and utilities for working with text beyond the basic {@link SchemaStatics.string}.
  * @remarks
  * This is generic over formatting an embedded object/atom types.
@@ -80,7 +94,24 @@ const formatKey: FieldKey = brand("format");
  */
 export namespace FormattedTextAsTree {
 	/**
-	 * Factory for formatted text schema as a function of the formatting and the embedded object (atom) types.
+	 * Creates a schema for a formatted text node, parameterized by the formatting and the embedded object (atom) types.
+	 *
+	 * @param inputSchemaFactory - The {@link SchemaFactoryBeta} used to scope the generated schema.
+	 * The generated types are scoped under `com.fluidframework.text.formatted<TUserScope>`, where `TUserScope` is the scope of this factory.
+	 * This scope is used to distinguish different usages of `createSchema` from each-other, and must be kept the same between versions for nodes to remain compatible.
+	 * It must be different to distinguish different formatted text schema within the same document.
+	 * @param formatSchema - Schema describing the formatting associated with each atom of text.
+	 * Use an {@link NodeKind.Object|Object node} to support {@link FormattedTextAsTree.Members.formatRange}.
+	 * @param extraAtoms - Additional atom schema to allow as text content beyond the built-in {@link FormattedTextAsTree.StringTextAtom}.
+	 * Use this to embed richer content (for example line breaks or inline objects) alongside plain characters.
+	 * @param defaultFormatInsertable - The formatting applied to text inserted via non-formatted APIs
+	 * (for example {@link TextAsTree.Members.insertAt} and {@link FormattedTextAsTree.Statics.fromString} when no explicit format is provided).
+	 * This is the initial value used for {@link FormattedTextAsTree.Members.defaultFormat}, but it can be reassigned on a per instance basis if desired.
+	 * @returns The schema for the formatted text node, whose nodes implement {@link FormattedTextAsTree.FormattedTextMembers} and whose statics implement {@link FormattedTextAsTree.Statics}.
+	 * @remarks
+	 * See {@link FormattedTextAsTreeDefault} for a default parameterization of this factory.
+	 * @privateRemarks
+	 * TODO: The choice to always include the built-in `StringTextAtom` is a design decision that should be re-evaluated before stabilizing.
 	 */
 	export function createSchema<
 		const TUserScope extends string,
@@ -125,7 +156,8 @@ export namespace FormattedTextAsTree {
 				const result = this.content.charactersCopy();
 				debugAssert(
 					() =>
-						compareArrays(result, this.charactersCopy_reference()) ||
+						(enableTextExpensiveDebugAsserts &&
+							compareArrays(result, this.#charactersCopy_reference())) ||
 						"invalid charactersCopy optimizations",
 				);
 				return result;
@@ -138,7 +170,9 @@ export namespace FormattedTextAsTree {
 			public fullString(): string {
 				const result = this.content.fullString();
 				debugAssert(
-					() => result === this.fullString_reference() || "invalid fullString optimizations",
+					() =>
+						(enableTextExpensiveDebugAsserts && result === this.#fullString_reference()) ||
+						"invalid fullString optimizations",
 				);
 				return result;
 			}
@@ -146,14 +180,14 @@ export namespace FormattedTextAsTree {
 			/**
 			 * A non-optimized reference implementation of fullString.
 			 */
-			public fullString_reference(): string {
+			#fullString_reference(): string {
 				return [...this.characters()].join("");
 			}
 
 			/**
 			 * Unoptimized trivially correct implementation of charactersCopy.
 			 */
-			public charactersCopy_reference(): string[] {
+			#charactersCopy_reference(): string[] {
 				return [...this.characters()];
 			}
 
@@ -190,21 +224,79 @@ export namespace FormattedTextAsTree {
 				end: number | undefined,
 				format: Partial<TreeNodeFromImplicitAllowedTypes<FormatSchema>>,
 			): void {
-				const formatStart = start ?? 0;
-				validateIndex(formatStart, this.content, "FormattedTextAsTree.formatRange", true);
-
-				const formatEnd = Math.min(this.content.length, end ?? this.content.length);
-				validateIndexRange(
-					formatStart,
-					formatEnd,
-					this.content,
-					"FormattedTextAsTree.formatRange",
-				);
-
-				const fieldFormats = Object.entries(format) as [
+				const fieldFormatsRaw = Object.entries(format) as [
 					keyof TreeNodeFromImplicitAllowedTypes<FormatSchema>,
 					unknown,
 				][];
+				const fieldFormats = fieldFormatsRaw.map(([key, value]) => {
+					// Object.entries should only return string keyed enumerable own properties.
+					// The TypeScript typing does not account for this, and thus this assertion is necessary for this code to compile.
+					assert(
+						typeof key === "string",
+						0xcc8 /* Object.entries returned a non-string key. */,
+					);
+					return [key, value] as const;
+				});
+				this.#editRange(start, end, "FormattedTextAsTree.formatRange", (atom) => {
+					const formatNode: TreeNode | TreeValue = atom.format;
+					const atomFormatSchema = TreeStatic.schema(formatNode);
+					if (!isObjectNodeSchema(atomFormatSchema)) {
+						throw new UsageError(
+							"formatRange currently only supports object nodes for the format.",
+						);
+					}
+					for (const [key, value] of fieldFormats) {
+						const field = atomFormatSchema.fields.get(key);
+						if (field === undefined) {
+							throw new UsageError(`Unknown format key: ${key}`);
+						}
+
+						// Ensures that if the input is a node, it is cloned before being inserted into the tree.
+						// Note that since this used field schema, `undefined` can pass through this if allowed by the schema.
+						const clonedValue = TreeBeta.clone(TreeBeta.create(field, value as never)) as
+							| TreeNode
+							| TreeValue;
+
+						(
+							formatNode as unknown as Record<
+								keyof TreeNodeFromImplicitAllowedTypes<FormatSchema>,
+								TreeNode | TreeValue
+							>
+						)[key] = clonedValue;
+					}
+				});
+			}
+
+			public reformat(
+				start: number | undefined,
+				end: number | undefined,
+				format: TreeFieldFromImplicitField<FormatSchema> = this.defaultFormat,
+			): void {
+				const node = TreeBeta.create<FormatSchema>(formatSchema, format as never);
+				this.#editRange(start, end, "FormattedTextAsTree.reformat", (atom) => {
+					const formatNode: TreeFieldFromImplicitField<FormatSchema> = TreeBeta.clone(node);
+					// Generics can't prove TreeFieldFromImplicitField is valid as TreeNodeFromImplicitAllowedTypes, so we have to cast:
+					atom.format = formatNode as TreeNodeFromImplicitAllowedTypes<FormatSchema>;
+				});
+			}
+
+			/**
+			 * Map an edit over a range of atoms, validating the range and running the edits in a transaction.
+			 * @remarks
+			 * This is not exposed in the API since this approach will have to be replaced when formatting is optimized,
+			 * so we don't want users to directly depend on this un-optimizable layer.
+			 */
+			#editRange(
+				start: number | undefined,
+				end: number | undefined,
+				method: string,
+				edit: (atom: StringAtom) => void,
+			): void {
+				const formatStart = start ?? 0;
+				validateIndex(formatStart, this.content, method, true);
+
+				const formatEnd = Math.min(this.content.length, end ?? this.content.length);
+				validateIndexRange(formatStart, formatEnd, this.content, method);
 
 				TreeAlpha.context(this).runTransaction(() => {
 					for (let i = formatStart; i < formatEnd; i++) {
@@ -214,39 +306,7 @@ export namespace FormattedTextAsTree {
 							atom !== undefined,
 							0xd08 /* Index out of bounds while formatting text range. */,
 						);
-						const formatNode: TreeNode | TreeValue = atom.format;
-						const atomFormatSchema = TreeStatic.schema(formatNode);
-						if (!isObjectNodeSchema(atomFormatSchema)) {
-							// TODO: redesign this API to work with all allowed FormatSchema types.
-							throw new UsageError(
-								"formatRange currently only supports object nodes for the format.",
-							);
-						}
-						for (const [key, value] of fieldFormats) {
-							// Object.entries should only return string keyed enumerable own properties.
-							// The TypeScript typing does not account for this, and thus this assertion is necessary for this code to compile.
-							assert(
-								typeof key === "string",
-								0xcc8 /* Object.entries returned a non-string key. */,
-							);
-
-							const field = atomFormatSchema.fields.get(key);
-							if (field === undefined) {
-								throw new UsageError(`Unknown format key: ${key}`);
-							}
-
-							// Ensures that if the input is a node, it is cloned before being inserted into the tree.
-							const clonedValue = TreeBeta.clone(TreeBeta.create(field, value as never)) as
-								| TreeNode
-								| TreeValue;
-
-							(
-								formatNode as unknown as Record<
-									keyof TreeNodeFromImplicitAllowedTypes<FormatSchema>,
-									TreeNode | TreeValue
-								>
-							)[key] = clonedValue;
-						}
+						edit(atom);
 					}
 				});
 			}
@@ -548,6 +608,16 @@ export namespace FormattedTextAsTree {
 	 *
 	 * @see {@link FormattedTextAsTree.Statics.fromString} for construction.
 	 * @see {@link FormattedTextAsTree.createSchema} for creating schemas whose nodes implement this.
+	 *
+	 * Rather than referring to this type, use the the instance type of the subclass of the schema from {@link FormattedTextAsTree.createSchema}.
+	 * When a generic interface is required, use {@link FormattedTextAsTree.FormattedTextMembers}.
+	 * The generic type parameterization of this interface is is not stable, and simply an implementation detail of {@link FormattedTextAsTree.FormattedTextMembers}.
+	 *
+	 * @privateRemarks
+	 * Maybe Merge/combine this with `FormattedTextMembers`.
+	 *
+	 * @system
+	 * @sealed
 	 * @internal
 	 */
 	export interface Members<TFormatTree, TPartialFormat, TFormattedAtom, TFormattedInsert>
@@ -558,6 +628,7 @@ export namespace FormattedTextAsTree {
 		 * This is not persisted in the tree, and observation of it is not tracked by the tree observation tracking.
 		 * @privateRemarks
 		 * Opt this into observation tracking.
+		 * TODO: This being an mutable instance property is not required, and might not be the best API design choice.
 		 */
 		defaultFormat: TFormatTree;
 
@@ -565,6 +636,9 @@ export namespace FormattedTextAsTree {
 		 * Gets an array type view of the characters currently in the text.
 		 * @remarks
 		 * This iterator matches the behavior of {@link (TreeArrayNode:interface)} with respect to edits during iteration.
+		 *
+		 * For more efficient access, use {@link FormattedTextAsTree.Members.getUniformRun} and {@link FormattedTextAsTree.Members.getString} to access ranges of characters
+		 * to avoid having to inspect the formatting on every atom.
 		 * @privateRemarks
 		 * Currently this is implemented by a node and changes with the text over time.
 		 * We might not want to leak a node like this in the API.
@@ -595,13 +669,44 @@ export namespace FormattedTextAsTree {
 		 * @param startIndex - The starting index (inclusive) of the range to format.
 		 * @param endIndex - The ending index (exclusive) of the range to format.
 		 * @param format - The formatting to apply to the specified range.
+		 * For each atom, every property of `format` will be cloned and assigned to the atom's format's corresponding subtree, overwriting any existing values for those properties.
+		 * All enumerable own properties of `format` will be applied, including those with `undefined` values.
 		 * @remarks
 		 * The start and end behave the same as in {@link (TreeArrayNode:interface).removeRange}.
+		 * This edits existing formatting subtrees on each atom, and only works when those atoms are object nodes.
+		 *
+		 * This is typically used to set some formatting property, like `bold` on a range of text without impacting other formatting properties.
+		 * @privateRemarks
+		 * This API is designed such that it can be optimized and improved in the future in a few different ways:
+		 * 1. TODO: It can be optimized to use lower level APIs directly, bypassing the overhead of the public API surface.
+		 * 2. TODO: A lower level editing API could be introduced and used to more efficiently express the edit (for example a bulk edit based on path, or a way to reuse the inserted content in multiple places instead of having to clone it before making the edit).
+		 * 3. TODO: Optimize the encoding of such edits, either with a dedicated format for range edits like this and/or encoding optimizations that can compress such edits over ranges to O(1) space.
+		 * 4. TODO: Preserve the range editing semantics through the whole stack to allow for better merge behavior, and make optimizations easier.
 		 */
 		formatRange(
 			startIndex: number | undefined,
 			endIndex: number | undefined,
 			format: TPartialFormat,
+		): void;
+
+		/**
+		 * Replace formatting of a range of characters based on character index.
+		 * @param startIndex - The starting index (inclusive) of the range to format.
+		 * @param endIndex - The ending index (exclusive) of the range to format.
+		 * @param format - The formatting to replace the formatting of the indicated range with.
+		 * For each atom, `format` will be cloned and assigned to the atom's format, overwriting any existing formatting.
+		 * If not specified the {@link FormattedTextAsTree.Members.defaultFormat} will be used.
+		 * @remarks
+		 * The start and end behave the same as in {@link (TreeArrayNode:interface).removeRange}.
+		 *
+		 * This is typically used to normalize formatting, like resetting formatting or a range to default settings.
+		 * @privateRemarks
+		 * See notes on {@link FormattedTextAsTree.Members.formatRange} for future optimization opportunities.
+		 */
+		reformat(
+			startIndex?: number | undefined,
+			endIndex?: number | undefined,
+			format?: TFormatTree,
 		): void;
 
 		/**

--- a/packages/dds/tree/src/text/textDomainFormatted.ts
+++ b/packages/dds/tree/src/text/textDomainFormatted.ts
@@ -599,9 +599,9 @@ export namespace FormattedTextAsTree {
 	 * @see {@link FormattedTextAsTree.Statics.fromString} for construction.
 	 * @see {@link FormattedTextAsTree.createSchema} for creating schemas whose nodes implement this.
 	 *
-	 * Rather than referring to this type, use the the instance type of the subclass of the schema from {@link FormattedTextAsTree.createSchema}.
+	 * Rather than referring to this type, use the instance type of the subclass of the schema from {@link FormattedTextAsTree.createSchema}.
 	 * When a generic interface is required, use {@link FormattedTextAsTree.FormattedTextMembers}.
-	 * The generic type parameterization of this interface is is not stable, and simply an implementation detail of {@link FormattedTextAsTree.FormattedTextMembers}.
+	 * The generic type parameterization of this interface is not stable, and is simply an implementation detail of {@link FormattedTextAsTree.FormattedTextMembers}.
 	 *
 	 * @privateRemarks
 	 * Maybe Merge/combine this with `FormattedTextMembers`.


### PR DESCRIPTION
## Description

Misc work before we want to take text to alpha.

1. Disable expensive asserts outside of text tests.
2. Use javascript private properties where APIs could collide with user subclass properties.
3. Note risk of name coillision for properties of erased types
4. add reformat API
5. Clarify formatRange API with docs and tests.
6. Fill in some lacking docs

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
