### PR TITLE
treeshape equals short circuit

### DIFF
--- a/packages/dds/tree/src/feature-libraries/chunked-forest/uniformChunk.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/uniformChunk.ts
@@ -197,6 +197,11 @@ export class TreeShape {
 			return true;
 		}
 
+		// A given type usually only has one shape, so check it next to speed up the false case.
+		if (this.type !== other.type) {
+			return false;
+		}
+
 		// TODO: either dedupe instances and/or store a collision resistant hash for fast compare.
 
 		if (
@@ -209,7 +214,6 @@ export class TreeShape {
 			return false;
 		}
 		return (
-			this.type === other.type &&
 			this.hasValue === other.hasValue &&
 			this.mayContainCompressedIds === other.mayContainCompressedIds
 		);

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/uniformChunk.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/uniformChunk.ts
@@ -191,6 +191,12 @@ export class TreeShape {
 	}
 
 	public equals(other: TreeShape): boolean {
+		// Shapes are commonly shared (e.g. all chunks from one chunker reference the same instance), so
+		// short-circuit on reference identity to avoid the full structural walk in the common case.
+		if (this === other) {
+			return true;
+		}
+
 		// TODO: either dedupe instances and/or store a collision resistant hash for fast compare.
 
 		if (


### PR DESCRIPTION
## Description

Add a reference-identity short circuit for `TreeShape.equals` so the common case of comparing a shape against itself skips the full structural walk