### PR TITLE
improvement(client-tree): pipe ChangeFamily context to transaction post-processors

### DIFF
--- a/packages/dds/tree/src/core/change-family/changeFamily.ts
+++ b/packages/dds/tree/src/core/change-family/changeFamily.ts
@@ -13,11 +13,11 @@ import type { ChangeRebaser, RevisionTag, TaggedChange } from "../rebase/index.j
 export interface ChangeFamily<
 	TEditor extends ChangeFamilyEditor,
 	TChange,
-	// Typically may be a concrete ChangeFamily implementation such as
+	// For simplicity may be a concrete ChangeFamily implementation such as
 	// ChangeFamilyFoo implements ChangeFamily<EditorFoo, ChangeFoo, ChangeFamilyFoo>
 	// to provide all details and helpers that processFn for ChangeFoo
 	// may require, but there is no requirement to follow that pattern.
-	TContext,
+	TChangeProcessingContext,
 > {
 	buildEditor(
 		mintRevisionTag: () => RevisionTag,
@@ -28,7 +28,7 @@ export interface ChangeFamily<
 	readonly codecs: ICodecFamily<TChange, ChangeEncodingContext, ChangeDecodingContext>;
 
 	buildProcessor(
-		processFn: (change: TChange, context: TContext) => TChange,
+		processFn: (change: TChange, context: TChangeProcessingContext) => TChange,
 	): (change: TChange) => TChange;
 }
 

--- a/packages/dds/tree/src/core/change-family/changeFamily.ts
+++ b/packages/dds/tree/src/core/change-family/changeFamily.ts
@@ -18,7 +18,7 @@ export type ProcessChangeFn<TChange, TChangeProcessingContext> =
 export interface ChangeFamily<
 	TEditor extends ChangeFamilyEditor,
 	TChange,
-	// For simplicity may be a concrete ChangeFamily implementation such as
+	// For simplicity, may be a concrete ChangeFamily implementation such as
 	// ChangeFamilyFoo implements ChangeFamily<EditorFoo, ChangeFoo, ChangeFamilyFoo>
 	// to provide all details and helpers that processFn for ChangeFoo
 	// may require, but there is no requirement to follow that pattern.

--- a/packages/dds/tree/src/core/change-family/changeFamily.ts
+++ b/packages/dds/tree/src/core/change-family/changeFamily.ts
@@ -10,6 +10,11 @@ import type { SchemaAndPolicy } from "../../core/index.js";
 import type { IdentifierHealingConfig, JsonCompatibleReadOnly } from "../../util/index.js";
 import type { ChangeRebaser, RevisionTag, TaggedChange } from "../rebase/index.js";
 
+export type ProcessChangeFn<TChange, TChangeProcessingContext> =
+	TChangeProcessingContext extends never
+		? (change: TChange) => TChange
+		: (change: TChange, context: TChangeProcessingContext) => TChange;
+
 export interface ChangeFamily<
 	TEditor extends ChangeFamilyEditor,
 	TChange,
@@ -17,7 +22,7 @@ export interface ChangeFamily<
 	// ChangeFamilyFoo implements ChangeFamily<EditorFoo, ChangeFoo, ChangeFamilyFoo>
 	// to provide all details and helpers that processFn for ChangeFoo
 	// may require, but there is no requirement to follow that pattern.
-	TChangeProcessingContext,
+	TChangeProcessingContext = never,
 > {
 	buildEditor(
 		mintRevisionTag: () => RevisionTag,
@@ -28,7 +33,7 @@ export interface ChangeFamily<
 	readonly codecs: ICodecFamily<TChange, ChangeEncodingContext, ChangeDecodingContext>;
 
 	buildProcessor(
-		processFn: (change: TChange, context: TChangeProcessingContext) => TChange,
+		processFn: ProcessChangeFn<TChange, TChangeProcessingContext>,
 	): (change: TChange) => TChange;
 }
 

--- a/packages/dds/tree/src/core/change-family/changeFamily.ts
+++ b/packages/dds/tree/src/core/change-family/changeFamily.ts
@@ -10,7 +10,15 @@ import type { SchemaAndPolicy } from "../../core/index.js";
 import type { IdentifierHealingConfig, JsonCompatibleReadOnly } from "../../util/index.js";
 import type { ChangeRebaser, RevisionTag, TaggedChange } from "../rebase/index.js";
 
-export interface ChangeFamily<TEditor extends ChangeFamilyEditor, TChange> {
+export interface ChangeFamily<
+	TEditor extends ChangeFamilyEditor,
+	TChange,
+	// Typically may be a concrete ChangeFamily implementation such as
+	// ChangeFamilyFoo implements ChangeFamily<EditorFoo, ChangeFoo, ChangeFamilyFoo>
+	// to provide all details and helpers that processFn for ChangeFoo
+	// may require, but there is no requirement to follow that pattern.
+	TContext,
+> {
 	buildEditor(
 		mintRevisionTag: () => RevisionTag,
 		changeReceiver: (change: TaggedChange<TChange>) => void,
@@ -18,6 +26,10 @@ export interface ChangeFamily<TEditor extends ChangeFamilyEditor, TChange> {
 
 	readonly rebaser: ChangeRebaser<TChange>;
 	readonly codecs: ICodecFamily<TChange, ChangeEncodingContext, ChangeDecodingContext>;
+
+	buildProcessor(
+		processFn: (change: TChange, context: TContext) => TChange,
+	): (change: TChange) => TChange;
 }
 
 export interface ChangeEncodingContext {

--- a/packages/dds/tree/src/core/change-family/index.ts
+++ b/packages/dds/tree/src/core/change-family/index.ts
@@ -9,5 +9,6 @@ export type {
 	ChangeEncodingContext,
 	ChangeDecodingContext,
 	ChangeFamilyCodec,
+	ProcessChangeFn,
 } from "./changeFamily.js";
 export { EditBuilder } from "./editBuilder.js";

--- a/packages/dds/tree/src/core/index.ts
+++ b/packages/dds/tree/src/core/index.ts
@@ -160,14 +160,15 @@ export {
 	SchemaFormatVersion,
 } from "./schema-stored/index.js";
 
-export {
-	type ChangeFamily,
-	type ChangeFamilyCodec,
-	type ChangeEncodingContext,
-	type ChangeDecodingContext,
-	type ChangeFamilyEditor,
-	EditBuilder,
+export type {
+	ChangeFamily,
+	ChangeFamilyCodec,
+	ChangeEncodingContext,
+	ChangeDecodingContext,
+	ChangeFamilyEditor,
+	ProcessChangeFn,
 } from "./change-family/index.js";
+export { EditBuilder } from "./change-family/index.js";
 
 export {
 	areEqualChangeAtomIds,

--- a/packages/dds/tree/src/feature-libraries/default-schema/defaultEditBuilder.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/defaultEditBuilder.ts
@@ -25,6 +25,7 @@ import {
 	type UpPath,
 	compareFieldUpPaths,
 	topDownPath,
+	type ProcessChangeFn,
 } from "../../core/index.js";
 import { brand } from "../../util/index.js";
 import {
@@ -88,10 +89,7 @@ export class DefaultChangeFamily
 	}
 
 	public buildProcessor(
-		processFn: (
-			change: DefaultChangeset,
-			context: DefaultChangeProcessingContext,
-		) => DefaultChangeset,
+		processFn: ProcessChangeFn<DefaultChangeset, DefaultChangeProcessingContext>,
 	): (change: DefaultChangeset) => DefaultChangeset {
 		return this.modularFamily.buildProcessor(processFn);
 	}

--- a/packages/dds/tree/src/feature-libraries/default-schema/defaultEditBuilder.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/defaultEditBuilder.ts
@@ -50,7 +50,7 @@ export type DefaultChangeset = ModularChangeset;
  * @sealed
  */
 export class DefaultChangeFamily
-	implements ChangeFamily<DefaultEditBuilder, DefaultChangeset>
+	implements ChangeFamily<DefaultEditBuilder, DefaultChangeset, DefaultChangeFamily>
 {
 	private readonly modularFamily: ModularChangeFamily;
 
@@ -82,6 +82,17 @@ export class DefaultChangeFamily
 			mintRevisionTag,
 			changeReceiver,
 			this.modularFamily.codecOptions,
+		);
+	}
+
+	public buildProcessor(
+		processFn: (
+			change: DefaultChangeset,
+			changeFamily: DefaultChangeFamily,
+		) => DefaultChangeset,
+	): (change: DefaultChangeset) => DefaultChangeset {
+		return this.modularFamily.buildProcessor((change, changeFamily) =>
+			processFn(change, this),
 		);
 	}
 }

--- a/packages/dds/tree/src/feature-libraries/default-schema/defaultEditBuilder.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/defaultEditBuilder.ts
@@ -44,13 +44,15 @@ import { fieldKinds } from "./defaultFieldKinds.js";
 
 export type DefaultChangeset = ModularChangeset;
 
+export type DefaultChangeProcessingContext = ModularChangeFamily;
+
 /**
  * Implementation of {@link ChangeFamily} based on the default set of supported field kinds.
  *
  * @sealed
  */
 export class DefaultChangeFamily
-	implements ChangeFamily<DefaultEditBuilder, DefaultChangeset, DefaultChangeFamily>
+	implements ChangeFamily<DefaultEditBuilder, DefaultChangeset, DefaultChangeProcessingContext>
 {
 	private readonly modularFamily: ModularChangeFamily;
 
@@ -88,12 +90,10 @@ export class DefaultChangeFamily
 	public buildProcessor(
 		processFn: (
 			change: DefaultChangeset,
-			changeFamily: DefaultChangeFamily,
+			context: DefaultChangeProcessingContext,
 		) => DefaultChangeset,
 	): (change: DefaultChangeset) => DefaultChangeset {
-		return this.modularFamily.buildProcessor((change, changeFamily) =>
-			processFn(change, this),
-		);
+		return this.modularFamily.buildProcessor(processFn);
 	}
 }
 

--- a/packages/dds/tree/src/feature-libraries/default-schema/index.ts
+++ b/packages/dds/tree/src/feature-libraries/default-schema/index.ts
@@ -12,6 +12,7 @@ export {
 } from "./defaultFieldKinds.js";
 
 export {
+	type DefaultChangeProcessingContext,
 	type DefaultChangeset,
 	DefaultChangeFamily,
 	DefaultEditBuilder,

--- a/packages/dds/tree/src/feature-libraries/index.ts
+++ b/packages/dds/tree/src/feature-libraries/index.ts
@@ -134,6 +134,7 @@ export {
 
 export {
 	FieldKinds,
+	type DefaultChangeProcessingContext,
 	type DefaultChangeset,
 	DefaultChangeFamily,
 	DefaultEditBuilder,

--- a/packages/dds/tree/src/feature-libraries/mitigatedChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/mitigatedChangeFamily.ts
@@ -27,11 +27,15 @@ import type {
  * @param onError - A callback invoked for each error thrown.
  * @returns a mitigated change family.
  */
-export function makeMitigatedChangeFamily<TEditor extends ChangeFamilyEditor, TChange>(
-	unmitigatedChangeFamily: ChangeFamily<TEditor, TChange>,
+export function makeMitigatedChangeFamily<
+	TEditor extends ChangeFamilyEditor,
+	TChange,
+	TChangeFamily extends ChangeFamily<TEditor, TChange, TChangeFamily>,
+>(
+	unmitigatedChangeFamily: ChangeFamily<TEditor, TChange, TChangeFamily>,
 	fallbackChange: TChange,
 	onError: (error: unknown) => void,
-): ChangeFamily<TEditor, TChange> {
+): ChangeFamily<TEditor, TChange, TChangeFamily> {
 	return {
 		buildEditor: (
 			mintRevisionTag: () => RevisionTag,
@@ -41,6 +45,19 @@ export function makeMitigatedChangeFamily<TEditor extends ChangeFamilyEditor, TC
 		},
 		rebaser: makeMitigatedRebaser(unmitigatedChangeFamily.rebaser, fallbackChange, onError),
 		codecs: unmitigatedChangeFamily.codecs,
+		buildProcessor: (
+			processFn: (change: TChange, changeFamily: TChangeFamily) => TChange,
+		): ((change: TChange) => TChange) => {
+			const unmitigatedProcessor = unmitigatedChangeFamily.buildProcessor(processFn);
+			return (change: TChange): TChange => {
+				try {
+					return unmitigatedProcessor(change);
+				} catch (error: unknown) {
+					onError(error);
+					return fallbackChange;
+				}
+			};
+		},
 	};
 }
 

--- a/packages/dds/tree/src/feature-libraries/mitigatedChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/mitigatedChangeFamily.ts
@@ -7,6 +7,7 @@ import type {
 	ChangeFamily,
 	ChangeFamilyEditor,
 	ChangeRebaser,
+	ProcessChangeFn,
 	RevisionMetadataSource,
 	RevisionReplacer,
 	RevisionTag,
@@ -46,7 +47,7 @@ export function makeMitigatedChangeFamily<
 		rebaser: makeMitigatedRebaser(unmitigatedChangeFamily.rebaser, fallbackChange, onError),
 		codecs: unmitigatedChangeFamily.codecs,
 		buildProcessor: (
-			processFn: (change: TChange, context: TChangeProcessingContext) => TChange,
+			processFn: ProcessChangeFn<TChange, TChangeProcessingContext>,
 		): ((change: TChange) => TChange) => {
 			const unmitigatedProcessor = unmitigatedChangeFamily.buildProcessor(processFn);
 			return (change: TChange): TChange => {

--- a/packages/dds/tree/src/feature-libraries/mitigatedChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/mitigatedChangeFamily.ts
@@ -30,12 +30,12 @@ import type {
 export function makeMitigatedChangeFamily<
 	TEditor extends ChangeFamilyEditor,
 	TChange,
-	TChangeFamily extends ChangeFamily<TEditor, TChange, TChangeFamily>,
+	TChangeProcessingContext,
 >(
-	unmitigatedChangeFamily: ChangeFamily<TEditor, TChange, TChangeFamily>,
+	unmitigatedChangeFamily: ChangeFamily<TEditor, TChange, TChangeProcessingContext>,
 	fallbackChange: TChange,
 	onError: (error: unknown) => void,
-): ChangeFamily<TEditor, TChange, TChangeFamily> {
+): ChangeFamily<TEditor, TChange, TChangeProcessingContext> {
 	return {
 		buildEditor: (
 			mintRevisionTag: () => RevisionTag,
@@ -46,7 +46,7 @@ export function makeMitigatedChangeFamily<
 		rebaser: makeMitigatedRebaser(unmitigatedChangeFamily.rebaser, fallbackChange, onError),
 		codecs: unmitigatedChangeFamily.codecs,
 		buildProcessor: (
-			processFn: (change: TChange, changeFamily: TChangeFamily) => TChange,
+			processFn: (change: TChange, context: TChangeProcessingContext) => TChange,
 		): ((change: TChange) => TChange) => {
 			const unmitigatedProcessor = unmitigatedChangeFamily.buildProcessor(processFn);
 			return (change: TChange): TChange => {

--- a/packages/dds/tree/src/feature-libraries/modular-schema/minimizeModularChange.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/minimizeModularChange.ts
@@ -20,7 +20,7 @@ import type { ModularChangeset } from "./modularChangeTypes.js";
  * future change.
  *
  * @param change - The change to minimize.
- * @param fieldKinds - The field kinds to delegate to when computing the change's delta.
+ * @param changeFamily - The change family used to compute the change's delta and identify built nodes.
  */
 export function minimizeModularChangeset(
 	change: ModularChangeset,

--- a/packages/dds/tree/src/feature-libraries/modular-schema/minimizeModularChange.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/minimizeModularChange.ts
@@ -3,9 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import type { FieldKindIdentifier } from "../../core/index.js";
-
-import type { FlexFieldKind } from "./fieldKind.js";
+import type { ModularChangeFamily } from "./modularChangeFamily.js";
 import type { ModularChangeset } from "./modularChangeTypes.js";
 
 /**
@@ -26,7 +24,7 @@ import type { ModularChangeset } from "./modularChangeTypes.js";
  */
 export function minimizeModularChangeset(
 	change: ModularChangeset,
-	fieldKinds: ReadonlyMap<FieldKindIdentifier, FlexFieldKind>,
+	changeFamily: ModularChangeFamily,
 ): ModularChangeset {
 	// TODO: Actually minimize the change. For now this is a no-op that returns the change unchanged.
 	return change;

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -111,7 +111,7 @@ import {
  */
 export class ModularChangeFamily
 	implements
-		ChangeFamily<ModularEditBuilder, ModularChangeset>,
+		ChangeFamily<ModularEditBuilder, ModularChangeset, ModularChangeFamily>,
 		ChangeRebaser<ModularChangeset>
 {
 	public static readonly emptyChange: ModularChangeset = makeModularChangeset();
@@ -132,6 +132,15 @@ export class ModularChangeFamily
 
 	public get rebaser(): ChangeRebaser<ModularChangeset> {
 		return this;
+	}
+
+	public buildProcessor(
+		processFn: (
+			change: ModularChangeset,
+			changeFamily: ModularChangeFamily,
+		) => ModularChangeset,
+	): (change: ModularChangeset) => ModularChangeset {
+		return (change: ModularChangeset) => processFn(change, this);
 	}
 
 	/**

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -135,10 +135,7 @@ export class ModularChangeFamily
 	}
 
 	public buildProcessor(
-		processFn: (
-			change: ModularChangeset,
-			changeFamily: ModularChangeFamily,
-		) => ModularChangeset,
+		processFn: (change: ModularChangeset, context: ModularChangeFamily) => ModularChangeset,
 	): (change: ModularChangeset) => ModularChangeset {
 		return (change: ModularChangeset) => processFn(change, this);
 	}

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -48,6 +48,7 @@ import {
 	type RevisionReplacer,
 	comparePartialRevisions,
 	comparePartialChangesetLocalIds,
+	type ProcessChangeFn,
 } from "../../core/index.js";
 import {
 	type IdAllocationState,
@@ -135,7 +136,7 @@ export class ModularChangeFamily
 	}
 
 	public buildProcessor(
-		processFn: (change: ModularChangeset, context: ModularChangeFamily) => ModularChangeset,
+		processFn: ProcessChangeFn<ModularChangeset, ModularChangeFamily>,
 	): (change: ModularChangeset) => ModularChangeset {
 		return (change: ModularChangeset) => processFn(change, this);
 	}

--- a/packages/dds/tree/src/shared-tree-core/branch.ts
+++ b/packages/dds/tree/src/shared-tree-core/branch.ts
@@ -64,7 +64,7 @@ export type SharedTreeBranchChange<TChange> =
 export interface SharedTreeBranchEvents<
 	TEditor extends ChangeFamilyEditor,
 	TChange,
-	TChangeFamily extends ChangeFamily<TEditor, TChange, TChangeFamily>,
+	TChangeProcessingContext,
 > extends BranchTrimmingEvents {
 	/**
 	 * Fired just before the head of this branch changes.
@@ -82,7 +82,7 @@ export interface SharedTreeBranchEvents<
 	 * Fired when this branch forks
 	 * @param fork - the new branch that forked off of this branch
 	 */
-	fork(fork: SharedTreeBranch<TEditor, TChange, TChangeFamily>): void;
+	fork(fork: SharedTreeBranch<TEditor, TChange, TChangeProcessingContext>): void;
 
 	/**
 	 * Fired after this branch is disposed
@@ -113,11 +113,13 @@ export interface BranchTrimmingEvents {
 export class SharedTreeBranch<
 	TEditor extends ChangeFamilyEditor,
 	TChange,
-	TChangeFamily extends ChangeFamily<TEditor, TChange, TChangeFamily>,
+	TChangeProcessingContext,
 > {
-	readonly #events = createEmitter<SharedTreeBranchEvents<TEditor, TChange, TChangeFamily>>();
-	public readonly events: Listenable<SharedTreeBranchEvents<TEditor, TChange, TChangeFamily>> =
-		this.#events;
+	readonly #events =
+		createEmitter<SharedTreeBranchEvents<TEditor, TChange, TChangeProcessingContext>>();
+	public readonly events: Listenable<
+		SharedTreeBranchEvents<TEditor, TChange, TChangeProcessingContext>
+	> = this.#events;
 	public readonly editor: TEditor;
 	private disposed = false;
 	private readonly unsubscribeBranchTrimmer?: () => void;
@@ -131,7 +133,7 @@ export class SharedTreeBranch<
 	 */
 	public constructor(
 		private head: GraphCommit<TChange>,
-		public readonly changeFamily: ChangeFamily<TEditor, TChange, TChangeFamily>,
+		public readonly changeFamily: ChangeFamily<TEditor, TChange, TChangeProcessingContext>,
 		private readonly mintRevisionTag: () => RevisionTag,
 		private readonly branchTrimmer?: Listenable<BranchTrimmingEvents>,
 		private readonly telemetryEventBatcher?: TelemetryEventBatcher<
@@ -202,7 +204,7 @@ export class SharedTreeBranch<
 	public fork(
 		commit: GraphCommit<TChange> = this.head,
 		mintRevisionTag: () => RevisionTag = this.mintRevisionTag,
-	): SharedTreeBranch<TEditor, TChange, TChangeFamily> {
+	): SharedTreeBranch<TEditor, TChange, TChangeProcessingContext> {
 		this.assertNotDisposed();
 		const fork = new SharedTreeBranch(
 			commit,
@@ -223,7 +225,7 @@ export class SharedTreeBranch<
 	 * @returns the result of the rebase or undefined if nothing changed
 	 */
 	public rebaseOnto(
-		branch: SharedTreeBranch<TEditor, TChange, TChangeFamily>,
+		branch: SharedTreeBranch<TEditor, TChange, TChangeProcessingContext>,
 		upTo = branch.getHead(),
 	): void {
 		this.assertNotDisposed();
@@ -299,7 +301,7 @@ export class SharedTreeBranch<
 	 * @returns the commits that were added to this branch by the merge, or undefined if nothing changed
 	 */
 	public merge(
-		branch: SharedTreeBranch<TEditor, TChange, TChangeFamily>,
+		branch: SharedTreeBranch<TEditor, TChange, TChangeProcessingContext>,
 	): { sourceCommits: GraphCommit<TChange>[] } | undefined {
 		this.assertNotDisposed();
 		branch.assertNotDisposed();
@@ -336,8 +338,8 @@ export class SharedTreeBranch<
 
 	/** Rebase `branchHead` onto `onto`, but return undefined if nothing changed */
 	private rebaseBranch(
-		branch: SharedTreeBranch<TEditor, TChange, TChangeFamily>,
-		onto: SharedTreeBranch<TEditor, TChange, TChangeFamily>,
+		branch: SharedTreeBranch<TEditor, TChange, TChangeProcessingContext>,
+		onto: SharedTreeBranch<TEditor, TChange, TChangeProcessingContext>,
 		upTo = onto.getHead(),
 	): BranchRebaseResult<TChange> | undefined {
 		const { head } = branch;

--- a/packages/dds/tree/src/shared-tree-core/branch.ts
+++ b/packages/dds/tree/src/shared-tree-core/branch.ts
@@ -61,8 +61,11 @@ export type SharedTreeBranchChange<TChange> =
 /**
  * The events emitted by a `SharedTreeBranch`
  */
-export interface SharedTreeBranchEvents<TEditor extends ChangeFamilyEditor, TChange>
-	extends BranchTrimmingEvents {
+export interface SharedTreeBranchEvents<
+	TEditor extends ChangeFamilyEditor,
+	TChange,
+	TChangeFamily extends ChangeFamily<TEditor, TChange, TChangeFamily>,
+> extends BranchTrimmingEvents {
 	/**
 	 * Fired just before the head of this branch changes.
 	 * @param change - the change to this branch's state and commits
@@ -79,7 +82,7 @@ export interface SharedTreeBranchEvents<TEditor extends ChangeFamilyEditor, TCha
 	 * Fired when this branch forks
 	 * @param fork - the new branch that forked off of this branch
 	 */
-	fork(fork: SharedTreeBranch<TEditor, TChange>): void;
+	fork(fork: SharedTreeBranch<TEditor, TChange, TChangeFamily>): void;
 
 	/**
 	 * Fired after this branch is disposed
@@ -107,9 +110,14 @@ export interface BranchTrimmingEvents {
 /**
  * A branch of changes that can be applied to a SharedTree.
  */
-export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> {
-	readonly #events = createEmitter<SharedTreeBranchEvents<TEditor, TChange>>();
-	public readonly events: Listenable<SharedTreeBranchEvents<TEditor, TChange>> = this.#events;
+export class SharedTreeBranch<
+	TEditor extends ChangeFamilyEditor,
+	TChange,
+	TChangeFamily extends ChangeFamily<TEditor, TChange, TChangeFamily>,
+> {
+	readonly #events = createEmitter<SharedTreeBranchEvents<TEditor, TChange, TChangeFamily>>();
+	public readonly events: Listenable<SharedTreeBranchEvents<TEditor, TChange, TChangeFamily>> =
+		this.#events;
 	public readonly editor: TEditor;
 	private disposed = false;
 	private readonly unsubscribeBranchTrimmer?: () => void;
@@ -123,7 +131,7 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> {
 	 */
 	public constructor(
 		private head: GraphCommit<TChange>,
-		public readonly changeFamily: ChangeFamily<TEditor, TChange>,
+		public readonly changeFamily: ChangeFamily<TEditor, TChange, TChangeFamily>,
 		private readonly mintRevisionTag: () => RevisionTag,
 		private readonly branchTrimmer?: Listenable<BranchTrimmingEvents>,
 		private readonly telemetryEventBatcher?: TelemetryEventBatcher<
@@ -194,7 +202,7 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> {
 	public fork(
 		commit: GraphCommit<TChange> = this.head,
 		mintRevisionTag: () => RevisionTag = this.mintRevisionTag,
-	): SharedTreeBranch<TEditor, TChange> {
+	): SharedTreeBranch<TEditor, TChange, TChangeFamily> {
 		this.assertNotDisposed();
 		const fork = new SharedTreeBranch(
 			commit,
@@ -215,7 +223,7 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> {
 	 * @returns the result of the rebase or undefined if nothing changed
 	 */
 	public rebaseOnto(
-		branch: SharedTreeBranch<TEditor, TChange>,
+		branch: SharedTreeBranch<TEditor, TChange, TChangeFamily>,
 		upTo = branch.getHead(),
 	): void {
 		this.assertNotDisposed();
@@ -291,7 +299,7 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> {
 	 * @returns the commits that were added to this branch by the merge, or undefined if nothing changed
 	 */
 	public merge(
-		branch: SharedTreeBranch<TEditor, TChange>,
+		branch: SharedTreeBranch<TEditor, TChange, TChangeFamily>,
 	): { sourceCommits: GraphCommit<TChange>[] } | undefined {
 		this.assertNotDisposed();
 		branch.assertNotDisposed();
@@ -328,8 +336,8 @@ export class SharedTreeBranch<TEditor extends ChangeFamilyEditor, TChange> {
 
 	/** Rebase `branchHead` onto `onto`, but return undefined if nothing changed */
 	private rebaseBranch(
-		branch: SharedTreeBranch<TEditor, TChange>,
-		onto: SharedTreeBranch<TEditor, TChange>,
+		branch: SharedTreeBranch<TEditor, TChange, TChangeFamily>,
+		onto: SharedTreeBranch<TEditor, TChange, TChangeFamily>,
 		upTo = onto.getHead(),
 	): BranchRebaseResult<TChange> | undefined {
 		const { head } = branch;

--- a/packages/dds/tree/src/shared-tree-core/editManager.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManager.ts
@@ -74,13 +74,13 @@ const maxRebaseStatsAggregationCount = 1000;
 export class EditManager<
 	TEditor extends ChangeFamilyEditor,
 	TChangeset,
-	TChangeFamily extends ChangeFamily<TEditor, TChangeset, TChangeFamily>,
+	TChangeProcessingContext = never,
 > {
 	private readonly _events = createEmitter<BranchTrimmingEvents>();
 
 	private readonly sharedBranches = new Map<
 		BranchId,
-		SharedBranch<TEditor, TChangeset, TChangeFamily>
+		SharedBranch<TEditor, TChangeset, TChangeProcessingContext>
 	>();
 
 	/**
@@ -93,7 +93,7 @@ export class EditManager<
 	 */
 	private readonly trunkBranches = new BTree<
 		SequenceId,
-		Set<SharedTreeBranch<TEditor, TChangeset, TChangeFamily>>
+		Set<SharedTreeBranch<TEditor, TChangeset, TChangeProcessingContext>>
 	>(undefined, sequenceIdComparator);
 
 	/**
@@ -124,7 +124,7 @@ export class EditManager<
 	 * @param retainHistory - when `true`, trunk commits are never trimmed/evicted.
 	 */
 	public constructor(
-		public readonly changeFamily: ChangeFamily<TEditor, TChangeset, TChangeFamily>,
+		public readonly changeFamily: ChangeFamily<TEditor, TChangeset, TChangeProcessingContext>,
 		public readonly localSessionId: SessionId,
 		private readonly mintRevisionTag: () => RevisionTag,
 		private readonly onSharedBranchCreated?: (branchId: BranchId) => void,
@@ -160,7 +160,7 @@ export class EditManager<
 
 	public getLocalBranch(
 		branchId: BranchId,
-	): SharedTreeBranch<TEditor, TChangeset, TChangeFamily> {
+	): SharedTreeBranch<TEditor, TChangeset, TChangeProcessingContext> {
 		return this.getSharedBranch(branchId).localBranch;
 	}
 
@@ -170,7 +170,7 @@ export class EditManager<
 
 	private getSharedBranch(
 		branchId: BranchId,
-	): SharedBranch<TEditor, TChangeset, TChangeFamily> {
+	): SharedBranch<TEditor, TChangeset, TChangeProcessingContext> {
 		const branch = this.sharedBranches.get(branchId);
 		if (branch === undefined) {
 			throw new UsageError("No shared branch with such ID");
@@ -187,7 +187,9 @@ export class EditManager<
 	 * TODO#AB6925: Maintain the divergence point between each branch and the trunk so that we don't have to recompute
 	 * it so often.
 	 */
-	private registerBranch(branch: SharedTreeBranch<TEditor, TChangeset, TChangeFamily>): void {
+	private registerBranch(
+		branch: SharedTreeBranch<TEditor, TChangeset, TChangeProcessingContext>,
+	): void {
 		this.trackBranch(branch);
 		// Whenever the branch is rebased, update our record of its base trunk commit
 		const offBeforeRebase = branch.events.on("beforeChange", (args) => {
@@ -211,7 +213,9 @@ export class EditManager<
 		});
 	}
 
-	private trackBranch(b: SharedTreeBranch<TEditor, TChangeset, TChangeFamily>): void {
+	private trackBranch(
+		b: SharedTreeBranch<TEditor, TChangeset, TChangeProcessingContext>,
+	): void {
 		const main = this.getSharedBranch("main");
 		const trunkCommit =
 			findCommonAncestor(main.trunk.getHead(), b.getHead()) ??
@@ -223,7 +227,9 @@ export class EditManager<
 		branches.add(b);
 	}
 
-	private untrackBranch(b: SharedTreeBranch<TEditor, TChangeset, TChangeFamily>): void {
+	private untrackBranch(
+		b: SharedTreeBranch<TEditor, TChangeset, TChangeProcessingContext>,
+	): void {
 		const main = this.getSharedBranch("main");
 		const trunkCommit =
 			findCommonAncestor(main.trunk.getHead(), b.getHead()) ??
@@ -505,9 +511,9 @@ export class EditManager<
 		branchId: BranchId,
 		branchName: string | undefined,
 		sessionId: SessionId | undefined,
-		parent: SharedBranch<TEditor, TChangeset, TChangeFamily> | undefined,
-		branch: SharedTreeBranch<TEditor, TChangeset, TChangeFamily>,
-	): SharedBranch<TEditor, TChangeset, TChangeFamily> {
+		parent: SharedBranch<TEditor, TChangeset, TChangeProcessingContext> | undefined,
+		branch: SharedTreeBranch<TEditor, TChangeset, TChangeProcessingContext>,
+	): SharedBranch<TEditor, TChangeset, TChangeProcessingContext> {
 		const sharedBranch = this.createSharedBranch(
 			branchId,
 			branchName,
@@ -521,7 +527,7 @@ export class EditManager<
 
 	private addSharedBranch(
 		branchId: BranchId,
-		branch: SharedBranch<TEditor, TChangeset, TChangeFamily>,
+		branch: SharedBranch<TEditor, TChangeset, TChangeProcessingContext>,
 	): void {
 		assert(
 			!this.sharedBranches.has(branchId),
@@ -544,9 +550,9 @@ export class EditManager<
 		branchId: BranchId,
 		branchName: string | undefined,
 		sessionId: SessionId | undefined,
-		parent: SharedBranch<TEditor, TChangeset, TChangeFamily> | undefined,
-		branch: SharedTreeBranch<TEditor, TChangeset, TChangeFamily>,
-	): SharedBranch<TEditor, TChangeset, TChangeFamily> {
+		parent: SharedBranch<TEditor, TChangeset, TChangeProcessingContext> | undefined,
+		branch: SharedTreeBranch<TEditor, TChangeset, TChangeProcessingContext>,
+	): SharedBranch<TEditor, TChangeset, TChangeProcessingContext> {
 		const sharedBranch = new SharedBranch(
 			parent,
 			branch,
@@ -682,15 +688,11 @@ function getPathFromBase<TCommit extends { parent?: TCommit }>(
 	return path;
 }
 
-class SharedBranch<
-	TEditor extends ChangeFamilyEditor,
-	TChangeset,
-	TChangeFamily extends ChangeFamily<TEditor, TChangeset, TChangeFamily>,
-> {
+class SharedBranch<TEditor extends ChangeFamilyEditor, TChangeset, TChangeProcessingContext> {
 	/**
 	 * This branch holds the changes made by this client which have not yet been confirmed as sequenced changes.
 	 */
-	public readonly localBranch: SharedTreeBranch<TEditor, TChangeset, TChangeFamily>;
+	public readonly localBranch: SharedTreeBranch<TEditor, TChangeset, TChangeProcessingContext>;
 
 	/**
 	 * Branches are maintained to represent the local change list that the issuing client had
@@ -699,7 +701,7 @@ class SharedBranch<
 	 */
 	private readonly peerLocalBranches: Map<
 		SessionId,
-		SharedTreeBranch<TEditor, TChangeset, TChangeFamily>
+		SharedTreeBranch<TEditor, TChangeset, TChangeProcessingContext>
 	> = new Map();
 
 	/**
@@ -727,13 +729,15 @@ class SharedBranch<
 	>();
 
 	public constructor(
-		public readonly parentBranch: SharedBranch<TEditor, TChangeset, TChangeFamily> | undefined,
-		public readonly trunk: SharedTreeBranch<TEditor, TChangeset, TChangeFamily>,
+		public readonly parentBranch:
+			| SharedBranch<TEditor, TChangeset, TChangeProcessingContext>
+			| undefined,
+		public readonly trunk: SharedTreeBranch<TEditor, TChangeset, TChangeProcessingContext>,
 		private readonly id: BranchId,
 		public readonly branchName: string | undefined,
 		private readonly sessionId: SessionId | undefined,
 		baseCommitSequenceId: SequenceId,
-		private readonly changeFamily: ChangeFamily<TEditor, TChangeset, TChangeFamily>,
+		private readonly changeFamily: ChangeFamily<TEditor, TChangeset, TChangeProcessingContext>,
 		private readonly mintRevisionTag: () => RevisionTag,
 		branchTrimmer: Listenable<BranchTrimmingEvents>,
 		telemetryEventBatcher: TelemetryEventBatcher<keyof RebaseStatsWithDuration> | undefined,
@@ -850,7 +854,7 @@ class SharedBranch<
 	public rebasePeer(
 		sessionId: SessionId,
 		referenceSequenceNumber: SeqNumber,
-	): SharedTreeBranch<TEditor, TChangeset, TChangeFamily> {
+	): SharedTreeBranch<TEditor, TChangeset, TChangeProcessingContext> {
 		const [, baseRevisionInTrunk] = this.getClosestTrunkCommit(referenceSequenceNumber);
 		const peerLocalBranch = getOrCreate(
 			this.peerLocalBranches,
@@ -863,7 +867,7 @@ class SharedBranch<
 
 	public getPeerBranchOrTrunk(
 		sessionId: SessionId,
-	): SharedTreeBranch<TEditor, TChangeset, TChangeFamily> {
+	): SharedTreeBranch<TEditor, TChangeset, TChangeProcessingContext> {
 		return this.peerLocalBranches.get(sessionId) ?? this.trunk;
 	}
 

--- a/packages/dds/tree/src/shared-tree-core/editManager.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManager.ts
@@ -74,11 +74,14 @@ const maxRebaseStatsAggregationCount = 1000;
 export class EditManager<
 	TEditor extends ChangeFamilyEditor,
 	TChangeset,
-	TChangeFamily extends ChangeFamily<TEditor, TChangeset>,
+	TChangeFamily extends ChangeFamily<TEditor, TChangeset, TChangeFamily>,
 > {
 	private readonly _events = createEmitter<BranchTrimmingEvents>();
 
-	private readonly sharedBranches = new Map<BranchId, SharedBranch<TEditor, TChangeset>>();
+	private readonly sharedBranches = new Map<
+		BranchId,
+		SharedBranch<TEditor, TChangeset, TChangeFamily>
+	>();
 
 	/**
 	 * Tracks where on the trunk of the main branch all registered branches are based.
@@ -90,7 +93,7 @@ export class EditManager<
 	 */
 	private readonly trunkBranches = new BTree<
 		SequenceId,
-		Set<SharedTreeBranch<TEditor, TChangeset>>
+		Set<SharedTreeBranch<TEditor, TChangeset, TChangeFamily>>
 	>(undefined, sequenceIdComparator);
 
 	/**
@@ -121,7 +124,7 @@ export class EditManager<
 	 * @param retainHistory - when `true`, trunk commits are never trimmed/evicted.
 	 */
 	public constructor(
-		public readonly changeFamily: TChangeFamily,
+		public readonly changeFamily: ChangeFamily<TEditor, TChangeset, TChangeFamily>,
 		public readonly localSessionId: SessionId,
 		private readonly mintRevisionTag: () => RevisionTag,
 		private readonly onSharedBranchCreated?: (branchId: BranchId) => void,
@@ -155,7 +158,9 @@ export class EditManager<
 		this.createAndAddSharedBranch("main", "main", undefined, undefined, mainTrunk);
 	}
 
-	public getLocalBranch(branchId: BranchId): SharedTreeBranch<TEditor, TChangeset> {
+	public getLocalBranch(
+		branchId: BranchId,
+	): SharedTreeBranch<TEditor, TChangeset, TChangeFamily> {
 		return this.getSharedBranch(branchId).localBranch;
 	}
 
@@ -163,7 +168,9 @@ export class EditManager<
 		return this.getSharedBranch(branchId).branchName;
 	}
 
-	private getSharedBranch(branchId: BranchId): SharedBranch<TEditor, TChangeset> {
+	private getSharedBranch(
+		branchId: BranchId,
+	): SharedBranch<TEditor, TChangeset, TChangeFamily> {
 		const branch = this.sharedBranches.get(branchId);
 		if (branch === undefined) {
 			throw new UsageError("No shared branch with such ID");
@@ -180,7 +187,7 @@ export class EditManager<
 	 * TODO#AB6925: Maintain the divergence point between each branch and the trunk so that we don't have to recompute
 	 * it so often.
 	 */
-	private registerBranch(branch: SharedTreeBranch<TEditor, TChangeset>): void {
+	private registerBranch(branch: SharedTreeBranch<TEditor, TChangeset, TChangeFamily>): void {
 		this.trackBranch(branch);
 		// Whenever the branch is rebased, update our record of its base trunk commit
 		const offBeforeRebase = branch.events.on("beforeChange", (args) => {
@@ -204,7 +211,7 @@ export class EditManager<
 		});
 	}
 
-	private trackBranch(b: SharedTreeBranch<TEditor, TChangeset>): void {
+	private trackBranch(b: SharedTreeBranch<TEditor, TChangeset, TChangeFamily>): void {
 		const main = this.getSharedBranch("main");
 		const trunkCommit =
 			findCommonAncestor(main.trunk.getHead(), b.getHead()) ??
@@ -216,7 +223,7 @@ export class EditManager<
 		branches.add(b);
 	}
 
-	private untrackBranch(b: SharedTreeBranch<TEditor, TChangeset>): void {
+	private untrackBranch(b: SharedTreeBranch<TEditor, TChangeset, TChangeFamily>): void {
 		const main = this.getSharedBranch("main");
 		const trunkCommit =
 			findCommonAncestor(main.trunk.getHead(), b.getHead()) ??
@@ -498,9 +505,9 @@ export class EditManager<
 		branchId: BranchId,
 		branchName: string | undefined,
 		sessionId: SessionId | undefined,
-		parent: SharedBranch<TEditor, TChangeset> | undefined,
-		branch: SharedTreeBranch<TEditor, TChangeset>,
-	): SharedBranch<TEditor, TChangeset> {
+		parent: SharedBranch<TEditor, TChangeset, TChangeFamily> | undefined,
+		branch: SharedTreeBranch<TEditor, TChangeset, TChangeFamily>,
+	): SharedBranch<TEditor, TChangeset, TChangeFamily> {
 		const sharedBranch = this.createSharedBranch(
 			branchId,
 			branchName,
@@ -514,7 +521,7 @@ export class EditManager<
 
 	private addSharedBranch(
 		branchId: BranchId,
-		branch: SharedBranch<TEditor, TChangeset>,
+		branch: SharedBranch<TEditor, TChangeset, TChangeFamily>,
 	): void {
 		assert(
 			!this.sharedBranches.has(branchId),
@@ -537,9 +544,9 @@ export class EditManager<
 		branchId: BranchId,
 		branchName: string | undefined,
 		sessionId: SessionId | undefined,
-		parent: SharedBranch<TEditor, TChangeset> | undefined,
-		branch: SharedTreeBranch<TEditor, TChangeset>,
-	): SharedBranch<TEditor, TChangeset> {
+		parent: SharedBranch<TEditor, TChangeset, TChangeFamily> | undefined,
+		branch: SharedTreeBranch<TEditor, TChangeset, TChangeFamily>,
+	): SharedBranch<TEditor, TChangeset, TChangeFamily> {
 		const sharedBranch = new SharedBranch(
 			parent,
 			branch,
@@ -675,19 +682,25 @@ function getPathFromBase<TCommit extends { parent?: TCommit }>(
 	return path;
 }
 
-class SharedBranch<TEditor extends ChangeFamilyEditor, TChangeset> {
+class SharedBranch<
+	TEditor extends ChangeFamilyEditor,
+	TChangeset,
+	TChangeFamily extends ChangeFamily<TEditor, TChangeset, TChangeFamily>,
+> {
 	/**
 	 * This branch holds the changes made by this client which have not yet been confirmed as sequenced changes.
 	 */
-	public readonly localBranch: SharedTreeBranch<TEditor, TChangeset>;
+	public readonly localBranch: SharedTreeBranch<TEditor, TChangeset, TChangeFamily>;
 
 	/**
 	 * Branches are maintained to represent the local change list that the issuing client had
 	 * at the time of submitting the latest known edit on the branch.
 	 * This means the head commit of each branch is always in its original (non-rebased) form.
 	 */
-	private readonly peerLocalBranches: Map<SessionId, SharedTreeBranch<TEditor, TChangeset>> =
-		new Map();
+	private readonly peerLocalBranches: Map<
+		SessionId,
+		SharedTreeBranch<TEditor, TChangeset, TChangeFamily>
+	> = new Map();
 
 	/**
 	 * A map from a sequence id to the commit which has that sequence id.
@@ -714,13 +727,13 @@ class SharedBranch<TEditor extends ChangeFamilyEditor, TChangeset> {
 	>();
 
 	public constructor(
-		public readonly parentBranch: SharedBranch<TEditor, TChangeset> | undefined,
-		public readonly trunk: SharedTreeBranch<TEditor, TChangeset>,
+		public readonly parentBranch: SharedBranch<TEditor, TChangeset, TChangeFamily> | undefined,
+		public readonly trunk: SharedTreeBranch<TEditor, TChangeset, TChangeFamily>,
 		private readonly id: BranchId,
 		public readonly branchName: string | undefined,
 		private readonly sessionId: SessionId | undefined,
 		baseCommitSequenceId: SequenceId,
-		private readonly changeFamily: ChangeFamily<TEditor, TChangeset>,
+		private readonly changeFamily: ChangeFamily<TEditor, TChangeset, TChangeFamily>,
 		private readonly mintRevisionTag: () => RevisionTag,
 		branchTrimmer: Listenable<BranchTrimmingEvents>,
 		telemetryEventBatcher: TelemetryEventBatcher<keyof RebaseStatsWithDuration> | undefined,
@@ -837,7 +850,7 @@ class SharedBranch<TEditor extends ChangeFamilyEditor, TChangeset> {
 	public rebasePeer(
 		sessionId: SessionId,
 		referenceSequenceNumber: SeqNumber,
-	): SharedTreeBranch<TEditor, TChangeset> {
+	): SharedTreeBranch<TEditor, TChangeset, TChangeFamily> {
 		const [, baseRevisionInTrunk] = this.getClosestTrunkCommit(referenceSequenceNumber);
 		const peerLocalBranch = getOrCreate(
 			this.peerLocalBranches,
@@ -848,7 +861,9 @@ class SharedBranch<TEditor extends ChangeFamilyEditor, TChangeset> {
 		return peerLocalBranch;
 	}
 
-	public getPeerBranchOrTrunk(sessionId: SessionId): SharedTreeBranch<TEditor, TChangeset> {
+	public getPeerBranchOrTrunk(
+		sessionId: SessionId,
+	): SharedTreeBranch<TEditor, TChangeset, TChangeFamily> {
 		return this.peerLocalBranches.get(sessionId) ?? this.trunk;
 	}
 

--- a/packages/dds/tree/src/shared-tree-core/editManagerSummarizer.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerSummarizer.ts
@@ -68,17 +68,16 @@ function minVersionToEditManagerSummaryFormatVersion(
 /**
  * Provides methods for summarizing and loading an `EditManager`
  */
-export class EditManagerSummarizer<TChangeset>
+export class EditManagerSummarizer<
+		TChangeset,
+		TChangeFamily extends ChangeFamily<ChangeFamilyEditor, TChangeset, TChangeFamily>,
+	>
 	extends VersionedSummarizer<EditManagerSummaryFormatVersion>
 	implements Summarizable
 {
 	public static readonly key = "EditManager";
 	public constructor(
-		private readonly editManager: EditManager<
-			ChangeFamilyEditor,
-			TChangeset,
-			ChangeFamily<ChangeFamilyEditor, TChangeset>
-		>,
+		private readonly editManager: EditManager<ChangeFamilyEditor, TChangeset, TChangeFamily>,
 		private readonly codec: IJsonCodec<
 			SummaryData<TChangeset>,
 			JsonCompatibleReadOnly,

--- a/packages/dds/tree/src/shared-tree-core/editManagerSummarizer.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerSummarizer.ts
@@ -15,7 +15,7 @@ import type {
 import type { SummaryTreeBuilder } from "@fluidframework/runtime-utils/internal";
 
 import type { IJsonCodec } from "../codec/index.js";
-import type { ChangeFamily, ChangeFamilyEditor, SchemaAndPolicy } from "../core/index.js";
+import type { ChangeFamilyEditor, SchemaAndPolicy } from "../core/index.js";
 import type { IdentifierHealingConfig, JsonCompatibleReadOnly } from "../util/index.js";
 
 import type { EditManager, SummaryData } from "./editManager.js";
@@ -68,16 +68,17 @@ function minVersionToEditManagerSummaryFormatVersion(
 /**
  * Provides methods for summarizing and loading an `EditManager`
  */
-export class EditManagerSummarizer<
-		TChangeset,
-		TChangeFamily extends ChangeFamily<ChangeFamilyEditor, TChangeset, TChangeFamily>,
-	>
+export class EditManagerSummarizer<TChangeset, TChangeProcessingContext>
 	extends VersionedSummarizer<EditManagerSummaryFormatVersion>
 	implements Summarizable
 {
 	public static readonly key = "EditManager";
 	public constructor(
-		private readonly editManager: EditManager<ChangeFamilyEditor, TChangeset, TChangeFamily>,
+		private readonly editManager: EditManager<
+			ChangeFamilyEditor,
+			TChangeset,
+			TChangeProcessingContext
+		>,
 		private readonly codec: IJsonCodec<
 			SummaryData<TChangeset>,
 			JsonCompatibleReadOnly,

--- a/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
+++ b/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
@@ -95,12 +95,19 @@ export interface EnrichmentConfig<TChange> {
  * Generic shared tree, which needs to be configured with indexes, field kinds and other configuration.
  */
 @breakingClass
-export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange>
+export class SharedTreeCore<
+		TEditor extends ChangeFamilyEditor,
+		TChange,
+		TChangeFamily extends ChangeFamily<TEditor, TChange, TChangeFamily>,
+	>
 	extends VersionedSummarizer<SharedTreeSummaryFormatVersion>
 	implements WithBreakable, Summarizable
 {
-	private readonly editManager: EditManager<TEditor, TChange, ChangeFamily<TEditor, TChange>>;
-	private readonly summarizables: readonly [EditManagerSummarizer<TChange>, ...Summarizable[]];
+	private readonly editManager: EditManager<TEditor, TChange, TChangeFamily>;
+	private readonly summarizables: readonly [
+		EditManagerSummarizer<TChange, TChangeFamily>,
+		...Summarizable[],
+	];
 	/**
 	 * The sequence number that this instance is at.
 	 * This number is artificial in that it is made up by this instance as opposed to being provided by the runtime.
@@ -147,7 +154,7 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange>
 		public readonly submitLocalMessage: (content: unknown, localOpMetadata?: unknown) => void,
 		logger: ITelemetryBaseLogger | undefined,
 		summarizables: readonly Summarizable[],
-		protected readonly changeFamily: ChangeFamily<TEditor, TChange>,
+		protected readonly changeFamily: ChangeFamily<TEditor, TChange, TChangeFamily>,
 		options: SharedTreeCoreOptionsInternal,
 		changeFormatVersionForEditManager: DependentFormatVersion<EditManagerFormatVersion>,
 		changeFormatVersionForMessage: DependentFormatVersion<MessageFormatVersion>,
@@ -519,7 +526,7 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange>
 		}
 	}
 
-	public getLocalBranch(): SharedTreeBranch<TEditor, TChange> {
+	public getLocalBranch(): SharedTreeBranch<TEditor, TChange, TChangeFamily> {
 		return this.editManager.getLocalBranch("main");
 	}
 
@@ -545,7 +552,9 @@ export class SharedTreeCore<TEditor extends ChangeFamilyEditor, TChange>
 		this.editManager.addNewBranch(branchId, branchName);
 	}
 
-	public getSharedBranch(branchId: BranchId): SharedTreeBranch<TEditor, TChange> {
+	public getSharedBranch(
+		branchId: BranchId,
+	): SharedTreeBranch<TEditor, TChange, TChangeFamily> {
 		return this.editManager.getLocalBranch(branchId);
 	}
 

--- a/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
+++ b/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
@@ -98,14 +98,14 @@ export interface EnrichmentConfig<TChange> {
 export class SharedTreeCore<
 		TEditor extends ChangeFamilyEditor,
 		TChange,
-		TChangeFamily extends ChangeFamily<TEditor, TChange, TChangeFamily>,
+		TChangeProcessingContext,
 	>
 	extends VersionedSummarizer<SharedTreeSummaryFormatVersion>
 	implements WithBreakable, Summarizable
 {
-	private readonly editManager: EditManager<TEditor, TChange, TChangeFamily>;
+	private readonly editManager: EditManager<TEditor, TChange, TChangeProcessingContext>;
 	private readonly summarizables: readonly [
-		EditManagerSummarizer<TChange, TChangeFamily>,
+		EditManagerSummarizer<TChange, TChangeProcessingContext>,
 		...Summarizable[],
 	];
 	/**
@@ -154,7 +154,7 @@ export class SharedTreeCore<
 		public readonly submitLocalMessage: (content: unknown, localOpMetadata?: unknown) => void,
 		logger: ITelemetryBaseLogger | undefined,
 		summarizables: readonly Summarizable[],
-		protected readonly changeFamily: ChangeFamily<TEditor, TChange, TChangeFamily>,
+		protected readonly changeFamily: ChangeFamily<TEditor, TChange, TChangeProcessingContext>,
 		options: SharedTreeCoreOptionsInternal,
 		changeFormatVersionForEditManager: DependentFormatVersion<EditManagerFormatVersion>,
 		changeFormatVersionForMessage: DependentFormatVersion<MessageFormatVersion>,
@@ -526,7 +526,7 @@ export class SharedTreeCore<
 		}
 	}
 
-	public getLocalBranch(): SharedTreeBranch<TEditor, TChange, TChangeFamily> {
+	public getLocalBranch(): SharedTreeBranch<TEditor, TChange, TChangeProcessingContext> {
 		return this.editManager.getLocalBranch("main");
 	}
 
@@ -554,7 +554,7 @@ export class SharedTreeCore<
 
 	public getSharedBranch(
 		branchId: BranchId,
-	): SharedTreeBranch<TEditor, TChange, TChangeFamily> {
+	): SharedTreeBranch<TEditor, TChange, TChangeProcessingContext> {
 		return this.editManager.getLocalBranch(branchId);
 	}
 

--- a/packages/dds/tree/src/shared-tree-core/transaction.ts
+++ b/packages/dds/tree/src/shared-tree-core/transaction.ts
@@ -17,6 +17,7 @@ import {
 	tagChange,
 	type ChangeFamilyEditor,
 	type GraphCommit,
+	type ProcessChangeFn,
 	type RevisionTag,
 } from "../core/index.js";
 import { getLast, getOrCreate } from "../util/index.js";
@@ -263,7 +264,7 @@ export enum ChangeProcessorApplicability {
  * (see the conversion helpers in the `shared-tree` layer) so that its internal
  * change representation does not leak into the public API.
  */
-export interface ChangeProcessor<TProcessChange> {
+export interface ChangeProcessor<TChange, TChangeProcessingContext> {
 	/**
 	 * Informs what context it should be invoked for.
 	 */
@@ -271,7 +272,7 @@ export interface ChangeProcessor<TProcessChange> {
 	/**
 	 * Processes the given change, returning a change with the same observable effect.
 	 */
-	readonly processChange: TProcessChange;
+	readonly processChange: ProcessChangeFn<TChange, TChangeProcessingContext>;
 }
 
 /**
@@ -288,9 +289,7 @@ export interface SquashingTransactionOptions<TChange, TChangeProcessingContext> 
 	 * How often the processor is invoked across nested transactions is governed by its
 	 * {@link ChangeProcessor.applicability | applicability}.
 	 */
-	readonly postProcessor?: ChangeProcessor<
-		(change: TChange, context: TChangeProcessingContext) => TChange
-	>;
+	readonly postProcessor?: ChangeProcessor<TChange, TChangeProcessingContext>;
 }
 
 /**
@@ -386,19 +385,15 @@ export class SquashingTransactionStack<
 		// innermost. Each in-progress transaction contributes exactly one entry: either the processor to apply when it
 		// commits, or `undefined` when none should be applied.
 		const postProcessorStack: (
-			| ChangeProcessor<(change: TChange, changeFamily: TChangeProcessingContext) => TChange>
+			| ChangeProcessor<TChange, TChangeProcessingContext>
 			| undefined
 		)[] = [];
 		// Determines the entry to push for a transaction that was started with the given `requested` processor (if any).
 		// A processor with "outermost" applicability that is already active in an enclosing transaction resolves to
 		// `undefined` so that it is only applied once (at the outermost transaction that supplied it).
 		const resolvePostProcessor = (
-			requested:
-				| ChangeProcessor<(change: TChange, changeFamily: TChangeProcessingContext) => TChange>
-				| undefined,
-		):
-			| ChangeProcessor<(change: TChange, changeFamily: TChangeProcessingContext) => TChange>
-			| undefined => {
+			requested: ChangeProcessor<TChange, TChangeProcessingContext> | undefined,
+		): ChangeProcessor<TChange, TChangeProcessingContext> | undefined => {
 			if (
 				requested?.applicability === ChangeProcessorApplicability.IfOutermost &&
 				postProcessorStack.includes(requested)

--- a/packages/dds/tree/src/shared-tree-core/transaction.ts
+++ b/packages/dds/tree/src/shared-tree-core/transaction.ts
@@ -15,7 +15,6 @@ import {
 	mintCommit,
 	rebaseBranch,
 	tagChange,
-	type ChangeFamily,
 	type ChangeFamilyEditor,
 	type GraphCommit,
 	type RevisionTag,
@@ -278,7 +277,7 @@ export interface ChangeProcessor<TProcessChange> {
 /**
  * Options for {@link Transactor.start | starting} a transaction.
  */
-export interface SquashingTransactionOptions<TChange, TChangeFamily> {
+export interface SquashingTransactionOptions<TChange, TChangeProcessingContext> {
 	/**
 	 * An optional {@link ChangeProcessor} applied to the squashed change produced when a transaction that was started
 	 * with this option is committed.
@@ -290,7 +289,7 @@ export interface SquashingTransactionOptions<TChange, TChangeFamily> {
 	 * {@link ChangeProcessor.applicability | applicability}.
 	 */
 	readonly postProcessor?: ChangeProcessor<
-		(change: TChange, changeFamily: TChangeFamily) => TChange
+		(change: TChange, context: TChangeProcessingContext) => TChange
 	>;
 }
 
@@ -303,9 +302,9 @@ export interface SquashingTransactionOptions<TChange, TChangeFamily> {
 export class SquashingTransactionStack<
 	TEditor extends ChangeFamilyEditor,
 	TChange,
-	TChangeFamily extends ChangeFamily<TEditor, TChange, TChangeFamily>,
-> extends TransactionStack<SquashingTransactionOptions<TChange, TChangeFamily>> {
-	#transactionBranch?: SharedTreeBranch<TEditor, TChange, TChangeFamily>;
+	TChangeProcessingContext,
+> extends TransactionStack<SquashingTransactionOptions<TChange, TChangeProcessingContext>> {
+	#transactionBranch?: SharedTreeBranch<TEditor, TChange, TChangeProcessingContext>;
 
 	/**
 	 * An editor for whichever branch is currently the {@link SquashingTransactionStack.activeBranch | active branch}.
@@ -321,7 +320,7 @@ export class SquashingTransactionStack<
 	/**
 	 * Get the "active branch" for this transactor - either the transaction branch if a transaction is in progress, or the original branch otherwise.
 	 */
-	public get activeBranch(): SharedTreeBranch<TEditor, TChange, TChangeFamily> {
+	public get activeBranch(): SharedTreeBranch<TEditor, TChange, TChangeProcessingContext> {
 		return this.#transactionBranch ?? this.branch;
 	}
 
@@ -331,11 +330,15 @@ export class SquashingTransactionStack<
 	 * In contrast, binding an event to the {@link SquashingTransactionStack.activeBranch | active branch} directly will not automatically transfer the listener when the active branch changes.
 	 */
 	public get activeBranchEvents(): Listenable<
-		SharedTreeBranchEvents<TEditor, TChange, TChangeFamily>
+		SharedTreeBranchEvents<TEditor, TChange, TChangeProcessingContext>
 	> {
 		const off = (
-			eventName: keyof SharedTreeBranchEvents<TEditor, TChange, TChangeFamily>,
-			listener: SharedTreeBranchEvents<TEditor, TChange, TChangeFamily>[typeof eventName],
+			eventName: keyof SharedTreeBranchEvents<TEditor, TChange, TChangeProcessingContext>,
+			listener: SharedTreeBranchEvents<
+				TEditor,
+				TChange,
+				TChangeProcessingContext
+			>[typeof eventName],
 		): void => {
 			this.activeBranch.events.off(eventName, listener);
 			const listeners = this.#activeBranchEvents.get(eventName);
@@ -355,13 +358,13 @@ export class SquashingTransactionStack<
 		};
 	}
 	readonly #activeBranchEvents = new Map<
-		keyof SharedTreeBranchEvents<TEditor, TChange, TChangeFamily>,
+		keyof SharedTreeBranchEvents<TEditor, TChange, TChangeProcessingContext>,
 		Set<
-			SharedTreeBranchEvents<TEditor, TChange, TChangeFamily>[keyof SharedTreeBranchEvents<
+			SharedTreeBranchEvents<
 				TEditor,
 				TChange,
-				TChangeFamily
-			>]
+				TChangeProcessingContext
+			>[keyof SharedTreeBranchEvents<TEditor, TChange, TChangeProcessingContext>]
 		>
 	>();
 
@@ -375,7 +378,7 @@ export class SquashingTransactionStack<
 	 * options rather than baked into this stack, so different transactions may supply different post-processors (or none).
 	 */
 	public constructor(
-		public readonly branch: SharedTreeBranch<TEditor, TChange, TChangeFamily>,
+		public readonly branch: SharedTreeBranch<TEditor, TChange, TChangeProcessingContext>,
 		mintRevisionTag: () => RevisionTag,
 		onPush?: () => OnPopWithViewUpdate<TChange> | void,
 	) {
@@ -383,7 +386,7 @@ export class SquashingTransactionStack<
 		// innermost. Each in-progress transaction contributes exactly one entry: either the processor to apply when it
 		// commits, or `undefined` when none should be applied.
 		const postProcessorStack: (
-			| ChangeProcessor<(change: TChange, changeFamily: TChangeFamily) => TChange>
+			| ChangeProcessor<(change: TChange, changeFamily: TChangeProcessingContext) => TChange>
 			| undefined
 		)[] = [];
 		// Determines the entry to push for a transaction that was started with the given `requested` processor (if any).
@@ -391,10 +394,10 @@ export class SquashingTransactionStack<
 		// `undefined` so that it is only applied once (at the outermost transaction that supplied it).
 		const resolvePostProcessor = (
 			requested:
-				| ChangeProcessor<(change: TChange, changeFamily: TChangeFamily) => TChange>
+				| ChangeProcessor<(change: TChange, changeFamily: TChangeProcessingContext) => TChange>
 				| undefined,
 		):
-			| ChangeProcessor<(change: TChange, changeFamily: TChangeFamily) => TChange>
+			| ChangeProcessor<(change: TChange, changeFamily: TChangeProcessingContext) => TChange>
 			| undefined => {
 			if (
 				requested?.applicability === ChangeProcessorApplicability.IfOutermost &&
@@ -408,8 +411,8 @@ export class SquashingTransactionStack<
 		super(
 			// Invoked when an outer transaction starts
 			(
-				startOptions?: SquashingTransactionOptions<TChange, TChangeFamily>,
-			): Callbacks<SquashingTransactionOptions<TChange, TChangeFamily>> => {
+				startOptions?: SquashingTransactionOptions<TChange, TChangeProcessingContext>,
+			): Callbacks<SquashingTransactionOptions<TChange, TChangeProcessingContext>> => {
 				postProcessorStack.push(resolvePostProcessor(startOptions?.postProcessor));
 				// Keep track of the commit that each transaction was on when it started
 				const startHead = this.activeBranch.getHead();
@@ -545,7 +548,7 @@ export class SquashingTransactionStack<
 				};
 				// Invoked when a nested transaction begins
 				const onNestedTransactionPush: OnPush<
-					SquashingTransactionOptions<TChange, TChangeFamily>
+					SquashingTransactionOptions<TChange, TChangeProcessingContext>
 				> = (nestedStartOptions) => {
 					postProcessorStack.push(resolvePostProcessor(nestedStartOptions?.postProcessor));
 					const nestedStartHead = this.activeBranch.getHead();
@@ -608,7 +611,9 @@ export class SquashingTransactionStack<
 
 	/** Updates the transaction branch (and therefore the active branch) and rebinds the branch events. */
 	private setTransactionBranch(
-		transactionBranch: SharedTreeBranch<TEditor, TChange, TChangeFamily> | undefined,
+		transactionBranch:
+			| SharedTreeBranch<TEditor, TChange, TChangeProcessingContext>
+			| undefined,
 	): void {
 		const oldActiveBranch = this.activeBranch;
 		this.#transactionBranch = transactionBranch;

--- a/packages/dds/tree/src/shared-tree-core/transaction.ts
+++ b/packages/dds/tree/src/shared-tree-core/transaction.ts
@@ -15,6 +15,7 @@ import {
 	mintCommit,
 	rebaseBranch,
 	tagChange,
+	type ChangeFamily,
 	type ChangeFamilyEditor,
 	type GraphCommit,
 	type RevisionTag,
@@ -263,7 +264,7 @@ export enum ChangeProcessorApplicability {
  * (see the conversion helpers in the `shared-tree` layer) so that its internal
  * change representation does not leak into the public API.
  */
-export interface ChangeProcessor<TChange> {
+export interface ChangeProcessor<TProcessChange> {
 	/**
 	 * Informs what context it should be invoked for.
 	 */
@@ -271,13 +272,13 @@ export interface ChangeProcessor<TChange> {
 	/**
 	 * Processes the given change, returning a change with the same observable effect.
 	 */
-	readonly processChange: (change: TChange) => TChange;
+	readonly processChange: TProcessChange;
 }
 
 /**
  * Options for {@link Transactor.start | starting} a transaction.
  */
-export interface SquashingTransactionOptions<TChange> {
+export interface SquashingTransactionOptions<TChange, TChangeFamily> {
 	/**
 	 * An optional {@link ChangeProcessor} applied to the squashed change produced when a transaction that was started
 	 * with this option is committed.
@@ -288,7 +289,9 @@ export interface SquashingTransactionOptions<TChange> {
 	 * How often the processor is invoked across nested transactions is governed by its
 	 * {@link ChangeProcessor.applicability | applicability}.
 	 */
-	readonly postProcessor?: ChangeProcessor<TChange>;
+	readonly postProcessor?: ChangeProcessor<
+		(change: TChange, changeFamily: TChangeFamily) => TChange
+	>;
 }
 
 /**
@@ -300,8 +303,9 @@ export interface SquashingTransactionOptions<TChange> {
 export class SquashingTransactionStack<
 	TEditor extends ChangeFamilyEditor,
 	TChange,
-> extends TransactionStack<SquashingTransactionOptions<TChange>> {
-	#transactionBranch?: SharedTreeBranch<TEditor, TChange>;
+	TChangeFamily extends ChangeFamily<TEditor, TChange, TChangeFamily>,
+> extends TransactionStack<SquashingTransactionOptions<TChange, TChangeFamily>> {
+	#transactionBranch?: SharedTreeBranch<TEditor, TChange, TChangeFamily>;
 
 	/**
 	 * An editor for whichever branch is currently the {@link SquashingTransactionStack.activeBranch | active branch}.
@@ -317,7 +321,7 @@ export class SquashingTransactionStack<
 	/**
 	 * Get the "active branch" for this transactor - either the transaction branch if a transaction is in progress, or the original branch otherwise.
 	 */
-	public get activeBranch(): SharedTreeBranch<TEditor, TChange> {
+	public get activeBranch(): SharedTreeBranch<TEditor, TChange, TChangeFamily> {
 		return this.#transactionBranch ?? this.branch;
 	}
 
@@ -326,10 +330,12 @@ export class SquashingTransactionStack<
 	 * @remarks When the active branch changes, the listeners for these events will automatically be transferred to the new active branch.
 	 * In contrast, binding an event to the {@link SquashingTransactionStack.activeBranch | active branch} directly will not automatically transfer the listener when the active branch changes.
 	 */
-	public get activeBranchEvents(): Listenable<SharedTreeBranchEvents<TEditor, TChange>> {
+	public get activeBranchEvents(): Listenable<
+		SharedTreeBranchEvents<TEditor, TChange, TChangeFamily>
+	> {
 		const off = (
-			eventName: keyof SharedTreeBranchEvents<TEditor, TChange>,
-			listener: SharedTreeBranchEvents<TEditor, TChange>[typeof eventName],
+			eventName: keyof SharedTreeBranchEvents<TEditor, TChange, TChangeFamily>,
+			listener: SharedTreeBranchEvents<TEditor, TChange, TChangeFamily>[typeof eventName],
 		): void => {
 			this.activeBranch.events.off(eventName, listener);
 			const listeners = this.#activeBranchEvents.get(eventName);
@@ -349,9 +355,13 @@ export class SquashingTransactionStack<
 		};
 	}
 	readonly #activeBranchEvents = new Map<
-		keyof SharedTreeBranchEvents<TEditor, TChange>,
+		keyof SharedTreeBranchEvents<TEditor, TChange, TChangeFamily>,
 		Set<
-			SharedTreeBranchEvents<TEditor, TChange>[keyof SharedTreeBranchEvents<TEditor, TChange>]
+			SharedTreeBranchEvents<TEditor, TChange, TChangeFamily>[keyof SharedTreeBranchEvents<
+				TEditor,
+				TChange,
+				TChangeFamily
+			>]
 		>
 	>();
 
@@ -365,20 +375,27 @@ export class SquashingTransactionStack<
 	 * options rather than baked into this stack, so different transactions may supply different post-processors (or none).
 	 */
 	public constructor(
-		public readonly branch: SharedTreeBranch<TEditor, TChange>,
+		public readonly branch: SharedTreeBranch<TEditor, TChange, TChangeFamily>,
 		mintRevisionTag: () => RevisionTag,
 		onPush?: () => OnPopWithViewUpdate<TChange> | void,
 	) {
 		// A stack of the post-processors to apply when each in-progress transaction commits, ordered from outermost to
 		// innermost. Each in-progress transaction contributes exactly one entry: either the processor to apply when it
 		// commits, or `undefined` when none should be applied.
-		const postProcessorStack: (ChangeProcessor<TChange> | undefined)[] = [];
+		const postProcessorStack: (
+			| ChangeProcessor<(change: TChange, changeFamily: TChangeFamily) => TChange>
+			| undefined
+		)[] = [];
 		// Determines the entry to push for a transaction that was started with the given `requested` processor (if any).
 		// A processor with "outermost" applicability that is already active in an enclosing transaction resolves to
 		// `undefined` so that it is only applied once (at the outermost transaction that supplied it).
 		const resolvePostProcessor = (
-			requested: ChangeProcessor<TChange> | undefined,
-		): ChangeProcessor<TChange> | undefined => {
+			requested:
+				| ChangeProcessor<(change: TChange, changeFamily: TChangeFamily) => TChange>
+				| undefined,
+		):
+			| ChangeProcessor<(change: TChange, changeFamily: TChangeFamily) => TChange>
+			| undefined => {
 			if (
 				requested?.applicability === ChangeProcessorApplicability.IfOutermost &&
 				postProcessorStack.includes(requested)
@@ -391,12 +408,13 @@ export class SquashingTransactionStack<
 		super(
 			// Invoked when an outer transaction starts
 			(
-				startOptions?: SquashingTransactionOptions<TChange>,
-			): Callbacks<SquashingTransactionOptions<TChange>> => {
+				startOptions?: SquashingTransactionOptions<TChange, TChangeFamily>,
+			): Callbacks<SquashingTransactionOptions<TChange, TChangeFamily>> => {
 				postProcessorStack.push(resolvePostProcessor(startOptions?.postProcessor));
 				// Keep track of the commit that each transaction was on when it started
 				const startHead = this.activeBranch.getHead();
-				const rebaser = this.branch.changeFamily.rebaser;
+				const changeFamily = this.branch.changeFamily;
+				const rebaser = changeFamily.rebaser;
 				const outerOnPop = onPush?.();
 				let transactionRevision: RevisionTag | undefined;
 				const transactionBranch = this.branch.fork(
@@ -462,7 +480,9 @@ export class SquashingTransactionStack<
 								// Apply this transaction's post-processor (if any) to the squashed change (for example, to
 								// "minimize" it so that it contains no extraneous information).
 								const change =
-									postProcessor === undefined ? squash : postProcessor.processChange(squash);
+									postProcessor === undefined
+										? squash
+										: changeFamily.buildProcessor(postProcessor.processChange)(squash);
 
 								if (change !== squash) {
 									// The post-processor produced a change that differs from the
@@ -524,9 +544,9 @@ export class SquashingTransactionStack<
 					outerOnPop?.(result, viewUpdate);
 				};
 				// Invoked when a nested transaction begins
-				const onNestedTransactionPush: OnPush<SquashingTransactionOptions<TChange>> = (
-					nestedStartOptions,
-				) => {
+				const onNestedTransactionPush: OnPush<
+					SquashingTransactionOptions<TChange, TChangeFamily>
+				> = (nestedStartOptions) => {
 					postProcessorStack.push(resolvePostProcessor(nestedStartOptions?.postProcessor));
 					const nestedStartHead = this.activeBranch.getHead();
 					const nestedOuterOnPop = onPush?.();
@@ -558,7 +578,9 @@ export class SquashingTransactionStack<
 												0xd07 /* Expected transaction revision in the presence of transaction steps */,
 											);
 											const squash = rebaser.compose(nestedSteps);
-											const processedSquash = nestedPostProcessor.processChange(squash);
+											const processedSquash = changeFamily.buildProcessor(
+												nestedPostProcessor.processChange,
+											)(squash);
 											// Roll back the transaction branch to the nested start head and apply the
 											// processed change if it differs from the original change.
 											if (processedSquash !== squash) {
@@ -586,7 +608,7 @@ export class SquashingTransactionStack<
 
 	/** Updates the transaction branch (and therefore the active branch) and rebinds the branch events. */
 	private setTransactionBranch(
-		transactionBranch: SharedTreeBranch<TEditor, TChange> | undefined,
+		transactionBranch: SharedTreeBranch<TEditor, TChange, TChangeFamily> | undefined,
 	): void {
 		const oldActiveBranch = this.activeBranch;
 		this.#transactionBranch = transactionBranch;

--- a/packages/dds/tree/src/shared-tree/serializedChange.ts
+++ b/packages/dds/tree/src/shared-tree/serializedChange.ts
@@ -48,7 +48,7 @@ function isSerializedChangeV1(value: unknown): value is SerializedChange {
 
 function encodeSerializedChangeV1(
 	idCompressor: IIdCompressor,
-	changeFamily: ChangeFamily<SharedTreeEditBuilder, SharedTreeChange>,
+	changeFamily: ChangeFamily<SharedTreeEditBuilder, SharedTreeChange, unknown>,
 	change: SharedTreeChange,
 	changeRevision: RevisionTag,
 	contextRevision?: RevisionTag,
@@ -73,7 +73,7 @@ function encodeSerializedChangeV1(
 
 function decodeSerializedChangeV1(
 	idCompressor: IIdCompressor,
-	changeFamily: ChangeFamily<SharedTreeEditBuilder, SharedTreeChange>,
+	changeFamily: ChangeFamily<SharedTreeEditBuilder, SharedTreeChange, unknown>,
 	serializedChange: JsonCompatibleReadOnly,
 ): TaggedChange<SharedTreeChange> {
 	if (!isSerializedChangeV1(serializedChange)) {

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -174,7 +174,7 @@ export type SharedTreeKernelView = Omit<ITreePrivate, keyof (IChannelView & IFlu
  */
 @breakingClass
 export class SharedTreeKernel
-	extends SharedTreeCore<SharedTreeEditBuilder, SharedTreeChange>
+	extends SharedTreeCore<SharedTreeEditBuilder, SharedTreeChange, SharedTreeChangeFamily>
 	implements SharedKernel
 {
 	public readonly checkout: TreeCheckout;
@@ -436,7 +436,11 @@ export class SharedTreeKernel
 
 	public override applyStashedOp(
 		...args: Parameters<
-			SharedTreeCore<SharedTreeEditBuilder, SharedTreeChange>["applyStashedOp"]
+			SharedTreeCore<
+				SharedTreeEditBuilder,
+				SharedTreeChange,
+				SharedTreeChangeFamily
+			>["applyStashedOp"]
 		>
 	): void {
 		for (const checkout of this.checkouts.values()) {

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -105,6 +105,7 @@ import {
 	getCodecTreeForChangeFormat,
 	SharedTreeChangeFormatVersion,
 } from "./sharedTreeChangeCodecs.js";
+import type { SharedTreeChangeProcessingContext } from "./sharedTreeChangeFamily.js";
 import { SharedTreeChangeFamily } from "./sharedTreeChangeFamily.js";
 import type { SharedTreeChange } from "./sharedTreeChangeTypes.js";
 import type { SharedTreeEditBuilder } from "./sharedTreeEditBuilder.js";
@@ -174,7 +175,11 @@ export type SharedTreeKernelView = Omit<ITreePrivate, keyof (IChannelView & IFlu
  */
 @breakingClass
 export class SharedTreeKernel
-	extends SharedTreeCore<SharedTreeEditBuilder, SharedTreeChange, SharedTreeChangeFamily>
+	extends SharedTreeCore<
+		SharedTreeEditBuilder,
+		SharedTreeChange,
+		SharedTreeChangeProcessingContext
+	>
 	implements SharedKernel
 {
 	public readonly checkout: TreeCheckout;
@@ -439,7 +444,7 @@ export class SharedTreeKernel
 			SharedTreeCore<
 				SharedTreeEditBuilder,
 				SharedTreeChange,
-				SharedTreeChangeFamily
+				SharedTreeChangeProcessingContext
 			>["applyStashedOp"]
 		>
 	): void {

--- a/packages/dds/tree/src/shared-tree/sharedTreeChangeFamily.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTreeChangeFamily.ts
@@ -49,7 +49,7 @@ import { SharedTreeEditBuilder } from "./sharedTreeEditBuilder.js";
  */
 export class SharedTreeChangeFamily
 	implements
-		ChangeFamily<SharedTreeEditBuilder, SharedTreeChange>,
+		ChangeFamily<SharedTreeEditBuilder, SharedTreeChange, SharedTreeChangeFamily>,
 		ChangeRebaser<SharedTreeChange>
 {
 	public static readonly emptyChange: SharedTreeChange = {
@@ -61,7 +61,7 @@ export class SharedTreeChangeFamily
 		ChangeEncodingContext,
 		ChangeDecodingContext
 	>;
-	private readonly modularChangeFamily: ModularChangeFamily;
+	public readonly modularChangeFamily: ModularChangeFamily;
 
 	public constructor(
 		revisionTagCodec: RevisionTagCodec,
@@ -97,6 +97,15 @@ export class SharedTreeChangeFamily
 			mintRevisionTag,
 			changeReceiver,
 		);
+	}
+
+	public buildProcessor(
+		processFn: (
+			change: SharedTreeChange,
+			changeFamily: SharedTreeChangeFamily,
+		) => SharedTreeChange,
+	): (change: SharedTreeChange) => SharedTreeChange {
+		return (change: SharedTreeChange) => processFn(change, this);
 	}
 
 	public compose(changes: TaggedChange<SharedTreeChange>[]): SharedTreeChange {

--- a/packages/dds/tree/src/shared-tree/sharedTreeChangeFamily.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTreeChangeFamily.ts
@@ -42,6 +42,10 @@ import { makeSharedTreeChangeCodecFamily } from "./sharedTreeChangeCodecs.js";
 import type { SharedTreeChange } from "./sharedTreeChangeTypes.js";
 import { SharedTreeEditBuilder } from "./sharedTreeEditBuilder.js";
 
+export interface SharedTreeChangeProcessingContext {
+	modularChangeFamily: ModularChangeFamily;
+}
+
 /**
  * Implementation of {@link ChangeFamily} that combines edits to fields and schema changes.
  *
@@ -49,7 +53,7 @@ import { SharedTreeEditBuilder } from "./sharedTreeEditBuilder.js";
  */
 export class SharedTreeChangeFamily
 	implements
-		ChangeFamily<SharedTreeEditBuilder, SharedTreeChange, SharedTreeChangeFamily>,
+		ChangeFamily<SharedTreeEditBuilder, SharedTreeChange, SharedTreeChangeProcessingContext>,
 		ChangeRebaser<SharedTreeChange>
 {
 	public static readonly emptyChange: SharedTreeChange = {
@@ -61,7 +65,7 @@ export class SharedTreeChangeFamily
 		ChangeEncodingContext,
 		ChangeDecodingContext
 	>;
-	public readonly modularChangeFamily: ModularChangeFamily;
+	private readonly modularChangeFamily: ModularChangeFamily;
 
 	public constructor(
 		revisionTagCodec: RevisionTagCodec,
@@ -102,10 +106,13 @@ export class SharedTreeChangeFamily
 	public buildProcessor(
 		processFn: (
 			change: SharedTreeChange,
-			changeFamily: SharedTreeChangeFamily,
+			context: SharedTreeChangeProcessingContext,
 		) => SharedTreeChange,
 	): (change: SharedTreeChange) => SharedTreeChange {
-		return (change: SharedTreeChange) => processFn(change, this);
+		return (change: SharedTreeChange) =>
+			processFn(change, {
+				modularChangeFamily: this.modularChangeFamily,
+			});
 	}
 
 	public compose(changes: TaggedChange<SharedTreeChange>[]): SharedTreeChange {

--- a/packages/dds/tree/src/shared-tree/sharedTreeChangeFamily.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTreeChangeFamily.ts
@@ -19,6 +19,7 @@ import {
 	type RevisionTagCodec,
 	type TaggedChange,
 	mapTaggedChange,
+	type ProcessChangeFn,
 } from "../core/index.js";
 import {
 	type FieldBatchCodec,
@@ -104,10 +105,7 @@ export class SharedTreeChangeFamily
 	}
 
 	public buildProcessor(
-		processFn: (
-			change: SharedTreeChange,
-			context: SharedTreeChangeProcessingContext,
-		) => SharedTreeChange,
+		processFn: ProcessChangeFn<SharedTreeChange, SharedTreeChangeProcessingContext>,
 	): (change: SharedTreeChange) => SharedTreeChange {
 		return (change: SharedTreeChange) =>
 			processFn(change, {

--- a/packages/dds/tree/src/shared-tree/transactionMinimize.ts
+++ b/packages/dds/tree/src/shared-tree/transactionMinimize.ts
@@ -12,7 +12,7 @@ import type { TransactionPostProcessor } from "../simple-tree/index.js";
 import { mapDataChanges } from "./sharedTreeChangeFamily.js";
 import type { SharedTreeChange } from "./sharedTreeChangeTypes.js";
 import { createTransactionPostProcessor } from "./transactionPostProcessor.js";
-import type { SharedTreeChangeFamily } from "./sharedTreeChangeFamily.js";
+import type { SharedTreeChangeProcessingContext } from "./sharedTreeChangeFamily.js";
 
 /**
  * "Minimizes" a {@link SharedTreeChange} so that it contains no extraneous
@@ -29,7 +29,7 @@ import type { SharedTreeChangeFamily } from "./sharedTreeChangeFamily.js";
  */
 function minimizeSharedTreeChange(
 	change: SharedTreeChange,
-	changeFamily: SharedTreeChangeFamily,
+	context: SharedTreeChangeProcessingContext,
 ): SharedTreeChange {
 	const countOfDataChanges = change.changes.filter(
 		(innerChange) => innerChange.type === "data",
@@ -40,7 +40,7 @@ function minimizeSharedTreeChange(
 		);
 	}
 	return mapDataChanges(change, (dataChange) =>
-		minimizeModularChangeset(dataChange, changeFamily.modularChangeFamily),
+		minimizeModularChangeset(dataChange, context.modularChangeFamily),
 	);
 }
 

--- a/packages/dds/tree/src/shared-tree/transactionMinimize.ts
+++ b/packages/dds/tree/src/shared-tree/transactionMinimize.ts
@@ -5,13 +5,14 @@
 
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
-import { fieldKinds, minimizeModularChangeset } from "../feature-libraries/index.js";
+import { minimizeModularChangeset } from "../feature-libraries/index.js";
 import { ChangeProcessorApplicability } from "../shared-tree-core/index.js";
 import type { TransactionPostProcessor } from "../simple-tree/index.js";
 
 import { mapDataChanges } from "./sharedTreeChangeFamily.js";
 import type { SharedTreeChange } from "./sharedTreeChangeTypes.js";
 import { createTransactionPostProcessor } from "./transactionPostProcessor.js";
+import type { SharedTreeChangeFamily } from "./sharedTreeChangeFamily.js";
 
 /**
  * "Minimizes" a {@link SharedTreeChange} so that it contains no extraneous
@@ -26,7 +27,10 @@ import { createTransactionPostProcessor } from "./transactionPostProcessor.js";
  *
  * Schema changes are left unchanged.
  */
-function minimizeSharedTreeChange(change: SharedTreeChange): SharedTreeChange {
+function minimizeSharedTreeChange(
+	change: SharedTreeChange,
+	changeFamily: SharedTreeChangeFamily,
+): SharedTreeChange {
 	const countOfDataChanges = change.changes.filter(
 		(innerChange) => innerChange.type === "data",
 	).length;
@@ -36,7 +40,7 @@ function minimizeSharedTreeChange(change: SharedTreeChange): SharedTreeChange {
 		);
 	}
 	return mapDataChanges(change, (dataChange) =>
-		minimizeModularChangeset(dataChange, fieldKinds),
+		minimizeModularChangeset(dataChange, changeFamily.modularChangeFamily),
 	);
 }
 

--- a/packages/dds/tree/src/shared-tree/transactionPostProcessor.ts
+++ b/packages/dds/tree/src/shared-tree/transactionPostProcessor.ts
@@ -6,6 +6,7 @@
 import type { ChangeProcessor } from "../shared-tree-core/index.js";
 import type { TransactionPostProcessor } from "../simple-tree/index.js";
 
+import type { SharedTreeChangeFamily } from "./sharedTreeChangeFamily.js";
 import type { SharedTreeChange } from "./sharedTreeChangeTypes.js";
 
 /**
@@ -13,7 +14,9 @@ import type { SharedTreeChange } from "./sharedTreeChangeTypes.js";
  * {@link SharedTreeChange}.
  * @remarks This is the (non-type-erased) form used internally to apply a transaction's post-processor.
  */
-export type TransactionPostProcessorInternal = ChangeProcessor<SharedTreeChange>;
+export type TransactionPostProcessorInternal = ChangeProcessor<
+	(change: SharedTreeChange, changeFamily: SharedTreeChangeFamily) => SharedTreeChange
+>;
 
 /**
  * Type-erases an internal {@link TransactionPostProcessorInternal | change processor} as a public

--- a/packages/dds/tree/src/shared-tree/transactionPostProcessor.ts
+++ b/packages/dds/tree/src/shared-tree/transactionPostProcessor.ts
@@ -15,7 +15,8 @@ import type { SharedTreeChange } from "./sharedTreeChangeTypes.js";
  * @remarks This is the (non-type-erased) form used internally to apply a transaction's post-processor.
  */
 export type TransactionPostProcessorInternal = ChangeProcessor<
-	(change: SharedTreeChange, context: SharedTreeChangeProcessingContext) => SharedTreeChange
+	SharedTreeChange,
+	SharedTreeChangeProcessingContext
 >;
 
 /**

--- a/packages/dds/tree/src/shared-tree/transactionPostProcessor.ts
+++ b/packages/dds/tree/src/shared-tree/transactionPostProcessor.ts
@@ -5,8 +5,8 @@
 
 import type { ChangeProcessor } from "../shared-tree-core/index.js";
 import type { TransactionPostProcessor } from "../simple-tree/index.js";
+import type { SharedTreeChangeProcessingContext } from "./sharedTreeChangeFamily.js";
 
-import type { SharedTreeChangeFamily } from "./sharedTreeChangeFamily.js";
 import type { SharedTreeChange } from "./sharedTreeChangeTypes.js";
 
 /**
@@ -15,7 +15,7 @@ import type { SharedTreeChange } from "./sharedTreeChangeTypes.js";
  * @remarks This is the (non-type-erased) form used internally to apply a transaction's post-processor.
  */
 export type TransactionPostProcessorInternal = ChangeProcessor<
-	(change: SharedTreeChange, changeFamily: SharedTreeChangeFamily) => SharedTreeChange
+	(change: SharedTreeChange, context: SharedTreeChangeProcessingContext) => SharedTreeChange
 >;
 
 /**

--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -210,7 +210,9 @@ export interface CheckoutEvents {
 /**
  * A collection of functions for managing transactions on a {@link ITreeCheckout}.
  */
-export type TreeTransactor = Transactor<SquashingTransactionOptions<SharedTreeChange>>;
+export type TreeTransactor = Transactor<
+	SquashingTransactionOptions<SharedTreeChange, SharedTreeChangeFamily>
+>;
 
 /**
  * Provides a means for interacting with a SharedTree.
@@ -305,8 +307,12 @@ export function createTreeCheckout(
 	mintRevisionTag: () => RevisionTag,
 	revisionTagCodec: RevisionTagCodec,
 	args?: {
-		branch?: SharedTreeBranch<SharedTreeEditBuilder, SharedTreeChange>;
-		changeFamily?: ChangeFamily<SharedTreeEditBuilder, SharedTreeChange>;
+		branch?: SharedTreeBranch<SharedTreeEditBuilder, SharedTreeChange, SharedTreeChangeFamily>;
+		changeFamily?: ChangeFamily<
+			SharedTreeEditBuilder,
+			SharedTreeChange,
+			SharedTreeChangeFamily
+		>;
 		schema?: TreeStoredSchemaRepository;
 		forest?: IEditableForest;
 		fieldBatchCodec?: FieldBatchCodec;
@@ -501,7 +507,7 @@ export class TreeCheckout implements ITreeCheckout {
 	 */
 	private readonly revertibleCommitBranches = new Map<
 		RevisionTag,
-		SharedTreeBranch<SharedTreeEditBuilder, SharedTreeChange>
+		SharedTreeBranch<SharedTreeEditBuilder, SharedTreeChange, SharedTreeChangeFamily>
 	>();
 
 	/**
@@ -514,10 +520,14 @@ export class TreeCheckout implements ITreeCheckout {
 	public events: Listenable<CheckoutEvents> = this.#events;
 
 	public constructor(
-		branch: SharedTreeBranch<SharedTreeEditBuilder, SharedTreeChange>,
+		branch: SharedTreeBranch<SharedTreeEditBuilder, SharedTreeChange, SharedTreeChangeFamily>,
 		/** True if and only if this checkout is for a branch which is persisted and shared with other clients. */
 		public readonly isSharedBranch: boolean,
-		private readonly changeFamily: ChangeFamily<SharedTreeEditBuilder, SharedTreeChange>,
+		private readonly changeFamily: ChangeFamily<
+			SharedTreeEditBuilder,
+			SharedTreeChange,
+			SharedTreeChangeFamily
+		>,
 		public readonly storedSchema: TreeStoredSchemaRepository,
 		public readonly forest: IEditableForest,
 		private readonly mintRevisionTag: () => RevisionTag,
@@ -660,8 +670,12 @@ export class TreeCheckout implements ITreeCheckout {
 	}
 
 	private createTransactionStack(
-		branch: SharedTreeBranch<SharedTreeEditBuilder, SharedTreeChange>,
-	): SquashingTransactionStack<SharedTreeEditBuilder, SharedTreeChange> {
+		branch: SharedTreeBranch<SharedTreeEditBuilder, SharedTreeChange, SharedTreeChangeFamily>,
+	): SquashingTransactionStack<
+		SharedTreeEditBuilder,
+		SharedTreeChange,
+		SharedTreeChangeFamily
+	> {
 		return new SquashingTransactionStack(branch, this.mintRevisionTag, () => {
 			// When each transaction is started, make a restorable checkpoint of the current state of removed roots
 			const restoreRemovedRoots = this._removedRoots.createCheckpoint();
@@ -1187,7 +1201,11 @@ export class TreeCheckout implements ITreeCheckout {
 	 * To avoid updating observers of the view state with intermediate results during a transaction,
 	 * use {@link ITreeCheckout#fork} and {@link ISharedTreeFork#merge}.
 	 */
-	#transaction: SquashingTransactionStack<SharedTreeEditBuilder, SharedTreeChange>;
+	#transaction: SquashingTransactionStack<
+		SharedTreeEditBuilder,
+		SharedTreeChange,
+		SharedTreeChangeFamily
+	>;
 
 	@throwIfBroken
 	public fork(): TreeCheckout {
@@ -1221,7 +1239,7 @@ export class TreeCheckout implements ITreeCheckout {
 	}
 
 	public switchBranch(
-		branch: SharedTreeBranch<SharedTreeEditBuilder, SharedTreeChange>,
+		branch: SharedTreeBranch<SharedTreeEditBuilder, SharedTreeChange, SharedTreeChangeFamily>,
 	): void {
 		// TODO: Dispose old branch, if necessary
 		assert(
@@ -1648,7 +1666,11 @@ export class TreeCheckout implements ITreeCheckout {
 		return enriched;
 	}
 
-	public get mainBranch(): SharedTreeBranch<SharedTreeEditBuilder, SharedTreeChange> {
+	public get mainBranch(): SharedTreeBranch<
+		SharedTreeEditBuilder,
+		SharedTreeChange,
+		SharedTreeChangeFamily
+	> {
 		return this.#transaction.branch;
 	}
 

--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -114,6 +114,7 @@ import {
 
 import { SchematizingSimpleTreeView } from "./schematizingTreeView.js";
 import { SharedTreeChangeEnricher } from "./sharedTreeChangeEnricher.js";
+import type { SharedTreeChangeProcessingContext } from "./sharedTreeChangeFamily.js";
 import { SharedTreeChangeFamily, hasSchemaChange } from "./sharedTreeChangeFamily.js";
 import type { SharedTreeChange } from "./sharedTreeChangeTypes.js";
 import type { ISharedTreeEditor, SharedTreeEditBuilder } from "./sharedTreeEditBuilder.js";
@@ -211,7 +212,7 @@ export interface CheckoutEvents {
  * A collection of functions for managing transactions on a {@link ITreeCheckout}.
  */
 export type TreeTransactor = Transactor<
-	SquashingTransactionOptions<SharedTreeChange, SharedTreeChangeFamily>
+	SquashingTransactionOptions<SharedTreeChange, SharedTreeChangeProcessingContext>
 >;
 
 /**
@@ -307,11 +308,15 @@ export function createTreeCheckout(
 	mintRevisionTag: () => RevisionTag,
 	revisionTagCodec: RevisionTagCodec,
 	args?: {
-		branch?: SharedTreeBranch<SharedTreeEditBuilder, SharedTreeChange, SharedTreeChangeFamily>;
+		branch?: SharedTreeBranch<
+			SharedTreeEditBuilder,
+			SharedTreeChange,
+			SharedTreeChangeProcessingContext
+		>;
 		changeFamily?: ChangeFamily<
 			SharedTreeEditBuilder,
 			SharedTreeChange,
-			SharedTreeChangeFamily
+			SharedTreeChangeProcessingContext
 		>;
 		schema?: TreeStoredSchemaRepository;
 		forest?: IEditableForest;
@@ -507,7 +512,11 @@ export class TreeCheckout implements ITreeCheckout {
 	 */
 	private readonly revertibleCommitBranches = new Map<
 		RevisionTag,
-		SharedTreeBranch<SharedTreeEditBuilder, SharedTreeChange, SharedTreeChangeFamily>
+		SharedTreeBranch<
+			SharedTreeEditBuilder,
+			SharedTreeChange,
+			SharedTreeChangeProcessingContext
+		>
 	>();
 
 	/**
@@ -520,13 +529,17 @@ export class TreeCheckout implements ITreeCheckout {
 	public events: Listenable<CheckoutEvents> = this.#events;
 
 	public constructor(
-		branch: SharedTreeBranch<SharedTreeEditBuilder, SharedTreeChange, SharedTreeChangeFamily>,
+		branch: SharedTreeBranch<
+			SharedTreeEditBuilder,
+			SharedTreeChange,
+			SharedTreeChangeProcessingContext
+		>,
 		/** True if and only if this checkout is for a branch which is persisted and shared with other clients. */
 		public readonly isSharedBranch: boolean,
 		private readonly changeFamily: ChangeFamily<
 			SharedTreeEditBuilder,
 			SharedTreeChange,
-			SharedTreeChangeFamily
+			SharedTreeChangeProcessingContext
 		>,
 		public readonly storedSchema: TreeStoredSchemaRepository,
 		public readonly forest: IEditableForest,
@@ -670,11 +683,15 @@ export class TreeCheckout implements ITreeCheckout {
 	}
 
 	private createTransactionStack(
-		branch: SharedTreeBranch<SharedTreeEditBuilder, SharedTreeChange, SharedTreeChangeFamily>,
+		branch: SharedTreeBranch<
+			SharedTreeEditBuilder,
+			SharedTreeChange,
+			SharedTreeChangeProcessingContext
+		>,
 	): SquashingTransactionStack<
 		SharedTreeEditBuilder,
 		SharedTreeChange,
-		SharedTreeChangeFamily
+		SharedTreeChangeProcessingContext
 	> {
 		return new SquashingTransactionStack(branch, this.mintRevisionTag, () => {
 			// When each transaction is started, make a restorable checkpoint of the current state of removed roots
@@ -1204,7 +1221,7 @@ export class TreeCheckout implements ITreeCheckout {
 	#transaction: SquashingTransactionStack<
 		SharedTreeEditBuilder,
 		SharedTreeChange,
-		SharedTreeChangeFamily
+		SharedTreeChangeProcessingContext
 	>;
 
 	@throwIfBroken
@@ -1239,7 +1256,11 @@ export class TreeCheckout implements ITreeCheckout {
 	}
 
 	public switchBranch(
-		branch: SharedTreeBranch<SharedTreeEditBuilder, SharedTreeChange, SharedTreeChangeFamily>,
+		branch: SharedTreeBranch<
+			SharedTreeEditBuilder,
+			SharedTreeChange,
+			SharedTreeChangeProcessingContext
+		>,
 	): void {
 		// TODO: Dispose old branch, if necessary
 		assert(
@@ -1669,7 +1690,7 @@ export class TreeCheckout implements ITreeCheckout {
 	public get mainBranch(): SharedTreeBranch<
 		SharedTreeEditBuilder,
 		SharedTreeChange,
-		SharedTreeChangeFamily
+		SharedTreeChangeProcessingContext
 	> {
 		return this.#transaction.branch;
 	}

--- a/packages/dds/tree/src/test/feature-libraries/mitigatedChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/mitigatedChangeFamily.spec.ts
@@ -26,7 +26,7 @@ const arg2: any = "arg2";
 const arg3: any = "arg3";
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
-const throwingFamily: ChangeFamily<ChangeFamilyEditor, string> = {
+const throwingFamily: ChangeFamily<ChangeFamilyEditor, string, never> = {
 	buildEditor: (
 		mintRevisionTagArg: () => RevisionTag,
 		changeReceiver: (change: TaggedChange<string>) => void,
@@ -61,8 +61,15 @@ const throwingFamily: ChangeFamily<ChangeFamilyEditor, string> = {
 		},
 	},
 	codecs: {} as unknown as ICodecFamily<string, ChangeEncodingContext>,
+	buildProcessor: (context: unknown): ((change: string) => string) => {
+		assert.equal(context, arg1);
+		return (change: string) => {
+			assert.equal(change, arg2);
+			throw new Error("buildProcessor return invocation");
+		};
+	},
 };
-const returningFamily: ChangeFamily<ChangeFamilyEditor, string> = {
+const returningFamily: ChangeFamily<ChangeFamilyEditor, string, never> = {
 	buildEditor: (
 		mintRevisionTagArg: () => RevisionTag,
 		changeReceiver: (change: TaggedChange<string>) => void,
@@ -97,6 +104,13 @@ const returningFamily: ChangeFamily<ChangeFamilyEditor, string> = {
 		},
 	},
 	codecs: {} as unknown as ICodecFamily<string, ChangeEncodingContext>,
+	buildProcessor: (context: unknown): ((change: string) => string) => {
+		assert.equal(context, arg1);
+		return (change: string) => {
+			assert.equal(change, arg2);
+			return "buildProcessor";
+		};
+	},
 };
 
 const errorLog: unknown[] = [];
@@ -134,6 +148,9 @@ describe("makeMitigatedChangeFamily", () => {
 			mitigatedReturningRebaser.changeRevision(arg1, arg2),
 			returningRebaser.changeRevision(arg1, arg2),
 		);
+		const mitigatedProcessor = mitigatedReturningFamily.buildProcessor(arg1);
+		const returningProcessor = returningFamily.buildProcessor(arg1);
+		assert.equal(mitigatedProcessor(arg2), returningProcessor(arg2));
 	});
 	describe("catches errors from", () => {
 		it("rebase", () => {
@@ -160,6 +177,12 @@ describe("makeMitigatedChangeFamily", () => {
 			errorLog.length = 0;
 			assert.equal(mitigatedThrowingRebaser.changeRevision(arg1, arg2), fallback);
 			assert.deepEqual(errorLog, ["changeRevision"]);
+		});
+		it("buildProcessor return invocation", () => {
+			errorLog.length = 0;
+			const processor = mitigatedThrowingFamily.buildProcessor(arg1);
+			assert.equal(processor(arg2), fallback);
+			assert.deepEqual(errorLog, ["buildProcessor return invocation"]);
 		});
 	});
 	it("does not catch errors from buildEditor", () => {

--- a/packages/dds/tree/src/test/feature-libraries/mitigatedChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/mitigatedChangeFamily.spec.ts
@@ -26,7 +26,7 @@ const arg2: any = "arg2";
 const arg3: any = "arg3";
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
-const throwingFamily: ChangeFamily<ChangeFamilyEditor, string, never> = {
+const throwingFamily: ChangeFamily<ChangeFamilyEditor, string, unknown> = {
 	buildEditor: (
 		mintRevisionTagArg: () => RevisionTag,
 		changeReceiver: (change: TaggedChange<string>) => void,
@@ -69,7 +69,7 @@ const throwingFamily: ChangeFamily<ChangeFamilyEditor, string, never> = {
 		};
 	},
 };
-const returningFamily: ChangeFamily<ChangeFamilyEditor, string, never> = {
+const returningFamily: ChangeFamily<ChangeFamilyEditor, string, unknown> = {
 	buildEditor: (
 		mintRevisionTagArg: () => RevisionTag,
 		changeReceiver: (change: TaggedChange<string>) => void,

--- a/packages/dds/tree/src/test/shared-tree-core/branch.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/branch.spec.ts
@@ -16,6 +16,7 @@ import {
 } from "../../core/index.js";
 import {
 	DefaultChangeFamily,
+	type DefaultChangeProcessingContext,
 	type DefaultChangeset,
 	type DefaultEditBuilder,
 } from "../../feature-libraries/index.js";
@@ -36,7 +37,7 @@ const defaultChangeFamily = new DefaultChangeFamily(failCodecFamily, {
 type DefaultBranch = SharedTreeBranch<
 	DefaultEditBuilder,
 	DefaultChangeset,
-	DefaultChangeFamily
+	DefaultChangeProcessingContext
 >;
 
 describe("Branches", () => {

--- a/packages/dds/tree/src/test/shared-tree-core/branch.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/branch.spec.ts
@@ -33,7 +33,11 @@ const defaultChangeFamily = new DefaultChangeFamily(failCodecFamily, {
 	minVersionForCollab: FluidClientVersion.v2_0,
 });
 
-type DefaultBranch = SharedTreeBranch<DefaultEditBuilder, DefaultChangeset>;
+type DefaultBranch = SharedTreeBranch<
+	DefaultEditBuilder,
+	DefaultChangeset,
+	DefaultChangeFamily
+>;
 
 describe("Branches", () => {
 	/** The tag used for the "origin commit" (the commit that all other commits share as a common ancestor) */

--- a/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManager.bench.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManager.bench.ts
@@ -63,7 +63,7 @@ describe("EditManager - Bench", () => {
 
 	interface Family<TChange> {
 		readonly name: string;
-		readonly changeFamily: ChangeFamily<ChangeFamilyEditor, TChange>;
+		readonly changeFamily: ChangeFamily<ChangeFamilyEditor, TChange, unknown>;
 		readonly mintChange: (revision: RevisionTag | undefined) => TChange;
 		readonly maxEditCount: number;
 	}

--- a/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerCorrectness.test.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerCorrectness.test.ts
@@ -15,6 +15,7 @@ import type {
 	SharedTreeBranch,
 } from "../../../shared-tree-core/index.js";
 import { brand, makeArray } from "../../../util/index.js";
+import type { TestChangeFamily } from "../../testChange.js";
 import { NoOpChangeRebaser, TestChange } from "../../testChange.js";
 import { mintRevisionTag } from "../../utils.js";
 
@@ -896,7 +897,7 @@ function applyLocalCommit(
 	manager: EditManager<
 		ChangeFamilyEditor,
 		TestChange,
-		ChangeFamily<ChangeFamilyEditor, TestChange>
+		ChangeFamily<ChangeFamilyEditor, TestChange, never>
 	>,
 	inputContext: readonly number[] = [],
 	intention: number | number[] = [],
@@ -905,7 +906,7 @@ function applyLocalCommit(
 }
 
 function applyBranchCommit(
-	branch: SharedTreeBranch<ChangeFamilyEditor, TestChange>,
+	branch: SharedTreeBranch<ChangeFamilyEditor, TestChange, TestChangeFamily>,
 	inputContext: readonly number[] = [],
 	intention: number | number[] = [],
 ): Commit<TestChange> {
@@ -935,7 +936,7 @@ function peerCommit(
 }
 
 function trackTrimmed(
-	branch: SharedTreeBranch<ChangeFamilyEditor, TestChange>,
+	branch: SharedTreeBranch<ChangeFamilyEditor, TestChange, TestChangeFamily>,
 ): ReadonlySet<RevisionTag> {
 	const trimmedCommits = new Set<RevisionTag>();
 	branch.events.on("ancestryTrimmed", (trimmedRevisions) => {

--- a/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerCorrectness.test.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerCorrectness.test.ts
@@ -894,11 +894,7 @@ export function testCorrectness(): void {
 }
 
 function applyLocalCommit(
-	manager: EditManager<
-		ChangeFamilyEditor,
-		TestChange,
-		ChangeFamily<ChangeFamilyEditor, TestChange, never>
-	>,
+	manager: EditManager<ChangeFamilyEditor, TestChange>,
 	inputContext: readonly number[] = [],
 	intention: number | number[] = [],
 ): Commit<TestChange> {

--- a/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerCorrectness.test.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerCorrectness.test.ts
@@ -8,7 +8,7 @@ import { strict as assert } from "node:assert";
 import { describeStress, StressMode } from "@fluid-private/stochastic-test-utils";
 import type { SessionId } from "@fluidframework/id-compressor";
 
-import type { ChangeFamily, ChangeFamilyEditor, RevisionTag } from "../../../core/index.js";
+import type { ChangeFamilyEditor, RevisionTag } from "../../../core/index.js";
 import type {
 	Commit,
 	EditManager,

--- a/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerScenario.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerScenario.ts
@@ -11,7 +11,7 @@ import type { SessionId } from "@fluidframework/id-compressor";
 import type { ChangeFamilyEditor, ChangeRebaser } from "../../../core/index.js";
 import type { Commit, EditManager, SeqNumber } from "../../../shared-tree-core/index.js";
 import { brand } from "../../../util/index.js";
-import { TestChange, type TestChangeFamily, asDelta } from "../../testChange.js";
+import { TestChange, asDelta } from "../../testChange.js";
 import { mintRevisionTag } from "../../utils.js";
 
 import {
@@ -19,7 +19,7 @@ import {
 	checkChangeList,
 	testChangeEditManagerFactory,
 } from "./editManagerTestUtils.js";
-export type TestEditManager = EditManager<ChangeFamilyEditor, TestChange, TestChangeFamily>;
+export type TestEditManager = EditManager<ChangeFamilyEditor, TestChange>;
 
 /**
  * Represents the minting and sending of a new local change.

--- a/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerTestUtils.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerTestUtils.ts
@@ -25,7 +25,7 @@ export function testChangeEditManagerFactory(options: {
 	autoDiscardRevertibles?: boolean;
 }): {
 	manager: TestEditManager;
-	family: ChangeFamily<ChangeFamilyEditor, TestChange, never>;
+	family: ChangeFamily<ChangeFamilyEditor, TestChange>;
 } {
 	const family = testChangeFamilyFactory(options.rebaser);
 	const manager = editManagerFactory(family, {
@@ -36,14 +36,14 @@ export function testChangeEditManagerFactory(options: {
 }
 
 export function editManagerFactory<TChange = TestChange>(
-	family: ChangeFamily<ChangeFamilyEditor, TChange, unknown>,
+	family: ChangeFamily<ChangeFamilyEditor, TChange>,
 	options: {
 		sessionId?: SessionId;
 	} = {},
-): EditManager<ChangeFamilyEditor, TChange, never> {
+): EditManager<ChangeFamilyEditor, TChange> {
 	const genId = () => testIdCompressor.generateCompressedId();
-	const manager = new EditManager<ChangeFamilyEditor, TChange, never>(
-		family as ChangeFamily<ChangeFamilyEditor, TChange, never>,
+	const manager = new EditManager<ChangeFamilyEditor, TChange>(
+		family,
 		options.sessionId ?? ("0" as SessionId),
 		genId,
 	);

--- a/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerTestUtils.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerTestUtils.ts
@@ -15,14 +15,9 @@ import {
 } from "../../../core/index.js";
 import { type Commit, EditManager } from "../../../shared-tree-core/index.js";
 import { type RecursiveReadonly, brand, makeArray } from "../../../util/index.js";
-import {
-	TestChange,
-	type TestChangeFamily,
-	asDelta,
-	testChangeFamilyFactory,
-} from "../../testChange.js";
+import { TestChange, asDelta, testChangeFamilyFactory } from "../../testChange.js";
 import { mintRevisionTag, testIdCompressor } from "../../utils.js";
-export type TestEditManager = EditManager<ChangeFamilyEditor, TestChange, TestChangeFamily>;
+export type TestEditManager = EditManager<ChangeFamilyEditor, TestChange>;
 
 export function testChangeEditManagerFactory(options: {
 	rebaser?: ChangeRebaser<TestChange>;
@@ -45,13 +40,9 @@ export function editManagerFactory<TChange = TestChange>(
 	options: {
 		sessionId?: SessionId;
 	} = {},
-): EditManager<ChangeFamilyEditor, TChange, ChangeFamily<ChangeFamilyEditor, TChange, never>> {
+): EditManager<ChangeFamilyEditor, TChange, never> {
 	const genId = () => testIdCompressor.generateCompressedId();
-	const manager = new EditManager<
-		ChangeFamilyEditor,
-		TChange,
-		ChangeFamily<ChangeFamilyEditor, TChange, never>
-	>(
+	const manager = new EditManager<ChangeFamilyEditor, TChange, never>(
 		family as ChangeFamily<ChangeFamilyEditor, TChange, never>,
 		options.sessionId ?? ("0" as SessionId),
 		genId,
@@ -84,11 +75,7 @@ export function editManagerFactory<TChange = TestChange>(
 export function rebaseLocalEditsOverTrunkEdits<TChange>(
 	localEditCount: number,
 	trunkEditCount: number,
-	manager: EditManager<
-		ChangeFamilyEditor,
-		TChange,
-		ChangeFamily<ChangeFamilyEditor, TChange, never>
-	>,
+	manager: EditManager<ChangeFamilyEditor, TChange>,
 	mintChange: (revision: RevisionTag | undefined) => TChange,
 ): void;
 /**
@@ -118,11 +105,7 @@ export function rebaseLocalEditsOverTrunkEdits<TChange>(
 export function rebaseLocalEditsOverTrunkEdits<TChange>(
 	localEditCount: number,
 	trunkEditCount: number,
-	manager: EditManager<
-		ChangeFamilyEditor,
-		TChange,
-		ChangeFamily<ChangeFamilyEditor, TChange, never>
-	>,
+	manager: EditManager<ChangeFamilyEditor, TChange>,
 	mintChange: (revision: RevisionTag | undefined) => TChange,
 	defer: true,
 	bunchCommits?: boolean,
@@ -130,11 +113,7 @@ export function rebaseLocalEditsOverTrunkEdits<TChange>(
 export function rebaseLocalEditsOverTrunkEdits<TChange>(
 	localEditCount: number,
 	trunkEditCount: number,
-	manager: EditManager<
-		ChangeFamilyEditor,
-		TChange,
-		ChangeFamily<ChangeFamilyEditor, TChange, never>
-	>,
+	manager: EditManager<ChangeFamilyEditor, TChange>,
 	mintChange: (revision: RevisionTag | undefined) => TChange,
 	defer: boolean = false,
 	bunchCommits: boolean = false,
@@ -196,11 +175,7 @@ export function rebaseLocalEditsOverTrunkEdits<TChange>(
 export function rebasePeerEditsOverTrunkEdits<TChange>(
 	peerEditCount: number,
 	trunkEditCount: number,
-	manager: EditManager<
-		ChangeFamilyEditor,
-		TChange,
-		ChangeFamily<ChangeFamilyEditor, TChange, never>
-	>,
+	manager: EditManager<ChangeFamilyEditor, TChange>,
 	mintChange: () => TChange,
 ): void;
 /**
@@ -230,11 +205,7 @@ export function rebasePeerEditsOverTrunkEdits<TChange>(
 export function rebasePeerEditsOverTrunkEdits<TChange>(
 	peerEditCount: number,
 	trunkEditCount: number,
-	manager: EditManager<
-		ChangeFamilyEditor,
-		TChange,
-		ChangeFamily<ChangeFamilyEditor, TChange, never>
-	>,
+	manager: EditManager<ChangeFamilyEditor, TChange>,
 	mintChange: (revision: RevisionTag | undefined) => TChange,
 	defer: true,
 	bunchCommits?: boolean,
@@ -242,11 +213,7 @@ export function rebasePeerEditsOverTrunkEdits<TChange>(
 export function rebasePeerEditsOverTrunkEdits<TChange>(
 	peerEditCount: number,
 	trunkEditCount: number,
-	manager: EditManager<
-		ChangeFamilyEditor,
-		TChange,
-		ChangeFamily<ChangeFamilyEditor, TChange, never>
-	>,
+	manager: EditManager<ChangeFamilyEditor, TChange>,
 	mintChange: (revision: RevisionTag | undefined) => TChange,
 	defer: boolean = false,
 	bunchCommits: boolean = false,
@@ -326,11 +293,7 @@ export function rebasePeerEditsOverTrunkEdits<TChange>(
  */
 export function rebaseAdvancingPeerEditsOverTrunkEdits<TChange>(
 	editCount: number,
-	manager: EditManager<
-		ChangeFamilyEditor,
-		TChange,
-		ChangeFamily<ChangeFamilyEditor, TChange, never>
-	>,
+	manager: EditManager<ChangeFamilyEditor, TChange>,
 	mintChange: () => TChange,
 ): void;
 /**
@@ -360,21 +323,13 @@ export function rebaseAdvancingPeerEditsOverTrunkEdits<TChange>(
  */
 export function rebaseAdvancingPeerEditsOverTrunkEdits<TChange>(
 	editCount: number,
-	manager: EditManager<
-		ChangeFamilyEditor,
-		TChange,
-		ChangeFamily<ChangeFamilyEditor, TChange, never>
-	>,
+	manager: EditManager<ChangeFamilyEditor, TChange>,
 	mintChange: (revision: RevisionTag | undefined) => TChange,
 	defer: true,
 ): () => void;
 export function rebaseAdvancingPeerEditsOverTrunkEdits<TChange>(
 	editCount: number,
-	manager: EditManager<
-		ChangeFamilyEditor,
-		TChange,
-		ChangeFamily<ChangeFamilyEditor, TChange, never>
-	>,
+	manager: EditManager<ChangeFamilyEditor, TChange>,
 	mintChange: (revision: RevisionTag | undefined) => TChange,
 	defer: boolean = false,
 ): void | (() => void) {
@@ -440,11 +395,7 @@ export function rebaseAdvancingPeerEditsOverTrunkEdits<TChange>(
 export function rebaseConcurrentPeerEdits<TChange>(
 	peerCount: number,
 	editsPerPeerCount: number,
-	manager: EditManager<
-		ChangeFamilyEditor,
-		TChange,
-		ChangeFamily<ChangeFamilyEditor, TChange, never>
-	>,
+	manager: EditManager<ChangeFamilyEditor, TChange>,
 	mintChange: (revision: RevisionTag | undefined) => TChange,
 	defer: true,
 ): () => void;
@@ -473,21 +424,13 @@ export function rebaseConcurrentPeerEdits<TChange>(
 export function rebaseConcurrentPeerEdits<TChange>(
 	peerCount: number,
 	editsPerPeerCount: number,
-	manager: EditManager<
-		ChangeFamilyEditor,
-		TChange,
-		ChangeFamily<ChangeFamilyEditor, TChange, never>
-	>,
+	manager: EditManager<ChangeFamilyEditor, TChange>,
 	mintChange: (revision: RevisionTag | undefined) => TChange,
 ): void;
 export function rebaseConcurrentPeerEdits<TChange>(
 	peerCount: number,
 	editsPerPeerCount: number,
-	manager: EditManager<
-		ChangeFamilyEditor,
-		TChange,
-		ChangeFamily<ChangeFamilyEditor, TChange, never>
-	>,
+	manager: EditManager<ChangeFamilyEditor, TChange>,
 	mintChange: (revision: RevisionTag | undefined) => TChange,
 	defer: boolean = false,
 ): void | (() => void) {
@@ -549,11 +492,7 @@ export function addSequencedChanges(
 
 /** Subscribe to the local branch to emulate the behavior of SharedTree */
 function subscribeToLocalBranch<TChange>(
-	manager: EditManager<
-		ChangeFamilyEditor,
-		TChange,
-		ChangeFamily<ChangeFamilyEditor, TChange, never>
-	>,
+	manager: EditManager<ChangeFamilyEditor, TChange>,
 ): void {
 	manager.getLocalBranch("main").events.on("afterChange", (branchChange) => {
 		// Reading the change property causes lazy computation to occur, and is important to accurately emulate SharedTree behavior

--- a/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerTestUtils.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerTestUtils.ts
@@ -30,7 +30,7 @@ export function testChangeEditManagerFactory(options: {
 	autoDiscardRevertibles?: boolean;
 }): {
 	manager: TestEditManager;
-	family: ChangeFamily<ChangeFamilyEditor, TestChange>;
+	family: ChangeFamily<ChangeFamilyEditor, TestChange, never>;
 } {
 	const family = testChangeFamilyFactory(options.rebaser);
 	const manager = editManagerFactory(family, {
@@ -41,17 +41,21 @@ export function testChangeEditManagerFactory(options: {
 }
 
 export function editManagerFactory<TChange = TestChange>(
-	family: ChangeFamily<ChangeFamilyEditor, TChange>,
+	family: ChangeFamily<ChangeFamilyEditor, TChange, unknown>,
 	options: {
 		sessionId?: SessionId;
 	} = {},
-): EditManager<ChangeFamilyEditor, TChange, ChangeFamily<ChangeFamilyEditor, TChange>> {
+): EditManager<ChangeFamilyEditor, TChange, ChangeFamily<ChangeFamilyEditor, TChange, never>> {
 	const genId = () => testIdCompressor.generateCompressedId();
 	const manager = new EditManager<
 		ChangeFamilyEditor,
 		TChange,
-		ChangeFamily<ChangeFamilyEditor, TChange>
-	>(family, options.sessionId ?? ("0" as SessionId), genId);
+		ChangeFamily<ChangeFamilyEditor, TChange, never>
+	>(
+		family as ChangeFamily<ChangeFamilyEditor, TChange, never>,
+		options.sessionId ?? ("0" as SessionId),
+		genId,
+	);
 
 	return manager;
 }
@@ -80,7 +84,11 @@ export function editManagerFactory<TChange = TestChange>(
 export function rebaseLocalEditsOverTrunkEdits<TChange>(
 	localEditCount: number,
 	trunkEditCount: number,
-	manager: EditManager<ChangeFamilyEditor, TChange, ChangeFamily<ChangeFamilyEditor, TChange>>,
+	manager: EditManager<
+		ChangeFamilyEditor,
+		TChange,
+		ChangeFamily<ChangeFamilyEditor, TChange, never>
+	>,
 	mintChange: (revision: RevisionTag | undefined) => TChange,
 ): void;
 /**
@@ -110,7 +118,11 @@ export function rebaseLocalEditsOverTrunkEdits<TChange>(
 export function rebaseLocalEditsOverTrunkEdits<TChange>(
 	localEditCount: number,
 	trunkEditCount: number,
-	manager: EditManager<ChangeFamilyEditor, TChange, ChangeFamily<ChangeFamilyEditor, TChange>>,
+	manager: EditManager<
+		ChangeFamilyEditor,
+		TChange,
+		ChangeFamily<ChangeFamilyEditor, TChange, never>
+	>,
 	mintChange: (revision: RevisionTag | undefined) => TChange,
 	defer: true,
 	bunchCommits?: boolean,
@@ -118,7 +130,11 @@ export function rebaseLocalEditsOverTrunkEdits<TChange>(
 export function rebaseLocalEditsOverTrunkEdits<TChange>(
 	localEditCount: number,
 	trunkEditCount: number,
-	manager: EditManager<ChangeFamilyEditor, TChange, ChangeFamily<ChangeFamilyEditor, TChange>>,
+	manager: EditManager<
+		ChangeFamilyEditor,
+		TChange,
+		ChangeFamily<ChangeFamilyEditor, TChange, never>
+	>,
 	mintChange: (revision: RevisionTag | undefined) => TChange,
 	defer: boolean = false,
 	bunchCommits: boolean = false,
@@ -180,7 +196,11 @@ export function rebaseLocalEditsOverTrunkEdits<TChange>(
 export function rebasePeerEditsOverTrunkEdits<TChange>(
 	peerEditCount: number,
 	trunkEditCount: number,
-	manager: EditManager<ChangeFamilyEditor, TChange, ChangeFamily<ChangeFamilyEditor, TChange>>,
+	manager: EditManager<
+		ChangeFamilyEditor,
+		TChange,
+		ChangeFamily<ChangeFamilyEditor, TChange, never>
+	>,
 	mintChange: () => TChange,
 ): void;
 /**
@@ -210,7 +230,11 @@ export function rebasePeerEditsOverTrunkEdits<TChange>(
 export function rebasePeerEditsOverTrunkEdits<TChange>(
 	peerEditCount: number,
 	trunkEditCount: number,
-	manager: EditManager<ChangeFamilyEditor, TChange, ChangeFamily<ChangeFamilyEditor, TChange>>,
+	manager: EditManager<
+		ChangeFamilyEditor,
+		TChange,
+		ChangeFamily<ChangeFamilyEditor, TChange, never>
+	>,
 	mintChange: (revision: RevisionTag | undefined) => TChange,
 	defer: true,
 	bunchCommits?: boolean,
@@ -218,7 +242,11 @@ export function rebasePeerEditsOverTrunkEdits<TChange>(
 export function rebasePeerEditsOverTrunkEdits<TChange>(
 	peerEditCount: number,
 	trunkEditCount: number,
-	manager: EditManager<ChangeFamilyEditor, TChange, ChangeFamily<ChangeFamilyEditor, TChange>>,
+	manager: EditManager<
+		ChangeFamilyEditor,
+		TChange,
+		ChangeFamily<ChangeFamilyEditor, TChange, never>
+	>,
 	mintChange: (revision: RevisionTag | undefined) => TChange,
 	defer: boolean = false,
 	bunchCommits: boolean = false,
@@ -298,7 +326,11 @@ export function rebasePeerEditsOverTrunkEdits<TChange>(
  */
 export function rebaseAdvancingPeerEditsOverTrunkEdits<TChange>(
 	editCount: number,
-	manager: EditManager<ChangeFamilyEditor, TChange, ChangeFamily<ChangeFamilyEditor, TChange>>,
+	manager: EditManager<
+		ChangeFamilyEditor,
+		TChange,
+		ChangeFamily<ChangeFamilyEditor, TChange, never>
+	>,
 	mintChange: () => TChange,
 ): void;
 /**
@@ -328,13 +360,21 @@ export function rebaseAdvancingPeerEditsOverTrunkEdits<TChange>(
  */
 export function rebaseAdvancingPeerEditsOverTrunkEdits<TChange>(
 	editCount: number,
-	manager: EditManager<ChangeFamilyEditor, TChange, ChangeFamily<ChangeFamilyEditor, TChange>>,
+	manager: EditManager<
+		ChangeFamilyEditor,
+		TChange,
+		ChangeFamily<ChangeFamilyEditor, TChange, never>
+	>,
 	mintChange: (revision: RevisionTag | undefined) => TChange,
 	defer: true,
 ): () => void;
 export function rebaseAdvancingPeerEditsOverTrunkEdits<TChange>(
 	editCount: number,
-	manager: EditManager<ChangeFamilyEditor, TChange, ChangeFamily<ChangeFamilyEditor, TChange>>,
+	manager: EditManager<
+		ChangeFamilyEditor,
+		TChange,
+		ChangeFamily<ChangeFamilyEditor, TChange, never>
+	>,
 	mintChange: (revision: RevisionTag | undefined) => TChange,
 	defer: boolean = false,
 ): void | (() => void) {
@@ -400,7 +440,11 @@ export function rebaseAdvancingPeerEditsOverTrunkEdits<TChange>(
 export function rebaseConcurrentPeerEdits<TChange>(
 	peerCount: number,
 	editsPerPeerCount: number,
-	manager: EditManager<ChangeFamilyEditor, TChange, ChangeFamily<ChangeFamilyEditor, TChange>>,
+	manager: EditManager<
+		ChangeFamilyEditor,
+		TChange,
+		ChangeFamily<ChangeFamilyEditor, TChange, never>
+	>,
 	mintChange: (revision: RevisionTag | undefined) => TChange,
 	defer: true,
 ): () => void;
@@ -429,13 +473,21 @@ export function rebaseConcurrentPeerEdits<TChange>(
 export function rebaseConcurrentPeerEdits<TChange>(
 	peerCount: number,
 	editsPerPeerCount: number,
-	manager: EditManager<ChangeFamilyEditor, TChange, ChangeFamily<ChangeFamilyEditor, TChange>>,
+	manager: EditManager<
+		ChangeFamilyEditor,
+		TChange,
+		ChangeFamily<ChangeFamilyEditor, TChange, never>
+	>,
 	mintChange: (revision: RevisionTag | undefined) => TChange,
 ): void;
 export function rebaseConcurrentPeerEdits<TChange>(
 	peerCount: number,
 	editsPerPeerCount: number,
-	manager: EditManager<ChangeFamilyEditor, TChange, ChangeFamily<ChangeFamilyEditor, TChange>>,
+	manager: EditManager<
+		ChangeFamilyEditor,
+		TChange,
+		ChangeFamily<ChangeFamilyEditor, TChange, never>
+	>,
 	mintChange: (revision: RevisionTag | undefined) => TChange,
 	defer: boolean = false,
 ): void | (() => void) {
@@ -497,7 +549,11 @@ export function addSequencedChanges(
 
 /** Subscribe to the local branch to emulate the behavior of SharedTree */
 function subscribeToLocalBranch<TChange>(
-	manager: EditManager<ChangeFamilyEditor, TChange, ChangeFamily<ChangeFamilyEditor, TChange>>,
+	manager: EditManager<
+		ChangeFamilyEditor,
+		TChange,
+		ChangeFamily<ChangeFamilyEditor, TChange, never>
+	>,
 ): void {
 	manager.getLocalBranch("main").events.on("afterChange", (branchChange) => {
 		// Reading the change property causes lazy computation to occur, and is important to accurately emulate SharedTree behavior

--- a/packages/dds/tree/src/test/shared-tree-core/sharedTreeCore.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/sharedTreeCore.spec.ts
@@ -822,19 +822,23 @@ describe("SharedTreeCore", () => {
 });
 
 /** Makes an arbitrary change to the given tree */
-function changeTree<TChange, TEditor extends DefaultEditBuilder>(
-	tree: SharedTreeCore<TEditor, TChange>,
-): void {
+function changeTree<
+	TChange,
+	TEditor extends DefaultEditBuilder,
+	TChangeFamily extends ChangeFamily<TEditor, TChange, TChangeFamily>,
+>(tree: SharedTreeCore<TEditor, TChange, TChangeFamily>): void {
 	const field = tree.getEditor().sequenceField({ parent: undefined, field: rootFieldKey });
 	field.insert(0, chunkFromJsonableTrees([{ type: brand("Node"), value: 42 }]));
 }
 
 /** Returns the length of the trunk branch in the given tree. Acquired via unholy cast; use for glass-box tests only. */
-function getTrunkLength<TEditor extends ChangeFamilyEditor, TChange>(
-	tree: SharedTreeCore<TEditor, TChange>,
-): number {
+function getTrunkLength<
+	TEditor extends ChangeFamilyEditor,
+	TChange,
+	TChangeFamily extends ChangeFamily<TEditor, TChange, TChangeFamily>,
+>(tree: SharedTreeCore<TEditor, TChange, TChangeFamily>): number {
 	const { editManager } = tree as unknown as {
-		editManager: EditManager<TEditor, TChange, ChangeFamily<TEditor, TChange>>;
+		editManager: EditManager<TEditor, TChange, ChangeFamily<TEditor, TChange, never>>;
 	};
 	assert(
 		editManager !== undefined,

--- a/packages/dds/tree/src/test/shared-tree-core/sharedTreeCore.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/sharedTreeCore.spec.ts
@@ -31,7 +31,6 @@ import {
 } from "@fluidframework/test-runtime-utils/internal";
 
 import {
-	type ChangeFamily,
 	type ChangeFamilyEditor,
 	type GraphCommit,
 	type RevisionTag,
@@ -822,23 +821,19 @@ describe("SharedTreeCore", () => {
 });
 
 /** Makes an arbitrary change to the given tree */
-function changeTree<
-	TChange,
-	TEditor extends DefaultEditBuilder,
-	TChangeFamily extends ChangeFamily<TEditor, TChange, TChangeFamily>,
->(tree: SharedTreeCore<TEditor, TChange, TChangeFamily>): void {
+function changeTree<TChange, TEditor extends DefaultEditBuilder, TChangeProcessingContext>(
+	tree: SharedTreeCore<TEditor, TChange, TChangeProcessingContext>,
+): void {
 	const field = tree.getEditor().sequenceField({ parent: undefined, field: rootFieldKey });
 	field.insert(0, chunkFromJsonableTrees([{ type: brand("Node"), value: 42 }]));
 }
 
 /** Returns the length of the trunk branch in the given tree. Acquired via unholy cast; use for glass-box tests only. */
-function getTrunkLength<
-	TEditor extends ChangeFamilyEditor,
-	TChange,
-	TChangeFamily extends ChangeFamily<TEditor, TChange, TChangeFamily>,
->(tree: SharedTreeCore<TEditor, TChange, TChangeFamily>): number {
+function getTrunkLength<TEditor extends ChangeFamilyEditor, TChange, TChangeProcessingContext>(
+	tree: SharedTreeCore<TEditor, TChange, TChangeProcessingContext>,
+): number {
 	const { editManager } = tree as unknown as {
-		editManager: EditManager<TEditor, TChange, ChangeFamily<TEditor, TChange, never>>;
+		editManager: EditManager<TEditor, TChange>;
 	};
 	assert(
 		editManager !== undefined,

--- a/packages/dds/tree/src/test/shared-tree-core/transaction.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/transaction.spec.ts
@@ -15,6 +15,7 @@ import {
 } from "../../core/index.js";
 import {
 	DefaultChangeFamily,
+	type DefaultChangeProcessingContext,
 	type DefaultChangeset,
 	type DefaultEditBuilder,
 } from "../../feature-libraries/index.js";
@@ -35,7 +36,7 @@ import { chunkFromJsonableTrees, failCodecFamily, mintRevisionTag } from "../uti
  * a function that receives the change and its owning change family and returns a change.
  */
 type DefaultChangeProcessor = ChangeProcessor<
-	(change: DefaultChangeset, changeFamily: DefaultChangeFamily) => DefaultChangeset
+	(change: DefaultChangeset, context: DefaultChangeProcessingContext) => DefaultChangeset
 >;
 
 describe("TransactionStacks", () => {
@@ -381,7 +382,7 @@ describe("SquashingTransactionStacks", () => {
 			transaction: SquashingTransactionStack<
 				DefaultEditBuilder,
 				DefaultChangeset,
-				DefaultChangeFamily
+				DefaultChangeProcessingContext
 			>;
 			branch: DefaultBranch;
 			/** A post-processor to pass via the transaction options. */
@@ -764,7 +765,7 @@ describe("SquashingTransactionStacks", () => {
 	type DefaultBranch = SharedTreeBranch<
 		DefaultEditBuilder,
 		DefaultChangeset,
-		DefaultChangeFamily
+		DefaultChangeProcessingContext
 	>;
 	const defaultChangeFamily = new DefaultChangeFamily(failCodecFamily, {
 		jsonValidator: FormatValidatorBasic,

--- a/packages/dds/tree/src/test/shared-tree-core/transaction.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/transaction.spec.ts
@@ -30,6 +30,14 @@ import {
 import { brand } from "../../util/index.js";
 import { chunkFromJsonableTrees, failCodecFamily, mintRevisionTag } from "../utils.js";
 
+/**
+ * The internal {@link ChangeProcessor} context type for the default change family:
+ * a function that receives the change and its owning change family and returns a change.
+ */
+type DefaultChangeProcessor = ChangeProcessor<
+	(change: DefaultChangeset, changeFamily: DefaultChangeFamily) => DefaultChangeset
+>;
+
 describe("TransactionStacks", () => {
 	it("emit an event after starting a transaction", () => {
 		const transaction = new TransactionStack();
@@ -370,17 +378,21 @@ describe("SquashingTransactionStacks", () => {
 		 * records the changes it receives (and returns them unchanged).
 		 */
 		function createWithSpyProcessor(applicability: ChangeProcessorApplicability): {
-			transaction: SquashingTransactionStack<DefaultEditBuilder, DefaultChangeset>;
+			transaction: SquashingTransactionStack<
+				DefaultEditBuilder,
+				DefaultChangeset,
+				DefaultChangeFamily
+			>;
 			branch: DefaultBranch;
 			/** A post-processor to pass via the transaction options. */
-			postProcessor: ChangeProcessor<DefaultChangeset>;
+			postProcessor: DefaultChangeProcessor;
 			/** The changes passed to the post-processor, in invocation order. */
 			received: DefaultChangeset[];
 		} {
 			const branch = createBranch();
 			const received: DefaultChangeset[] = [];
 			const transaction = new SquashingTransactionStack(branch, mintRevisionTag);
-			const postProcessor: ChangeProcessor<DefaultChangeset> = {
+			const postProcessor: DefaultChangeProcessor = {
 				applicability,
 				processChange: (change) => {
 					received.push(change);
@@ -398,7 +410,7 @@ describe("SquashingTransactionStacks", () => {
 			applicability: ChangeProcessorApplicability,
 			received: { processor: string; change: DefaultChangeset }[],
 			label: string,
-		): ChangeProcessor<DefaultChangeset> {
+		): DefaultChangeProcessor {
 			return {
 				applicability,
 				processChange: (change) => {
@@ -731,7 +743,7 @@ describe("SquashingTransactionStacks", () => {
 			const branch = createBranch();
 			// A post-processor that replaces the squashed change with an empty change.
 			const replacement = defaultChangeFamily.rebaser.compose([]);
-			const postProcessor: ChangeProcessor<DefaultChangeset> = {
+			const postProcessor: DefaultChangeProcessor = {
 				applicability: ChangeProcessorApplicability.IfOutermost,
 				processChange: () => replacement,
 			};
@@ -749,7 +761,11 @@ describe("SquashingTransactionStacks", () => {
 		});
 	});
 
-	type DefaultBranch = SharedTreeBranch<DefaultEditBuilder, DefaultChangeset>;
+	type DefaultBranch = SharedTreeBranch<
+		DefaultEditBuilder,
+		DefaultChangeset,
+		DefaultChangeFamily
+	>;
 	const defaultChangeFamily = new DefaultChangeFamily(failCodecFamily, {
 		jsonValidator: FormatValidatorBasic,
 		minVersionForCollab: FluidClientVersion.v2_0,

--- a/packages/dds/tree/src/test/shared-tree-core/transaction.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/transaction.spec.ts
@@ -36,7 +36,8 @@ import { chunkFromJsonableTrees, failCodecFamily, mintRevisionTag } from "../uti
  * a function that receives the change and its owning change family and returns a change.
  */
 type DefaultChangeProcessor = ChangeProcessor<
-	(change: DefaultChangeset, context: DefaultChangeProcessingContext) => DefaultChangeset
+	DefaultChangeset,
+	DefaultChangeProcessingContext
 >;
 
 describe("TransactionStacks", () => {

--- a/packages/dds/tree/src/test/shared-tree-core/utils.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/utils.ts
@@ -51,6 +51,7 @@ import {
 import { FormatValidatorBasic } from "../../external-utilities/index.js";
 import {
 	DefaultChangeFamily,
+	type DefaultChangeProcessingContext,
 	type DefaultChangeset,
 	type DefaultEditBuilder,
 	type ModularChangeFormatVersion,
@@ -98,7 +99,7 @@ export function createTree<TIndexes extends readonly Summarizable[]>(options: {
 	indexes: TIndexes;
 	enrichmentConfig?: EnrichmentConfig<DefaultChangeset>;
 	codecOptions?: CodecWriteOptions;
-}): SharedTreeCore<DefaultEditBuilder, DefaultChangeset, DefaultChangeFamily> {
+}): SharedTreeCore<DefaultEditBuilder, DefaultChangeset, DefaultChangeProcessingContext> {
 	const { indexes, enrichmentConfig, codecOptions } = options;
 	// This could use TestSharedTreeCore then return its kernel instead of using these mocks, but that would depend on far more code than needed (including other mocks).
 
@@ -211,7 +212,7 @@ function createTreeInner(
 	enrichmentConfig?: EnrichmentConfig<DefaultChangeset>,
 	editor?: () => DefaultEditBuilder,
 ): [
-	SharedTreeCore<DefaultEditBuilder, DefaultChangeset, DefaultChangeFamily>,
+	SharedTreeCore<DefaultEditBuilder, DefaultChangeset, DefaultChangeProcessingContext>,
 	DefaultChangeFamily,
 ] {
 	const changeFamily = makeTestDefaultChangeFamily({ idCompressor, chunkCompressionStrategy });
@@ -267,7 +268,7 @@ export class TestSharedTreeCore extends SharedObject {
 	public readonly kernel: SharedTreeCore<
 		DefaultEditBuilder,
 		DefaultChangeset,
-		DefaultChangeFamily
+		DefaultChangeProcessingContext
 	>;
 
 	private static readonly attributes: IChannelAttributes = {
@@ -279,7 +280,7 @@ export class TestSharedTreeCore extends SharedObject {
 	public readonly transaction: SquashingTransactionStack<
 		DefaultEditBuilder,
 		DefaultChangeset,
-		DefaultChangeFamily
+		DefaultChangeProcessingContext
 	>;
 	private readonly changeFamily: DefaultChangeFamily;
 
@@ -341,7 +342,7 @@ export class TestSharedTreeCore extends SharedObject {
 			SharedTreeCore<
 				DefaultEditBuilder,
 				DefaultChangeset,
-				DefaultChangeFamily
+				DefaultChangeProcessingContext
 			>["applyStashedOp"]
 		>
 	): void {
@@ -351,14 +352,18 @@ export class TestSharedTreeCore extends SharedObject {
 	public getLocalBranch(): SharedTreeBranch<
 		DefaultEditBuilder,
 		DefaultChangeset,
-		DefaultChangeFamily
+		DefaultChangeProcessingContext
 	> {
 		return this.kernel.getLocalBranch();
 	}
 
 	protected override reSubmitCore(
 		...args: Parameters<
-			SharedTreeCore<DefaultEditBuilder, DefaultChangeset, DefaultChangeFamily>["reSubmitCore"]
+			SharedTreeCore<
+				DefaultEditBuilder,
+				DefaultChangeset,
+				DefaultChangeProcessingContext
+			>["reSubmitCore"]
 		>
 	): void {
 		this.kernel.reSubmitCore(...args);

--- a/packages/dds/tree/src/test/shared-tree-core/utils.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/utils.ts
@@ -98,7 +98,7 @@ export function createTree<TIndexes extends readonly Summarizable[]>(options: {
 	indexes: TIndexes;
 	enrichmentConfig?: EnrichmentConfig<DefaultChangeset>;
 	codecOptions?: CodecWriteOptions;
-}): SharedTreeCore<DefaultEditBuilder, DefaultChangeset> {
+}): SharedTreeCore<DefaultEditBuilder, DefaultChangeset, DefaultChangeFamily> {
 	const { indexes, enrichmentConfig, codecOptions } = options;
 	// This could use TestSharedTreeCore then return its kernel instead of using these mocks, but that would depend on far more code than needed (including other mocks).
 
@@ -210,7 +210,10 @@ function createTreeInner(
 	codecOptions: CodecWriteOptions = testCodecOptions,
 	enrichmentConfig?: EnrichmentConfig<DefaultChangeset>,
 	editor?: () => DefaultEditBuilder,
-): [SharedTreeCore<DefaultEditBuilder, DefaultChangeset>, DefaultChangeFamily] {
+): [
+	SharedTreeCore<DefaultEditBuilder, DefaultChangeset, DefaultChangeFamily>,
+	DefaultChangeFamily,
+] {
 	const changeFamily = makeTestDefaultChangeFamily({ idCompressor, chunkCompressionStrategy });
 	return [
 		new SharedTreeCore(
@@ -261,7 +264,11 @@ class NoOpChangeEnricher<TChange> implements ChangeEnricher<TChange> {
  * Once the above is done for all users, this class should be removed.
  */
 export class TestSharedTreeCore extends SharedObject {
-	public readonly kernel: SharedTreeCore<DefaultEditBuilder, DefaultChangeset>;
+	public readonly kernel: SharedTreeCore<
+		DefaultEditBuilder,
+		DefaultChangeset,
+		DefaultChangeFamily
+	>;
 
 	private static readonly attributes: IChannelAttributes = {
 		type: "TestSharedTreeCore",
@@ -269,7 +276,11 @@ export class TestSharedTreeCore extends SharedObject {
 		packageVersion: "0.0.0",
 	};
 
-	public readonly transaction: SquashingTransactionStack<DefaultEditBuilder, DefaultChangeset>;
+	public readonly transaction: SquashingTransactionStack<
+		DefaultEditBuilder,
+		DefaultChangeset,
+		DefaultChangeFamily
+	>;
 	private readonly changeFamily: DefaultChangeFamily;
 
 	public constructor(
@@ -326,17 +337,29 @@ export class TestSharedTreeCore extends SharedObject {
 	}
 
 	protected override applyStashedOp(
-		...args: Parameters<SharedTreeCore<DefaultEditBuilder, DefaultChangeset>["applyStashedOp"]>
+		...args: Parameters<
+			SharedTreeCore<
+				DefaultEditBuilder,
+				DefaultChangeset,
+				DefaultChangeFamily
+			>["applyStashedOp"]
+		>
 	): void {
 		this.kernel.applyStashedOp(...args);
 	}
 
-	public getLocalBranch(): SharedTreeBranch<DefaultEditBuilder, DefaultChangeset> {
+	public getLocalBranch(): SharedTreeBranch<
+		DefaultEditBuilder,
+		DefaultChangeset,
+		DefaultChangeFamily
+	> {
 		return this.kernel.getLocalBranch();
 	}
 
 	protected override reSubmitCore(
-		...args: Parameters<SharedTreeCore<DefaultEditBuilder, DefaultChangeset>["reSubmitCore"]>
+		...args: Parameters<
+			SharedTreeCore<DefaultEditBuilder, DefaultChangeset, DefaultChangeFamily>["reSubmitCore"]
+		>
 	): void {
 		this.kernel.reSubmitCore(...args);
 	}

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -962,7 +962,7 @@ describe("SharedTree", () => {
 			editManager?: EditManager<
 				ChangeFamilyEditor,
 				unknown,
-				ChangeFamily<ChangeFamilyEditor, unknown>
+				ChangeFamily<ChangeFamilyEditor, unknown, never>
 			>;
 		};
 	}

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -35,7 +35,6 @@ import {
 	moveToDetachedField,
 	rootFieldKey,
 	storedEmptyFieldSchema,
-	type ChangeFamily,
 	type ChangeFamilyEditor,
 	EmptyKey,
 	ValueSchema,
@@ -959,11 +958,7 @@ describe("SharedTree", () => {
 	// If we do then this test should be updated to use that code path.
 	interface EditManagerKludge {
 		kernel?: {
-			editManager?: EditManager<
-				ChangeFamilyEditor,
-				unknown,
-				ChangeFamily<ChangeFamilyEditor, unknown, never>
-			>;
+			editManager?: EditManager<ChangeFamilyEditor, unknown>;
 		};
 	}
 

--- a/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
@@ -40,6 +40,8 @@ import {
 } from "../../shared-tree/transactionPostProcessor.js";
 // eslint-disable-next-line import-x/no-internal-modules
 import { SchematizingSimpleTreeView } from "../../shared-tree/schematizingTreeView.js";
+// eslint-disable-next-line import-x/no-internal-modules
+import type { SharedTreeChangeFamily } from "../../shared-tree/sharedTreeChangeFamily.js";
 import {
 	getInnerNode,
 	SchemaFactory,
@@ -885,7 +887,9 @@ describe("sharedTreeView", () => {
 				commits: 0,
 			};
 			const originalStart = transactor.start.bind(transactor);
-			transactor.start = (options?: SquashingTransactionOptions<SharedTreeChange>): void => {
+			transactor.start = (
+				options?: SquashingTransactionOptions<SharedTreeChange, SharedTreeChangeFamily>,
+			): void => {
 				result.postProcessors.push(options?.postProcessor);
 				originalStart(options);
 			};

--- a/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
@@ -41,7 +41,7 @@ import {
 // eslint-disable-next-line import-x/no-internal-modules
 import { SchematizingSimpleTreeView } from "../../shared-tree/schematizingTreeView.js";
 // eslint-disable-next-line import-x/no-internal-modules
-import type { SharedTreeChangeFamily } from "../../shared-tree/sharedTreeChangeFamily.js";
+import type { SharedTreeChangeProcessingContext } from "../../shared-tree/sharedTreeChangeFamily.js";
 import {
 	getInnerNode,
 	SchemaFactory,
@@ -888,7 +888,10 @@ describe("sharedTreeView", () => {
 			};
 			const originalStart = transactor.start.bind(transactor);
 			transactor.start = (
-				options?: SquashingTransactionOptions<SharedTreeChange, SharedTreeChangeFamily>,
+				options?: SquashingTransactionOptions<
+					SharedTreeChange,
+					SharedTreeChangeProcessingContext
+				>,
 			): void => {
 				result.postProcessors.push(options?.postProcessor);
 				originalStart(options);

--- a/packages/dds/tree/src/test/testChange.ts
+++ b/packages/dds/tree/src/test/testChange.ts
@@ -320,7 +320,7 @@ export class TestAnchorSet extends AnchorSet implements AnchorRebaseData {
 	public intentions: number[] = [];
 }
 
-export type TestChangeFamily = ChangeFamily<ChangeFamilyEditor, TestChange, never>;
+export type TestChangeFamily = ChangeFamily<ChangeFamilyEditor, TestChange>;
 
 const rootKey: FieldKey = brand("root");
 
@@ -340,7 +340,7 @@ export function asDelta(intentions: number[]): DeltaRoot {
 
 export function testChangeFamilyFactory(
 	rebaser?: ChangeRebaser<TestChange>,
-): ChangeFamily<ChangeFamilyEditor, TestChange, never> {
+): ChangeFamily<ChangeFamilyEditor, TestChange> {
 	const family = {
 		rebaser: rebaser ?? new TestChangeRebaser(),
 		codecs: TestChange.codecs,

--- a/packages/dds/tree/src/test/testChange.ts
+++ b/packages/dds/tree/src/test/testChange.ts
@@ -320,7 +320,7 @@ export class TestAnchorSet extends AnchorSet implements AnchorRebaseData {
 	public intentions: number[] = [];
 }
 
-export type TestChangeFamily = ChangeFamily<ChangeFamilyEditor, TestChange>;
+export type TestChangeFamily = ChangeFamily<ChangeFamilyEditor, TestChange, never>;
 
 const rootKey: FieldKey = brand("root");
 
@@ -340,7 +340,7 @@ export function asDelta(intentions: number[]): DeltaRoot {
 
 export function testChangeFamilyFactory(
 	rebaser?: ChangeRebaser<TestChange>,
-): ChangeFamily<ChangeFamilyEditor, TestChange> {
+): ChangeFamily<ChangeFamilyEditor, TestChange, never> {
 	const family = {
 		rebaser: rebaser ?? new TestChangeRebaser(),
 		codecs: TestChange.codecs,
@@ -348,6 +348,9 @@ export function testChangeFamilyFactory(
 			enterTransaction: () => assert.fail("Unexpected edit"),
 			exitTransaction: () => assert.fail("Unexpected edit"),
 		}),
+		buildProcessor: (): never => {
+			assert.fail("Unexpected buildProcessor call");
+		},
 	};
 	return family;
 }

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -1242,10 +1242,12 @@ export function makeDiscontinuedEncodingTestSuite(
  * convenience, but is otherwise unused.
  * @returns a change receiver function and a function that will return all changes received
  */
-export function testChangeReceiver<TChange>(
-	_changeFamily?: ChangeFamily<ChangeFamilyEditor, TChange>,
+export function testChangeReceiver<TChange, TContext = unknown>(
+	_changeFamily?: ChangeFamily<ChangeFamilyEditor, TChange, TContext>,
 ): [
-	changeReceiver: Parameters<ChangeFamily<ChangeFamilyEditor, TChange>["buildEditor"]>[1],
+	changeReceiver: Parameters<
+		ChangeFamily<ChangeFamilyEditor, TChange, TContext>["buildEditor"]
+	>[1],
 	getChanges: () => readonly TChange[],
 ] {
 	const changes: TChange[] = [];

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -1242,11 +1242,11 @@ export function makeDiscontinuedEncodingTestSuite(
  * convenience, but is otherwise unused.
  * @returns a change receiver function and a function that will return all changes received
  */
-export function testChangeReceiver<TChange, TContext = unknown>(
-	_changeFamily?: ChangeFamily<ChangeFamilyEditor, TChange, TContext>,
+export function testChangeReceiver<TChange, TChangeProcessingContext>(
+	_changeFamily?: ChangeFamily<ChangeFamilyEditor, TChange, TChangeProcessingContext>,
 ): [
 	changeReceiver: Parameters<
-		ChangeFamily<ChangeFamilyEditor, TChange, TContext>["buildEditor"]
+		ChangeFamily<ChangeFamilyEditor, TChange, TChangeProcessingContext>["buildEditor"]
 	>[1],
 	getChanges: () => readonly TChange[],
 ] {


### PR DESCRIPTION
Transaction post-processors previously received only the squashed change to
process. Some post-processing (e.g. minimization) needs access to
change-family–specific helpers such as the `ModularChangeFamily`, which were
not reachable from the processor callback.

This change threads a new `TChangeProcessingContext` type parameter through the
change-processing pipeline so a `ChangeFamily` can supply a context to its
related processors:

- `ChangeFamily` gains a `buildProcessor` method and a `ProcessChangeFn<TChange,
  TChangeProcessingContext>` helper type. When `TChangeProcessingContext` is
  `never` (default), the processor keeps its original `(change) => change` shape;
  otherwise, it receives `(change, context)`.
- `ChangeProcessor`, `SquashingTransactionOptions`, `SquashingTransactionStack`,
  `SharedTreeBranch`, `EditManager`, and the transaction plumbing are
  parameterized on `TChangeProcessingContext` and pass the context through.
- `SharedTreeChangeFamily` implements `buildProcessor` and exposes a
  context with `ModularChangeFamily` now available to post-processors.
- `DefaultChangeFamily`, `ModularChangeFamily`, and `mitigatedChangeFamily` are
  updated to the new signatures.
- `EditManager`'s `TChangeFamily` parameter that allowed concrete `ChangeFamily` to be read from public `changeFamily` has been removed as no callers required the concrete type. `TChangeProcessingContext` with a default of `never` appears in its place.

The context is now piped end-to-end so transaction post-processors (such as the
minimizer) can access the change family that produced the change.