### PR TITLE
refactor(tree): codec-free DetachedFieldIndex

### DIFF
--- a/packages/dds/tree/src/core/index.ts
+++ b/packages/dds/tree/src/core/index.ts
@@ -83,6 +83,7 @@ export {
 	CursorMarker,
 	isCursor,
 	DetachedFieldIndex,
+	type DetachedFieldSummaryData,
 	type ReadOnlyDetachedFieldIndex,
 	type DetachedFieldIndexCheckpoint,
 	type ForestRootId,

--- a/packages/dds/tree/src/core/tree/detachedFieldIndex.ts
+++ b/packages/dds/tree/src/core/tree/detachedFieldIndex.ts
@@ -4,17 +4,8 @@
  */
 
 import { assert } from "@fluidframework/core-utils/internal";
-import type { IIdCompressor } from "@fluidframework/id-compressor";
-
-import {
-	type CodecWriteOptions,
-	FluidClientVersion,
-	FormatValidatorNoOp,
-	type IJsonCodec,
-} from "../../codec/index.js";
 import {
 	type IdAllocator,
-	type JsonCompatibleReadOnly,
 	type NestedMap,
 	brand,
 	deleteFromNestedMap,
@@ -24,11 +15,10 @@ import {
 	setInNestedMap,
 	tryGetFromNestedMap,
 } from "../../util/index.js";
-import type { RevisionTag, RevisionTagCodec } from "../rebase/index.js";
+import type { RevisionTag } from "../rebase/index.js";
 import type { FieldKey } from "../schema-stored/index.js";
 
 import type * as Delta from "./delta.js";
-import { detachedFieldIndexCodecBuilder } from "./detachedFieldIndexCodecs.js";
 import type {
 	DetachedField,
 	DetachedFieldSummaryData,
@@ -92,9 +82,6 @@ export class DetachedFieldIndex implements ReadOnlyDetachedFieldIndex {
 		Delta.DetachedNodeId
 	> = new Map();
 
-	private readonly codec: IJsonCodec<DetachedFieldSummaryData>;
-	private readonly options: CodecWriteOptions;
-
 	/**
 	 * The process for loading `DetachedFieldIndex` data from a summary is split into two steps:
 	 * 1. Call {@link loadData}
@@ -112,28 +99,12 @@ export class DetachedFieldIndex implements ReadOnlyDetachedFieldIndex {
 	public constructor(
 		private readonly name: string,
 		private rootIdAllocator: IdAllocator<ForestRootId>,
-		private readonly revisionTagCodec: RevisionTagCodec,
-		private readonly idCompressor: IIdCompressor,
-		options?: CodecWriteOptions,
-	) {
-		this.options = options ?? {
-			jsonValidator: FormatValidatorNoOp,
-			minVersionForCollab: FluidClientVersion.v2_0,
-		};
-		this.codec = detachedFieldIndexCodecBuilder.build({
-			...this.options,
-			revisionTagCodec,
-			idCompressor,
-		});
-	}
+	) {}
 
 	public clone(): DetachedFieldIndex {
 		const clone = new DetachedFieldIndex(
 			this.name,
 			idAllocatorFromMaxId(this.rootIdAllocator.getMaxId()) as IdAllocator<ForestRootId>,
-			this.revisionTagCodec,
-			this.idCompressor,
-			this.options,
 		);
 		populateNestedMap(this.detachedNodeToField, clone.detachedNodeToField, true);
 		populateNestedMap(
@@ -307,19 +278,17 @@ export class DetachedFieldIndex implements ReadOnlyDetachedFieldIndex {
 		});
 	}
 
-	public encode(): JsonCompatibleReadOnly {
-		return this.codec.encode({
+	public getSummaryData(): DetachedFieldSummaryData {
+		return {
 			data: this.detachedNodeToField,
 			maxId: this.rootIdAllocator.getMaxId(),
-		});
+		};
 	}
 
 	/**
-	 * Loads the tree index from the given string, this overrides any existing data.
+	 * Loads the tree index from summary data, this overrides any existing data.
 	 */
-	public loadData(data: JsonCompatibleReadOnly): void {
-		const detachedFieldIndex: DetachedFieldSummaryData = this.codec.decode(data);
-
+	public loadData(detachedFieldIndex: DetachedFieldSummaryData): void {
 		this.rootIdAllocator = idAllocatorFromMaxId(
 			detachedFieldIndex.maxId,
 		) as IdAllocator<ForestRootId>;

--- a/packages/dds/tree/src/core/tree/index.ts
+++ b/packages/dds/tree/src/core/tree/index.ts
@@ -127,6 +127,8 @@ export {
 	type ReadOnlyDetachedFieldIndex,
 } from "./detachedFieldIndex.js";
 
+export { type DetachedFieldSummaryData } from "./detachedFieldIndexTypes.js";
+
 export { detachedFieldIndexCodecBuilder } from "./detachedFieldIndexCodecs.js";
 export { DetachedFieldIndexFormatVersion } from "./detachedFieldIndexFormatCommon.js";
 export { type FormatV1 } from "./detachedFieldIndexFormatV1.js";

--- a/packages/dds/tree/src/core/tree/visitorUtils.ts
+++ b/packages/dds/tree/src/core/tree/visitorUtils.ts
@@ -3,11 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import type { IIdCompressor } from "@fluidframework/id-compressor";
-
-import type { CodecWriteOptions } from "../../codec/index.js";
 import { type IdAllocator, idAllocatorFromMaxId } from "../../util/index.js";
-import type { RevisionTag, RevisionTagCodec } from "../rebase/index.js";
+import type { RevisionTag } from "../rebase/index.js";
 import type { FieldKey } from "../schema-stored/index.js";
 
 import type { ITreeCursorSynchronous } from "./cursor.js";
@@ -17,19 +14,8 @@ import type { ForestRootId } from "./detachedFieldIndexTypes.js";
 import type { PlaceIndex, Range } from "./pathTree.js";
 import { type DeltaVisitor, visitDelta } from "./visitDelta.js";
 
-export function makeDetachedFieldIndex(
-	prefix: string = "Temp",
-	revisionTagCodec: RevisionTagCodec,
-	idCompressor: IIdCompressor,
-	options?: CodecWriteOptions,
-): DetachedFieldIndex {
-	return new DetachedFieldIndex(
-		prefix,
-		idAllocatorFromMaxId() as IdAllocator<ForestRootId>,
-		revisionTagCodec,
-		idCompressor,
-		options,
-	);
+export function makeDetachedFieldIndex(prefix: string = "Temp"): DetachedFieldIndex {
+	return new DetachedFieldIndex(prefix, idAllocatorFromMaxId() as IdAllocator<ForestRootId>);
 }
 
 export function applyDelta(

--- a/packages/dds/tree/src/feature-libraries/detachedFieldIndexSummarizer.ts
+++ b/packages/dds/tree/src/feature-libraries/detachedFieldIndexSummarizer.ts
@@ -5,6 +5,7 @@
 
 import { bufferToString } from "@fluid-internal/client-utils";
 import type { IChannelStorageService } from "@fluidframework/datastore-definitions/internal";
+import type { IIdCompressor } from "@fluidframework/id-compressor";
 import type {
 	IExperimentalIncrementalSummaryContext,
 	ITelemetryContext,
@@ -12,7 +13,18 @@ import type {
 } from "@fluidframework/runtime-definitions/internal";
 import type { SummaryTreeBuilder } from "@fluidframework/runtime-utils/internal";
 
-import type { DetachedFieldIndex } from "../core/index.js";
+import {
+	type CodecWriteOptions,
+	FluidClientVersion,
+	FormatValidatorNoOp,
+	type IJsonCodec,
+} from "../codec/index.js";
+import {
+	type DetachedFieldIndex,
+	type DetachedFieldSummaryData,
+	type RevisionTagCodec,
+	detachedFieldIndexCodecBuilder,
+} from "../core/index.js";
 import {
 	type Summarizable,
 	type SummaryElementParser,
@@ -66,16 +78,31 @@ export class DetachedFieldIndexSummarizer
 	extends VersionedSummarizer<DetachedFieldIndexSummaryFormatVersion>
 	implements Summarizable
 {
+	private readonly codec: IJsonCodec<DetachedFieldSummaryData>;
+
 	public constructor(
 		private readonly detachedFieldIndex: DetachedFieldIndex,
-		minVersionForCollab: MinimumVersionForCollab,
+		revisionTagCodec: RevisionTagCodec,
+		idCompressor: IIdCompressor,
+		options?: CodecWriteOptions,
 	) {
+		const normalizedOptions = options ?? {
+			jsonValidator: FormatValidatorNoOp,
+			minVersionForCollab: FluidClientVersion.v2_0,
+		};
 		super(
 			"DetachedFieldIndex",
-			minVersionToDetachedFieldIndexSummaryFormatVersion(minVersionForCollab),
+			minVersionToDetachedFieldIndexSummaryFormatVersion(
+				normalizedOptions.minVersionForCollab,
+			),
 			supportedVersions,
 			true,
 		);
+		this.codec = detachedFieldIndexCodecBuilder.build({
+			...normalizedOptions,
+			revisionTagCodec,
+			idCompressor,
+		});
 	}
 
 	protected summarizeInternal(props: {
@@ -87,7 +114,7 @@ export class DetachedFieldIndexSummarizer
 		builder: SummaryTreeBuilder;
 	}): void {
 		const { stringify, builder } = props;
-		const data = this.detachedFieldIndex.encode();
+		const data = this.codec.encode(this.detachedFieldIndex.getSummaryData());
 		builder.addBlob(detachedFieldIndexBlobKey, stringify(data));
 	}
 
@@ -99,7 +126,8 @@ export class DetachedFieldIndexSummarizer
 			const detachedFieldIndexBuffer = await services.readBlob(detachedFieldIndexBlobKey);
 			const treeBufferString = bufferToString(detachedFieldIndexBuffer, "utf8");
 			const parsed = parse(treeBufferString) as JsonCompatibleReadOnly;
-			this.detachedFieldIndex.loadData(parsed);
+			const decoded = this.codec.decode(parsed);
+			this.detachedFieldIndex.loadData(decoded);
 		}
 	}
 }

--- a/packages/dds/tree/src/feature-libraries/forest-summary/forestSummarizer.ts
+++ b/packages/dds/tree/src/feature-libraries/forest-summary/forestSummarizer.ts
@@ -20,7 +20,6 @@ import {
 	type IEditableForest,
 	type ITreeCursorSynchronous,
 	type ITreeSubscriptionCursor,
-	type RevisionTagCodec,
 	TreeNavigationResult,
 	applyDelta,
 	forEachField,
@@ -79,7 +78,6 @@ export class ForestSummarizer
 	 */
 	public constructor(
 		private readonly forest: IEditableForest,
-		private readonly revisionTagCodec: RevisionTagCodec,
 		private readonly encoderContext: FieldBatchEncodingContext,
 		private readonly decoderContext: FieldBatchDecodingContext,
 		options: CodecWriteOptions,
@@ -240,7 +238,7 @@ export class ForestSummarizer
 			{ build, fields: new Map(fieldChanges) },
 			undefined,
 			this.forest,
-			makeDetachedFieldIndex("init", this.revisionTagCodec, this.idCompressor),
+			makeDetachedFieldIndex("init"),
 		);
 	}
 }

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -219,13 +219,7 @@ export class SharedTreeKernel
 			idCompressor,
 			options.shouldEncodeIncrementally,
 		);
-		const revisionTagCodec = new RevisionTagCodec(idCompressor);
-		const removedRoots = makeDetachedFieldIndex(
-			"repair",
-			revisionTagCodec,
-			idCompressor,
-			options,
-		);
+		const removedRoots = makeDetachedFieldIndex("repair");
 		const schemaCodec = schemaCodecBuilder.build(options);
 		const schemaSummarizer = new SchemaSummarizer(
 			schema,
@@ -257,7 +251,6 @@ export class SharedTreeKernel
 		});
 		const forestSummarizer = new ForestSummarizer(
 			forest,
-			revisionTagCodec,
 			encoderContext,
 			decoderContext,
 			options,
@@ -265,9 +258,12 @@ export class SharedTreeKernel
 			initialSequenceNumber,
 			options.shouldEncodeIncrementally,
 		);
+		const revisionTagCodec = new RevisionTagCodec(idCompressor);
 		const removedRootsSummarizer = new DetachedFieldIndexSummarizer(
 			removedRoots,
-			options.minVersionForCollab,
+			revisionTagCodec,
+			idCompressor,
+			options,
 		);
 		const innerChangeFamily = new SharedTreeChangeFamily(
 			revisionTagCodec,

--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -523,11 +523,7 @@ export class TreeCheckout implements ITreeCheckout {
 		private readonly mintRevisionTag: () => RevisionTag,
 		private readonly revisionTagCodec: RevisionTagCodec,
 		private readonly idCompressor: IIdCompressor,
-		private readonly _removedRoots: DetachedFieldIndex = makeDetachedFieldIndex(
-			"repair",
-			revisionTagCodec,
-			idCompressor,
-		),
+		private readonly _removedRoots: DetachedFieldIndex = makeDetachedFieldIndex("repair"),
 		/** Optional logger for telemetry. */
 		private readonly logger?: TelemetryLoggerExt,
 		public readonly breaker: Breakable = new Breakable("TreeCheckout", logger),

--- a/packages/dds/tree/src/test/core/tree/anchorSet.spec.ts
+++ b/packages/dds/tree/src/test/core/tree/anchorSet.spec.ts
@@ -29,13 +29,7 @@ import {
 } from "../../../core/index.js";
 import { stringSchema } from "../../../simple-tree/index.js";
 import { brand } from "../../../util/index.js";
-import {
-	applyTestDelta,
-	chunkFromJsonableTrees,
-	expectEqualPaths,
-	testIdCompressor,
-	testRevisionTagCodec,
-} from "../../utils.js";
+import { applyTestDelta, chunkFromJsonableTrees, expectEqualPaths } from "../../utils.js";
 
 const fieldFoo: FieldKey = brand("foo");
 const fieldBar: FieldKey = brand("bar");
@@ -256,11 +250,7 @@ describe("AnchorSet", () => {
 			count: 1,
 			detach: detachId,
 		};
-		const detachedFieldIndex = makeDetachedFieldIndex(
-			"repair",
-			testRevisionTagCodec,
-			testIdCompressor,
-		);
+		const detachedFieldIndex = makeDetachedFieldIndex("repair");
 
 		applyTestDelta(makeDelta(detachMark, makePath([fieldFoo, 3])), anchors, {
 			detachedFieldIndex,
@@ -290,11 +280,7 @@ describe("AnchorSet", () => {
 			count: 3,
 			detach: detachId,
 		};
-		const detachedFieldIndex = makeDetachedFieldIndex(
-			"repair",
-			testRevisionTagCodec,
-			testIdCompressor,
-		);
+		const detachedFieldIndex = makeDetachedFieldIndex("repair");
 
 		applyTestDelta(makeDelta(detachMark, makePath([fieldFoo, 3])), anchors, {
 			detachedFieldIndex,

--- a/packages/dds/tree/src/test/core/tree/detachedFieldIndex.spec.ts
+++ b/packages/dds/tree/src/test/core/tree/detachedFieldIndex.spec.ts
@@ -13,6 +13,7 @@ import { FluidClientVersion, type CodecWriteOptions } from "../../../codec/index
 import {
 	DetachedFieldIndex,
 	type ForestRootId,
+	makeDetachedFieldIndex,
 	makeDetachedNodeId,
 	RevisionTagCodec,
 } from "../../../core/index.js";
@@ -227,35 +228,37 @@ function generateTestCases(
 	];
 }
 
-function makeDetachedFieldIndex(): DetachedFieldIndex {
-	return new DetachedFieldIndex(
-		"test",
-		idAllocatorFromMaxId() as IdAllocator<ForestRootId>,
-		testRevisionTagCodec,
-		testIdCompressor,
-	);
+const defaultCodecWriteOptions: CodecWriteOptions = {
+	jsonValidator: FormatValidatorBasic,
+	minVersionForCollab: FluidClientVersion.v2_0,
+};
+
+function makeDetachedFieldIndexCodec(
+	idCompressor: IIdCompressor = testIdCompressor,
+	options: CodecWriteOptions = defaultCodecWriteOptions,
+) {
+	return detachedFieldIndexCodecBuilder.build({
+		...options,
+		revisionTagCodec: new RevisionTagCodec(idCompressor),
+		idCompressor,
+	});
 }
 
 describe("DetachedFieldIndex Codecs", () => {
-	const options: CodecWriteOptions = {
-		jsonValidator: FormatValidatorBasic,
-		minVersionForCollab: FluidClientVersion.v2_0,
-	};
-
 	it("encodes with a version stamp.", () => {
 		const detachedFieldIndex = new DetachedFieldIndex(
 			"test",
 			idAllocatorFromMaxId() as IdAllocator<ForestRootId>,
-			testRevisionTagCodec,
-			testIdCompressor,
-			options,
 		);
 		const expected = {
 			version: 1,
 			data: [],
 			maxId: -1,
 		};
-		assert.deepEqual(detachedFieldIndex.encode(), expected);
+		const codec = makeDetachedFieldIndexCodec();
+		const data = detachedFieldIndex.getSummaryData();
+		const encoded = codec.encode(data);
+		assert.deepEqual(encoded, expected);
 	});
 
 	describe("round-trip through JSON", () => {
@@ -274,7 +277,7 @@ describe("DetachedFieldIndex Codecs", () => {
 					}
 					it(`version ${codec.formatVersion}`, () => {
 						const inner = codec.codec({
-							...options,
+							...defaultCodecWriteOptions,
 							revisionTagCodec: new RevisionTagCodec(idCompressor),
 							idCompressor,
 						});
@@ -288,7 +291,7 @@ describe("DetachedFieldIndex Codecs", () => {
 	});
 	describe("loadData", () => {
 		const codec = detachedFieldIndexCodecBuilder.build({
-			...options,
+			...defaultCodecWriteOptions,
 			revisionTagCodec: testRevisionTagCodec,
 			idCompressor: testIdCompressor,
 		});
@@ -328,7 +331,7 @@ describe("DetachedFieldIndex Codecs", () => {
 					useSnapshotDirectory(dir);
 					it(`version ${version}`, () => {
 						const codec = format.codec({
-							...options,
+							...defaultCodecWriteOptions,
 							revisionTagCodec: new RevisionTagCodec(idCompressor),
 							idCompressor,
 						});
@@ -471,10 +474,11 @@ describe("DetachedFieldIndex methods", () => {
 		const revisionTag2 = mintRevisionTag();
 		const rootId = detachedIndex.createEntry(detachedNodeId, revisionTag2);
 
-		const encodedDetachedIndex = detachedIndex.encode();
+		const codec = makeDetachedFieldIndexCodec();
+		const encodedDetachedIndex = codec.encode(detachedIndex.getSummaryData());
 
 		const detachedIndex2 = makeDetachedFieldIndex();
-		detachedIndex2.loadData(encodedDetachedIndex);
+		detachedIndex2.loadData(codec.decode(encodedDetachedIndex));
 		assert.equal(detachedIndex2.tryGetEntry(detachedNodeId), rootId);
 
 		// Check that loadData set the latestRelevantRevision to undefined.
@@ -494,10 +498,11 @@ describe("DetachedFieldIndex methods", () => {
 		const revisionTag2 = mintRevisionTag();
 		const rootId = detachedIndex.createEntry(detachedNodeId, revisionTag2);
 
-		const encodedDetachedIndex = detachedIndex.encode();
+		const codec = makeDetachedFieldIndexCodec();
+		const encodedDetachedIndex = codec.encode(detachedIndex.getSummaryData());
 
 		const detachedIndex2 = makeDetachedFieldIndex();
-		detachedIndex2.loadData(encodedDetachedIndex);
+		detachedIndex2.loadData(codec.decode(encodedDetachedIndex));
 		assert.equal(detachedIndex2.tryGetEntry(detachedNodeId), rootId);
 
 		// Sets the new revision tag after loading
@@ -575,16 +580,16 @@ describe("DetachedFieldIndex methods", () => {
 			const revisionTag1 = mintRevisionTag();
 			index.createEntry(makeDetachedNodeId(revisionTag1, 1));
 
-			const originalData = index.encode();
+			const originalData = index.getSummaryData();
 			const restore = index.createCheckpoint();
 
 			// Make changes to the index
 			index.deleteEntry(makeDetachedNodeId(revisionTag1, 1));
 			index.createEntry(makeDetachedNodeId(revisionTag1, 2), revisionTag1);
-			assert.notDeepEqual(index.encode(), originalData);
+			assert.notDeepEqual(index.getSummaryData(), originalData);
 
 			restore();
-			assert.deepEqual(index.encode(), originalData);
+			assert.deepEqual(index.getSummaryData(), originalData);
 		});
 
 		it("multiple checkpoints can exist for the same index", () => {
@@ -592,22 +597,22 @@ describe("DetachedFieldIndex methods", () => {
 			const revisionTag1 = mintRevisionTag();
 			index.createEntry(makeDetachedNodeId(revisionTag1, 1));
 
-			const originalData = index.encode();
+			const originalData = index.getSummaryData();
 			const restore1 = index.createCheckpoint();
 
 			// Make changes to the index
 			index.deleteEntry(makeDetachedNodeId(revisionTag1, 1));
 			index.createEntry(makeDetachedNodeId(revisionTag1, 2), revisionTag1);
-			assert.notDeepEqual(index.encode(), originalData);
+			assert.notDeepEqual(index.getSummaryData(), originalData);
 
-			const changedData = index.encode();
+			const changedData = index.getSummaryData();
 			const restore2 = index.createCheckpoint();
 
 			restore1();
-			assert.deepEqual(index.encode(), originalData);
+			assert.deepEqual(index.getSummaryData(), originalData);
 
 			restore2();
-			assert.deepEqual(index.encode(), changedData);
+			assert.deepEqual(index.getSummaryData(), changedData);
 		});
 
 		it("a checkpoint can be restored multiple times", () => {
@@ -615,23 +620,23 @@ describe("DetachedFieldIndex methods", () => {
 			const revisionTag1 = mintRevisionTag();
 			index.createEntry(makeDetachedNodeId(revisionTag1, 1));
 
-			const originalData = index.encode();
+			const originalData = index.getSummaryData();
 			const restore = index.createCheckpoint();
 
 			// Make changes to the index
 			index.deleteEntry(makeDetachedNodeId(revisionTag1, 1));
 			index.createEntry(makeDetachedNodeId(revisionTag1, 2), revisionTag1);
-			assert.notDeepEqual(index.encode(), originalData);
+			assert.notDeepEqual(index.getSummaryData(), originalData);
 
 			restore();
-			assert.deepEqual(index.encode(), originalData);
+			assert.deepEqual(index.getSummaryData(), originalData);
 
 			// Make more changes to the index
 			index.createEntry(makeDetachedNodeId(revisionTag1, 3), revisionTag1);
-			assert.notDeepEqual(index.encode(), originalData);
+			assert.notDeepEqual(index.getSummaryData(), originalData);
 
 			restore();
-			assert.deepEqual(index.encode(), originalData);
+			assert.deepEqual(index.getSummaryData(), originalData);
 		});
 	});
 });

--- a/packages/dds/tree/src/test/core/tree/visitDelta.spec.ts
+++ b/packages/dds/tree/src/test/core/tree/visitDelta.spec.ts
@@ -28,8 +28,6 @@ import {
 	chunkToMapTreeField,
 	mintRevisionTag,
 	rootFromDeltaFieldMap,
-	testIdCompressor,
-	testRevisionTagCodec,
 	type DeltaParams,
 } from "../../utils.js";
 
@@ -40,12 +38,7 @@ function visit(
 	revision?: RevisionTag,
 ): void {
 	deepFreeze(delta);
-	visitDelta(
-		delta,
-		visitor,
-		detachedFieldIndex ?? makeDetachedFieldIndex("", testRevisionTagCodec, testIdCompressor),
-		revision,
-	);
+	visitDelta(delta, visitor, detachedFieldIndex ?? makeDetachedFieldIndex(""), revision);
 }
 
 type CallSignatures<T> = {
@@ -151,7 +144,7 @@ describe("visitDelta", () => {
 		]);
 	});
 	it("insert root", () => {
-		const index = makeDetachedFieldIndex("", testRevisionTagCodec, testIdCompressor);
+		const index = makeDetachedFieldIndex("");
 		const node = { minor: 42 };
 		const rootFieldDelta: DeltaFieldChanges = { marks: [{ count: 1, attach: node }] };
 		const delta: DeltaRoot = {
@@ -170,7 +163,7 @@ describe("visitDelta", () => {
 		assert.equal(index.entries().next().done, true);
 	});
 	it("throws on build of existing tree", () => {
-		const index = makeDetachedFieldIndex("", testRevisionTagCodec, testIdCompressor);
+		const index = makeDetachedFieldIndex("");
 		const node = { minor: 42 };
 		index.createEntry(node);
 		const rootFieldDelta: DeltaFieldChanges = { marks: [{ count: 1, attach: node }] };
@@ -182,7 +175,7 @@ describe("visitDelta", () => {
 		assert.deepEqual([...index.entries()], [{ id: { minor: 42 }, root: 0 }]);
 	});
 	it("insert child", () => {
-		const index = makeDetachedFieldIndex("", testRevisionTagCodec, testIdCompressor);
+		const index = makeDetachedFieldIndex("");
 		const buildId = { minor: 42 };
 		const rootFieldDelta: DeltaFieldChanges = {
 			marks: [
@@ -216,7 +209,7 @@ describe("visitDelta", () => {
 		assert.equal(index.entries().next().done, true);
 	});
 	it("remove root", () => {
-		const index = makeDetachedFieldIndex("", testRevisionTagCodec, testIdCompressor);
+		const index = makeDetachedFieldIndex("");
 		const mark: DeltaMark = {
 			count: 2,
 			detach: { minor: 42 },
@@ -245,7 +238,7 @@ describe("visitDelta", () => {
 		);
 	});
 	it("remove child", () => {
-		const index = makeDetachedFieldIndex("", testRevisionTagCodec, testIdCompressor);
+		const index = makeDetachedFieldIndex("");
 		const remove: DeltaMark = {
 			count: 1,
 			detach: { minor: 42 },
@@ -273,7 +266,7 @@ describe("visitDelta", () => {
 		assert.deepEqual([...index.entries()], [{ id: { minor: 42 }, root: 0 }]);
 	});
 	it("changes under insert", () => {
-		const index = makeDetachedFieldIndex("", testRevisionTagCodec, testIdCompressor);
+		const index = makeDetachedFieldIndex("");
 		const moveId = { minor: 1 };
 		const moveOut: DeltaMark = {
 			count: 1,
@@ -317,7 +310,7 @@ describe("visitDelta", () => {
 		assert.equal(index.entries().next().done, true);
 	});
 	it("move node to the right", () => {
-		const index = makeDetachedFieldIndex("", testRevisionTagCodec, testIdCompressor);
+		const index = makeDetachedFieldIndex("");
 		// start with 0123 then move 1 so the order is 0213
 		const moveId = { minor: 1 };
 		const moveOut: DeltaMark = {
@@ -341,7 +334,7 @@ describe("visitDelta", () => {
 		assert.equal(index.entries().next().done, true);
 	});
 	it("move children to the left", () => {
-		const index = makeDetachedFieldIndex("", testRevisionTagCodec, testIdCompressor);
+		const index = makeDetachedFieldIndex("");
 		const moveId = { minor: 1 };
 		const moveOut: DeltaMark = {
 			count: 2,
@@ -378,7 +371,7 @@ describe("visitDelta", () => {
 		assert.equal(index.entries().next().done, true);
 	});
 	it("move cousins", () => {
-		const index = makeDetachedFieldIndex("", testRevisionTagCodec, testIdCompressor);
+		const index = makeDetachedFieldIndex("");
 		const moveId = { minor: 1 };
 		const moveOut: DeltaMark = {
 			count: 1,
@@ -420,7 +413,7 @@ describe("visitDelta", () => {
 		assert.equal(index.entries().next().done, true);
 	});
 	it("changes under remove", () => {
-		const index = makeDetachedFieldIndex("", testRevisionTagCodec, testIdCompressor);
+		const index = makeDetachedFieldIndex("");
 		const moveId = { minor: 1 };
 		const moveOut: DeltaMark = {
 			count: 1,
@@ -459,7 +452,7 @@ describe("visitDelta", () => {
 		assert.deepEqual([...index.entries()], [{ id: { minor: 42 }, root: 1 }]);
 	});
 	it("changes under destroy", () => {
-		const index = makeDetachedFieldIndex("", testRevisionTagCodec, testIdCompressor);
+		const index = makeDetachedFieldIndex("");
 		const node1 = { minor: 42 };
 		index.createEntry(node1);
 		const moveId = { minor: 1 };
@@ -500,7 +493,7 @@ describe("visitDelta", () => {
 		assert.equal(index.entries().next().done, true);
 	});
 	it("destroy (root level)", () => {
-		const index = makeDetachedFieldIndex("", testRevisionTagCodec, testIdCompressor);
+		const index = makeDetachedFieldIndex("");
 		const id = { minor: 42 };
 		index.createEntry(id, undefined, 2);
 		const delta: DeltaRoot = {
@@ -514,7 +507,7 @@ describe("visitDelta", () => {
 		assert.equal(index.entries().next().done, true);
 	});
 	it("build-rename-destroy (field level)", () => {
-		const index = makeDetachedFieldIndex("", testRevisionTagCodec, testIdCompressor);
+		const index = makeDetachedFieldIndex("");
 		const buildId = { minor: 42 };
 		const detachId = { minor: 43 };
 		const delta: DeltaRoot = {
@@ -533,7 +526,7 @@ describe("visitDelta", () => {
 		assert.equal(index.entries().next().done, true);
 	});
 	it("changes under move-out", () => {
-		const index = makeDetachedFieldIndex("", testRevisionTagCodec, testIdCompressor);
+		const index = makeDetachedFieldIndex("");
 		const moveId1 = { minor: 1 };
 		const moveId2 = { minor: 2 };
 		const moveIn1: DeltaMark = {
@@ -577,7 +570,7 @@ describe("visitDelta", () => {
 	});
 
 	it("changes under move-out of range", () => {
-		const index = makeDetachedFieldIndex("", testRevisionTagCodec, testIdCompressor);
+		const index = makeDetachedFieldIndex("");
 		const buildId = { minor: 1 };
 		const moveId = { minor: 2 };
 
@@ -658,12 +651,12 @@ describe("visitDelta", () => {
 			["exitField", rootKey],
 		];
 
-		const index = makeDetachedFieldIndex("", testRevisionTagCodec, testIdCompressor);
+		const index = makeDetachedFieldIndex("");
 		testDeltaVisit(delta, expected, index);
 	});
 
 	it("changes under replaced node", () => {
-		const index = makeDetachedFieldIndex("", testRevisionTagCodec, testIdCompressor);
+		const index = makeDetachedFieldIndex("");
 		const moveId1 = { minor: 1 };
 		const moveId2 = { minor: 2 };
 		const moveOut2: DeltaMark = {
@@ -711,7 +704,7 @@ describe("visitDelta", () => {
 	});
 
 	it("changes under replacement node", () => {
-		const index = makeDetachedFieldIndex("", testRevisionTagCodec, testIdCompressor);
+		const index = makeDetachedFieldIndex("");
 		const moveId1 = { minor: 1 };
 		const moveId2 = { minor: 2 };
 		const moveOut2: DeltaMark = {
@@ -756,7 +749,7 @@ describe("visitDelta", () => {
 		assert.deepEqual([...index.entries()], [{ id: { minor: 42 }, root: 0 }]);
 	});
 	it("transient insert", () => {
-		const index = makeDetachedFieldIndex("", testRevisionTagCodec, testIdCompressor);
+		const index = makeDetachedFieldIndex("");
 		const delta: DeltaRoot = {
 			build: [{ id: { minor: 42 }, trees: chunkX }],
 			rename: [{ oldId: { minor: 42 }, count: 1, newId: { minor: 43 } }],
@@ -771,7 +764,7 @@ describe("visitDelta", () => {
 		assert.deepEqual([...index.entries()], [{ id: { minor: 43 }, root: 1 }]);
 	});
 	it("changes under transient", () => {
-		const index = makeDetachedFieldIndex("", testRevisionTagCodec, testIdCompressor);
+		const index = makeDetachedFieldIndex("");
 		const moveId = { minor: 1 };
 		const moveOut: DeltaMark = {
 			count: 1,
@@ -812,7 +805,7 @@ describe("visitDelta", () => {
 		assert.deepEqual([...index.entries()], [{ id: detachId, root: 2 }]);
 	});
 	it("restore", () => {
-		const index = makeDetachedFieldIndex("", testRevisionTagCodec, testIdCompressor);
+		const index = makeDetachedFieldIndex("");
 		const node1 = { minor: 1 };
 		index.createEntry(node1);
 		const restore: DeltaMark = {
@@ -831,7 +824,7 @@ describe("visitDelta", () => {
 		assert.equal(index.entries().next().done, true);
 	});
 	it("move removed node", () => {
-		const index = makeDetachedFieldIndex("", testRevisionTagCodec, testIdCompressor);
+		const index = makeDetachedFieldIndex("");
 		const node1 = { minor: 1 };
 		index.createEntry(node1);
 		const moveId = { minor: 2 };
@@ -859,7 +852,7 @@ describe("visitDelta", () => {
 		assert.equal(index.entries().next().done, true);
 	});
 	it("changes under removed node", () => {
-		const index = makeDetachedFieldIndex("", testRevisionTagCodec, testIdCompressor);
+		const index = makeDetachedFieldIndex("");
 		const node1 = { minor: 1 };
 		index.createEntry(node1);
 		const moveId = { minor: 2 };
@@ -896,7 +889,7 @@ describe("visitDelta", () => {
 		assert.deepEqual([...index.entries()], [{ id: { minor: 1 }, root: 0 }]);
 	});
 	it("changes under transient move-in", () => {
-		const index = makeDetachedFieldIndex("", testRevisionTagCodec, testIdCompressor);
+		const index = makeDetachedFieldIndex("");
 		const moveId1 = { minor: 1 };
 		const moveId2 = { minor: 2 };
 		const detachId = { minor: 42 };
@@ -950,7 +943,7 @@ describe("visitDelta", () => {
 		assert.deepEqual([...index.entries()], [{ id: detachId, root: 2 }]);
 	});
 	it("transient restore", () => {
-		const index = makeDetachedFieldIndex("", testRevisionTagCodec, testIdCompressor);
+		const index = makeDetachedFieldIndex("");
 		const node1 = { minor: 1 };
 		index.createEntry(node1);
 		const restore: DeltaDetachedNodeRename = {
@@ -968,7 +961,7 @@ describe("visitDelta", () => {
 		assert.deepEqual([...index.entries()], [{ id: { minor: 42 }, root: 1 }]);
 	});
 	it("update detached node", () => {
-		const index = makeDetachedFieldIndex("", testRevisionTagCodec, testIdCompressor);
+		const index = makeDetachedFieldIndex("");
 		const node1 = { minor: 1 };
 		index.createEntry(node1);
 		const buildId = { minor: 2 };
@@ -1008,7 +1001,7 @@ describe("visitDelta", () => {
 
 	describe("refreshers", () => {
 		it("for restores at the root", () => {
-			const index = makeDetachedFieldIndex("", testRevisionTagCodec, testIdCompressor);
+			const index = makeDetachedFieldIndex("");
 			const node = { minor: 42 };
 			const rootFieldDelta: DeltaFieldChanges = { marks: [{ count: 1, attach: node }] };
 			const delta: DeltaRoot = {
@@ -1028,7 +1021,7 @@ describe("visitDelta", () => {
 		});
 
 		it("for restores under a child", () => {
-			const index = makeDetachedFieldIndex("", testRevisionTagCodec, testIdCompressor);
+			const index = makeDetachedFieldIndex("");
 			const buildId = { minor: 42 };
 			const rootFieldDelta: DeltaFieldChanges = {
 				marks: [
@@ -1063,7 +1056,7 @@ describe("visitDelta", () => {
 		});
 
 		it("for partial restores", () => {
-			const index = makeDetachedFieldIndex("", testRevisionTagCodec, testIdCompressor);
+			const index = makeDetachedFieldIndex("");
 			const node = { minor: 42 };
 			const rootFieldDelta: DeltaFieldChanges = {
 				marks: [{ count: 1, attach: { minor: 43 } }],
@@ -1085,7 +1078,7 @@ describe("visitDelta", () => {
 		});
 
 		it("for changes to detached trees", () => {
-			const index = makeDetachedFieldIndex("", testRevisionTagCodec, testIdCompressor);
+			const index = makeDetachedFieldIndex("");
 			const refresherId = { minor: 42 };
 			const buildId = { minor: 43 };
 			const expected: VisitScript = [
@@ -1122,7 +1115,7 @@ describe("visitDelta", () => {
 	});
 
 	it("creates refreshers and updates latest revision for root transfers", () => {
-		const index = makeDetachedFieldIndex("", testRevisionTagCodec, testIdCompressor);
+		const index = makeDetachedFieldIndex("");
 		const node1 = { minor: 1 };
 		index.createEntry(node1);
 		const moveId = { minor: 2 };
@@ -1150,7 +1143,7 @@ describe("visitDelta", () => {
 
 	describe("updates latest revision", () => {
 		it("when building a detached tree", () => {
-			const index = makeDetachedFieldIndex("", testRevisionTagCodec, testIdCompressor);
+			const index = makeDetachedFieldIndex("");
 			const node = { minor: 42 };
 			const delta: DeltaRoot = {
 				build: [{ id: node, trees: chunkX }],
@@ -1165,7 +1158,7 @@ describe("visitDelta", () => {
 		});
 
 		it("when applying changes to detached trees", () => {
-			const index = makeDetachedFieldIndex("", testRevisionTagCodec, testIdCompressor);
+			const index = makeDetachedFieldIndex("");
 			const node1 = { minor: 1 };
 			index.createEntry(node1);
 			const moveId = { minor: 2 };
@@ -1236,7 +1229,7 @@ describe("visitDelta", () => {
 			];
 
 			const revision = mintRevisionTag();
-			const index = makeDetachedFieldIndex("", testRevisionTagCodec, testIdCompressor);
+			const index = makeDetachedFieldIndex("");
 			testDeltaVisit(delta, expected, index, revision);
 			const iteratorResult = index.entries().next();
 			assert.equal(iteratorResult.done, false);
@@ -1247,7 +1240,7 @@ describe("visitDelta", () => {
 
 	describe("tolerates superfluous refreshers", () => {
 		it("when the delta can be applied without the refresher", () => {
-			const index = makeDetachedFieldIndex("", testRevisionTagCodec, testIdCompressor);
+			const index = makeDetachedFieldIndex("");
 			const node = { minor: 42 };
 			const node2 = { minor: 43 };
 			const rootFieldDelta: DeltaFieldChanges = { marks: [{ count: 1, attach: node2 }] };
@@ -1271,7 +1264,7 @@ describe("visitDelta", () => {
 		});
 
 		it("when the refreshed tree already exists in the forest", () => {
-			const index = makeDetachedFieldIndex("", testRevisionTagCodec, testIdCompressor);
+			const index = makeDetachedFieldIndex("");
 			const node = { minor: 42 };
 			index.createEntry(node, undefined, 1);
 			const rootFieldDelta: DeltaFieldChanges = { marks: [{ count: 1, attach: node }] };
@@ -1291,7 +1284,7 @@ describe("visitDelta", () => {
 		});
 
 		it("when the refreshed tree is included in the builds", () => {
-			const index = makeDetachedFieldIndex("", testRevisionTagCodec, testIdCompressor);
+			const index = makeDetachedFieldIndex("");
 			const node = { minor: 42 };
 			const rootFieldDelta: DeltaFieldChanges = { marks: [{ count: 1, attach: node }] };
 			const delta: DeltaRoot = {
@@ -1319,7 +1312,7 @@ describe("visitDelta", () => {
 				const end = cycle ? pointA : { minor: 42 };
 				describe("1-step", () => {
 					it("Rename ordering: 1/1", () => {
-						const index = makeDetachedFieldIndex("", testRevisionTagCodec, testIdCompressor);
+						const index = makeDetachedFieldIndex("");
 						index.createEntry(pointA);
 						const rename: DeltaDetachedNodeRename = {
 							count: 1,
@@ -1343,7 +1336,7 @@ describe("visitDelta", () => {
 				describe("2-step", () => {
 					for (let ordering = 1; ordering <= 2; ordering++) {
 						it(`Rename ordering: ${ordering}/2`, () => {
-							const index = makeDetachedFieldIndex("", testRevisionTagCodec, testIdCompressor);
+							const index = makeDetachedFieldIndex("");
 							index.createEntry(pointA);
 							const pointB = { minor: 2 };
 							const rename1: DeltaDetachedNodeRename = {
@@ -1416,7 +1409,7 @@ describe("visitDelta", () => {
 								["detach", { start: 0, end: 1 }, field3, end, false],
 								["exitField", field2],
 							];
-							const index = makeDetachedFieldIndex("", testRevisionTagCodec, testIdCompressor);
+							const index = makeDetachedFieldIndex("");
 							index.createEntry(pointA);
 							testDeltaVisit(delta, expected, index);
 							assert.deepEqual([...index.entries()], [{ id: end, root: 3 }]);

--- a/packages/dds/tree/src/test/domains/json/jsonCursor.bench.ts
+++ b/packages/dds/tree/src/test/domains/json/jsonCursor.bench.ts
@@ -44,7 +44,7 @@ import { toInitialSchema } from "../../../simple-tree/toStoredSchema.js";
 import { brand, type JsonCompatible } from "../../../util/index.js";
 import { initializeForest } from "../../feature-libraries/index.js";
 import { cursorToJsonObject, singleJsonCursor } from "../../json/index.js";
-import { buildTestForest, testIdCompressor, testRevisionTagCodec } from "../../utils.js";
+import { buildTestForest } from "../../utils.js";
 
 import { averageValues, sum, sumMap } from "./benchmarks.js";
 import { Canada, generateCanada } from "./canada.js";
@@ -126,12 +126,7 @@ function bench(
 							"object-forest Cursor",
 							() => {
 								const forest = buildTestForest({ additionalAsserts: true });
-								initializeForest(
-									forest,
-									cursorForJsonableTreeField([encodedTree]),
-									testRevisionTagCodec,
-									testIdCompressor,
-								);
+								initializeForest(forest, cursorForJsonableTreeField([encodedTree]));
 								const cursor = forest.allocateCursor();
 								moveToDetachedField(forest, cursor);
 								assert(cursor.firstNode());
@@ -161,12 +156,7 @@ function bench(
 										defaultIncrementalEncodingPolicy,
 									),
 								);
-								initializeForest(
-									forest,
-									cursorForJsonableTreeField([encodedTree]),
-									testRevisionTagCodec,
-									testIdCompressor,
-								);
+								initializeForest(forest, cursorForJsonableTreeField([encodedTree]));
 								const cursor = forest.allocateCursor();
 								moveToDetachedField(forest, cursor);
 								assert(cursor.firstNode());

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkEncodingEndToEnd.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkEncodingEndToEnd.spec.ts
@@ -202,7 +202,6 @@ describe("End to end chunked encoding", () => {
 
 		const forestSummarizer = new ForestSummarizer(
 			checkout.forest,
-			revisionTagCodec,
 			context,
 			decodeContext,
 			options,
@@ -239,7 +238,6 @@ describe("End to end chunked encoding", () => {
 
 		const forestSummarizer = new ForestSummarizer(
 			forest,
-			revisionTagCodec,
 			context,
 			decodeContext,
 			options,
@@ -276,7 +274,6 @@ describe("End to end chunked encoding", () => {
 
 			const forestSummarizer = new ForestSummarizer(
 				checkout.forest,
-				new RevisionTagCodec(testIdCompressor),
 				encoderContext,
 				decoderContext,
 				options,
@@ -304,7 +301,6 @@ describe("End to end chunked encoding", () => {
 
 			const forestSummarizer = new ForestSummarizer(
 				checkout.forest,
-				new RevisionTagCodec(testIdCompressor),
 				encoderContext,
 				decoderContext,
 				options,
@@ -327,7 +323,6 @@ describe("End to end chunked encoding", () => {
 
 			const forestSummarizer = new ForestSummarizer(
 				checkout.forest,
-				new RevisionTagCodec(testIdCompressor),
 				encoderContext,
 				decoderContext,
 				options,

--- a/packages/dds/tree/src/test/feature-libraries/default-field-kinds/defaultChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/default-field-kinds/defaultChangeFamily.spec.ts
@@ -35,8 +35,6 @@ import {
 	chunkFromJsonableTrees,
 	failCodecFamily,
 	mintRevisionTag,
-	testIdCompressor,
-	testRevisionTagCodec,
 } from "../../utils.js";
 import { initializeForest } from "../initializeForest.js";
 
@@ -121,20 +119,11 @@ function initializeEditableForest(data?: JsonableTree): {
 } {
 	const forest = buildTestForest({ additionalAsserts: true });
 	if (data !== undefined) {
-		initializeForest(
-			forest,
-			cursorForJsonableTreeField([data]),
-			testRevisionTagCodec,
-			testIdCompressor,
-		);
+		initializeForest(forest, cursorForJsonableTreeField([data]));
 	}
 	const changes: TaggedChange<DefaultChangeset>[] = [];
 	const deltas: DeltaRoot[] = [];
-	const detachedFieldIndex = makeDetachedFieldIndex(
-		undefined,
-		testRevisionTagCodec,
-		testIdCompressor,
-	);
+	const detachedFieldIndex = makeDetachedFieldIndex();
 	const builder = new DefaultEditBuilder(
 		family,
 		mintRevisionTag,

--- a/packages/dds/tree/src/test/feature-libraries/detachedFieldIndexSummarizer.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/detachedFieldIndexSummarizer.spec.ts
@@ -14,11 +14,11 @@ import {
 import type { MinimumVersionForCollab } from "@fluidframework/runtime-definitions/internal";
 import { MockStorage, validateUsageError } from "@fluidframework/test-runtime-utils/internal";
 
-import { FluidClientVersion } from "../../codec/index.js";
+import { FluidClientVersion, FormatValidatorNoOp } from "../../codec/index.js";
 import {
 	DetachedFieldIndex,
 	DetachedFieldIndexFormatVersion,
-	type ForestRootId,
+	makeDetachedFieldIndex,
 } from "../../core/index.js";
 // eslint-disable-next-line import-x/no-internal-modules
 import type { FormatV1 } from "../../core/tree/detachedFieldIndexFormatV1.js";
@@ -32,7 +32,7 @@ import {
 	summarizablesMetadataKey,
 	type SharedTreeSummarizableMetadata,
 } from "../../shared-tree-core/index.js";
-import { brand, type IdAllocator, idAllocatorFromMaxId } from "../../util/index.js";
+import { brand } from "../../util/index.js";
 import { testIdCompressor, testRevisionTagCodec } from "../utils.js";
 
 function createDetachedFieldIndexSummarizer(options?: {
@@ -41,15 +41,15 @@ function createDetachedFieldIndexSummarizer(options?: {
 	summarizer: DetachedFieldIndexSummarizer;
 	index: DetachedFieldIndex;
 } {
-	const index = new DetachedFieldIndex(
-		"test",
-		idAllocatorFromMaxId() as IdAllocator<ForestRootId>,
-		testRevisionTagCodec,
-		testIdCompressor,
-	);
+	const index = makeDetachedFieldIndex();
 	const summarizer = new DetachedFieldIndexSummarizer(
 		index,
-		options?.minVersionForCollab ?? FluidClientVersion.v2_74,
+		testRevisionTagCodec,
+		testIdCompressor,
+		{
+			jsonValidator: FormatValidatorNoOp,
+			minVersionForCollab: options?.minVersionForCollab ?? FluidClientVersion.v2_74,
+		},
 	);
 	return { summarizer, index };
 }

--- a/packages/dds/tree/src/test/feature-libraries/forest-summary/forestSummarizer.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/forest-summary/forestSummarizer.spec.ts
@@ -70,7 +70,6 @@ import {
 	fieldCursorFromInsertable,
 	makeTestFieldBatchContexts,
 	testIdCompressor,
-	testRevisionTagCodec,
 	type TreeStoredContentStrict,
 } from "../../utils.js";
 
@@ -111,7 +110,6 @@ function createForestSummarizer(args: {
 		checkout,
 		forestSummarizer: new ForestSummarizer(
 			checkout.forest,
-			testRevisionTagCodec,
 			encoderContext,
 			decoderContext,
 			options,

--- a/packages/dds/tree/src/test/feature-libraries/initializeForest.ts
+++ b/packages/dds/tree/src/test/feature-libraries/initializeForest.ts
@@ -4,13 +4,12 @@
  */
 
 import { assert } from "@fluidframework/core-utils/internal";
-import type { SessionSpaceCompressedId, IIdCompressor } from "@fluidframework/id-compressor";
+import type { SessionSpaceCompressedId } from "@fluidframework/id-compressor";
 
 import {
 	type DeltaRoot,
 	type IEditableForest,
 	type ITreeCursorSynchronous,
-	type RevisionTagCodec,
 	combineVisitors,
 	deltaForRootInitialization,
 	makeDetachedFieldIndex,
@@ -31,8 +30,6 @@ import { combineChunks } from "../../feature-libraries/index.js";
 export function initializeForest(
 	forest: IEditableForest,
 	content: ITreeCursorSynchronous,
-	revisionTagCodec: RevisionTagCodec,
-	idCompressor: IIdCompressor,
 	visitAnchors = false,
 ): void {
 	assert(forest.isEmpty, 0x747 /* forest must be empty */);
@@ -48,11 +45,6 @@ export function initializeForest(
 
 	// any detached trees built here are immediately attached so the revision used here doesn't matter
 	// we use a dummy revision to make correctness checks in the detached field index easier
-	visitDelta(
-		delta,
-		visitor,
-		makeDetachedFieldIndex("init", revisionTagCodec, idCompressor),
-		0 as SessionSpaceCompressedId,
-	);
+	visitDelta(delta, visitor, makeDetachedFieldIndex("init"), 0 as SessionSpaceCompressedId);
 	visitor.free();
 }

--- a/packages/dds/tree/src/test/feature-libraries/objectForest.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/objectForest.spec.ts
@@ -22,7 +22,6 @@ import { SchemaFactory, toInitialSchema } from "../../simple-tree/index.js";
 import { Breakable, type JsonCompatible, brand } from "../../util/index.js";
 import { testForest } from "../forestTestSuite.js";
 import { fieldJsonCursor } from "../json/index.js";
-import { testIdCompressor, testRevisionTagCodec } from "../utils.js";
 
 import { initializeForest } from "./initializeForest.js";
 
@@ -52,12 +51,7 @@ describe("object-forest", () => {
 	describe("Throws an error for invalid edits", () => {
 		it("attaching content into the detached field it is being transferred from", () => {
 			const forest = buildForest(new Breakable("test"));
-			initializeForest(
-				forest,
-				fieldJsonCursor([content]),
-				testRevisionTagCodec,
-				testIdCompressor,
-			);
+			initializeForest(forest, fieldJsonCursor([content]));
 			const visitor = forest.acquireVisitor();
 			visitor.enterField(rootFieldKey);
 			assert.throws(
@@ -70,12 +64,7 @@ describe("object-forest", () => {
 
 		it("detaching content from the detached field it is being transferred to", () => {
 			const forest = buildForest(new Breakable("test"));
-			initializeForest(
-				forest,
-				fieldJsonCursor([content]),
-				testRevisionTagCodec,
-				testIdCompressor,
-			);
+			initializeForest(forest, fieldJsonCursor([content]));
 			const visitor = forest.acquireVisitor();
 			visitor.enterField(rootFieldKey);
 			assert.throws(
@@ -91,12 +80,7 @@ describe("object-forest", () => {
 
 	it("moveCursorToPath with an undefined path points to dummy node above detachedFields.", () => {
 		const forest = buildForest(new Breakable("test"));
-		initializeForest(
-			forest,
-			fieldJsonCursor([[1, 2]]),
-			testRevisionTagCodec,
-			testIdCompressor,
-		);
+		initializeForest(forest, fieldJsonCursor([[1, 2]]));
 		const cursor = forest.allocateCursor();
 		forest.moveCursorToPath(undefined, cursor);
 		assert.deepEqual(cursor.fieldIndex, cursorForMapTreeNode(forest.roots).fieldIndex);
@@ -104,12 +88,7 @@ describe("object-forest", () => {
 
 	it("uses cursor sources in errors", () => {
 		const forest = buildForest(new Breakable("test"));
-		initializeForest(
-			forest,
-			fieldJsonCursor([content]),
-			testRevisionTagCodec,
-			testIdCompressor,
-		);
+		initializeForest(forest, fieldJsonCursor([content]));
 		const named = forest.allocateCursor("named");
 		moveToDetachedField(forest, named);
 		const forkOfNamed = named.fork();
@@ -154,12 +133,7 @@ describe("object-forest", () => {
 		assert.throws(
 			() =>
 				// Adds something to field which allows nothing: should error.
-				initializeForest(
-					forest,
-					fieldJsonCursor(["root"]),
-					testRevisionTagCodec,
-					testIdCompressor,
-				),
+				initializeForest(forest, fieldJsonCursor(["root"])),
 			validateUsageError(/Tree does not conform to schema/),
 		);
 	});

--- a/packages/dds/tree/src/test/forestTestSuite.ts
+++ b/packages/dds/tree/src/test/forestTestSuite.ts
@@ -5,13 +5,11 @@
 
 import { strict as assert } from "node:assert";
 
-import { FluidClientVersion } from "../codec/index.js";
 import {
 	type DeltaFieldChanges,
 	type DeltaFieldMap,
 	type DeltaMark,
 	type DetachedField,
-	DetachedFieldIndex,
 	EmptyKey,
 	type FieldKey,
 	type FieldUpPath,
@@ -26,11 +24,11 @@ import {
 	clonePath,
 	createAnnouncedVisitor,
 	detachedFieldAsKey,
+	makeDetachedFieldIndex,
 	mapCursorField,
 	moveToDetachedField,
 	rootFieldKey,
 } from "../core/index.js";
-import { FormatValidatorBasic } from "../external-utilities/index.js";
 import {
 	cursorForJsonableTreeField,
 	jsonableTreeFromCursor,
@@ -43,12 +41,7 @@ import {
 	stringSchema,
 	toInitialSchema,
 } from "../simple-tree/index.js";
-import {
-	type IdAllocator,
-	type JsonCompatible,
-	brand,
-	idAllocatorFromMaxId,
-} from "../util/index.js";
+import { type JsonCompatible, brand } from "../util/index.js";
 
 import { testGeneralPurposeTreeCursor, testTreeSchema } from "./cursorTestSuite.js";
 import { initializeForest } from "./feature-libraries/index.js";
@@ -60,8 +53,6 @@ import {
 	chunkFromJsonTrees,
 	expectEqualFieldPaths,
 	expectEqualPaths,
-	testIdCompressor,
-	testRevisionTagCodec,
 } from "./utils.js";
 
 /**
@@ -118,12 +109,7 @@ export function testForest(config: ForestTestConfiguration): void {
 
 				const forest = factory(schema);
 
-				initializeForest(
-					forest,
-					fieldJsonCursor([data]),
-					testRevisionTagCodec,
-					testIdCompressor,
-				);
+				initializeForest(forest, fieldJsonCursor([data]));
 
 				const reader = forest.allocateCursor();
 				moveToDetachedField(forest, reader);
@@ -138,12 +124,7 @@ export function testForest(config: ForestTestConfiguration): void {
 
 	it("cursor use", () => {
 		const forest = factory(new TreeStoredSchemaRepository(optionalArraySchema));
-		initializeForest(
-			forest,
-			fieldJsonCursor([[1, 2]]),
-			testRevisionTagCodec,
-			testIdCompressor,
-		);
+		initializeForest(forest, fieldJsonCursor([[1, 2]]));
 
 		const reader = forest.allocateCursor();
 		moveToDetachedField(forest, reader);
@@ -175,7 +156,7 @@ export function testForest(config: ForestTestConfiguration): void {
 	it("isEmpty: rootFieldKey", () => {
 		const forest = factory(new TreeStoredSchemaRepository(optionalArraySchema));
 		assert(forest.isEmpty);
-		initializeForest(forest, fieldJsonCursor([[]]), testRevisionTagCodec, testIdCompressor);
+		initializeForest(forest, fieldJsonCursor([[]]));
 		assert(!forest.isEmpty);
 	});
 
@@ -200,12 +181,7 @@ export function testForest(config: ForestTestConfiguration): void {
 	it("tryMoveCursorToNode", () => {
 		const forest = factory(new TreeStoredSchemaRepository(optionalArraySchema));
 
-		initializeForest(
-			forest,
-			fieldJsonCursor([[1, 2]]),
-			testRevisionTagCodec,
-			testIdCompressor,
-		);
+		initializeForest(forest, fieldJsonCursor([[1, 2]]));
 
 		const parentPath: UpPath = {
 			parent: undefined,
@@ -241,12 +217,7 @@ export function testForest(config: ForestTestConfiguration): void {
 	it("tryMoveCursorToField", () => {
 		const forest = factory(new TreeStoredSchemaRepository(optionalArraySchema));
 
-		initializeForest(
-			forest,
-			fieldJsonCursor([[1, 2]]),
-			testRevisionTagCodec,
-			testIdCompressor,
-		);
+		initializeForest(forest, fieldJsonCursor([[1, 2]]));
 
 		const parentPath: FieldUpPath = {
 			parent: undefined,
@@ -283,12 +254,7 @@ export function testForest(config: ForestTestConfiguration): void {
 	describe("moveCursorToPath", () => {
 		it("moves cursor to specified path.", () => {
 			const forest = factory(new TreeStoredSchemaRepository(optionalArraySchema));
-			initializeForest(
-				forest,
-				fieldJsonCursor([[1, 2]]),
-				testRevisionTagCodec,
-				testIdCompressor,
-			);
+			initializeForest(forest, fieldJsonCursor([[1, 2]]));
 
 			const cursor = forest.allocateCursor();
 			const path: UpPath = {
@@ -304,12 +270,7 @@ export function testForest(config: ForestTestConfiguration): void {
 
 	it("getCursorAboveDetachedFields", () => {
 		const forest = factory(new TreeStoredSchemaRepository(optionalArraySchema));
-		initializeForest(
-			forest,
-			fieldJsonCursor([[1, 2]]),
-			testRevisionTagCodec,
-			testIdCompressor,
-		);
+		initializeForest(forest, fieldJsonCursor([[1, 2]]));
 
 		const forestCursor = forest.allocateCursor();
 		moveToDetachedField(forest, forestCursor);
@@ -323,12 +284,7 @@ export function testForest(config: ForestTestConfiguration): void {
 
 	it("anchors creation and use", () => {
 		const forest = factory(new TreeStoredSchemaRepository(optionalArraySchema));
-		initializeForest(
-			forest,
-			fieldJsonCursor([[1, 2]]),
-			testRevisionTagCodec,
-			testIdCompressor,
-		);
+		initializeForest(forest, fieldJsonCursor([[1, 2]]));
 
 		const cursor = forest.allocateCursor();
 		moveToDetachedField(forest, cursor);
@@ -392,12 +348,7 @@ export function testForest(config: ForestTestConfiguration): void {
 	it("tryMoveCursorToNode with anchor to deleted node returns NotFound", () => {
 		const forest = factory(new TreeStoredSchemaRepository(optionalArraySchema));
 
-		initializeForest(
-			forest,
-			fieldJsonCursor([[1, 2]]),
-			testRevisionTagCodec,
-			testIdCompressor,
-		);
+		initializeForest(forest, fieldJsonCursor([[1, 2]]));
 
 		const cursor = forest.allocateCursor();
 		moveToDetachedField(forest, cursor);
@@ -421,19 +372,13 @@ export function testForest(config: ForestTestConfiguration): void {
 	it("can destroy detached fields", () => {
 		const forest = factory(new TreeStoredSchemaRepository(optionalArraySchema));
 		const content: JsonCompatible[] = [1, 2];
-		initializeForest(forest, fieldJsonCursor(content), testRevisionTagCodec, testIdCompressor);
+		initializeForest(forest, fieldJsonCursor(content));
 
 		const mark: DeltaMark = {
 			count: 1,
 			detach: detachId,
 		};
-		const detachedFieldIndex = new DetachedFieldIndex(
-			"test",
-			idAllocatorFromMaxId() as IdAllocator<ForestRootId>,
-			testRevisionTagCodec,
-			testIdCompressor,
-			{ jsonValidator: FormatValidatorBasic, minVersionForCollab: FluidClientVersion.v2_0 },
-		);
+		const detachedFieldIndex = makeDetachedFieldIndex();
 		const delta: DeltaFieldMap = new Map<FieldKey, DeltaFieldChanges>([
 			[rootFieldKey, { marks: [mark] }],
 		]);
@@ -473,12 +418,7 @@ export function testForest(config: ForestTestConfiguration): void {
 			const schema = new TreeStoredSchemaRepository(optionalArraySchema);
 			const forest = factory(schema);
 			const content: JsonCompatible[] = [1, true, "test"];
-			initializeForest(
-				forest,
-				fieldJsonCursor(content),
-				testRevisionTagCodec,
-				testIdCompressor,
-			);
+			initializeForest(forest, fieldJsonCursor(content));
 
 			const clone = forest.clone(schema);
 			const reader = clone.allocateCursor();
@@ -495,12 +435,7 @@ export function testForest(config: ForestTestConfiguration): void {
 		it("multiple fields", () => {
 			const schema = new TreeStoredSchemaRepository(optionalArraySchema);
 			const forest = factory(schema);
-			initializeForest(
-				forest,
-				fieldJsonCursor([nestedContent]),
-				testRevisionTagCodec,
-				testIdCompressor,
-			);
+			initializeForest(forest, fieldJsonCursor([nestedContent]));
 
 			const clone = forest.clone(schema);
 			const reader = clone.allocateCursor();
@@ -513,12 +448,7 @@ export function testForest(config: ForestTestConfiguration): void {
 		it("clone has an independent anchor set", () => {
 			const schema = new TreeStoredSchemaRepository(optionalArraySchema);
 			const forest = factory(schema);
-			initializeForest(
-				forest,
-				fieldJsonCursor([nestedContent]),
-				testRevisionTagCodec,
-				testIdCompressor,
-			);
+			initializeForest(forest, fieldJsonCursor([nestedContent]));
 
 			const clone = forest.clone(schema);
 
@@ -545,12 +475,7 @@ export function testForest(config: ForestTestConfiguration): void {
 			{ type: brand(booleanSchema.identifier), value: true },
 			{ type: brand(stringSchema.identifier), value: "test" },
 		];
-		initializeForest(
-			forest,
-			cursorForJsonableTreeField(content),
-			testRevisionTagCodec,
-			testIdCompressor,
-		);
+		initializeForest(forest, cursorForJsonableTreeField(content));
 
 		const clone = forest.clone(schema);
 		const mark: DeltaMark = { count: 1, detach: detachId };
@@ -574,7 +499,7 @@ export function testForest(config: ForestTestConfiguration): void {
 		if (!config.skipCursorErrorCheck) {
 			it("ensures cursors are cleared before applying changes", () => {
 				const forest = factory(new TreeStoredSchemaRepository(jsonSequenceRootSchema));
-				initializeForest(forest, fieldJsonCursor([1]), testRevisionTagCodec, testIdCompressor);
+				initializeForest(forest, fieldJsonCursor([1]));
 				const cursor = forest.allocateCursor();
 				moveToDetachedField(forest, cursor);
 
@@ -585,7 +510,7 @@ export function testForest(config: ForestTestConfiguration): void {
 
 			it("ensures cursors created in events during delta processing are cleared", () => {
 				const forest = factory(new TreeStoredSchemaRepository(jsonSequenceRootSchema));
-				initializeForest(forest, fieldJsonCursor([1]), testRevisionTagCodec, testIdCompressor);
+				initializeForest(forest, fieldJsonCursor([1]));
 
 				const log: string[] = [];
 				forest.events.on("beforeChange", () => {
@@ -603,7 +528,7 @@ export function testForest(config: ForestTestConfiguration): void {
 
 		it("beforeChange events", () => {
 			const forest = factory(new TreeStoredSchemaRepository(jsonSequenceRootSchema));
-			initializeForest(forest, fieldJsonCursor([1]), testRevisionTagCodec, testIdCompressor);
+			initializeForest(forest, fieldJsonCursor([1]));
 
 			const log: string[] = [];
 			forest.events.on("beforeChange", () => {
@@ -618,12 +543,7 @@ export function testForest(config: ForestTestConfiguration): void {
 
 		it("set fields as remove and insert", () => {
 			const forest = factory(new TreeStoredSchemaRepository(jsonSequenceRootSchema));
-			initializeForest(
-				forest,
-				fieldJsonCursor([nestedContent]),
-				testRevisionTagCodec,
-				testIdCompressor,
-			);
+			initializeForest(forest, fieldJsonCursor([nestedContent]));
 
 			const setField: DeltaMark = {
 				count: 1,
@@ -656,12 +576,7 @@ export function testForest(config: ForestTestConfiguration): void {
 
 		it("set fields as replace", () => {
 			const forest = factory(new TreeStoredSchemaRepository(jsonSequenceRootSchema));
-			initializeForest(
-				forest,
-				fieldJsonCursor([nestedContent]),
-				testRevisionTagCodec,
-				testIdCompressor,
-			);
+			initializeForest(forest, fieldJsonCursor([nestedContent]));
 
 			const setField: DeltaMark = {
 				count: 1,
@@ -695,12 +610,7 @@ export function testForest(config: ForestTestConfiguration): void {
 		it("remove", () => {
 			const forest = factory(new TreeStoredSchemaRepository(optionalArraySchema));
 			const content: JsonCompatible[] = [1, 2];
-			initializeForest(
-				forest,
-				fieldJsonCursor(content),
-				testRevisionTagCodec,
-				testIdCompressor,
-			);
+			initializeForest(forest, fieldJsonCursor(content));
 
 			const mark: DeltaMark = {
 				count: 1,
@@ -720,12 +630,7 @@ export function testForest(config: ForestTestConfiguration): void {
 		it("a skip", () => {
 			const forest = factory(new TreeStoredSchemaRepository(optionalArraySchema));
 			const content: JsonCompatible[] = [1, 2];
-			initializeForest(
-				forest,
-				fieldJsonCursor(content),
-				testRevisionTagCodec,
-				testIdCompressor,
-			);
+			initializeForest(forest, fieldJsonCursor(content));
 			const cursor = forest.allocateCursor();
 			moveToDetachedField(forest, cursor);
 			cursor.firstNode();
@@ -750,12 +655,7 @@ export function testForest(config: ForestTestConfiguration): void {
 		it("insert", () => {
 			const forest = factory(new TreeStoredSchemaRepository(optionalArraySchema));
 			const content: JsonCompatible[] = [1, 2];
-			initializeForest(
-				forest,
-				fieldJsonCursor(content),
-				testRevisionTagCodec,
-				testIdCompressor,
-			);
+			initializeForest(forest, fieldJsonCursor(content));
 
 			const delta: DeltaFieldMap = new Map([
 				[rootFieldKey, { marks: [{ count: 1, attach: buildId }] }],
@@ -807,12 +707,7 @@ export function testForest(config: ForestTestConfiguration): void {
 
 		it("move out and move in", () => {
 			const forest = factory(new TreeStoredSchemaRepository(jsonSequenceRootSchema));
-			initializeForest(
-				forest,
-				fieldJsonCursor([nestedContent]),
-				testRevisionTagCodec,
-				testIdCompressor,
-			);
+			initializeForest(forest, fieldJsonCursor([nestedContent]));
 
 			const moveId = { minor: 0 };
 			const moveOut: DeltaMark = {
@@ -845,12 +740,7 @@ export function testForest(config: ForestTestConfiguration): void {
 		it("insert and modify", () => {
 			const forest = factory(new TreeStoredSchemaRepository(jsonSequenceRootSchema));
 			const content: JsonCompatible[] = [1, 2];
-			initializeForest(
-				forest,
-				fieldJsonCursor(content),
-				testRevisionTagCodec,
-				testIdCompressor,
-			);
+			initializeForest(forest, fieldJsonCursor(content));
 
 			const delta: DeltaFieldMap = new Map([
 				[rootFieldKey, { marks: [{ count: 1, attach: buildId }] }],
@@ -904,12 +794,7 @@ export function testForest(config: ForestTestConfiguration): void {
 
 		it("modify and remove", () => {
 			const forest = factory(new TreeStoredSchemaRepository(jsonSequenceRootSchema));
-			initializeForest(
-				forest,
-				fieldJsonCursor([nestedContent]),
-				testRevisionTagCodec,
-				testIdCompressor,
-			);
+			initializeForest(forest, fieldJsonCursor([nestedContent]));
 
 			const moveId = { minor: 0 };
 			const mark: DeltaMark = {
@@ -932,12 +817,7 @@ export function testForest(config: ForestTestConfiguration): void {
 
 		it("modify and move out", () => {
 			const forest = factory(new TreeStoredSchemaRepository(jsonSequenceRootSchema));
-			initializeForest(
-				forest,
-				fieldJsonCursor([nestedContent]),
-				testRevisionTagCodec,
-				testIdCompressor,
-			);
+			initializeForest(forest, fieldJsonCursor([nestedContent]));
 
 			const moveId = { minor: 0 };
 			const mark: DeltaMark = {
@@ -1022,12 +902,7 @@ export function testForest(config: ForestTestConfiguration): void {
 				],
 			]);
 			const expected: JsonCompatible[] = [{ y: 1 }];
-			initializeForest(
-				forest,
-				fieldJsonCursor([nestedContent]),
-				testRevisionTagCodec,
-				testIdCompressor,
-			);
+			initializeForest(forest, fieldJsonCursor([nestedContent]));
 			applyTestDelta(delta, forest);
 			const readCursor = forest.allocateCursor();
 			moveToDetachedField(forest, readCursor);
@@ -1037,12 +912,7 @@ export function testForest(config: ForestTestConfiguration): void {
 		});
 		it("when moving the last node in the field", () => {
 			const forest = factory(new TreeStoredSchemaRepository(jsonSequenceRootSchema));
-			initializeForest(
-				forest,
-				fieldJsonCursor([{ x: 2 }]),
-				testRevisionTagCodec,
-				testIdCompressor,
-			);
+			initializeForest(forest, fieldJsonCursor([{ x: 2 }]));
 			// Move from field x to y:
 			const moveId = { minor: 0 };
 			const moveOut: DeltaMark = {
@@ -1084,7 +954,7 @@ export function testForest(config: ForestTestConfiguration): void {
 
 		const forest = factory(new TreeStoredSchemaRepository(jsonSequenceRootSchema));
 		const content: JsonCompatible[] = [1, 2];
-		initializeForest(forest, fieldJsonCursor(content), testRevisionTagCodec, testIdCompressor);
+		initializeForest(forest, fieldJsonCursor(content));
 
 		forest.registerAnnouncedVisitor(acquireVisitor);
 		const delta: DeltaFieldMap = new Map([
@@ -1106,12 +976,7 @@ export function testForest(config: ForestTestConfiguration): void {
 		"forest cursor",
 		(data): ITreeCursor => {
 			const forest = factory(new TreeStoredSchemaRepository(toInitialSchema(testTreeSchema)));
-			initializeForest(
-				forest,
-				cursorForJsonableTreeField([data]),
-				testRevisionTagCodec,
-				testIdCompressor,
-			);
+			initializeForest(forest, cursorForJsonableTreeField([data]));
 			const cursor = forest.allocateCursor();
 			moveToDetachedField(forest, cursor);
 			assert(cursor.firstNode());

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -885,7 +885,7 @@ function createCheckoutWithContent(
 		testIdCompressor,
 		args?.shouldEncodeIncrementally ?? defaultIncrementalEncodingPolicy,
 	);
-	initializeForest(forest, fieldCursor, testRevisionTagCodec, testIdCompressor);
+	initializeForest(forest, fieldCursor);
 
 	const logger = createMockLoggerExt();
 	const checkout = createTreeCheckout(
@@ -1312,8 +1312,7 @@ export function applyTestDelta(
 		rootDelta,
 		revision,
 		deltaProcessor,
-		detachedFieldIndex ??
-			makeDetachedFieldIndex(undefined, testRevisionTagCodec, testIdCompressor),
+		detachedFieldIndex ?? makeDetachedFieldIndex(),
 	);
 }
 


### PR DESCRIPTION
## Description

Decouples DetachedFieldIndex codec state from DetachedFieldIndex's own state.
This is useful because several usages (some which will be merged soon) of DetachedFieldIndex have no need for summarizing DetachedFieldIndex state and therefore no need for the codecs.

## Breaking Changes

None