### PR TITLE
refactor(tree): Compose IdDecodingContext in FieldBatchDecodingContext

### DIFF
--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/codecs.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/codecs.ts
@@ -133,10 +133,10 @@ export interface FieldBatchEncodingContext {
 /**
  * Decode-side context for {@link FieldBatchCodec}.
  *
- * Carries the per-call `resolveEncodedId` function that encapsulates the
- * originator-session lookup and (for the forest-summarizer's legacy heal path)
- * the deterministic UUIDv5 synthesis. Heal and originator-session flags live
- * inside that function, not on this context.
+ * Composes an {@link IdDecodingContext} (which carries the per-call `resolveEncodedId`
+ * function encapsulating the originator-session lookup and, for the forest-summarizer's
+ * legacy heal path, the deterministic UUIDv5 synthesis) together with the optional
+ * incremental decoder for this batch.
  *
  * Constructed via one of the two named static factories — {@link forOp} or
  * {@link forSummary} — depending on the call site's semantics. The constructor
@@ -144,18 +144,19 @@ export interface FieldBatchEncodingContext {
  * op-style and summary-style decoding is load-bearing (different invariants
  * apply, and bugs in this area are typically the result of conflating them).
  */
-export class FieldBatchDecodingContext extends IdDecodingContext {
+export class FieldBatchDecodingContext {
 	private constructor(
-		private readonly options: IdDecoderOptionsOriginatorless | IdDecoderOptionsWithOriginator,
+		/**
+		 * Resolves the encoded identifiers contained in this batch.
+		 */
+		public readonly idDecodingContext: IdDecodingContext,
 		/**
 		 * Decoder for incremental fields. Defined when the encoded batch contains
 		 * incremental chunks. Only populated on summary-style contexts; op-style
 		 * contexts always have this undefined.
 		 */
 		public readonly incrementalDecoder?: IncrementalDecoder,
-	) {
-		super(options);
-	}
+	) {}
 
 	/**
 	 * Construct a decode context for an op.
@@ -167,7 +168,7 @@ export class FieldBatchDecodingContext extends IdDecodingContext {
 	 * a UUID. Incremental decoding is not used for ops.
 	 */
 	public static forOp(options: IdDecoderOptionsWithOriginator): FieldBatchDecodingContext {
-		return new FieldBatchDecodingContext(options);
+		return new FieldBatchDecodingContext(new IdDecodingContext(options));
 	}
 
 	/**
@@ -189,7 +190,7 @@ export class FieldBatchDecodingContext extends IdDecodingContext {
 	public static forSummary(
 		options: IdDecoderOptionsOriginatorless | IdDecoderOptionsWithOriginator,
 	): FieldBatchDecodingContext {
-		return new FieldBatchDecodingContext(options);
+		return new FieldBatchDecodingContext(new IdDecodingContext(options));
 	}
 
 	/**
@@ -206,10 +207,10 @@ export class FieldBatchDecodingContext extends IdDecodingContext {
 		// This mitigates the risk of using incorrect originator session ID identifiers in incremental chunks.
 		// See also private remarks on forSummary.
 		assert(
-			!this.hasOriginatorSessionId,
+			!this.idDecodingContext.hasOriginatorSessionId,
 			0xd0c /* withIncrementalDecoder can only be called on contexts without an originator session ID */,
 		);
-		return new FieldBatchDecodingContext(this.options, incrementalDecoder);
+		return new FieldBatchDecodingContext(this.idDecodingContext, incrementalDecoder);
 	}
 }
 
@@ -298,7 +299,9 @@ function makeFieldBatchCodecForVersion(
 			context: FieldBatchDecodingContext,
 		): FieldBatch => {
 			// TODO: consider checking data is in schema.
-			return decode(data, context, context.incrementalDecoder).map((chunk) => chunk.cursor());
+			return decode(data, context.idDecodingContext, context.incrementalDecoder).map((chunk) =>
+				chunk.cursor(),
+			);
 		},
 		schema: encodedFieldBatchType,
 	};

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkEncodingEndToEnd.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/chunkEncodingEndToEnd.spec.ts
@@ -36,8 +36,6 @@ import {
 import { ChunkedForest } from "../../../feature-libraries/chunked-forest/chunkedForest.js";
 // eslint-disable-next-line import-x/no-internal-modules
 import { decode } from "../../../feature-libraries/chunked-forest/codec/chunkDecoding.js";
-// eslint-disable-next-line import-x/no-internal-modules
-import { FieldBatchDecodingContext } from "../../../feature-libraries/chunked-forest/codec/codecs.js";
 import type {
 	EncodedFieldBatchV1OrV2,
 	// eslint-disable-next-line import-x/no-internal-modules
@@ -80,7 +78,7 @@ import {
 	toInitialSchema,
 } from "../../../simple-tree/index.js";
 import { configuredSharedTree } from "../../../treeFactory.js";
-import { brand } from "../../../util/index.js";
+import { IdDecodingContext, brand } from "../../../util/index.js";
 import { jsonSequenceRootSchema } from "../../sequenceRootUtils.js";
 import {
 	MockTreeCheckout,
@@ -213,7 +211,7 @@ describe("End to end chunked encoding", () => {
 		function stringify(content: unknown) {
 			const insertedChunk = decode(
 				(content as FormatCommon).fields as EncodedFieldBatchV1OrV2,
-				FieldBatchDecodingContext.forOp({
+				new IdDecodingContext({
 					idCompressor,
 					originatorId: idCompressor.localSessionId,
 				}),
@@ -249,7 +247,7 @@ describe("End to end chunked encoding", () => {
 		function stringify(content: unknown) {
 			const insertedChunk = decode(
 				(content as FormatCommon).fields as EncodedFieldBatchV1OrV2,
-				FieldBatchDecodingContext.forOp({
+				new IdDecodingContext({
 					idCompressor,
 					originatorId: idCompressor.localSessionId,
 				}),

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/checkEncode.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/checkEncode.ts
@@ -95,7 +95,7 @@ function testDecode(
 	expectedTree: JsonableTree[][],
 	identifierFilter: CounterFilter<string>,
 	version: FieldBatchFormatVersion,
-	idCompressor?: IIdCompressor,
+	idCompressor: IIdCompressor = testIdCompressor,
 	incrementalDecoder?: IncrementalDecoder,
 ): EncodedFieldBatchV1OrV2 {
 	const chunk = updateShapesAndIdentifiersEncoding(
@@ -106,18 +106,17 @@ function testDecode(
 
 	// TODO: check chunk matches schema
 
+	// This assumes the encoded data was encoded using the same localSessionId of the current session.
+	// This is ok for these tests which comply with this, but would be very bad to assume in any real use-case.
+	const context = new IdDecodingContext({
+		idCompressor,
+		originatorId: idCompressor.localSessionId,
+	});
 	// Check decode
 	const result = decode(
 		chunk,
-		idCompressor === undefined
-			? new IdDecodingContext({
-					idCompressor: testIdCompressor,
-					originatorId: testIdCompressor.localSessionId,
-				})
-			: new IdDecodingContext({
-					idCompressor,
-					originatorId: idCompressor.localSessionId,
-				}),
+
+		context,
 		incrementalDecoder,
 	);
 	assertChunkCursorBatchEquals(result, expectedTree);
@@ -144,19 +143,7 @@ function testDecode(
 		// can't check this due to undefined fields
 		// assert.deepEqual(parsed, chunk);
 		// Instead check that it works properly:
-		const parsedResult = decode(
-			parsed,
-			idCompressor === undefined
-				? new IdDecodingContext({
-						idCompressor: testIdCompressor,
-						originatorId: testIdCompressor.localSessionId,
-					})
-				: new IdDecodingContext({
-						idCompressor,
-						originatorId: idCompressor.localSessionId,
-					}),
-			incrementalDecoder,
-		);
+		const parsedResult = decode(parsed, context, incrementalDecoder);
 		assert.deepEqual(parsedResult, result);
 	}
 

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/checkEncode.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/checkEncode.ts
@@ -15,8 +15,7 @@ import type { CounterFilter } from "../../../../feature-libraries/chunked-forest
 import { decode } from "../../../../feature-libraries/chunked-forest/codec/chunkDecoding.js";
 // eslint-disable-next-line import-x/no-internal-modules
 import { updateShapesAndIdentifiersEncoding } from "../../../../feature-libraries/chunked-forest/codec/chunkEncodingGeneric.js";
-// eslint-disable-next-line import-x/no-internal-modules
-import { FieldBatchDecodingContext } from "../../../../feature-libraries/chunked-forest/codec/codecs.js";
+import { IdDecodingContext } from "../../../../util/index.js";
 import type {
 	BufferFormat,
 	EncoderContext,
@@ -111,11 +110,11 @@ function testDecode(
 	const result = decode(
 		chunk,
 		idCompressor === undefined
-			? FieldBatchDecodingContext.forOp({
+			? new IdDecodingContext({
 					idCompressor: testIdCompressor,
 					originatorId: testIdCompressor.localSessionId,
 				})
-			: FieldBatchDecodingContext.forOp({
+			: new IdDecodingContext({
 					idCompressor,
 					originatorId: idCompressor.localSessionId,
 				}),
@@ -148,11 +147,11 @@ function testDecode(
 		const parsedResult = decode(
 			parsed,
 			idCompressor === undefined
-				? FieldBatchDecodingContext.forOp({
+				? new IdDecodingContext({
 						idCompressor: testIdCompressor,
 						originatorId: testIdCompressor.localSessionId,
 					})
-				: FieldBatchDecodingContext.forOp({
+				: new IdDecodingContext({
 						idCompressor,
 						originatorId: idCompressor.localSessionId,
 					}),

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/chunkDecodingGeneric.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/chunkDecodingGeneric.spec.ts
@@ -23,10 +23,7 @@ import {
 	readStreamIdentifier,
 	// eslint-disable-next-line import-x/no-internal-modules
 } from "../../../../feature-libraries/chunked-forest/codec/chunkDecodingGeneric.js";
-import {
-	FieldBatchDecodingContext,
-	// eslint-disable-next-line import-x/no-internal-modules
-} from "../../../../feature-libraries/chunked-forest/codec/codecs.js";
+import { IdDecodingContext } from "../../../../util/index.js";
 import {
 	EncodedFieldBatchGeneric,
 	// eslint-disable-next-line import-x/no-internal-modules
@@ -123,7 +120,7 @@ const rootDecoder: ChunkDecoder = {
 	},
 };
 
-const idDecodingContext = FieldBatchDecodingContext.forOp({
+const idDecodingContext = new IdDecodingContext({
 	idCompressor: testIdCompressor,
 	originatorId: testIdCompressor.localSessionId,
 });

--- a/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/compressedEncode.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/chunked-forest/codec/compressedEncode.spec.ts
@@ -86,7 +86,11 @@ import {
 	jsonableTreeFromFieldCursor,
 	fieldBatchCodecBuilder,
 } from "../../../../feature-libraries/index.js";
-import { type JsonCompatibleReadOnly, brand } from "../../../../util/index.js";
+import {
+	type JsonCompatibleReadOnly,
+	IdDecodingContext,
+	brand,
+} from "../../../../util/index.js";
 import { testTrees as schemalessTestTrees } from "../../../cursorTestSuite.js";
 import { takeJsonSnapshot, useSnapshotDirectory } from "../../../snapshots/index.js";
 import { makeTestFieldBatchContexts, testIdCompressor } from "../../../utils.js";
@@ -126,7 +130,9 @@ function makeFieldBatchCodec(
 					fieldBatchContext: FieldBatchDecodingContext,
 				): FieldBatch => {
 					// TODO: consider checking data is in schema.
-					return decode(data, fieldBatchContext).map((chunk) => chunk.cursor());
+					return decode(data, fieldBatchContext.idDecodingContext).map((chunk) =>
+						chunk.cursor(),
+					);
 				},
 				schema: format,
 			},
@@ -206,7 +212,7 @@ describe("compressedEncode", () => {
 				const decoded = readValue(
 					stream,
 					shape,
-					FieldBatchDecodingContext.forOp({
+					new IdDecodingContext({
 						idCompressor: testIdCompressor,
 						originatorId: testIdCompressor.localSessionId,
 					}),

--- a/packages/dds/tree/src/test/shared-tree/sharedTreeChangeCodec.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTreeChangeCodec.spec.ts
@@ -120,7 +120,9 @@ describe("sharedTreeChangeCodec", () => {
 				data: EncodedFieldBatchV1OrV2,
 				context: FieldBatchDecodingContext,
 			): FieldBatch => {
-				return decode(data, context).map((chunk) => chunk.cursor());
+				return decode(data, context.idDecodingContext, context.incrementalDecoder).map(
+					(chunk) => chunk.cursor(),
+				);
 			},
 			writeVersion: FieldBatchFormatVersion.v2,
 		};

--- a/packages/dds/tree/src/util/compressedIds.ts
+++ b/packages/dds/tree/src/util/compressedIds.ts
@@ -261,9 +261,13 @@ export interface IdDecoderOptionsWithOriginator {
  */
 export class IdDecodingContext {
 	/**
-	 * Used internally to prevent the use of this decoder in incremental chunks if it has a session id (which would be wrong in those chunks).
+	 * Whether this context resolves identifiers using an originator session id.
+	 * @remarks
+	 * Consulted by {@link FieldBatchDecodingContext} to prevent using an originator-based
+	 * decoder in incremental chunks (which may come from other sessions, making such a
+	 * decoder wrong there).
 	 */
-	protected readonly hasOriginatorSessionId: boolean;
+	public readonly hasOriginatorSessionId: boolean;
 
 	/**
 	 * Compressor which can decompress session-space identifiers from {@link resolveEncodedId} as needed.

--- a/packages/dds/tree/src/util/compressedIds.ts
+++ b/packages/dds/tree/src/util/compressedIds.ts
@@ -261,7 +261,7 @@ export interface IdDecoderOptionsWithOriginator {
  */
 export class IdDecodingContext {
 	/**
-	 * Whether this context resolves identifiers using an originator session id.
+	 * Whether this context resolves identifiers using an originator session ID.
 	 * @remarks
 	 * Consulted by {@link FieldBatchDecodingContext} to prevent using an originator-based
 	 * decoder in incremental chunks (which may come from other sessions, making such a


### PR DESCRIPTION
## Description

Refactors `FieldBatchDecodingContext` to **compose** an `IdDecodingContext` (as a public `idDecodingContext` field) instead of **subclassing** it.

Previously `FieldBatchDecodingContext extends IdDecodingContext`, so the decode context was passed directly wherever an `IdDecodingContext` was expected. That coupling only mattered at a single boundary (the field-batch codec's `decode`), while the generic `DecoderContext` already composed an `idDecodingContext` separately. Subclassing also meant that reusing an existing `IdDecodingContext` to build a `FieldBatchDecodingContext` would have required copy-constructing the base context.

With composition:

- `FieldBatchDecodingContext` holds `idDecodingContext` and `incrementalDecoder`; it is no longer an `IdDecodingContext`.
- The codec decode boundary passes `context.idDecodingContext` to `decode(...)`.
- `IdDecodingContext.hasOriginatorSessionId` is now `public` (consulted by `withIncrementalDecoder`, which previously relied on protected subclass access).
- A handful of tests that abused the subclassing to use a `FieldBatchDecodingContext` where an `IdDecodingContext` was wanted now construct an `IdDecodingContext` directly.

This is a pure internal refactor with no runtime, wire-format, or public-API change. It unblocks upcoming adoption of `IdDecodingContext` in the change codecs, where an existing `IdDecodingContext` can be reused to build a `FieldBatchDecodingContext` without copying.

