### PR TITLE
Avoid depending on the build when linting

### DIFF
--- a/fluidBuild.config.cjs
+++ b/fluidBuild.config.cjs
@@ -7,7 +7,24 @@
 // See https://www.typescriptlang.org/docs/handbook/intro-to-js-ts.html#ts-check
 // @ts-check
 
+/**
+ * Dependencies for type-checking (and emitting js) for the production (non-test) portion of a package.
+ */
 const tscDependsOn = ["^tsc", "^api", "build:genver", "ts2esm"];
+
+/**
+ * Dependencies for the "eslint" (and "eslint:fix") tasks.
+ *
+ * eslint does type-aware linting driven by the TypeScript *sources* (via projectService),
+ * so it must resolve the same imported types that tsc does.
+ * For production (non-test code), this is handled by reusing {@link {@link tscDependsOn}}.
+ *
+ * To handle test code we also depend on code generation which is either linted or used by tests.
+ *
+ * We specifically avoid depending on this package's test compilation: it is unnecessary
+ * and would slow down building individual packages by starting lint much later.
+ */
+const eslintDependsOn = [...tscDependsOn, "typetests:gen", "api"];
 
 // release group packages; while ** is supported, it is very slow, so these entries capture all the levels we
 // have packages at today. Once we can upgrade to a later version of
@@ -23,7 +40,7 @@ const releaseGroupPackageJsonGlobs = [
  * The settings in this file configure the Fluid build tools, such as fluid-build and flub. Some settings apply to the
  * whole repo, while others apply only to the client release group.
  *
- * See https://github.com/microsoft/FluidFramework/blob/main/build-tools/packages/build-tools/src/common/fluidTaskDefinitions.ts
+ * See https://github.com/microsoft/FluidFramework/blob/main/build-tools/packages/build-tools/src/fluidBuild/fluidTaskDefinitions.ts
  * for details on the task and dependency definition format.
  *
  * @type {import("@fluidframework/build-tools").IFluidBuildConfig & import("@fluid-tools/build-cli").FlubConfig}
@@ -184,10 +201,8 @@ module.exports = {
 		},
 		"check:biome": [],
 		"check:prettier": [],
-		// ADO #7297: Review why the direct dependency on 'build:esm:test' is necessary.
-		//            Should 'compile' be enough?  compile -> build:test -> build:test:esm
-		"eslint": ["compile", "build:test:esm"],
-		"eslint:fix": ["compile", "build:test:esm"],
+		"eslint": eslintDependsOn,
+		"eslint:fix": eslintDependsOn,
 		"good-fences": [],
 		"format:biome": [],
 		"format:prettier": [],


### PR DESCRIPTION
## Description

The `eslint` (and `eslint:fix`) fluid-build tasks previously depended on `["compile", "build:test:esm"]`. Because `compile` pulls in `build:test` (both `build:test:esm` and `build:test:cjs`), linting could not start until a package's **test** compilation had finished. That work is serialized behind the worker memory limit, so for larger packages eslint began very late in the build even though it never consumes the test compilation output.

eslint here does type-aware linting driven directly by the TypeScript *sources* (via `projectService`), so it only needs the same imported types that `tsc` resolves — not the package's own compiled test/CJS output. This change points the eslint tasks at the same dependency closure `tsc` already uses, plus the code-generation steps that lint/tests rely on:

```js
const eslintDependsOn = [...tscDependsOn, "typetests:gen", "api"];
```

The `^`-prefixed entries in `tscDependsOn` build the full dependency closure (so imported types resolve), and are the only prerequisites that survive for test-only packages that have no local `tsc`/`api` task. eslint no longer waits on the local test compilation, so it starts much earlier and runs in parallel with the rest of the build.

This is a repo-wide build-tooling change (single edit to `fluidBuild.config.cjs`) and benefits every package, with the largest wins on packages that have substantial test compilation.

### Performance data

Measured in this dev container. "Before" = `main`, "After" = this branch. Full workspace runs are `pnpm clean && pnpm build:fast`; tree runs are `pnpm clean && pnpm build --worker` in `packages/dds/tree` with all dependencies already built.

| Scenario | Before (`main`) | After | Improvement |
| --- | --- | --- | --- |
| Full workspace clean build | 430.6s (7m 10.6s) | 408.3s (6m 48.3s) | −22.3s (~5.2%) |
| `@fluidframework/tree` clean build (deps prebuilt) | 81.4s (1m 21.4s) | 54.3s | −27.1s (~33%) |

Both configurations built successfully with 0 errors. In the tree build, eslint no longer waits for `build:test:cjs` to finish (~50s in) and instead starts early and overlaps with the remaining compilation.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

- The historical `["compile", "build:test:esm"]` dependency carried an `ADO #7297` note questioning why the direct `build:test:esm` dependency was necessary; this change resolves that by removing the dependency on test compilation entirely.
- Key correctness point: eslint's type-aware rules read TS sources, so the required prerequisite is the *dependency* type information (covered by the `^`-prefixed entries and `api`/`typetests:gen`), not this package's own test/CJS build output. Please sanity-check that reasoning, especially for test-only packages.
- Validated with a full `pnpm build:fast` (0 errors) and the `fluid-build-tasks-eslint` policy handler (clean repo-wide).

