### PR TITLE
improvement(client-tree): remove unused member

### DIFF
--- a/packages/dds/tree/src/core/change-family/editBuilder.ts
+++ b/packages/dds/tree/src/core/change-family/editBuilder.ts
@@ -5,11 +5,10 @@
 
 import type { TaggedChange } from "../rebase/index.js";
 
-import type { ChangeFamily, ChangeFamilyEditor } from "./changeFamily.js";
+import type { ChangeFamilyEditor } from "./changeFamily.js";
 
 export abstract class EditBuilder<TChange> implements ChangeFamilyEditor {
 	public constructor(
-		protected readonly changeFamily: ChangeFamily<ChangeFamilyEditor, TChange>,
 		private readonly changeReceiver: (change: TaggedChange<TChange>) => void,
 	) {}
 

--- a/packages/dds/tree/src/feature-libraries/default-schema/defaultEditBuilder.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/defaultEditBuilder.ts
@@ -73,7 +73,7 @@ export class DefaultChangeFamily
 		changeReceiver: (change: TaggedChange<DefaultChangeset>) => void,
 	): DefaultEditBuilder {
 		return new DefaultEditBuilder(
-			this,
+			this.modularFamily.rebaser,
 			mintRevisionTag,
 			changeReceiver,
 			this.modularFamily.codecOptions,
@@ -194,13 +194,13 @@ export class DefaultEditBuilder implements ChangeFamilyEditor, IDefaultEditBuild
 	private readonly modularBuilder: ModularEditBuilder;
 
 	public constructor(
-		family: ChangeFamily<ChangeFamilyEditor, DefaultChangeset>,
+		rebaser: ChangeRebaser<DefaultChangeset>,
 		private readonly mintRevisionTag: () => RevisionTag,
 		changeReceiver: (change: TaggedChange<DefaultChangeset>) => void,
 		codecOptions: CodecWriteOptions,
 	) {
 		this.modularBuilder = new ModularEditBuilder(
-			family,
+			rebaser,
 			fieldKinds,
 			changeReceiver,
 			codecOptions,

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -16,7 +16,6 @@ import {
 import {
 	type ChangeEncodingContext,
 	type ChangeFamily,
-	type ChangeFamilyEditor,
 	type ChangeRebaser,
 	type ChangesetLocalId,
 	type DeltaDetachedNodeBuild,
@@ -1635,7 +1634,12 @@ export class ModularChangeFamily
 		mintRevisionTag: () => RevisionTag,
 		changeReceiver: (change: TaggedChange<ModularChangeset>) => void,
 	): ModularEditBuilder {
-		return new ModularEditBuilder(this, this.fieldKinds, changeReceiver, this.codecOptions);
+		return new ModularEditBuilder(
+			this.rebaser,
+			this.fieldKinds,
+			changeReceiver,
+			this.codecOptions,
+		);
 	}
 
 	private createEmptyFieldChange(fieldKind: FieldKindIdentifier): FieldChange {
@@ -2669,12 +2673,12 @@ export class ModularEditBuilder extends EditBuilder<ModularChangeset> {
 	private readonly codecOptions: CodecWriteOptions;
 
 	public constructor(
-		family: ChangeFamily<ChangeFamilyEditor, ModularChangeset>,
+		private readonly rebaser: ChangeRebaser<ModularChangeset>,
 		private readonly fieldKinds: ReadonlyMap<FieldKindIdentifier, FlexFieldKind>,
 		changeReceiver: (change: TaggedChange<ModularChangeset>) => void,
 		codecOptions: CodecWriteOptions,
 	) {
-		super(family, changeReceiver);
+		super(changeReceiver);
 		this.idAllocator = idAllocatorFromMaxId();
 		this.codecOptions = codecOptions;
 	}
@@ -2791,7 +2795,7 @@ export class ModularEditBuilder extends EditBuilder<ModularChangeset> {
 		});
 		const revInfo = [...revisions].map((revision) => ({ revision }));
 		const composedChange: Mutable<ModularChangeset> = {
-			...this.changeFamily.rebaser.compose(changeMaps),
+			...this.rebaser.compose(changeMaps),
 			revisions: revInfo,
 		};
 

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkEncodingEndToEnd.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkEncodingEndToEnd.spec.ts
@@ -170,7 +170,7 @@ describe("End to end chunked encoding", () => {
 			{ jsonValidator: FormatValidatorBasic },
 		);
 		const dummyEditor = new DefaultEditBuilder(
-			new DefaultChangeFamily(codec, options),
+			new DefaultChangeFamily(codec, options).rebaser,
 			mintRevisionTag,
 			changeReceiver,
 			options,

--- a/packages/dds/tree/src/test/feature-libraries/default-field-kinds/defaultChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/default-field-kinds/defaultChangeFamily.spec.ts
@@ -44,8 +44,7 @@ const codecOptions = {
 	jsonValidator: FormatValidatorBasic,
 	minVersionForCollab: FluidClientVersion.v2_0,
 };
-const defaultChangeFamily = new DefaultChangeFamily(failCodecFamily, codecOptions);
-const family = defaultChangeFamily;
+const rebaser = new DefaultChangeFamily(failCodecFamily, codecOptions).rebaser;
 
 const rootKey = rootFieldKey;
 const fooKey = brand<FieldKey>("foo");
@@ -136,7 +135,7 @@ function initializeEditableForest(data?: JsonableTree): {
 		testIdCompressor,
 	);
 	const builder = new DefaultEditBuilder(
-		family,
+		rebaser,
 		mintRevisionTag,
 		(taggedChange) => {
 			changes.push(taggedChange);


### PR DESCRIPTION
EditBuilder.changeFamily is only used by derived ModularEditBuilder and then only ChangeRebaser is needed. Update ModularEditBuilder to keep rebaser for itself allowing EditBuilder to drop changeFamily altogether.