### PR TITLE
refactor(tree): split encode/decode contexts for EditManager and Message codecs

### DIFF
--- a/packages/dds/tree/src/shared-tree-core/editManagerCodecs.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerCodecs.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import type { IIdCompressor } from "@fluidframework/id-compressor";
 import type { MinimumVersionForCollab } from "@fluidframework/runtime-definitions/internal";
 import { lowestMinVersionForCollab } from "@fluidframework/runtime-utils/internal";
 
@@ -18,29 +17,16 @@ import {
 	type IJsonCodec,
 	makeDiscontinuedCodecAndSchema,
 } from "../codec/index.js";
-import type {
-	ChangeEncodingContext,
-	EncodedRevisionTag,
-	RevisionTag,
-	SchemaAndPolicy,
-} from "../core/index.js";
-import type { IdentifierHealingConfig } from "../util/index.js";
+import type { ChangeEncodingContext, EncodedRevisionTag, RevisionTag } from "../core/index.js";
 
 import type { SummaryData } from "./editManager.js";
+import type {
+	EditManagerDecodingContext,
+	EditManagerEncodingContext,
+} from "./editManagerCodecsCommons.js";
 import { makeV1toV4andV6CodecWithVersion } from "./editManagerCodecsV1toV4.js";
 import { makeSharedBranchesCodecWithVersion } from "./editManagerCodecsVSharedBranches.js";
 import { EditManagerFormatVersion } from "./editManagerFormatCommons.js";
-
-/**
- * Context required for encoding/decoding the {@link EditManager}'s {@link SummaryData}.
- */
-export interface EditManagerEncodingContext {
-	idCompressor: IIdCompressor;
-	readonly schema?: SchemaAndPolicy;
-	readonly isSummary: boolean;
-	/** See {@link IdentifierHealingConfig}. */
-	readonly healing?: IdentifierHealingConfig;
-}
 
 /**
  * Codec name used to identify the {@link EditManager} codec, see {@link makeEditManagerCodecBuilder}.
@@ -72,14 +58,16 @@ export function makeEditManagerCodecBuilder<TChangeset>(): VersionDispatchingCod
 	SummaryData<TChangeset>,
 	EditManagerEncodingContext,
 	EditManagerFormatVersion,
-	typeof editManagerCodecName
+	typeof editManagerCodecName,
+	EditManagerDecodingContext
 > {
 	// See EditManagerFormatVersion and its members for documentation on what changed in each version.
 	const versions: CodecVersion<
 		SummaryData<TChangeset>,
 		EditManagerEncodingContext,
 		EditManagerFormatVersion,
-		EditManagerCodecOptions<TChangeset>
+		EditManagerCodecOptions<TChangeset>,
+		EditManagerDecodingContext
 	>[] = [
 		makeDiscontinuedCodecAndSchema(EditManagerFormatVersion.v1, "2.73.0"),
 		makeDiscontinuedCodecAndSchema(EditManagerFormatVersion.v2, "2.73.0"),

--- a/packages/dds/tree/src/shared-tree-core/editManagerCodecsCommons.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerCodecsCommons.ts
@@ -39,6 +39,17 @@ export interface EditManagerEncodingContext {
 	 * but it is carried explicitly so downstream codecs can read it.
 	 */
 	readonly isSummary: boolean;
+}
+
+/**
+ * Context required for decoding the {@link EditManager}'s {@link SummaryData}.
+ * @remarks
+ * Unlike {@link EditManagerEncodingContext}, this carries {@link IdentifierHealingConfig} (used only
+ * on decode) and omits `schema` (only consulted when encoding).
+ */
+export interface EditManagerDecodingContext {
+	readonly idCompressor: IIdCompressor;
+	readonly isSummary: boolean;
 	/** See {@link IdentifierHealingConfig}. */
 	readonly healing?: IdentifierHealingConfig;
 }
@@ -192,7 +203,7 @@ export function decodeSharedBranch<TChangeset>(
 		ChangeEncodingContext
 	>,
 	json: EncodedSharedBranch<TChangeset>,
-	context: EditManagerEncodingContext,
+	context: EditManagerDecodingContext,
 	originatorId: SessionId | undefined,
 ): SharedBranchSummaryData<TChangeset> {
 	// TODO: sort out EncodedCommit vs Commit, and make this type check without type assertion.

--- a/packages/dds/tree/src/shared-tree-core/editManagerCodecsV1toV4.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerCodecsV1toV4.ts
@@ -3,33 +3,22 @@
  * Licensed under the MIT License.
  */
 
-import type { IIdCompressor } from "@fluidframework/id-compressor";
-
 import type { CodecAndSchema, IJsonCodec, Versioned } from "../codec/index.js";
-import type {
-	ChangeEncodingContext,
-	EncodedRevisionTag,
-	RevisionTag,
-	SchemaAndPolicy,
-} from "../core/index.js";
+import type { ChangeEncodingContext, EncodedRevisionTag, RevisionTag } from "../core/index.js";
 import {
-	type IdentifierHealingConfig,
 	type JsonCompatibleReadOnly,
 	type JsonCompatibleReadOnlyObject,
 	JsonCompatibleReadOnlySchema,
 } from "../util/index.js";
 
 import type { SummaryData } from "./editManager.js";
-import { decodeSharedBranch, encodeSharedBranch } from "./editManagerCodecsCommons.js";
+import {
+	decodeSharedBranch,
+	encodeSharedBranch,
+	type EditManagerDecodingContext,
+	type EditManagerEncodingContext,
+} from "./editManagerCodecsCommons.js";
 import { EncodedEditManager } from "./editManagerFormatV1toV4.js";
-
-export interface EditManagerEncodingContext {
-	idCompressor: IIdCompressor;
-	readonly schema?: SchemaAndPolicy;
-	readonly isSummary: boolean;
-	/** See {@link IdentifierHealingConfig}. */
-	readonly healing?: IdentifierHealingConfig;
-}
 
 /**
  * Create the provided version of the {@link EditManager} codec (which encodes it's {@link SummaryData}).
@@ -53,10 +42,18 @@ export function makeV1toV4andV6CodecWithVersion<TChangeset>(
 		ChangeEncodingContext
 	>,
 	version: EncodedEditManager<TChangeset>["version"],
-): CodecAndSchema<SummaryData<TChangeset>, EditManagerEncodingContext> {
+): CodecAndSchema<
+	SummaryData<TChangeset>,
+	EditManagerEncodingContext,
+	EditManagerDecodingContext
+> {
 	const schema = EncodedEditManager(changeCodec.encodedSchema ?? JsonCompatibleReadOnlySchema);
 
-	const codec: CodecAndSchema<SummaryData<TChangeset>, EditManagerEncodingContext> = {
+	const codec: CodecAndSchema<
+		SummaryData<TChangeset>,
+		EditManagerEncodingContext,
+		EditManagerDecodingContext
+	> = {
 		schema,
 		encode: (
 			data: SummaryData<TChangeset>,
@@ -80,7 +77,7 @@ export function makeV1toV4andV6CodecWithVersion<TChangeset>(
 		},
 		decode: (
 			json: EncodedEditManager<TChangeset> & JsonCompatibleReadOnly,
-			context: EditManagerEncodingContext,
+			context: EditManagerDecodingContext,
 		): SummaryData<TChangeset> => {
 			return {
 				main: decodeSharedBranch(

--- a/packages/dds/tree/src/shared-tree-core/editManagerCodecsVSharedBranches.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerCodecsVSharedBranches.ts
@@ -4,17 +4,10 @@
  */
 
 import { assert } from "@fluidframework/core-utils/internal";
-import type { IIdCompressor } from "@fluidframework/id-compressor";
 
 import type { CodecAndSchema, IJsonCodec } from "../codec/index.js";
-import type {
-	ChangeEncodingContext,
-	EncodedRevisionTag,
-	RevisionTag,
-	SchemaAndPolicy,
-} from "../core/index.js";
+import type { ChangeEncodingContext, EncodedRevisionTag, RevisionTag } from "../core/index.js";
 import {
-	type IdentifierHealingConfig,
 	type JsonCompatibleReadOnly,
 	type JsonCompatibleReadOnlyObject,
 	JsonCompatibleReadOnlySchema,
@@ -23,17 +16,14 @@ import {
 
 import type { BranchId } from "./branch.js";
 import type { SharedBranchSummaryData, SummaryData } from "./editManager.js";
-import { decodeSharedBranch, encodeSharedBranch } from "./editManagerCodecsCommons.js";
+import {
+	decodeSharedBranch,
+	encodeSharedBranch,
+	type EditManagerDecodingContext,
+	type EditManagerEncodingContext,
+} from "./editManagerCodecsCommons.js";
 import type { EncodedSharedBranch } from "./editManagerFormatCommons.js";
 import { EncodedEditManager } from "./editManagerFormatVSharedBranches.js";
-
-export interface EditManagerEncodingContext {
-	idCompressor: IIdCompressor;
-	readonly schema?: SchemaAndPolicy;
-	readonly isSummary: boolean;
-	/** See {@link IdentifierHealingConfig}. */
-	readonly healing?: IdentifierHealingConfig;
-}
 
 export function makeSharedBranchesCodecWithVersion<TChangeset>(
 	changeCodec: IJsonCodec<
@@ -49,10 +39,18 @@ export function makeSharedBranchesCodecWithVersion<TChangeset>(
 		ChangeEncodingContext
 	>,
 	version: EncodedEditManager<TChangeset>["version"],
-): CodecAndSchema<SummaryData<TChangeset>, EditManagerEncodingContext> {
+): CodecAndSchema<
+	SummaryData<TChangeset>,
+	EditManagerEncodingContext,
+	EditManagerDecodingContext
+> {
 	const schema = EncodedEditManager(changeCodec.encodedSchema ?? JsonCompatibleReadOnlySchema);
 
-	const codec: CodecAndSchema<SummaryData<TChangeset>, EditManagerEncodingContext> = {
+	const codec: CodecAndSchema<
+		SummaryData<TChangeset>,
+		EditManagerEncodingContext,
+		EditManagerDecodingContext
+	> = {
 		schema,
 		encode: (data: SummaryData<TChangeset>, context: EditManagerEncodingContext) => {
 			const mainBranch = encodeSharedBranch(
@@ -90,7 +88,7 @@ export function makeSharedBranchesCodecWithVersion<TChangeset>(
 		},
 		decode: (
 			json: EncodedEditManager<TChangeset> & JsonCompatibleReadOnlyObject,
-			context: EditManagerEncodingContext,
+			context: EditManagerDecodingContext,
 		): SummaryData<TChangeset> => {
 			const mainBranch = decodeSharedBranch(
 				changeCodec,

--- a/packages/dds/tree/src/shared-tree-core/editManagerSummarizer.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerSummarizer.ts
@@ -19,7 +19,10 @@ import type { ChangeFamily, ChangeFamilyEditor, SchemaAndPolicy } from "../core/
 import type { IdentifierHealingConfig, JsonCompatibleReadOnly } from "../util/index.js";
 
 import type { EditManager, SummaryData } from "./editManager.js";
-import type { EditManagerEncodingContext } from "./editManagerCodecs.js";
+import type {
+	EditManagerDecodingContext,
+	EditManagerEncodingContext,
+} from "./editManagerCodecsCommons.js";
 import type {
 	Summarizable,
 	SummaryElementParser,
@@ -80,7 +83,8 @@ export class EditManagerSummarizer<TChangeset>
 			SummaryData<TChangeset>,
 			JsonCompatibleReadOnly,
 			JsonCompatibleReadOnly,
-			EditManagerEncodingContext
+			EditManagerEncodingContext,
+			EditManagerDecodingContext
 		>,
 		private readonly idCompressor: IIdCompressor,
 		minVersionForCollab: MinimumVersionForCollab,
@@ -109,7 +113,6 @@ export class EditManagerSummarizer<TChangeset>
 			idCompressor: this.idCompressor,
 			schema: this.schemaAndPolicy,
 			isSummary: true,
-			healing: this.healing,
 		};
 		const jsonCompatible = this.codec.encode(this.editManager.getSummaryData(), context);
 		const dataString = stringify(jsonCompatible);

--- a/packages/dds/tree/src/shared-tree-core/messageCodecV1ToV4.ts
+++ b/packages/dds/tree/src/shared-tree-core/messageCodecV1ToV4.ts
@@ -17,7 +17,7 @@ import {
 	JsonCompatibleReadOnlySchema,
 } from "../util/index.js";
 
-import type { MessageEncodingContext } from "./messageCodecs.js";
+import type { MessageDecodingContext, MessageEncodingContext } from "./messageCodecs.js";
 import type { MessageFormatVersion } from "./messageFormat.js";
 import { Message } from "./messageFormatV1ToV4.js";
 import type { DecodedMessage } from "./messageTypes.js";
@@ -36,7 +36,7 @@ export function makeV1ToV4CodecWithVersion<TChangeset>(
 		| typeof MessageFormatVersion.v3
 		| typeof MessageFormatVersion.v4
 		| typeof MessageFormatVersion.v6,
-): CodecAndSchema<DecodedMessage<TChangeset>, MessageEncodingContext> {
+): CodecAndSchema<DecodedMessage<TChangeset>, MessageEncodingContext, MessageDecodingContext> {
 	const schema = Message(changeCodec.encodedSchema ?? JsonCompatibleReadOnlySchema);
 	return {
 		schema,
@@ -70,7 +70,7 @@ export function makeV1ToV4CodecWithVersion<TChangeset>(
 		},
 		decode: (
 			encoded: Message & JsonCompatibleReadOnlyObject & Versioned,
-			context: MessageEncodingContext,
+			context: MessageDecodingContext,
 		): DecodedMessage<TChangeset> => {
 			const { revision: encodedRevision, originatorId, changeset } = encoded;
 

--- a/packages/dds/tree/src/shared-tree-core/messageCodecVSharedBranches.ts
+++ b/packages/dds/tree/src/shared-tree-core/messageCodecVSharedBranches.ts
@@ -17,7 +17,7 @@ import type {
 import type { JsonCompatibleReadOnlyObject } from "../util/index.js";
 
 import { decodeBranchId, encodeBranchId } from "./branchIdCodec.js";
-import type { MessageEncodingContext } from "./messageCodecs.js";
+import type { MessageDecodingContext, MessageEncodingContext } from "./messageCodecs.js";
 import type { MessageFormatVersion } from "./messageFormat.js";
 import { Message } from "./messageFormatVSharedBranches.js";
 import type { DecodedMessage } from "./messageTypes.js";
@@ -79,7 +79,7 @@ export function makeSharedBranchesCodecWithVersion<TChangeset>(
 		},
 		decode: (
 			encoded: Message & JsonCompatibleReadOnlyObject & Versioned,
-			context: MessageEncodingContext,
+			context: MessageDecodingContext,
 		): DecodedMessage<TChangeset> => {
 			const {
 				revision: encodedRevision,

--- a/packages/dds/tree/src/shared-tree-core/messageCodecs.ts
+++ b/packages/dds/tree/src/shared-tree-core/messageCodecs.ts
@@ -36,6 +36,14 @@ export interface MessageEncodingContext {
 }
 
 /**
+ * Context required for decoding a message. Unlike {@link MessageEncodingContext}, no schema is
+ * needed: message decoding is schema-agnostic.
+ */
+export interface MessageDecodingContext {
+	idCompressor: IIdCompressor;
+}
+
+/**
  * Codec name used to identify the message codec, see {@link makeMessageCodecBuilder}.
  */
 export const messageCodecName = "Message";
@@ -65,14 +73,16 @@ export function makeMessageCodecBuilder<TChangeset>(): VersionDispatchingCodecBu
 	DecodedMessage<TChangeset>,
 	MessageEncodingContext,
 	MessageFormatVersion | undefined,
-	typeof messageCodecName
+	typeof messageCodecName,
+	MessageDecodingContext
 > {
 	// See MessageFormatVersion and its members for documentation on what changed in each version.
 	const versions: CodecVersion<
 		DecodedMessage<TChangeset>,
 		MessageEncodingContext,
 		MessageFormatVersion | undefined,
-		MessageCodecBuilderOptions<TChangeset>
+		MessageCodecBuilderOptions<TChangeset>,
+		MessageDecodingContext
 	>[] = [
 		// The "undefined" wire format (no version field) is discontinued.
 		makeDiscontinuedCodecAndSchema(undefined, "2.73.0"),


### PR DESCRIPTION
## Description

Continues the codec encode/decode context separation, now for the EditManager and Message codecs (the change/field codecs were split in #27758). Pure type-level refactor — **no runtime behavior change**.

- Consolidates the four structurally-identical `EditManagerEncodingContext` redeclarations into a single definition in `editManagerCodecsCommons.ts`.
- Adds `EditManagerDecodingContext` and `MessageDecodingContext`, and threads `TDecodeContext` through `VersionDispatchingCodecBuilder`, `CodecVersion`, and `CodecAndSchema` for both codecs.
- Prunes one-sided fields: encode contexts drop the decode-only `healing`; decode contexts drop the encode-only `schema` (`MessageDecodingContext` ends up as just `{ idCompressor }`, which the op-decode call sites already passed).

The change-codec/revision-tag-codec parameters intentionally stay single-context (building `ChangeEncodingContext` internally), so this doesn't yet touch the change-codec interaction — dropping `ChangeEncodingContext.healing` still requires splitting the `revisionTagCodec`/`branchIdCodec`/`modularChange` decode helpers, which is a planned follow-up.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
