### PR TITLE
Enable skipLibCheck for API Extractor runs

### DIFF
--- a/common/build/build-common/api-extractor-base.json
+++ b/common/build/build-common/api-extractor-base.json
@@ -2,7 +2,11 @@
 	"$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
 
 	"compiler": {
-		"tsconfigFilePath": "<projectFolder>/tsconfig.json"
+		"tsconfigFilePath": "<projectFolder>/tsconfig.json",
+		// Skip type-checking of .d.ts files during API Extractor's analysis. The production build
+		// (tsc/build:esnext) already type-checks declarations with skipLibCheck off, so re-checking
+		// them here is redundant; disabling it roughly halves each API Extractor run without changing output.
+		"skipLibCheck": true
 	},
 
 	/**


### PR DESCRIPTION
## Description

API Extractor is used in this repo to generate API reports and to validate that API release tags are consistent — not to type-check code (the production build via `tsc`/`build:esnext` already does that, with `skipLibCheck` off). However, each API Extractor invocation was building a full TypeScript program over the package's `.d.ts` files and type-checking them, which is redundant.

This enables `skipLibCheck` in the shared API Extractor base config (`common/build/build-common/api-extractor-base.json`), so it applies to every API Extractor invocation repo-wide (report generation, `check:exports` release-tag linting, and docs). Because API Extractor's entire input program is `.d.ts` files, `skipLibCheck` skips the bulk of its type-checking work.

Impact (measured):
- Per package (`@fluidframework/tree`, full `check:exports` = 9 concurrent runs): ~7.0s -> ~3.4s (~2x).
- Full workspace clean build (`pnpm build:fast`): ~430s -> ~345s (~20% / ~85s).
- API report output is unchanged: after a full workspace build, there are zero diffs in any generated `api-report/*.md` (byte-identical).

The production build keeps `skipLibCheck` off, so cross-package `.d.ts` type errors are still caught there; this change only affects API Extractor, which does not emit code and whose reports do not depend on lib-checking.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
