### PR TITLE
tree: move @fluidframework/container-runtime to devDependencies

### DIFF
--- a/packages/dds/tree/package.json
+++ b/packages/dds/tree/package.json
@@ -162,7 +162,6 @@
 	},
 	"dependencies": {
 		"@fluid-internal/client-utils": "workspace:~",
-		"@fluidframework/container-runtime": "workspace:~",
 		"@fluidframework/core-interfaces": "workspace:~",
 		"@fluidframework/core-utils": "workspace:~",
 		"@fluidframework/datastore-definitions": "workspace:~",
@@ -192,6 +191,7 @@
 		"@fluidframework/build-tools": "catalog:buildTools",
 		"@fluidframework/container-definitions": "workspace:~",
 		"@fluidframework/container-loader": "workspace:~",
+		"@fluidframework/container-runtime": "workspace:~",
 		"@fluidframework/eslint-config-fluid": "catalog:eslint",
 		"@fluidframework/local-driver": "workspace:~",
 		"@fluidframework/test-runtime-utils": "workspace:~",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9594,9 +9594,6 @@ importers:
       '@fluid-internal/client-utils':
         specifier: workspace:~
         version: link:../../common/client-utils
-      '@fluidframework/container-runtime':
-        specifier: workspace:~
-        version: link:../../runtime/container-runtime
       '@fluidframework/core-interfaces':
         specifier: workspace:~
         version: link:../../common/core-interfaces
@@ -9679,6 +9676,9 @@ importers:
       '@fluidframework/container-loader':
         specifier: workspace:~
         version: link:../../loader/container-loader
+      '@fluidframework/container-runtime':
+        specifier: workspace:~
+        version: link:../../runtime/container-runtime
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
         version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)


### PR DESCRIPTION
## Description

`@fluidframework/tree` declared `@fluidframework/container-runtime` under `dependencies`, but it is only used by test code — a single type-only import of `ISummarizer` in `src/test/utils.ts`. No production source (`src/`, excluding `src/test/`) references it.

This moves it to `devDependencies` so tree's published runtime dependencies accurately reflect what consumers need at runtime (`container-runtime` is not one of them).

This is dependency hygiene only. It does not change build ordering — fluid-build follows `dependencies` and `devDependencies` identically (`combinedDependencies`), and `container-runtime` is still pulled into tree's test builds via other test dependencies (e.g. `local-driver`). Verified: policy check passes, and tree's test project recompiles cleanly with the type import resolving.