### PR TITLE
fix: decouple git tag creation from public npmjs publishing in release pipeline

### DIFF
--- a/tools/pipelines/templates/include-publish-npm-package.yml
+++ b/tools/pipelines/templates/include-publish-npm-package.yml
@@ -56,6 +56,7 @@ stages:
       # Environment should match the condition for publish_npm_internal_dev
       environment: package-build-feed
       pool: ${{ parameters.pool }}
+      tagName: ${{ parameters.tagName }}
 
 # Only add a stage to publish packages to the dev feed for release groups, which have separate lists of packages to
 # publish to each feed. Non-release-group builds (for an independent package) only need to publish to the build feed.
@@ -90,7 +91,6 @@ stages:
       environment: package-npmjs-feed
       pool: ${{ parameters.pool }}
       customEndPoint: npmjs
-      tagName: ${{ parameters.tagName }}
 
 # Only upload release manifest files for runs in the internal project (i.e. CI runs, not PR runs), for the main, test, and release branches, and
 # for builds of release groups that currently publish manifests.


### PR DESCRIPTION
## Problem

The `TagRelease` job (which creates the release git tag, in turn triggering the `push-tag-create-release.yml` GitHub Actions workflow that publishes the GitHub Release) was chained via `dependsOn` to the `publish_npm_public` deployment job. `tagName` was only ever passed as a parameter to that stage's deployment template call.

Since public npmjs.org publishing is now gated behind the `allowPublishingToNpmjs` parameter (default `false`, introduced in [PR #27707](https://github.com/microsoft/FluidFramework/pull/27707)), skipping that publish stage also silently skipped git tag creation as an unintended side effect. This caused the 2.113.0 client release build to complete without ever creating the `client_v2.113.0` tag or GitHub Release; both had to be created manually.

## Fix

Move `tagName` from the `publish_npm_public` stage to the `publish_npm_internal_build` stage instead. `publish_npm_internal_build` always runs for non-test builds, independent of `allowPublishingToNpmjs`. The actual tag push remains further gated on `variables['release'] == 'release'` in `include-git-tag-steps.yml`, so this does not tag every regular build — only builds explicitly queued in "release" mode, same as before.

This template (`include-publish-npm-package.yml`) is shared across client, server/historian/gitrest, and generic npm package pipelines, so all of them benefit from the fix.

## Testing

Reviewed the dependency chain in `include-publish-npm-package-deployment.yml` (the `TagRelease` job depends on `publish_${{ replace(parameters.environment, '-', '_') }}`) and confirmed `publish_npm_internal_build`'s environment name resolves correctly. No functional pipeline run was performed as part of this PR; verification will happen on the next release build.