### PR TITLE
test(tree): add index performance benchmark suite with identifier index tests

### DIFF
--- a/packages/dds/tree/src/test/simple-tree/identifierIndex.bench.ts
+++ b/packages/dds/tree/src/test/simple-tree/identifierIndex.bench.ts
@@ -14,6 +14,7 @@ import { getView, configureBenchmarkHooks } from "../utils.js";
 
 import {
 	defaultIndexBenchmarkSizes,
+	deepTreeBenchmarkSizes,
 	generateIndexBenchmarkSuite,
 	type IndexBenchmarkScenario,
 	type IndexBenchmarkSetup,
@@ -257,7 +258,7 @@ describe("IdentifierIndex benchmarks", () => {
 	describe("deep (tall) tree", () => {
 		generateIndexBenchmarkSuite({
 			indexName: "IdentifierIndex (deep)",
-			sizes: defaultIndexBenchmarkSizes,
+			sizes: deepTreeBenchmarkSizes,
 			createScenario: createDeepScenario,
 		});
 	});

--- a/packages/dds/tree/src/test/simple-tree/identifierIndex.bench.ts
+++ b/packages/dds/tree/src/test/simple-tree/identifierIndex.bench.ts
@@ -89,14 +89,19 @@ function createWideScenario(nodeCount: number): IndexBenchmarkScenario<string, T
 				existingKeys,
 				missingKeys,
 				insertNode: () => {
-					view.root.children.insertAtEnd(
-						new WideChild({ id: makeId("wide", insertCounter++) }),
-					);
+					const id = makeId("wide", insertCounter++);
+					view.root.children.insertAtEnd(new WideChild({ id }));
+					return () => {
+						view.root.children.removeAt(view.root.children.length - 1);
+					};
 				},
 				removeNode: () => {
-					if (view.root.children.length > 0) {
-						view.root.children.removeAt(view.root.children.length - 1);
-					}
+					const lastIndex = view.root.children.length - 1;
+					const removedId = view.root.children[lastIndex]!.id;
+					view.root.children.removeAt(lastIndex);
+					return () => {
+						view.root.children.insertAtEnd(new WideChild({ id: removedId }));
+					};
 				},
 			};
 		},
@@ -128,7 +133,6 @@ function createDeepScenario(nodeCount: number): IndexBenchmarkScenario<string, T
 			const missingKeys = Array.from({ length: 10 }, (_, i) => `miss-${i}`);
 
 			let insertCounter = nodeCount;
-			// Walk to the deepest node for insert/remove operations
 			const findDeepest = (): DeepNode => {
 				let node = view.root;
 				while (node.child !== undefined) {
@@ -143,20 +147,26 @@ function createDeepScenario(nodeCount: number): IndexBenchmarkScenario<string, T
 				missingKeys,
 				insertNode: () => {
 					const deepest = findDeepest();
-					deepest.child = new DeepNode({ id: makeId("deep", insertCounter++) });
+					const id = makeId("deep", insertCounter++);
+					deepest.child = new DeepNode({ id });
+					return () => {
+						deepest.child = undefined;
+					};
 				},
 				removeNode: () => {
-					const deepest = findDeepest();
-					// Remove the deepest node by clearing its parent's child
-					// Walk to parent-of-deepest instead
-					let node = view.root;
-					if (node.child === undefined) {
-						return;
+					// Walk to parent-of-deepest and remove the leaf
+					let parent = view.root;
+					if (parent.child === undefined) {
+						return () => {};
 					}
-					while (node.child?.child !== undefined) {
-						node = node.child;
+					while (parent.child?.child !== undefined) {
+						parent = parent.child;
 					}
-					node.child = undefined;
+					const removedId = parent.child!.id;
+					parent.child = undefined;
+					return () => {
+						parent.child = new DeepNode({ id: removedId });
+					};
 				},
 			};
 		},
@@ -225,17 +235,30 @@ function createIrregularScenario(
 				existingKeys: ids,
 				missingKeys,
 				insertNode: () => {
+					const id = makeId("irreg", insertCounter++);
 					view.root.children.insertAtEnd(
 						new IrregularNode({
-							id: makeId("irreg", insertCounter++),
+							id,
 							children: new IrregularChildren([]),
 						}),
 					);
+					return () => {
+						view.root.children.removeAt(view.root.children.length - 1);
+					};
 				},
 				removeNode: () => {
-					if (view.root.children.length > 0) {
-						view.root.children.removeAt(view.root.children.length - 1);
-					}
+					const lastIndex = view.root.children.length - 1;
+					const removed = view.root.children[lastIndex]!;
+					const removedId = removed.id;
+					view.root.children.removeAt(lastIndex);
+					return () => {
+						view.root.children.insertAtEnd(
+							new IrregularNode({
+								id: removedId,
+								children: new IrregularChildren([]),
+							}),
+						);
+					};
 				},
 			};
 		},

--- a/packages/dds/tree/src/test/simple-tree/identifierIndex.bench.ts
+++ b/packages/dds/tree/src/test/simple-tree/identifierIndex.bench.ts
@@ -214,9 +214,7 @@ function buildIrregularTree(targetCount: number): {
 	return { root, ids };
 }
 
-function createIrregularScenario(
-	nodeCount: number,
-): IndexBenchmarkScenario<string, TreeNode> {
+function createIrregularScenario(nodeCount: number): IndexBenchmarkScenario<string, TreeNode> {
 	return {
 		title: `irregular tree with ${nodeCount} nodes`,
 		setup(): IndexBenchmarkSetup<string, TreeNode> {

--- a/packages/dds/tree/src/test/simple-tree/identifierIndex.bench.ts
+++ b/packages/dds/tree/src/test/simple-tree/identifierIndex.bench.ts
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+import { strict as assert } from "node:assert";
+
 import {
 	SchemaFactory,
 	TreeViewConfiguration,
@@ -97,7 +99,7 @@ function createWideScenario(nodeCount: number): IndexBenchmarkScenario<string, T
 				},
 				removeNode: () => {
 					const lastIndex = view.root.children.length - 1;
-					const removedId = view.root.children[lastIndex]!.id;
+					const removedId = view.root.children[lastIndex].id;
 					view.root.children.removeAt(lastIndex);
 					return () => {
 						view.root.children.insertAtEnd(new WideChild({ id: removedId }));
@@ -111,9 +113,9 @@ function createWideScenario(nodeCount: number): IndexBenchmarkScenario<string, T
 // ── Deep (tall) scenario ──
 
 function buildDeepChain(depth: number, ids: string[]): DeepNode {
-	let current = new DeepNode({ id: ids[depth - 1]! });
+	let current = new DeepNode({ id: ids[depth - 1] });
 	for (let i = depth - 2; i >= 0; i--) {
-		current = new DeepNode({ id: ids[i]!, child: current });
+		current = new DeepNode({ id: ids[i], child: current });
 	}
 	return current;
 }
@@ -162,7 +164,9 @@ function createDeepScenario(nodeCount: number): IndexBenchmarkScenario<string, T
 					while (parent.child?.child !== undefined) {
 						parent = parent.child;
 					}
-					const removedId = parent.child!.id;
+					const child = parent.child;
+					assert(child !== undefined, "parent.child should exist after loop");
+					const removedId = child.id;
 					parent.child = undefined;
 					return () => {
 						parent.child = new DeepNode({ id: removedId });
@@ -246,7 +250,7 @@ function createIrregularScenario(nodeCount: number): IndexBenchmarkScenario<stri
 				},
 				removeNode: () => {
 					const lastIndex = view.root.children.length - 1;
-					const removed = view.root.children[lastIndex]!;
+					const removed = view.root.children[lastIndex];
 					const removedId = removed.id;
 					view.root.children.removeAt(lastIndex);
 					return () => {

--- a/packages/dds/tree/src/test/simple-tree/identifierIndex.bench.ts
+++ b/packages/dds/tree/src/test/simple-tree/identifierIndex.bench.ts
@@ -1,0 +1,100 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+	SchemaFactory,
+	TreeViewConfiguration,
+	createIdentifierIndex,
+} from "../../simple-tree/index.js";
+import { getView, configureBenchmarkHooks } from "../utils.js";
+
+import {
+	defaultIndexBenchmarkSizes,
+	generateIndexBenchmarkSuite,
+	type IndexBenchmarkScenario,
+	type IndexBenchmarkSetup,
+} from "./indexBenchmarkUtilities.js";
+
+const schemaFactory = new SchemaFactory("identifierIndex.bench");
+
+class IndexedChild extends schemaFactory.object("IndexedChild", {
+	id: schemaFactory.identifier,
+}) {}
+
+class IndexedParent extends schemaFactory.object("IndexedParent", {
+	id: schemaFactory.identifier,
+	children: schemaFactory.array(IndexedChild),
+}) {}
+
+/**
+ * Creates identifiers for a given count, producing deterministic string IDs.
+ */
+function makeId(index: number): string {
+	return `node-id-${index}`;
+}
+
+/**
+ * Creates an identifier index benchmark scenario for a given number of child nodes.
+ */
+function createIdentifierIndexScenario(
+	nodeCount: number,
+): IndexBenchmarkScenario<string, import("../../simple-tree/index.js").TreeNode> {
+	return {
+		title: `IdentifierIndex with ${nodeCount} nodes`,
+		setup(): IndexBenchmarkSetup<
+			string,
+			import("../../simple-tree/index.js").TreeNode
+		> {
+			const children = Array.from({ length: nodeCount }, (_, i) => {
+				return new IndexedChild({ id: makeId(i) });
+			});
+
+			const config = new TreeViewConfiguration({ schema: IndexedParent });
+			const view = getView(config);
+			view.initialize(
+				new IndexedParent({
+					id: "root-id",
+					children,
+				}),
+			);
+
+			const index = createIdentifierIndex(view);
+
+			// Existing keys: the root + all children
+			const existingKeys = ["root-id", ...children.map((_, i) => makeId(i))];
+
+			// Missing keys: IDs that definitely don't exist
+			const missingKeys = Array.from({ length: 10 }, (_, i) => `missing-id-${i}`);
+
+			// Track a counter for unique insertions across repeated calls
+			let insertCounter = nodeCount;
+
+			return {
+				index,
+				existingKeys,
+				missingKeys,
+				insertNode: () => {
+					const newId = makeId(insertCounter++);
+					view.root.children.insertAtEnd(new IndexedChild({ id: newId }));
+				},
+				removeNode: () => {
+					if (view.root.children.length > 0) {
+						view.root.children.removeAt(view.root.children.length - 1);
+					}
+				},
+			};
+		},
+	};
+}
+
+describe("IdentifierIndex benchmarks", () => {
+	configureBenchmarkHooks();
+
+	generateIndexBenchmarkSuite({
+		indexName: "IdentifierIndex",
+		sizes: defaultIndexBenchmarkSizes,
+		createScenario: createIdentifierIndexScenario,
+	});
+});

--- a/packages/dds/tree/src/test/simple-tree/identifierIndex.bench.ts
+++ b/packages/dds/tree/src/test/simple-tree/identifierIndex.bench.ts
@@ -6,6 +6,7 @@
 import {
 	SchemaFactory,
 	TreeViewConfiguration,
+	type ValidateRecursiveSchema,
 	createIdentifierIndex,
 	type TreeNode,
 } from "../../simple-tree/index.js";
@@ -20,62 +21,76 @@ import {
 
 const schemaFactory = new SchemaFactory("identifierIndex.bench");
 
-class IndexedChild extends schemaFactory.object("IndexedChild", {
+// -- Wide (flat) tree: one root with N leaf children in an array --
+
+class WideChild extends schemaFactory.object("WideChild", {
 	id: schemaFactory.identifier,
 }) {}
 
-class IndexedParent extends schemaFactory.object("IndexedParent", {
+class WideRoot extends schemaFactory.object("WideRoot", {
 	id: schemaFactory.identifier,
-	children: schemaFactory.array(IndexedChild),
+	children: schemaFactory.array(WideChild),
 }) {}
 
-/**
- * Creates identifiers for a given count, producing deterministic string IDs.
- */
-function makeId(index: number): string {
-	return `node-id-${index}`;
+// -- Deep (tall) tree: a linear chain of N nodes --
+
+class DeepNode extends schemaFactory.objectRecursive("DeepNode", {
+	id: schemaFactory.identifier,
+	child: schemaFactory.optionalRecursive([() => DeepNode]),
+}) {}
+{
+	type _check = ValidateRecursiveSchema<typeof DeepNode>;
 }
 
-/**
- * Creates an identifier index benchmark scenario for a given number of child nodes.
- */
-function createIdentifierIndexScenario(
-	nodeCount: number,
-): IndexBenchmarkScenario<string, TreeNode> {
-	return {
-		title: `IdentifierIndex with ${nodeCount} nodes`,
-		setup(): IndexBenchmarkSetup<string, TreeNode> {
-			const children = Array.from({ length: nodeCount }, (_, i) => {
-				return new IndexedChild({ id: makeId(i) });
-			});
+// -- Irregular tree: interior nodes have varying numbers of children at different depths --
 
-			const config = new TreeViewConfiguration({ schema: IndexedParent });
-			const view = getView(config);
-			view.initialize(
-				new IndexedParent({
-					id: "root-id",
-					children,
-				}),
+class IrregularChildren extends schemaFactory.arrayRecursive("IrregularChildren", [
+	() => IrregularNode,
+]) {}
+{
+	type _check = ValidateRecursiveSchema<typeof IrregularChildren>;
+}
+
+class IrregularNode extends schemaFactory.objectRecursive("IrregularNode", {
+	id: schemaFactory.identifier,
+	children: IrregularChildren,
+}) {}
+{
+	type _check = ValidateRecursiveSchema<typeof IrregularNode>;
+}
+
+function makeId(prefix: string, index: number): string {
+	return `${prefix}-${index}`;
+}
+
+// ── Wide (flat) scenario ──
+
+function createWideScenario(nodeCount: number): IndexBenchmarkScenario<string, TreeNode> {
+	return {
+		title: `wide tree with ${nodeCount} nodes`,
+		setup(): IndexBenchmarkSetup<string, TreeNode> {
+			const children = Array.from(
+				{ length: nodeCount },
+				(_, i) => new WideChild({ id: makeId("wide", i) }),
 			);
 
+			const config = new TreeViewConfiguration({ schema: WideRoot });
+			const view = getView(config);
+			view.initialize(new WideRoot({ id: "wide-root", children }));
+
 			const index = createIdentifierIndex(view);
+			const existingKeys = ["wide-root", ...children.map((_, i) => makeId("wide", i))];
+			const missingKeys = Array.from({ length: 10 }, (_, i) => `miss-${i}`);
 
-			// Existing keys: the root + all children
-			const existingKeys = ["root-id", ...children.map((_, i) => makeId(i))];
-
-			// Missing keys: IDs that definitely don't exist
-			const missingKeys = Array.from({ length: 10 }, (_, i) => `missing-id-${i}`);
-
-			// Track a counter for unique insertions across repeated calls
 			let insertCounter = nodeCount;
-
 			return {
 				index,
 				existingKeys,
 				missingKeys,
 				insertNode: () => {
-					const newId = makeId(insertCounter++);
-					view.root.children.insertAtEnd(new IndexedChild({ id: newId }));
+					view.root.children.insertAtEnd(
+						new WideChild({ id: makeId("wide", insertCounter++) }),
+					);
 				},
 				removeNode: () => {
 					if (view.root.children.length > 0) {
@@ -87,12 +102,171 @@ function createIdentifierIndexScenario(
 	};
 }
 
+// ── Deep (tall) scenario ──
+
+function buildDeepChain(depth: number, ids: string[]): DeepNode {
+	let current = new DeepNode({ id: ids[depth - 1]! });
+	for (let i = depth - 2; i >= 0; i--) {
+		current = new DeepNode({ id: ids[i]!, child: current });
+	}
+	return current;
+}
+
+function createDeepScenario(nodeCount: number): IndexBenchmarkScenario<string, TreeNode> {
+	return {
+		title: `deep tree with ${nodeCount} nodes`,
+		setup(): IndexBenchmarkSetup<string, TreeNode> {
+			const ids = Array.from({ length: nodeCount }, (_, i) => makeId("deep", i));
+			const root = buildDeepChain(nodeCount, ids);
+
+			const config = new TreeViewConfiguration({ schema: DeepNode });
+			const view = getView(config);
+			view.initialize(root);
+
+			const index = createIdentifierIndex(view);
+			const missingKeys = Array.from({ length: 10 }, (_, i) => `miss-${i}`);
+
+			let insertCounter = nodeCount;
+			// Walk to the deepest node for insert/remove operations
+			const findDeepest = (): DeepNode => {
+				let node = view.root;
+				while (node.child !== undefined) {
+					node = node.child;
+				}
+				return node;
+			};
+
+			return {
+				index,
+				existingKeys: ids,
+				missingKeys,
+				insertNode: () => {
+					const deepest = findDeepest();
+					deepest.child = new DeepNode({ id: makeId("deep", insertCounter++) });
+				},
+				removeNode: () => {
+					const deepest = findDeepest();
+					// Remove the deepest node by clearing its parent's child
+					// Walk to parent-of-deepest instead
+					let node = view.root;
+					if (node.child === undefined) {
+						return;
+					}
+					while (node.child?.child !== undefined) {
+						node = node.child;
+					}
+					node.child = undefined;
+				},
+			};
+		},
+	};
+}
+
+// ── Irregular (bushy) scenario ──
+// Builds a tree where each level i has a branching factor of (i % 3) + 2,
+// producing an uneven shape with varying widths at different depths.
+
+function buildIrregularTree(targetCount: number): {
+	root: IrregularNode;
+	ids: string[];
+} {
+	let idCounter = 0;
+	const ids: string[] = [];
+
+	function buildLevel(remaining: number, depth: number): IrregularNode {
+		const id = makeId("irreg", idCounter++);
+		ids.push(id);
+		const nodesLeft = remaining - 1;
+
+		if (nodesLeft <= 0 || depth > 50) {
+			return new IrregularNode({ id, children: new IrregularChildren([]) });
+		}
+
+		const branchingFactor = (depth % 3) + 2; // 2, 3, or 4 children per level
+		const childCount = Math.min(branchingFactor, nodesLeft);
+		const perChild = Math.floor(nodesLeft / childCount);
+		const extraNodes = nodesLeft % childCount;
+
+		const childNodes: IrregularNode[] = [];
+		let allocated = 0;
+		for (let i = 0; i < childCount && allocated < nodesLeft; i++) {
+			const childBudget = perChild + (i < extraNodes ? 1 : 0);
+			if (childBudget <= 0) break;
+			childNodes.push(buildLevel(childBudget, depth + 1));
+			allocated += childBudget;
+		}
+
+		return new IrregularNode({ id, children: new IrregularChildren(childNodes) });
+	}
+
+	const root = buildLevel(targetCount, 0);
+	return { root, ids };
+}
+
+function createIrregularScenario(
+	nodeCount: number,
+): IndexBenchmarkScenario<string, TreeNode> {
+	return {
+		title: `irregular tree with ${nodeCount} nodes`,
+		setup(): IndexBenchmarkSetup<string, TreeNode> {
+			const { root, ids } = buildIrregularTree(nodeCount);
+
+			const config = new TreeViewConfiguration({ schema: IrregularNode });
+			const view = getView(config);
+			view.initialize(root);
+
+			const index = createIdentifierIndex(view);
+			const missingKeys = Array.from({ length: 10 }, (_, i) => `miss-${i}`);
+
+			let insertCounter = nodeCount;
+			return {
+				index,
+				existingKeys: ids,
+				missingKeys,
+				insertNode: () => {
+					view.root.children.insertAtEnd(
+						new IrregularNode({
+							id: makeId("irreg", insertCounter++),
+							children: new IrregularChildren([]),
+						}),
+					);
+				},
+				removeNode: () => {
+					if (view.root.children.length > 0) {
+						view.root.children.removeAt(view.root.children.length - 1);
+					}
+				},
+			};
+		},
+	};
+}
+
+// ── Benchmark suites ──
+
 describe("IdentifierIndex benchmarks", () => {
 	configureBenchmarkHooks();
 
-	generateIndexBenchmarkSuite({
-		indexName: "IdentifierIndex",
-		sizes: defaultIndexBenchmarkSizes,
-		createScenario: createIdentifierIndexScenario,
+	describe("wide (flat) tree", () => {
+		generateIndexBenchmarkSuite({
+			indexName: "IdentifierIndex (wide)",
+			sizes: defaultIndexBenchmarkSizes,
+			createScenario: createWideScenario,
+		});
+	});
+
+	describe("deep (tall) tree", () => {
+		generateIndexBenchmarkSuite({
+			indexName: "IdentifierIndex (deep)",
+			sizes: defaultIndexBenchmarkSizes,
+			createScenario: createDeepScenario,
+		});
+	});
+
+	describe("irregular (bushy) tree", () => {
+		generateIndexBenchmarkSuite({
+			indexName: "IdentifierIndex (irregular)",
+			sizes: defaultIndexBenchmarkSizes,
+			createScenario: createIrregularScenario,
+		});
 	});
 });

--- a/packages/dds/tree/src/test/simple-tree/identifierIndex.bench.ts
+++ b/packages/dds/tree/src/test/simple-tree/identifierIndex.bench.ts
@@ -7,6 +7,7 @@ import {
 	SchemaFactory,
 	TreeViewConfiguration,
 	createIdentifierIndex,
+	type TreeNode,
 } from "../../simple-tree/index.js";
 import { getView, configureBenchmarkHooks } from "../utils.js";
 
@@ -40,13 +41,10 @@ function makeId(index: number): string {
  */
 function createIdentifierIndexScenario(
 	nodeCount: number,
-): IndexBenchmarkScenario<string, import("../../simple-tree/index.js").TreeNode> {
+): IndexBenchmarkScenario<string, TreeNode> {
 	return {
 		title: `IdentifierIndex with ${nodeCount} nodes`,
-		setup(): IndexBenchmarkSetup<
-			string,
-			import("../../simple-tree/index.js").TreeNode
-		> {
+		setup(): IndexBenchmarkSetup<string, TreeNode> {
 			const children = Array.from({ length: nodeCount }, (_, i) => {
 				return new IndexedChild({ id: makeId(i) });
 			});

--- a/packages/dds/tree/src/test/simple-tree/indexBenchmarkUtilities.ts
+++ b/packages/dds/tree/src/test/simple-tree/indexBenchmarkUtilities.ts
@@ -14,7 +14,6 @@ import {
 } from "@fluid-tools/benchmark";
 
 import type { TreeIndex } from "../../feature-libraries/index.js";
-import type { ImplicitFieldSchema, TreeNode, TreeView } from "../../simple-tree/index.js";
 
 /**
  * Configuration for a single index benchmark scenario.

--- a/packages/dds/tree/src/test/simple-tree/indexBenchmarkUtilities.ts
+++ b/packages/dds/tree/src/test/simple-tree/indexBenchmarkUtilities.ts
@@ -99,6 +99,19 @@ export const defaultIndexBenchmarkSizes: [number, BenchmarkType][] = [
 ];
 
 /**
+ * Smaller node counts for deep (tall) trees that hit call-stack limits at high depths.
+ */
+export const deepTreeBenchmarkSizes: [number, BenchmarkType][] = [
+	[10, BenchmarkType.Measurement],
+	...(currentBenchmarkMode === BenchmarkMode.Performance
+		? [
+				[100, BenchmarkType.Perspective] as [number, BenchmarkType],
+				[500, BenchmarkType.Measurement] as [number, BenchmarkType],
+			]
+		: []),
+];
+
+/**
  * Generates a complete benchmark suite for a tree index.
  *
  * This produces benchmarks for:

--- a/packages/dds/tree/src/test/simple-tree/indexBenchmarkUtilities.ts
+++ b/packages/dds/tree/src/test/simple-tree/indexBenchmarkUtilities.ts
@@ -253,20 +253,18 @@ export function generateIndexBenchmarkSuite<TKey, TValue>(
 				title: `${indexName}: insert node with index maintenance (${nodeCount} nodes)`,
 				...benchmarkDuration({
 					benchmarkFnCustom: async (state) => {
-						const { index, insertNode } = scenario.setup();
-						if (insertNode === undefined) {
-							return;
-						}
-						const sizeBefore = index.size;
-
-						state.timeAllBatches(() => {
-							insertNode();
-						});
-						assert(
-							index.size >= sizeBefore,
-							"Index size should not decrease after insertion",
-						);
-						index.dispose();
+						let running: boolean;
+						do {
+							// Fresh tree per batch so inserts don't accumulate
+							const { index, insertNode } = scenario.setup();
+							if (insertNode === undefined) {
+								return;
+							}
+							running = state.timeBatch(() => {
+								insertNode();
+							});
+							index.dispose();
+						} while (running);
 					},
 				}),
 			});
@@ -281,20 +279,18 @@ export function generateIndexBenchmarkSuite<TKey, TValue>(
 				title: `${indexName}: remove node with index maintenance (${nodeCount} nodes)`,
 				...benchmarkDuration({
 					benchmarkFnCustom: async (state) => {
-						const { index, removeNode } = scenario.setup();
-						if (removeNode === undefined) {
-							return;
-						}
-						const sizeBefore = index.size;
-
-						state.timeAllBatches(() => {
-							removeNode();
-						});
-						assert(
-							index.size <= sizeBefore,
-							"Index size should not increase after removal",
-						);
-						index.dispose();
+						let running: boolean;
+						do {
+							// Fresh tree per batch so removes don't exhaust nodes
+							const { index, removeNode } = scenario.setup();
+							if (removeNode === undefined) {
+								return;
+							}
+							running = state.timeBatch(() => {
+								removeNode();
+							});
+							index.dispose();
+						} while (running);
 					},
 				}),
 			});

--- a/packages/dds/tree/src/test/simple-tree/indexBenchmarkUtilities.ts
+++ b/packages/dds/tree/src/test/simple-tree/indexBenchmarkUtilities.ts
@@ -52,15 +52,18 @@ export interface IndexBenchmarkSetup<TKey, TValue> {
 	readonly missingKeys: readonly TKey[];
 
 	/**
-	 * Optional function that mutates the tree (for measuring index update costs).
-	 * Should add a single node to the tree.
+	 * Inserts a node and returns an undo function that removes it.
+	 * Each call must be self-contained so that calling insert then its undo
+	 * leaves the tree in the original state.
 	 */
-	readonly insertNode?: () => void;
+	readonly insertNode?: () => () => void;
 
 	/**
-	 * Optional function that removes a node from the tree (for measuring index update costs on removal).
+	 * Removes a node and returns an undo function that re-inserts it.
+	 * Each call must be self-contained so that calling remove then its undo
+	 * leaves the tree in the original state.
 	 */
-	readonly removeNode?: () => void;
+	readonly removeNode?: () => () => void;
 }
 
 /**
@@ -253,18 +256,24 @@ export function generateIndexBenchmarkSuite<TKey, TValue>(
 				title: `${indexName}: insert node with index maintenance (${nodeCount} nodes)`,
 				...benchmarkDuration({
 					benchmarkFnCustom: async (state) => {
-						let running: boolean;
+						const { index, insertNode } = scenario.setup();
+						if (insertNode === undefined) {
+							return;
+						}
+						// Time only the insert; undo between iterations keeps tree at consistent size.
+						let duration: number;
 						do {
-							// Fresh tree per batch so inserts don't accumulate
-							const { index, insertNode } = scenario.setup();
-							if (insertNode === undefined) {
-								return;
+							let elapsed = 0;
+							for (let i = 0; i < state.iterationsPerBatch; i++) {
+								const before = state.timer.now();
+								const undo = insertNode();
+								const after = state.timer.now();
+								elapsed += state.timer.toSeconds(before, after);
+								undo();
 							}
-							running = state.timeBatch(() => {
-								insertNode();
-							});
-							index.dispose();
-						} while (running);
+							duration = elapsed;
+						} while (state.recordBatch(duration));
+						index.dispose();
 					},
 				}),
 			});
@@ -279,18 +288,24 @@ export function generateIndexBenchmarkSuite<TKey, TValue>(
 				title: `${indexName}: remove node with index maintenance (${nodeCount} nodes)`,
 				...benchmarkDuration({
 					benchmarkFnCustom: async (state) => {
-						let running: boolean;
+						const { index, removeNode } = scenario.setup();
+						if (removeNode === undefined) {
+							return;
+						}
+						// Time only the remove; undo between iterations keeps tree at consistent size.
+						let duration: number;
 						do {
-							// Fresh tree per batch so removes don't exhaust nodes
-							const { index, removeNode } = scenario.setup();
-							if (removeNode === undefined) {
-								return;
+							let elapsed = 0;
+							for (let i = 0; i < state.iterationsPerBatch; i++) {
+								const before = state.timer.now();
+								const undo = removeNode();
+								const after = state.timer.now();
+								elapsed += state.timer.toSeconds(before, after);
+								undo();
 							}
-							running = state.timeBatch(() => {
-								removeNode();
-							});
-							index.dispose();
-						} while (running);
+							duration = elapsed;
+						} while (state.recordBatch(duration));
+						index.dispose();
 					},
 				}),
 			});

--- a/packages/dds/tree/src/test/simple-tree/indexBenchmarkUtilities.ts
+++ b/packages/dds/tree/src/test/simple-tree/indexBenchmarkUtilities.ts
@@ -1,0 +1,289 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "node:assert";
+
+import {
+	BenchmarkMode,
+	BenchmarkType,
+	benchmarkDuration,
+	benchmarkIt,
+	currentBenchmarkMode,
+} from "@fluid-tools/benchmark";
+
+import type { TreeIndex } from "../../feature-libraries/index.js";
+import type { ImplicitFieldSchema, TreeNode, TreeView } from "../../simple-tree/index.js";
+
+/**
+ * Configuration for a single index benchmark scenario.
+ */
+export interface IndexBenchmarkScenario<TKey, TValue> {
+	/**
+	 * Human-readable title for the scenario.
+	 */
+	readonly title: string;
+
+	/**
+	 * Creates a fresh TreeView and index for this scenario.
+	 * Called once per benchmark iteration batch to ensure fresh state.
+	 */
+	setup(): IndexBenchmarkSetup<TKey, TValue>;
+}
+
+/**
+ * The result of setting up an index benchmark, providing access to the index and test data.
+ */
+export interface IndexBenchmarkSetup<TKey, TValue> {
+	/**
+	 * The index under test.
+	 */
+	readonly index: TreeIndex<TKey, TValue>;
+
+	/**
+	 * Keys that are known to exist in the index for lookup benchmarks.
+	 */
+	readonly existingKeys: readonly TKey[];
+
+	/**
+	 * Keys that are known NOT to exist in the index for miss benchmarks.
+	 */
+	readonly missingKeys: readonly TKey[];
+
+	/**
+	 * Optional function that mutates the tree (for measuring index update costs).
+	 * Should add a single node to the tree.
+	 */
+	readonly insertNode?: () => void;
+
+	/**
+	 * Optional function that removes a node from the tree (for measuring index update costs on removal).
+	 */
+	readonly removeNode?: () => void;
+}
+
+/**
+ * Configuration for the index benchmark suite.
+ */
+export interface IndexBenchmarkSuiteConfig<TKey, TValue> {
+	/**
+	 * The name of the index being benchmarked (used in test titles).
+	 */
+	readonly indexName: string;
+
+	/**
+	 * Scenarios at different sizes. Each entry is [nodeCount, BenchmarkType].
+	 */
+	readonly sizes: readonly (readonly [number, BenchmarkType])[];
+
+	/**
+	 * Factory that creates a benchmark scenario for a given node count.
+	 */
+	createScenario(nodeCount: number): IndexBenchmarkScenario<TKey, TValue>;
+}
+
+/**
+ * Default node counts for index benchmarks.
+ * Uses small count for regular test runs and larger counts for full performance mode.
+ */
+export const defaultIndexBenchmarkSizes: [number, BenchmarkType][] = [
+	[10, BenchmarkType.Measurement],
+	...(currentBenchmarkMode === BenchmarkMode.Performance
+		? [
+				[100, BenchmarkType.Perspective] as [number, BenchmarkType],
+				[1000, BenchmarkType.Measurement] as [number, BenchmarkType],
+			]
+		: []),
+];
+
+/**
+ * Generates a complete benchmark suite for a tree index.
+ *
+ * This produces benchmarks for:
+ * - Index creation time
+ * - Key lookup (hit)
+ * - Key lookup (miss)
+ * - Iteration over entries
+ * - Size property access
+ * - Node insertion (index update)
+ * - Node removal (index update)
+ *
+ * @param config - Configuration for the benchmark suite.
+ */
+export function generateIndexBenchmarkSuite<TKey, TValue>(
+	config: IndexBenchmarkSuiteConfig<TKey, TValue>,
+): void {
+	const { indexName, sizes, createScenario } = config;
+
+	describe(`Index creation`, () => {
+		for (const [nodeCount, benchmarkType] of sizes) {
+			const scenario = createScenario(nodeCount);
+			benchmarkIt({
+				type: benchmarkType,
+				title: `${indexName}: create index with ${nodeCount} nodes`,
+				...benchmarkDuration({
+					benchmarkFnCustom: async (state) => {
+						state.timeAllBatches(() => {
+							const { index } = scenario.setup();
+							index.dispose();
+						});
+					},
+				}),
+			});
+		}
+	});
+
+	describe(`Key lookup (hit)`, () => {
+		for (const [nodeCount, benchmarkType] of sizes) {
+			const scenario = createScenario(nodeCount);
+			benchmarkIt({
+				type: benchmarkType,
+				title: `${indexName}: lookup existing key (${nodeCount} nodes)`,
+				...benchmarkDuration({
+					benchmarkFnCustom: async (state) => {
+						const { index, existingKeys } = scenario.setup();
+						assert(existingKeys.length > 0, "Must have at least one existing key");
+
+						let result: TValue | undefined;
+						state.timeAllBatches(() => {
+							for (const key of existingKeys) {
+								result = index.get(key);
+							}
+						});
+						assert(result !== undefined, "Lookup should return a value for existing key");
+						index.dispose();
+					},
+				}),
+			});
+		}
+	});
+
+	describe(`Key lookup (miss)`, () => {
+		for (const [nodeCount, benchmarkType] of sizes) {
+			const scenario = createScenario(nodeCount);
+			benchmarkIt({
+				type: benchmarkType,
+				title: `${indexName}: lookup missing key (${nodeCount} nodes)`,
+				...benchmarkDuration({
+					benchmarkFnCustom: async (state) => {
+						const { index, missingKeys } = scenario.setup();
+						assert(missingKeys.length > 0, "Must have at least one missing key");
+
+						let result: TValue | undefined;
+						state.timeAllBatches(() => {
+							for (const key of missingKeys) {
+								result = index.get(key);
+							}
+						});
+						assert(result === undefined, "Lookup should return undefined for missing key");
+						index.dispose();
+					},
+				}),
+			});
+		}
+	});
+
+	describe(`Iteration`, () => {
+		for (const [nodeCount, benchmarkType] of sizes) {
+			const scenario = createScenario(nodeCount);
+			benchmarkIt({
+				type: benchmarkType,
+				title: `${indexName}: iterate all entries (${nodeCount} nodes)`,
+				...benchmarkDuration({
+					benchmarkFnCustom: async (state) => {
+						const { index } = scenario.setup();
+
+						let count = 0;
+						state.timeAllBatches(() => {
+							count = 0;
+							for (const _ of index) {
+								count++;
+							}
+						});
+						assert(count > 0, "Iteration should yield entries");
+						index.dispose();
+					},
+				}),
+			});
+		}
+	});
+
+	describe(`Size`, () => {
+		for (const [nodeCount, benchmarkType] of sizes) {
+			const scenario = createScenario(nodeCount);
+			benchmarkIt({
+				type: benchmarkType,
+				title: `${indexName}: read size (${nodeCount} nodes)`,
+				...benchmarkDuration({
+					benchmarkFnCustom: async (state) => {
+						const { index } = scenario.setup();
+
+						let size = 0;
+						state.timeAllBatches(() => {
+							size = index.size;
+						});
+						assert(size > 0, "Index should have entries");
+						index.dispose();
+					},
+				}),
+			});
+		}
+	});
+
+	describe(`Node insertion (index update)`, () => {
+		for (const [nodeCount, benchmarkType] of sizes) {
+			const scenario = createScenario(nodeCount);
+			benchmarkIt({
+				type: benchmarkType,
+				title: `${indexName}: insert node with index maintenance (${nodeCount} nodes)`,
+				...benchmarkDuration({
+					benchmarkFnCustom: async (state) => {
+						const { index, insertNode } = scenario.setup();
+						if (insertNode === undefined) {
+							return;
+						}
+						const sizeBefore = index.size;
+
+						state.timeAllBatches(() => {
+							insertNode();
+						});
+						assert(
+							index.size >= sizeBefore,
+							"Index size should not decrease after insertion",
+						);
+						index.dispose();
+					},
+				}),
+			});
+		}
+	});
+
+	describe(`Node removal (index update)`, () => {
+		for (const [nodeCount, benchmarkType] of sizes) {
+			const scenario = createScenario(nodeCount);
+			benchmarkIt({
+				type: benchmarkType,
+				title: `${indexName}: remove node with index maintenance (${nodeCount} nodes)`,
+				...benchmarkDuration({
+					benchmarkFnCustom: async (state) => {
+						const { index, removeNode } = scenario.setup();
+						if (removeNode === undefined) {
+							return;
+						}
+						const sizeBefore = index.size;
+
+						state.timeAllBatches(() => {
+							removeNode();
+						});
+						assert(
+							index.size <= sizeBefore,
+							"Index size should not increase after removal",
+						);
+						index.dispose();
+					},
+				}),
+			});
+		}
+	});
+}

--- a/packages/dds/tree/src/test/simple-tree/indexBenchmarkUtilities.ts
+++ b/packages/dds/tree/src/test/simple-tree/indexBenchmarkUtilities.ts
@@ -92,7 +92,8 @@ export const defaultIndexBenchmarkSizes: [number, BenchmarkType][] = [
 	...(currentBenchmarkMode === BenchmarkMode.Performance
 		? [
 				[100, BenchmarkType.Perspective] as [number, BenchmarkType],
-				[1000, BenchmarkType.Measurement] as [number, BenchmarkType],
+				[1000, BenchmarkType.Perspective] as [number, BenchmarkType],
+				[10_000, BenchmarkType.Measurement] as [number, BenchmarkType],
 			]
 		: []),
 ];

--- a/packages/dds/tree/src/test/simple-tree/indexBenchmarkUtilities.ts
+++ b/packages/dds/tree/src/test/simple-tree/indexBenchmarkUtilities.ts
@@ -116,7 +116,7 @@ export function generateIndexBenchmarkSuite<TKey, TValue>(
 ): void {
 	const { indexName, sizes, createScenario } = config;
 
-	describe(`Index creation`, () => {
+	describe(`index creation`, () => {
 		for (const [nodeCount, benchmarkType] of sizes) {
 			const scenario = createScenario(nodeCount);
 			benchmarkIt({
@@ -134,7 +134,7 @@ export function generateIndexBenchmarkSuite<TKey, TValue>(
 		}
 	});
 
-	describe(`Key lookup (hit)`, () => {
+	describe(`key lookup (hit)`, () => {
 		for (const [nodeCount, benchmarkType] of sizes) {
 			const scenario = createScenario(nodeCount);
 			benchmarkIt({
@@ -159,7 +159,7 @@ export function generateIndexBenchmarkSuite<TKey, TValue>(
 		}
 	});
 
-	describe(`Key lookup (miss)`, () => {
+	describe(`key lookup (miss)`, () => {
 		for (const [nodeCount, benchmarkType] of sizes) {
 			const scenario = createScenario(nodeCount);
 			benchmarkIt({
@@ -184,7 +184,7 @@ export function generateIndexBenchmarkSuite<TKey, TValue>(
 		}
 	});
 
-	describe(`Iteration`, () => {
+	describe(`iteration`, () => {
 		for (const [nodeCount, benchmarkType] of sizes) {
 			const scenario = createScenario(nodeCount);
 			benchmarkIt({
@@ -209,7 +209,7 @@ export function generateIndexBenchmarkSuite<TKey, TValue>(
 		}
 	});
 
-	describe(`Size`, () => {
+	describe(`size`, () => {
 		for (const [nodeCount, benchmarkType] of sizes) {
 			const scenario = createScenario(nodeCount);
 			benchmarkIt({
@@ -231,7 +231,7 @@ export function generateIndexBenchmarkSuite<TKey, TValue>(
 		}
 	});
 
-	describe(`Node insertion (index update)`, () => {
+	describe(`node insertion (index update)`, () => {
 		for (const [nodeCount, benchmarkType] of sizes) {
 			const scenario = createScenario(nodeCount);
 			benchmarkIt({
@@ -259,7 +259,7 @@ export function generateIndexBenchmarkSuite<TKey, TValue>(
 		}
 	});
 
-	describe(`Node removal (index update)`, () => {
+	describe(`node removal (index update)`, () => {
 		for (const [nodeCount, benchmarkType] of sizes) {
 			const scenario = createScenario(nodeCount);
 			benchmarkIt({


### PR DESCRIPTION
## Description

Adds a reusable benchmark harness for tree indexes (`indexBenchmarkUtilities.ts`) and uses it to write comprehensive performance benchmarks for `IdentifierIndex` (`identifierIndex.bench.ts`).

### Reusable harness

`generateIndexBenchmarkSuite()` accepts any `TreeIndex` implementation via `IndexBenchmarkSuiteConfig` and generates benchmarks for:
- Index creation
- Key lookup (hit and miss)
- Entry iteration
- Size access
- Node insertion / removal with index maintenance

Mutation benchmarks use manual timer calls with an undo pattern: each iteration times only the operation itself, then calls an untimed undo function to restore the tree to its original state. This ensures every iteration operates on a consistently-sized tree.

### IdentifierIndex benchmarks

Three tree shapes are tested at multiple sizes (10 → 10,000 nodes in perf mode):
- **Wide (flat)** — one root with all children in a single array
- **Deep (tall)** — a linear chain of parent→child nodes (capped at 500 due to call-stack limits)
- **Irregular (bushy)** — varying branching factor (2–4) per depth level

### Benchmark results

Results from a local run (`FLUID_TEST_PERF_MODE=1`):

<details>
<summary><strong>Wide (flat) tree</strong> — 10 to 10,000 nodes</summary>

| Operation | 10 nodes | 100 nodes | 1,000 nodes | 10,000 nodes |
|---|---|---|---|---|
| Create index | 607 µs | 2.95 ms | 34.3 ms | 1.01 s |
| Lookup (hit) | 8.78 µs | 83.3 µs | 853 µs | 11.2 ms |
| Lookup (miss) | 122 ns | 78 ns | 75 ns | 80 ns |
| Iterate entries | 9.26 µs | 84.9 µs | 848 µs | 10.2 ms |
| Read size | 8.61 µs | 81.1 µs | 805 µs | 9.32 ms |
| Insert node | 136 µs | 368 µs | 2.85 ms | 29.5 ms |
| Remove node | 90.3 µs | 329 µs | 2.72 ms | 29.6 ms |

</details>

<details>
<summary><strong>Deep (tall) tree</strong> — 10 to 500 nodes</summary>

| Operation | 10 nodes | 100 nodes | 500 nodes |
|---|---|---|---|
| Create index | 548 µs | 6.95 ms | 117 ms |
| Lookup (hit) | 8.05 µs | 82.6 µs | 418 µs |
| Lookup (miss) | 108 ns | 91.6 ns | 92.9 ns |
| Iterate entries | 8.38 µs | 82.7 µs | 421 µs |
| Read size | 7.81 µs | 80.0 µs | 400 µs |
| Insert node | 218 µs | 5.54 ms | 125 ms |
| Remove node | 206 µs | 6.40 ms | 149 ms |

</details>

<details>
<summary><strong>Irregular (bushy) tree</strong> — 10 to 10,000 nodes</summary>

| Operation | 10 nodes | 100 nodes | 1,000 nodes | 10,000 nodes |
|---|---|---|---|---|
| Create index | 796 µs | 5.76 ms | 63.2 ms | 706 ms |
| Lookup (hit) | 7.98 µs | 83.7 µs | 865 µs | 14.4 ms |
| Lookup (miss) | 72.3 ns | 80.9 ns | 84.4 ns | 83.7 ns |
| Iterate entries | 8.43 µs | 86.1 µs | 865 µs | 11.9 ms |
| Read size | 7.91 µs | 81.1 µs | 817 µs | 10.9 ms |
| Insert node | 161 µs | 645 µs | 7.08 ms | 85.5 ms |
| Remove node | 91.6 µs | 325 µs | 3.29 ms | 43.5 ms |

</details>


**Key observations:**
- **Lookup (miss)** is O(1) ~80–120 ns regardless of tree size — a single map miss.
- **Lookup (hit), iterate, size** all scale linearly with node count (the benchmark looks up every key / iterates every entry).
- **Insert/remove** are ~10–30× more expensive than reads due to tree mutation + index re-evaluation.
- **Deep trees** show disproportionately expensive mutations at 500 nodes (~125–149 ms) vs wide trees at 1,000 nodes (~2.7–2.9 ms), reflecting the cost of deep recursive tree traversal during mutation.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

- These are test-only changes — no runtime or API surface modifications.
- The harness is designed to be reused for other index types (e.g., custom `createTreeIndex` indexes) by implementing `IndexBenchmarkScenario`.