### PR TITLE
docs: update release schedule and note allowPublishingToNpmjs in release-execution skill

### DIFF
--- a/.claude/skills/fluid-release/references/release-execution.md
+++ b/.claude/skills/fluid-release/references/release-execution.md
@@ -53,7 +53,7 @@ The command will:
 
 Follow the tool's interactive prompts. The user will need to queue the ADO build manually — this cannot be automated.
 
-**Note:** The ADO pipeline has an `allowPublishingToNpmjs` parameter (default `false`) that controls whether packages are published to the public npmjs.org registry. Ask the user whether public npm publishing should happen for this release, and if so, remind them to set this parameter to `true` when queuing the build. Git tag creation and the GitHub Release happen regardless of this parameter's value.
+**Note:** The ADO pipeline has an `allowPublishingToNpmjs` parameter (default `false`) that controls whether packages are published to the public npmjs.org registry. Ask the user whether public npm publishing should happen for this release, and if so, remind them to set this parameter to `true` when queuing the build. Git tag creation and the GitHub Release happen regardless of this parameter's value. Default behaviour for a new minor release: `allowPublishingToNpmjs` should be set to `true` — new minors should be published to npmjs.org. Follow up patch should be only published internally.
 
 **Autonomous mode:** After running `flub release`, report:
 

--- a/.claude/skills/fluid-release/references/release-execution.md
+++ b/.claude/skills/fluid-release/references/release-execution.md
@@ -53,11 +53,9 @@ The command will:
 
 Follow the tool's interactive prompts. The user will need to queue the ADO build manually — this cannot be automated.
 
-**Note:** The ADO pipeline has an `allowPublishingToNpmjs` parameter (default `false`) that controls whether packages are published to the public npmjs.org registry. Ask the user whether public npm publishing should happen for this release, and if so, remind them to set this parameter to `true` when queuing the build. Git tag creation and the GitHub Release happen regardless of this parameter's value. Default behaviour for a new minor release: `allowPublishingToNpmjs` should be set to `true` — new minors should be published to npmjs.org. Follow up patch should be only published internally.
-
 **Autonomous mode:** After running `flub release`, report:
 
-> **Action required:** Queue the release build in ADO (choose the "release" option, and set `allowPublishingToNpmjs` to `true` if public npm publishing is desired). After the build completes, verify the release appears in GitHub releases (and npm, if publishing was enabled), then re-invoke for the patch bump.
+> **Action required:** Queue the release build in ADO (choose the "release" option, and set `allowPublishingToNpmjs` to `true` if public npm publishing is desired). After the build completes, a downstream publishing pipeline will publish the packages. Verify the release appears in GitHub releases (and npm, if publishing was enabled), then re-invoke for the patch bump.
 
 ### Verify the release
 

--- a/.claude/skills/fluid-release/references/release-execution.md
+++ b/.claude/skills/fluid-release/references/release-execution.md
@@ -53,15 +53,17 @@ The command will:
 
 Follow the tool's interactive prompts. The user will need to queue the ADO build manually — this cannot be automated.
 
+**Note:** The ADO pipeline has an `allowPublishingToNpmjs` parameter (default `false`) that controls whether packages are published to the public npmjs.org registry. Ask the user whether public npm publishing should happen for this release, and if so, remind them to set this parameter to `true` when queuing the build. Git tag creation and the GitHub Release happen regardless of this parameter's value.
+
 **Autonomous mode:** After running `flub release`, report:
 
-> **Action required:** Queue the release build in ADO (choose the "release" option). After the build completes, verify the release appears in GitHub releases and npm, then re-invoke for the patch bump.
+> **Action required:** Queue the release build in ADO (choose the "release" option, and set `allowPublishingToNpmjs` to `true` if public npm publishing is desired). After the build completes, verify the release appears in GitHub releases (and npm, if publishing was enabled), then re-invoke for the patch bump.
 
 ### Verify the release
 
 After the build completes, confirm:
 - Listed in [GitHub releases](https://github.com/microsoft/FluidFramework/releases)
-- Published on [npm](https://www.npmjs.com/search?q=%40fluidframework)
+- Published on [npm](https://www.npmjs.com/search?q=%40fluidframework), if `allowPublishingToNpmjs` was set to `true` for this build
 
 Once confirmed, remind the user to announce the release in the Fluid Framework "General" Teams channel with a link to the GitHub release. (Never auto-announce in either mode.)
 

--- a/.claude/skills/fluid-release/references/release-schedule.md
+++ b/.claude/skills/fluid-release/references/release-schedule.md
@@ -1,27 +1,34 @@
-# 2.x Release Schedule
+# Client Release Schedule
 
 Dates are in MM/DD/YY format. The schedule is ordered newest-first.
 
 | Proposed Date | Released Date | Release Type | Release Ver | "main" Ver | Release Notes |
 |---------------|---------------|--------------|-------------|------------|---------------|
-| 06/06/26 | | minor | 2.103.0 | 2.110.0 | |
-| 05/26/26 | | minor | 2.102.0 | 2.103.0 | |
-| 05/11/26 | | minor | 2.101.0 | 2.102.0 | |
-| 04/27/26 | | minor+beta/legacy breaks | 2.100.0 | 2.101.0 | |
-| 04/13/26 | | minor | 2.93.0 | 2.100.0 | |
-| 03/30/26 | | minor | 2.92.0 | 2.93.0 | |
-| 03/16/26 | | minor | 2.91.0 | 2.92.0 | |
-| 03/02/26 | | minor+beta/legacy breaks | 2.90.0 | 2.91.0 | |
-| 02/17/26 | | minor | 2.83.0 | 2.90.0 | |
-| 02/02/26 | | minor | 2.82.0 | 2.83.0 | |
+| 10/26/26 | | minor+[beta/legacy breaks](https://github.com/microsoft/FluidFramework/issues/27471) | 3.10.0 | 3.11.0 | |
+| 10/19/26 | | minor | 3.7.0 | 3.10.0 | |
+| 10/12/26 | | minor | 3.6.0 | 3.7.0 | |
+| 10/05/26 | | minor | 3.5.0 | 3.6.0 | |
+| 09/28/26 | | minor | 3.4.0 | 3.5.0 | |
+| 09/21/26 | | minor | 3.3.0 | 3.4.0 | |
+| 09/14/26 | | minor | 3.2.0 | 3.3.0 | |
+| 09/07/26 | | minor | 3.1.0 | 3.2.0 | |
+| 08/24/26 - 08/31/26 | | major+[breaks](https://github.com/microsoft/FluidFramework/issues/23271) | 3.0.0 | 3.1.0 | |
+| 08/17/26 | | minor | 2.116.0 | 3.0.0 | |
+| 08/10/26 | | minor | 2.115.0 | 2.116.0 | |
+| 08/03/26 | | minor | 2.114.0 | 2.115.0 | |
+| 07/27/26 | 07/27/26 | minor | 2.113.0 | 2.114.0 | |
+| 07/20/26 | | minor | 2.112.0 | 2.113.0 | |
+| 07/06/26 | | minor | 2.111.0 | 2.112.0 | |
+| 06/22/26 | | minor+[beta/legacy breaks](https://github.com/microsoft/FluidFramework/issues/26499) | 2.110.0 | 2.111.0 | |
+| 06/08/26 | | minor | 2.103.0 | 2.110.0 | |
 
 ## How to use this schedule
 
 The **"Release Ver"** column is the version that gets released on the proposed date. The **"main" Ver** column is the version that `main` is bumped to _after_ the release branch is cut (i.e., the next development version).
 
-For example, for the 2.91.0 release:
-- Release version: **2.91.0**
-- Next version on main after branch cut: **2.92.0**
-- Scheduled date: **03/16/26**
+For example, for the 2.113.0 release:
+- Release version: **2.113.0**
+- Next version on main after branch cut: **2.114.0**
+- Scheduled date: **07/27/26**
 
-Note that the "main" Ver can jump non-sequentially (e.g., 2.93.0 -> 2.100.0) at designated breaking-change releases.
+Note that the "main" Ver can jump non-sequentially (e.g., 2.116.0 -> 3.0.0) at designated breaking-change releases.

--- a/.claude/skills/fluid-release/references/release-schedule.md
+++ b/.claude/skills/fluid-release/references/release-schedule.md
@@ -31,4 +31,4 @@ For example, for the 2.113.0 release:
 - Next version on main after branch cut: **2.114.0**
 - Scheduled date: **07/27/26**
 
-Note that the "main" Ver can jump non-sequentially (e.g., 2.116.0 -> 3.0.0) at designated breaking-change releases.
+Note that the "main" Ver can jump non-sequentially (e.g., 3.7.0 -> 3.10.0) at designated breaking-change releases.


### PR DESCRIPTION
## Description

- Refreshed `release-schedule.md` with the latest proposed dates/versions through the 3.11.0 release, including the upcoming 3.0.0 major/breaking release, and marked 2.113.0 as released (07/27/26). Renamed the doc title since the schedule now spans both 2.x and 3.x releases.
- Noted the `allowPublishingToNpmjs` ADO pipeline parameter (added in [PR #27707](https://github.com/microsoft/FluidFramework/pull/27707)) in `release-execution.md` so the release skill reminds the human to decide whether public npmjs.org publishing should happen when queuing a release build.