### PR TITLE
refactor(tree): drop decode-only healing from ChangeEncodingContext

### DIFF
--- a/packages/dds/tree/src/core/change-family/changeFamily.ts
+++ b/packages/dds/tree/src/core/change-family/changeFamily.ts
@@ -36,28 +36,22 @@ export interface ChangeEncodingContext {
 	 * (possibly broken) attach-summary blob, never when applying ops.
 	 */
 	readonly isSummary: boolean;
-	/**
-	 * Heal-on-decode workaround configuration. See {@link IdentifierHealingConfig}.
-	 * Only takes effect when `isSummary` is also `true`.
-	 */
-	readonly healing?: IdentifierHealingConfig;
 }
 
 /**
  * Context provided to change codecs when decoding.
  * @remarks
- * The same as {@link ChangeEncodingContext} except that it omits `schema`: that field is only
- * consulted when *encoding* (for schema-aware compression), whereas decoding relies on the
- * self-describing encoded format and never reads it. Keeping decode-irrelevant fields off this
- * type documents the decode-side contract and lets the two contexts diverge further in the future.
- *
- * @privateRemarks
- * `healing` is only meaningful on the decode side, but it is retained on {@link ChangeEncodingContext}
- * (rather than moved here) because the EditManager and Message codecs still use a single
- * `ChangeEncodingContext` for both encode and decode; moving it would require splitting those codecs
- * first.
+ * The same as {@link ChangeEncodingContext} except that it omits `schema` (only consulted when
+ * *encoding*, for schema-aware compression) and adds `healing` (only consulted when *decoding*, to
+ * recover unresolvable identifiers from a summary blob).
  */
-export type ChangeDecodingContext = Omit<ChangeEncodingContext, "schema">;
+export type ChangeDecodingContext = Omit<ChangeEncodingContext, "schema"> & {
+	/**
+	 * Heal-on-decode workaround configuration. See {@link IdentifierHealingConfig}.
+	 * Only takes effect when `isSummary` is also `true`.
+	 */
+	readonly healing?: IdentifierHealingConfig;
+};
 
 export type ChangeFamilyCodec<TChange> = IJsonCodec<
 	TChange,

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecV1.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecV1.ts
@@ -16,6 +16,7 @@ import {
 } from "../../codec/index.js";
 import type {
 	ChangeEncodingContext,
+	ChangeDecodingContext,
 	ChangesetLocalId,
 	EncodedRevisionTag,
 	FieldKey,
@@ -75,7 +76,8 @@ type ModularChangeCodec = IJsonCodec<
 	ModularChangeset,
 	EncodedModularChangesetV1,
 	EncodedModularChangesetV1,
-	ChangeEncodingContext
+	ChangeEncodingContext,
+	ChangeDecodingContext
 >;
 
 type FieldCodec = IJsonCodec<
@@ -183,7 +185,7 @@ export function decodeFieldChangesFromJson(
 	encodedChange: EncodedFieldChangeMap,
 	parentId: NodeId | undefined,
 	decoded: ModularChangeset,
-	context: ChangeEncodingContext,
+	context: ChangeDecodingContext,
 	idAllocator: IdAllocator,
 	fieldKinds: FieldKindConfiguration,
 	fieldChangesetCodecs: FieldChangesetCodecs,
@@ -253,7 +255,7 @@ export function decodeNodeChangesetFromJson(
 	encodedChange: EncodedNodeChangeset,
 	id: NodeId,
 	decoded: ModularChangeset,
-	context: ChangeEncodingContext,
+	context: ChangeDecodingContext,
 	idAllocator: IdAllocator,
 	fieldKinds: FieldKindConfiguration,
 	fieldChangesetCodecs: FieldChangesetCodecs,
@@ -338,7 +340,7 @@ export function encodeDetachedNodes(
 
 export function decodeDetachedNodes(
 	encoded: EncodedBuilds | undefined,
-	context: ChangeEncodingContext,
+	context: ChangeDecodingContext,
 	revisionTagCodec: JsonCodecPart<
 		RevisionTag,
 		typeof RevisionTagSchema,
@@ -431,7 +433,7 @@ export function encodeRevisionInfos(
 
 export function decodeRevisionInfos(
 	revisions: readonly EncodedRevisionInfo[] | undefined,
-	context: ChangeEncodingContext,
+	context: ChangeDecodingContext,
 	revisionTagCodec: JsonCodecPart<
 		RevisionTag,
 		typeof RevisionTagSchema,
@@ -510,7 +512,7 @@ export function encodeChange(
 
 export function decodeChange(
 	encodedChange: EncodedModularChangesetV1,
-	context: ChangeEncodingContext,
+	context: ChangeDecodingContext,
 	fieldKinds: FieldKindConfiguration,
 	fieldChangesetCodecs: Map<
 		FieldKindIdentifier,

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecV2.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecV2.ts
@@ -11,6 +11,7 @@ import {
 } from "../../codec/index.js";
 import type {
 	ChangeEncodingContext,
+	ChangeDecodingContext,
 	RevisionTag,
 	RevisionTagSchema,
 } from "../../core/index.js";
@@ -30,7 +31,8 @@ type ModularChangeCodec = IJsonCodec<
 	ModularChangeset,
 	EncodedModularChangesetV2,
 	EncodedModularChangesetV2,
-	ChangeEncodingContext
+	ChangeEncodingContext,
+	ChangeDecodingContext
 >;
 
 export function makeModularChangeCodecV2(

--- a/packages/dds/tree/src/shared-tree-core/editManagerCodecsCommons.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerCodecsCommons.ts
@@ -9,6 +9,7 @@ import type { IIdCompressor, SessionId } from "@fluidframework/id-compressor";
 import type { IJsonCodec } from "../codec/index.js";
 import type {
 	ChangeEncodingContext,
+	ChangeDecodingContext,
 	EncodedRevisionTag,
 	RevisionTag,
 	SchemaAndPolicy,
@@ -98,7 +99,7 @@ function decodeCommit<TChangeset, T extends EncodedCommit<JsonCompatibleReadOnly
 		ChangeEncodingContext
 	>,
 	commit: T,
-	context: ChangeEncodingContext,
+	context: ChangeDecodingContext,
 ) {
 	const revision = revisionTagCodec.decode(commit.revision, {
 		originatorId: commit.sessionId,


### PR DESCRIPTION
## Description

Completes the separation of the change codec's encode and decode contexts by removing the last decode-only field, `healing`, from `ChangeEncodingContext`. Builds on #27758 and #27779. Pure type-level refactor — **no runtime behavior change**.

- `ChangeEncodingContext` no longer carries `healing`; `ChangeDecodingContext` is now `Omit<ChangeEncodingContext, "schema"> & { healing? }`, so each context holds exactly what its side uses: encode has `schema` (schema-aware compression), decode has `healing` (unresolvable-identifier recovery).
- Threads `ChangeDecodingContext` through the `modularChangeCodecV1`/`V2` codec types, the five modularChange decode helpers (`decodeChange`, `decodeFieldChangesFromJson`, `decodeNodeChangesetFromJson`, `decodeDetachedNodes`, `decodeRevisionInfos`), and EditManager `decodeCommit`.

The leaf codecs (`revisionTagCodec`/`changeAtomIdCodec`/`branchIdCodec`) stay single-context: their decode builds a `ChangeEncodingContext` without `healing` (still valid) or receives a `ChangeDecodingContext` (assignable), so no change was needed there.

No changeset: all affected types are `@internal`, with no customer-facing API or behavior change.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

- No-op at runtime; the value is that `healing` and `schema` now live only on the side that uses them. Full tree suite passes (14758 passing).