### PR TITLE
chore: enable pnpm dedupePeers to shrink lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,6 +2,7 @@ lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true
+  dedupePeers: true
   excludeLinksFromLockfile: false
 
 catalogs:
@@ -118,7 +119,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@8.1.1)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
       '@fluidframework/test-tools':
         specifier: ^2.0.0
         version: 2.0.1
@@ -127,7 +128,7 @@ importers:
         version: 7.58.1(patch_hash=949a26f6cec9ac4e37522f178b8e4982136ccfeb8c6d0835130ef2aa6788f4fa)(@types/node@22.19.17)
       '@vvago/vale':
         specifier: ^3.12.0
-        version: 3.12.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 3.12.0(debug@4.4.3)(supports-color@8.1.1)
       auto-changelog:
         specifier: ^2.4.0
         version: 2.5.0
@@ -136,7 +137,7 @@ importers:
         version: 10.1.3
       changesets-format-with-issue-links:
         specifier: ^0.3.0
-        version: 0.3.0(@changesets/cli@2.29.8(@types/node@22.19.17))(supports-color@8.1.1)
+        version: 0.3.0(@changesets/cli@2.29.8)(supports-color@8.1.1)
       concurrently:
         specifier: ^10.0.3
         version: 10.0.3
@@ -151,7 +152,7 @@ importers:
         version: 9.39.1(jiti@2.6.1)(supports-color@8.1.1)
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@22.19.17)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))
+        version: 29.7.0(@types/node@22.19.17)(supports-color@8.1.1)(ts-node@10.9.2)
       mocha:
         specifier: ^11.7.5
         version: 11.7.5
@@ -178,7 +179,7 @@ importers:
     dependencies:
       tinylicious:
         specifier: ^7.0.1
-        version: 7.0.1(debug@4.3.7(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 7.0.1(debug@4.3.7)(supports-color@10.2.2)
     devDependencies:
       '@biomejs/biome':
         specifier: ~2.4.5
@@ -191,13 +192,13 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       eslint:
         specifier: catalog:eslint
         version: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
       eslint-config-prettier:
         specifier: catalog:eslint
-        version: 10.1.8(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))
+        version: 10.1.8(eslint@9.39.1)
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
@@ -240,7 +241,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.58.1
         version: 7.58.1(patch_hash=949a26f6cec9ac4e37522f178b8e4982136ccfeb8c6d0835130ef2aa6788f4fa)(@types/node@22.19.17)
@@ -258,7 +259,7 @@ importers:
         version: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
       eslint-config-prettier:
         specifier: catalog:eslint
-        version: 10.1.8(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))
+        version: 10.1.8(eslint@9.39.1)
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
@@ -337,7 +338,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/test-tools':
         specifier: ^2.0.0
         version: 2.0.1
@@ -370,16 +371,16 @@ importers:
         version: 5.6.3(webpack@5.109.0)
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))
+        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2)
       jest-environment-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(supports-color@10.2.2)(typescript@5.4.5)
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
       jest-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(puppeteer@23.10.3(supports-color@10.2.2)(typescript@5.4.5))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(puppeteer@23.10.3)(supports-color@10.2.2)(typescript@5.4.5)
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
@@ -397,10 +398,10 @@ importers:
         version: 6.1.3
       tinylicious:
         specifier: ^7.0.1
-        version: 7.0.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 7.0.1(debug@4.4.3)(supports-color@10.2.2)
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.29.7(supports-color@10.2.2))(@jest/transform@29.7.0(supports-color@10.2.2))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(jest@29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0)(jest@29.7.0)(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.109.0)
@@ -415,7 +416,7 @@ importers:
         version: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.6)(webpack@5.109.0)
       webpack-dev-server:
         specifier: ~5.2.6
-        version: 5.2.6(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
+        version: 5.2.6(debug@4.4.3)(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
 
   examples/apps/collaborative-textarea:
     dependencies:
@@ -467,7 +468,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/test-tools':
         specifier: ^2.0.0
         version: 2.0.1
@@ -503,16 +504,16 @@ importers:
         version: 5.6.3(webpack@5.109.0)
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))
+        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2)
       jest-environment-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(supports-color@10.2.2)(typescript@5.4.5)
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
       jest-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(puppeteer@23.10.3(supports-color@10.2.2)(typescript@5.4.5))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(puppeteer@23.10.3)(supports-color@10.2.2)(typescript@5.4.5)
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
@@ -527,10 +528,10 @@ importers:
         version: 6.1.3
       tinylicious:
         specifier: ^7.0.1
-        version: 7.0.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 7.0.1(debug@4.4.3)(supports-color@10.2.2)
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.29.7(supports-color@10.2.2))(@jest/transform@29.7.0(supports-color@10.2.2))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(jest@29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0)(jest@29.7.0)(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.109.0)
@@ -545,7 +546,7 @@ importers:
         version: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.6)(webpack@5.109.0)
       webpack-dev-server:
         specifier: ~5.2.6
-        version: 5.2.6(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
+        version: 5.2.6(debug@4.4.3)(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
 
   examples/apps/contact-collection:
     dependencies:
@@ -597,7 +598,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/test-tools':
         specifier: ^2.0.0
         version: 2.0.1
@@ -630,16 +631,16 @@ importers:
         version: 5.6.3(webpack@5.109.0)
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))
+        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2)
       jest-environment-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(supports-color@10.2.2)(typescript@5.4.5)
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
       jest-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(puppeteer@23.10.3(supports-color@10.2.2)(typescript@5.4.5))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(puppeteer@23.10.3)(supports-color@10.2.2)(typescript@5.4.5)
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
@@ -654,10 +655,10 @@ importers:
         version: 6.1.3
       tinylicious:
         specifier: ^7.0.1
-        version: 7.0.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 7.0.1(debug@4.4.3)(supports-color@10.2.2)
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.29.7(supports-color@10.2.2))(@jest/transform@29.7.0(supports-color@10.2.2))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(jest@29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0)(jest@29.7.0)(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.109.0)
@@ -672,13 +673,13 @@ importers:
         version: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.6)(webpack@5.109.0)
       webpack-dev-server:
         specifier: ~5.2.6
-        version: 5.2.6(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
+        version: 5.2.6(debug@4.4.3)(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
 
   examples/apps/data-object-grid:
     dependencies:
       '@fluentui/react-components':
         specifier: ^9.47.5
-        version: 9.56.5(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
+        version: 9.56.5(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
       '@fluentui/react-icons':
         specifier: ^2.0.233
         version: 2.0.266(react@18.3.1)
@@ -732,13 +733,13 @@ importers:
         version: 18.3.1
       react-collapsible:
         specifier: ^2.7.0
-        version: 2.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 2.10.0(react-dom@18.3.1)(react@18.3.1)
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
       react-grid-layout:
         specifier: ^1.5.1
-        version: 1.5.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 1.5.1(react-dom@18.3.1)(react@18.3.1)
       scheduler:
         specifier: ^0.20.0
         version: 0.20.2
@@ -760,7 +761,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/test-tools':
         specifier: ^2.0.0
         version: 2.0.1
@@ -808,16 +809,16 @@ importers:
         version: 5.6.3(webpack@5.109.0)
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))
+        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2)
       jest-environment-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(supports-color@10.2.2)(typescript@5.4.5)
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
       jest-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(puppeteer@23.10.3(supports-color@10.2.2)(typescript@5.4.5))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(puppeteer@23.10.3)(supports-color@10.2.2)(typescript@5.4.5)
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
@@ -838,7 +839,7 @@ importers:
         version: 4.0.0(webpack@5.109.0)
       tinylicious:
         specifier: ^7.0.1
-        version: 7.0.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 7.0.1(debug@4.4.3)(supports-color@10.2.2)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.109.0)
@@ -847,7 +848,7 @@ importers:
         version: 5.4.5
       url-loader:
         specifier: ^4.1.1
-        version: 4.1.1(file-loader@6.2.0(webpack@5.109.0))(webpack@5.109.0)
+        version: 4.1.1(file-loader@6.2.0)(webpack@5.109.0)
       webpack:
         specifier: ^5.104.1
         version: 5.109.0(clean-css@5.3.3)(html-minifier-terser@7.2.0)(postcss@8.5.16)(uglify-js@3.19.3)(webpack-cli@5.1.4)
@@ -856,7 +857,7 @@ importers:
         version: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.6)(webpack@5.109.0)
       webpack-dev-server:
         specifier: ~5.2.6
-        version: 5.2.6(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
+        version: 5.2.6(debug@4.4.3)(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
 
   examples/apps/diceroller:
     dependencies:
@@ -899,7 +900,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/test-tools':
         specifier: ^2.0.0
         version: 2.0.1
@@ -929,16 +930,16 @@ importers:
         version: 5.6.3(webpack@5.109.0)
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))
+        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2)
       jest-environment-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(supports-color@10.2.2)(typescript@5.4.5)
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
       jest-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(puppeteer@23.10.3(supports-color@10.2.2)(typescript@5.4.5))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(puppeteer@23.10.3)(supports-color@10.2.2)(typescript@5.4.5)
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
@@ -950,10 +951,10 @@ importers:
         version: 6.1.3
       tinylicious:
         specifier: ^7.0.1
-        version: 7.0.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 7.0.1(debug@4.4.3)(supports-color@10.2.2)
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.29.7(supports-color@10.2.2))(@jest/transform@29.7.0(supports-color@10.2.2))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(jest@29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0)(jest@29.7.0)(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.109.0)
@@ -968,7 +969,7 @@ importers:
         version: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.6)(webpack@5.109.0)
       webpack-dev-server:
         specifier: ~5.2.6
-        version: 5.2.6(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
+        version: 5.2.6(debug@4.4.3)(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
 
   examples/apps/presence-tracker:
     dependencies:
@@ -1044,7 +1045,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/test-tools':
         specifier: ^2.0.0
         version: 2.0.1
@@ -1071,16 +1072,16 @@ importers:
         version: 5.6.3(webpack@5.109.0)
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))
+        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2)
       jest-environment-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(supports-color@10.2.2)(typescript@5.4.5)
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
       jest-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(puppeteer@23.10.3(supports-color@10.2.2)(typescript@5.4.5))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(puppeteer@23.10.3)(supports-color@10.2.2)(typescript@5.4.5)
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
@@ -1098,10 +1099,10 @@ importers:
         version: 2.0.8(supports-color@10.2.2)
       tinylicious:
         specifier: ^7.0.1
-        version: 7.0.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 7.0.1(debug@4.4.3)(supports-color@10.2.2)
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.29.7(supports-color@10.2.2))(@jest/transform@29.7.0(supports-color@10.2.2))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(jest@29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0)(jest@29.7.0)(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.109.0)
@@ -1116,7 +1117,7 @@ importers:
         version: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.6)(webpack@5.109.0)
       webpack-dev-server:
         specifier: ~5.2.6
-        version: 5.2.6(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
+        version: 5.2.6(debug@4.4.3)(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
 
   examples/apps/staging:
     dependencies:
@@ -1192,7 +1193,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/test-tools':
         specifier: ^2.0.0
         version: 2.0.1
@@ -1228,16 +1229,16 @@ importers:
         version: 5.6.3(webpack@5.109.0)
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))
+        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2)
       jest-environment-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(supports-color@10.2.2)(typescript@5.4.5)
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
       jest-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(puppeteer@23.10.3(supports-color@10.2.2)(typescript@5.4.5))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(puppeteer@23.10.3)(supports-color@10.2.2)(typescript@5.4.5)
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
@@ -1255,10 +1256,10 @@ importers:
         version: 4.0.0(webpack@5.109.0)
       tinylicious:
         specifier: ^7.0.1
-        version: 7.0.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 7.0.1(debug@4.4.3)(supports-color@10.2.2)
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.29.7(supports-color@10.2.2))(@jest/transform@29.7.0(supports-color@10.2.2))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(jest@29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0)(jest@29.7.0)(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.109.0)
@@ -1273,7 +1274,7 @@ importers:
         version: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.6)(webpack@5.109.0)
       webpack-dev-server:
         specifier: ~5.2.6
-        version: 5.2.6(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
+        version: 5.2.6(debug@4.4.3)(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
 
   examples/apps/task-selection:
     dependencies:
@@ -1328,7 +1329,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/test-tools':
         specifier: ^2.0.0
         version: 2.0.1
@@ -1355,16 +1356,16 @@ importers:
         version: 5.6.3(webpack@5.109.0)
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))
+        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2)
       jest-environment-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(supports-color@10.2.2)(typescript@5.4.5)
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
       jest-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(puppeteer@23.10.3(supports-color@10.2.2)(typescript@5.4.5))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(puppeteer@23.10.3)(supports-color@10.2.2)(typescript@5.4.5)
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
@@ -1379,10 +1380,10 @@ importers:
         version: 6.1.3
       tinylicious:
         specifier: ^7.0.1
-        version: 7.0.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 7.0.1(debug@4.4.3)(supports-color@10.2.2)
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.29.7(supports-color@10.2.2))(@jest/transform@29.7.0(supports-color@10.2.2))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(jest@29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0)(jest@29.7.0)(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.109.0)
@@ -1397,7 +1398,7 @@ importers:
         version: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.6)(webpack@5.109.0)
       webpack-dev-server:
         specifier: ~5.2.6
-        version: 5.2.6(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
+        version: 5.2.6(debug@4.4.3)(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
 
   examples/apps/tree-cli-app:
     dependencies:
@@ -1428,7 +1429,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
@@ -1534,7 +1535,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/test-tools':
         specifier: ^2.0.0
         version: 2.0.1
@@ -1570,16 +1571,16 @@ importers:
         version: 5.6.3(webpack@5.109.0)
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))
+        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2)
       jest-environment-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(supports-color@10.2.2)(typescript@5.4.5)
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
       jest-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(puppeteer@23.10.3(supports-color@10.2.2)(typescript@5.4.5))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(puppeteer@23.10.3)(supports-color@10.2.2)(typescript@5.4.5)
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
@@ -1597,10 +1598,10 @@ importers:
         version: 4.0.0(webpack@5.109.0)
       tinylicious:
         specifier: ^7.0.1
-        version: 7.0.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 7.0.1(debug@4.4.3)(supports-color@10.2.2)
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.29.7(supports-color@10.2.2))(@jest/transform@29.7.0(supports-color@10.2.2))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(jest@29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0)(jest@29.7.0)(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.109.0)
@@ -1615,7 +1616,7 @@ importers:
         version: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.6)(webpack@5.109.0)
       webpack-dev-server:
         specifier: ~5.2.6
-        version: 5.2.6(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
+        version: 5.2.6(debug@4.4.3)(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
 
   examples/benchmarks/bubblebench/baseline:
     dependencies:
@@ -1658,7 +1659,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/test-tools':
         specifier: ^2.0.0
         version: 2.0.1
@@ -1682,16 +1683,16 @@ importers:
         version: 9.0.2
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))
+        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2)
       jest-environment-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(supports-color@10.2.2)(typescript@5.4.5)
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
       jest-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(puppeteer@23.10.3(supports-color@10.2.2)(typescript@5.4.5))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(puppeteer@23.10.3)(supports-color@10.2.2)(typescript@5.4.5)
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
@@ -1703,7 +1704,7 @@ importers:
         version: 6.1.3
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.29.7(supports-color@10.2.2))(@jest/transform@29.7.0(supports-color@10.2.2))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(jest@29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0)(jest@29.7.0)(typescript@5.4.5)
       typescript:
         specifier: ~5.4.5
         version: 5.4.5
@@ -1715,7 +1716,7 @@ importers:
         version: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.6)(webpack@5.109.0)
       webpack-dev-server:
         specifier: ~5.2.6
-        version: 5.2.6(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
+        version: 5.2.6(debug@4.4.3)(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
 
   examples/benchmarks/bubblebench/common:
     dependencies:
@@ -1748,7 +1749,7 @@ importers:
         version: 18.3.1(react@18.3.1)
       use-resize-observer:
         specifier: ^7.0.0
-        version: 7.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 7.1.0(react-dom@18.3.1)(react@18.3.1)
     devDependencies:
       '@biomejs/biome':
         specifier: ~2.4.5
@@ -1764,7 +1765,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@types/react':
         specifier: ^18.3.11
         version: 18.3.15
@@ -1828,7 +1829,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/test-tools':
         specifier: ^2.0.0
         version: 2.0.1
@@ -1855,16 +1856,16 @@ importers:
         version: 9.0.2
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))
+        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2)
       jest-environment-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(supports-color@10.2.2)(typescript@5.4.5)
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
       jest-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(puppeteer@23.10.3(supports-color@10.2.2)(typescript@5.4.5))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(puppeteer@23.10.3)(supports-color@10.2.2)(typescript@5.4.5)
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
@@ -1876,7 +1877,7 @@ importers:
         version: 6.1.3
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.29.7(supports-color@10.2.2))(@jest/transform@29.7.0(supports-color@10.2.2))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(jest@29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0)(jest@29.7.0)(typescript@5.4.5)
       typescript:
         specifier: ~5.4.5
         version: 5.4.5
@@ -1888,7 +1889,7 @@ importers:
         version: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.6)(webpack@5.109.0)
       webpack-dev-server:
         specifier: ~5.2.6
-        version: 5.2.6(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
+        version: 5.2.6(debug@4.4.3)(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
 
   examples/benchmarks/bubblebench/ot:
     dependencies:
@@ -1937,7 +1938,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/test-tools':
         specifier: ^2.0.0
         version: 2.0.1
@@ -1964,16 +1965,16 @@ importers:
         version: 9.0.2
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))
+        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2)
       jest-environment-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(supports-color@10.2.2)(typescript@5.4.5)
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
       jest-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(puppeteer@23.10.3(supports-color@10.2.2)(typescript@5.4.5))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(puppeteer@23.10.3)(supports-color@10.2.2)(typescript@5.4.5)
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
@@ -1985,7 +1986,7 @@ importers:
         version: 6.1.3
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.29.7(supports-color@10.2.2))(@jest/transform@29.7.0(supports-color@10.2.2))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(jest@29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0)(jest@29.7.0)(typescript@5.4.5)
       typescript:
         specifier: ~5.4.5
         version: 5.4.5
@@ -1997,7 +1998,7 @@ importers:
         version: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.6)(webpack@5.109.0)
       webpack-dev-server:
         specifier: ~5.2.6
-        version: 5.2.6(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
+        version: 5.2.6(debug@4.4.3)(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
 
   examples/benchmarks/bubblebench/shared-tree:
     dependencies:
@@ -2037,7 +2038,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/test-tools':
         specifier: ^2.0.0
         version: 2.0.1
@@ -2064,16 +2065,16 @@ importers:
         version: 9.0.2
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))
+        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2)
       jest-environment-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(supports-color@10.2.2)(typescript@5.4.5)
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
       jest-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(puppeteer@23.10.3(supports-color@10.2.2)(typescript@5.4.5))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(puppeteer@23.10.3)(supports-color@10.2.2)(typescript@5.4.5)
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
@@ -2085,7 +2086,7 @@ importers:
         version: 6.1.3
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.29.7(supports-color@10.2.2))(@jest/transform@29.7.0(supports-color@10.2.2))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(jest@29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0)(jest@29.7.0)(typescript@5.4.5)
       typescript:
         specifier: ~5.4.5
         version: 5.4.5
@@ -2097,7 +2098,7 @@ importers:
         version: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.6)(webpack@5.109.0)
       webpack-dev-server:
         specifier: ~5.2.6
-        version: 5.2.6(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
+        version: 5.2.6(debug@4.4.3)(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
 
   examples/benchmarks/tablebench:
     dependencies:
@@ -2146,7 +2147,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/id-compressor':
         specifier: workspace:~
         version: link:../../../packages/runtime/id-compressor
@@ -2179,7 +2180,7 @@ importers:
         version: 2.0.8(supports-color@10.2.2)
       tinylicious:
         specifier: ^7.0.1
-        version: 7.0.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 7.0.1(debug@4.4.3)(supports-color@10.2.2)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.109.0)
@@ -2194,7 +2195,7 @@ importers:
         version: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.6)(webpack@5.109.0)
       webpack-dev-server:
         specifier: ~5.2.6
-        version: 5.2.6(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
+        version: 5.2.6(debug@4.4.3)(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
       webpack-merge:
         specifier: ^6.0.1
         version: 6.0.1
@@ -2249,7 +2250,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@testing-library/dom':
         specifier: ^10.4.0
         version: 10.4.1
@@ -2258,7 +2259,7 @@ importers:
         version: 5.17.0
       '@testing-library/react':
         specifier: ^16.3.0
-        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@testing-library/user-event':
         specifier: ^14.4.3
         version: 14.5.2(@testing-library/dom@10.4.1)
@@ -2282,22 +2283,22 @@ importers:
         version: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
       eslint-config-prettier:
         specifier: catalog:eslint
-        version: 10.1.8(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))
+        version: 10.1.8(eslint@9.39.1)
       eslint-plugin-jest:
         specifier: ~29.5.0
-        version: 29.5.0(@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(jest@29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 29.5.0(@typescript-eslint/eslint-plugin@8.54.0)(eslint@9.39.1)(jest@29.7.0)(supports-color@10.2.2)(typescript@5.4.5)
       eslint-plugin-react:
         specifier: ~7.37.5
-        version: 7.37.5(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))
+        version: 7.37.5(eslint@9.39.1)
       eslint-plugin-react-hooks:
         specifier: ~7.0.1
-        version: 7.0.1(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 7.0.1(eslint@9.39.1)(supports-color@10.2.2)
       html-webpack-plugin:
         specifier: ^5.6.0
         version: 5.6.3(webpack@5.109.0)
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))
+        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2)
       jest-environment-jsdom:
         specifier: ^29.6.2
         version: 29.7.0(supports-color@10.2.2)
@@ -2315,10 +2316,10 @@ importers:
         version: 2.0.8(supports-color@10.2.2)
       tinylicious:
         specifier: ^7.0.1
-        version: 7.0.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 7.0.1(debug@4.4.3)(supports-color@10.2.2)
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.29.7(supports-color@10.2.2))(@jest/transform@29.7.0(supports-color@10.2.2))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(jest@29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0)(jest@29.7.0)(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.109.0)
@@ -2336,7 +2337,7 @@ importers:
         version: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.6)(webpack@5.109.0)
       webpack-dev-server:
         specifier: ~5.2.6
-        version: 5.2.6(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
+        version: 5.2.6(debug@4.4.3)(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
 
   examples/data-objects/canvas:
     dependencies:
@@ -2370,7 +2371,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/test-tools':
         specifier: ^2.0.0
         version: 2.0.1
@@ -2400,16 +2401,16 @@ importers:
         version: 9.0.2
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))
+        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2)
       jest-environment-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(supports-color@10.2.2)(typescript@5.4.5)
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
       jest-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(puppeteer@23.10.3(supports-color@10.2.2)(typescript@5.4.5))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(puppeteer@23.10.3)(supports-color@10.2.2)(typescript@5.4.5)
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
@@ -2433,7 +2434,7 @@ importers:
         version: 5.4.5
       url-loader:
         specifier: ^4.1.1
-        version: 4.1.1(file-loader@6.2.0(webpack@5.109.0))(webpack@5.109.0)
+        version: 4.1.1(file-loader@6.2.0)(webpack@5.109.0)
       webpack:
         specifier: ^5.104.1
         version: 5.109.0(clean-css@5.3.3)(html-minifier-terser@7.2.0)(postcss@8.5.16)(uglify-js@3.19.3)(webpack-cli@5.1.4)
@@ -2442,7 +2443,7 @@ importers:
         version: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.6)(webpack@5.109.0)
       webpack-dev-server:
         specifier: ~5.2.6
-        version: 5.2.6(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
+        version: 5.2.6(debug@4.4.3)(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
       webpack-merge:
         specifier: ^6.0.1
         version: 6.0.1
@@ -2485,7 +2486,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/test-tools':
         specifier: ^2.0.0
         version: 2.0.1
@@ -2515,16 +2516,16 @@ importers:
         version: 9.0.2
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))
+        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2)
       jest-environment-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(supports-color@10.2.2)(typescript@5.4.5)
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
       jest-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(puppeteer@23.10.3(supports-color@10.2.2)(typescript@5.4.5))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(puppeteer@23.10.3)(supports-color@10.2.2)(typescript@5.4.5)
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
@@ -2536,7 +2537,7 @@ importers:
         version: 6.1.3
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.29.7(supports-color@10.2.2))(@jest/transform@29.7.0(supports-color@10.2.2))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(jest@29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0)(jest@29.7.0)(typescript@5.4.5)
       typescript:
         specifier: ~5.4.5
         version: 5.4.5
@@ -2548,7 +2549,7 @@ importers:
         version: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.6)(webpack@5.109.0)
       webpack-dev-server:
         specifier: ~5.2.6
-        version: 5.2.6(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
+        version: 5.2.6(debug@4.4.3)(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
       webpack-merge:
         specifier: ^6.0.1
         version: 6.0.1
@@ -2612,7 +2613,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@types/codemirror':
         specifier: 5.60.7
         version: 5.60.7
@@ -2651,7 +2652,7 @@ importers:
         version: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.6)(webpack@5.109.0)
       webpack-dev-server:
         specifier: ~5.2.6
-        version: 5.2.6(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
+        version: 5.2.6(debug@4.4.3)(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
       webpack-merge:
         specifier: ^6.0.1
         version: 6.0.1
@@ -2691,10 +2692,10 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@testing-library/react':
         specifier: ^16.3.0
-        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
@@ -2709,13 +2710,13 @@ importers:
         version: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
       eslint-plugin-react:
         specifier: ~7.37.5
-        version: 7.37.5(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))
+        version: 7.37.5(eslint@9.39.1)
       eslint-plugin-react-hooks:
         specifier: ~7.0.1
-        version: 7.0.1(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 7.0.1(eslint@9.39.1)(supports-color@10.2.2)
       global-jsdom:
         specifier: ^26.0.0
-        version: 26.0.0(jsdom@26.1.0(supports-color@10.2.2))
+        version: 26.0.0(jsdom@26.1.0)
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
@@ -2739,7 +2740,7 @@ importers:
         version: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.6)(webpack@5.109.0)
       webpack-dev-server:
         specifier: ~5.2.6
-        version: 5.2.6(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
+        version: 5.2.6(debug@4.4.3)(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
 
   examples/data-objects/monaco:
     dependencies:
@@ -2782,7 +2783,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@types/react':
         specifier: ^18.3.11
         version: 18.3.15
@@ -2827,7 +2828,7 @@ importers:
         version: 5.4.5
       url-loader:
         specifier: ^4.1.1
-        version: 4.1.1(file-loader@6.2.0(webpack@5.109.0))(webpack@5.109.0)
+        version: 4.1.1(file-loader@6.2.0)(webpack@5.109.0)
       webpack:
         specifier: ^5.104.1
         version: 5.109.0(clean-css@5.3.3)(html-minifier-terser@7.2.0)(postcss@8.5.16)(uglify-js@3.19.3)(webpack-cli@5.1.4)
@@ -2836,7 +2837,7 @@ importers:
         version: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.6)(webpack@5.109.0)
       webpack-dev-server:
         specifier: ~5.2.6
-        version: 5.2.6(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
+        version: 5.2.6(debug@4.4.3)(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
       webpack-merge:
         specifier: ^6.0.1
         version: 6.0.1
@@ -2870,7 +2871,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       eslint:
         specifier: catalog:eslint
         version: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
@@ -2907,7 +2908,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@types/react':
         specifier: ^18.3.11
         version: 18.3.15
@@ -2989,7 +2990,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/test-tools':
         specifier: ^2.0.0
         version: 2.0.1
@@ -3022,16 +3023,16 @@ importers:
         version: 9.0.2
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))
+        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2)
       jest-environment-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(supports-color@10.2.2)(typescript@5.4.5)
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
       jest-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(puppeteer@23.10.3(supports-color@10.2.2)(typescript@5.4.5))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(puppeteer@23.10.3)(supports-color@10.2.2)(typescript@5.4.5)
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
@@ -3046,7 +3047,7 @@ importers:
         version: 4.0.0(webpack@5.109.0)
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.29.7(supports-color@10.2.2))(@jest/transform@29.7.0(supports-color@10.2.2))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(jest@29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0)(jest@29.7.0)(typescript@5.4.5)
       typescript:
         specifier: ~5.4.5
         version: 5.4.5
@@ -3058,7 +3059,7 @@ importers:
         version: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.6)(webpack@5.109.0)
       webpack-dev-server:
         specifier: ~5.2.6
-        version: 5.2.6(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
+        version: 5.2.6(debug@4.4.3)(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
       webpack-merge:
         specifier: ^6.0.1
         version: 6.0.1
@@ -3086,7 +3087,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       eslint:
         specifier: catalog:eslint
         version: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
@@ -3120,7 +3121,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       eslint:
         specifier: catalog:eslint
         version: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
@@ -3154,7 +3155,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@types/react':
         specifier: ^18.3.11
         version: 18.3.15
@@ -3194,7 +3195,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@types/react':
         specifier: ^18.3.11
         version: 18.3.15
@@ -3234,7 +3235,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@types/react':
         specifier: ^18.3.11
         version: 18.3.15
@@ -3346,7 +3347,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@types/node':
         specifier: ~22.19.17
         version: 22.19.17
@@ -3394,7 +3395,7 @@ importers:
         version: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.6)(webpack@5.109.0)
       webpack-dev-server:
         specifier: ~5.2.6
-        version: 5.2.6(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
+        version: 5.2.6(debug@4.4.3)(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
       webpack-merge:
         specifier: ^6.0.1
         version: 6.0.1
@@ -3442,7 +3443,7 @@ importers:
         version: link:../../../packages/runtime/datastore-definitions
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/map':
         specifier: workspace:~
         version: link:../../../packages/dds/map
@@ -3496,7 +3497,7 @@ importers:
         version: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.6)(webpack@5.109.0)
       webpack-dev-server:
         specifier: ~5.2.6
-        version: 5.2.6(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
+        version: 5.2.6(debug@4.4.3)(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
       webpack-merge:
         specifier: ^6.0.1
         version: 6.0.1
@@ -3557,7 +3558,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/runtime-utils':
         specifier: workspace:~
         version: link:../../../packages/runtime/runtime-utils
@@ -3611,7 +3612,7 @@ importers:
     dependencies:
       '@fluentui/react-components':
         specifier: ^9.47.5
-        version: 9.56.5(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
+        version: 9.56.5(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
       '@fluentui/react-icons':
         specifier: ^2.0.233
         version: 2.0.266(react@18.3.1)
@@ -3666,7 +3667,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/test-tools':
         specifier: ^2.0.0
         version: 2.0.1
@@ -3702,16 +3703,16 @@ importers:
         version: 9.0.2
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))
+        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2)
       jest-environment-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(supports-color@10.2.2)(typescript@5.4.5)
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
       jest-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(puppeteer@23.10.3(supports-color@10.2.2)(typescript@5.4.5))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(puppeteer@23.10.3)(supports-color@10.2.2)(typescript@5.4.5)
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
@@ -3735,7 +3736,7 @@ importers:
         version: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.6)(webpack@5.109.0)
       webpack-dev-server:
         specifier: ~5.2.6
-        version: 5.2.6(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
+        version: 5.2.6(debug@4.4.3)(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
       webpack-merge:
         specifier: ^6.0.1
         version: 6.0.1
@@ -3793,10 +3794,10 @@ importers:
         version: link:../../../packages/tools/devtools/devtools
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@testing-library/react':
         specifier: ^16.3.0
-        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
@@ -3817,13 +3818,13 @@ importers:
         version: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
       eslint-plugin-react:
         specifier: ~7.37.5
-        version: 7.37.5(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))
+        version: 7.37.5(eslint@9.39.1)
       eslint-plugin-react-hooks:
         specifier: ~7.0.1
-        version: 7.0.1(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 7.0.1(eslint@9.39.1)(supports-color@10.2.2)
       global-jsdom:
         specifier: ^26.0.0
-        version: 26.0.0(jsdom@26.1.0(supports-color@10.2.2))
+        version: 26.0.0(jsdom@26.1.0)
       html-webpack-plugin:
         specifier: ^5.6.0
         version: 5.6.3(webpack@5.109.0)
@@ -3847,7 +3848,7 @@ importers:
         version: 4.0.0(webpack@5.109.0)
       tinylicious:
         specifier: ^7.0.1
-        version: 7.0.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 7.0.1(debug@4.4.3)(supports-color@10.2.2)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.109.0)
@@ -3862,7 +3863,7 @@ importers:
         version: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.6)(webpack@5.109.0)
       webpack-dev-server:
         specifier: ~5.2.6
-        version: 5.2.6(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
+        version: 5.2.6(debug@4.4.3)(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
       webpack-merge:
         specifier: ^6.0.1
         version: 6.0.1
@@ -3920,7 +3921,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/test-tools':
         specifier: ^2.0.0
         version: 2.0.1
@@ -3956,16 +3957,16 @@ importers:
         version: 9.0.2
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))
+        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2)
       jest-environment-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(supports-color@10.2.2)(typescript@5.4.5)
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
       jest-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(puppeteer@23.10.3(supports-color@10.2.2)(typescript@5.4.5))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(puppeteer@23.10.3)(supports-color@10.2.2)(typescript@5.4.5)
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
@@ -3989,7 +3990,7 @@ importers:
         version: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.6)(webpack@5.109.0)
       webpack-dev-server:
         specifier: ~5.2.6
-        version: 5.2.6(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
+        version: 5.2.6(debug@4.4.3)(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
       webpack-merge:
         specifier: ^6.0.1
         version: 6.0.1
@@ -4053,7 +4054,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/runtime-utils':
         specifier: workspace:~
         version: link:../../../packages/runtime/runtime-utils
@@ -4098,7 +4099,7 @@ importers:
         version: 6.2.0(webpack@5.109.0)
       global-jsdom:
         specifier: ^26.0.0
-        version: 26.0.0(jsdom@26.1.0(supports-color@10.2.2))
+        version: 26.0.0(jsdom@26.1.0)
       html-loader:
         specifier: ^5.1.0
         version: 5.1.0(webpack@5.109.0)
@@ -4128,7 +4129,7 @@ importers:
         version: 5.4.5
       url-loader:
         specifier: ^4.1.1
-        version: 4.1.1(file-loader@6.2.0(webpack@5.109.0))(webpack@5.109.0)
+        version: 4.1.1(file-loader@6.2.0)(webpack@5.109.0)
       webpack:
         specifier: ^5.104.1
         version: 5.109.0(clean-css@5.3.3)(html-minifier-terser@7.2.0)(postcss@8.5.16)(uglify-js@3.19.3)(webpack-cli@5.1.4)
@@ -4140,7 +4141,7 @@ importers:
         version: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.6)(webpack@5.109.0)
       webpack-dev-server:
         specifier: ~5.2.6
-        version: 5.2.6(debug@4.4.3(supports-color@8.1.1))(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
+        version: 5.2.6(debug@4.4.3)(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
       webpack-merge:
         specifier: ^6.0.1
         version: 6.0.1
@@ -4243,7 +4244,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/test-tools':
         specifier: ^2.0.0
         version: 2.0.1
@@ -4285,7 +4286,7 @@ importers:
         version: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
       eslint-config-prettier:
         specifier: catalog:eslint
-        version: 10.1.8(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))
+        version: 10.1.8(eslint@9.39.1)
       expect-puppeteer:
         specifier: ^9.0.2
         version: 9.0.2
@@ -4297,16 +4298,16 @@ importers:
         version: 5.6.3(webpack@5.109.0)
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))
+        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2)
       jest-environment-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(supports-color@10.2.2)(typescript@5.4.5)
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
       jest-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(puppeteer@23.10.3(supports-color@10.2.2)(typescript@5.4.5))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(puppeteer@23.10.3)(supports-color@10.2.2)(typescript@5.4.5)
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
@@ -4327,10 +4328,10 @@ importers:
         version: 3.4.2(supports-color@10.2.2)
       tinylicious:
         specifier: ^7.0.1
-        version: 7.0.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 7.0.1(debug@4.4.3)(supports-color@10.2.2)
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.29.7(supports-color@10.2.2))(@jest/transform@29.7.0(supports-color@10.2.2))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(jest@29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0)(jest@29.7.0)(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.109.0)
@@ -4345,7 +4346,7 @@ importers:
         version: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.6)(webpack@5.109.0)
       webpack-dev-server:
         specifier: ~5.2.6
-        version: 5.2.6(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
+        version: 5.2.6(debug@4.4.3)(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
 
   examples/service-clients/azure-client/external-controller:
     dependencies:
@@ -4366,7 +4367,7 @@ importers:
         version: 2.1.0
       axios:
         specifier: 1.18.1
-        version: 1.18.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 1.18.1(debug@4.4.3)(supports-color@10.2.2)
       events_pkg:
         specifier: npm:events@^3.1.0
         version: events@3.3.0
@@ -4400,7 +4401,7 @@ importers:
         version: link:../../../../packages/tools/devtools/devtools
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/fluid-static':
         specifier: workspace:~
         version: link:../../../../packages/framework/fluid-static
@@ -4442,16 +4443,16 @@ importers:
         version: 5.6.3(webpack@5.109.0)
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))
+        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2)
       jest-environment-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(supports-color@10.2.2)(typescript@5.4.5)
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
       jest-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(puppeteer@23.10.3(supports-color@10.2.2)(typescript@5.4.5))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(puppeteer@23.10.3)(supports-color@10.2.2)(typescript@5.4.5)
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
@@ -4472,10 +4473,10 @@ importers:
         version: 2.0.8(supports-color@10.2.2)
       tinylicious:
         specifier: ^7.0.1
-        version: 7.0.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 7.0.1(debug@4.4.3)(supports-color@10.2.2)
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.29.7(supports-color@10.2.2))(@jest/transform@29.7.0(supports-color@10.2.2))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(jest@29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0)(jest@29.7.0)(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.109.0)
@@ -4490,7 +4491,7 @@ importers:
         version: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.6)(webpack@5.109.0)
       webpack-dev-server:
         specifier: ~5.2.6
-        version: 5.2.6(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
+        version: 5.2.6(debug@4.4.3)(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
 
   examples/service-clients/azure-client/todo-list:
     dependencies:
@@ -4517,7 +4518,7 @@ importers:
         version: 2.1.0
       axios:
         specifier: 1.18.1
-        version: 1.18.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 1.18.1(debug@4.4.3)(supports-color@10.2.2)
       events_pkg:
         specifier: npm:events@^3.1.0
         version: events@3.3.0
@@ -4554,7 +4555,7 @@ importers:
         version: link:../../../../packages/tools/devtools/devtools
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/fluid-static':
         specifier: workspace:~
         version: link:../../../../packages/framework/fluid-static
@@ -4605,16 +4606,16 @@ importers:
         version: 5.6.3(webpack@5.109.0)
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))
+        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2)
       jest-environment-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(supports-color@10.2.2)(typescript@5.4.5)
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
       jest-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(puppeteer@23.10.3(supports-color@10.2.2)(typescript@5.4.5))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(puppeteer@23.10.3)(supports-color@10.2.2)(typescript@5.4.5)
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
@@ -4638,10 +4639,10 @@ importers:
         version: 4.0.0(webpack@5.109.0)
       tinylicious:
         specifier: ^7.0.1
-        version: 7.0.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 7.0.1(debug@4.4.3)(supports-color@10.2.2)
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.29.7(supports-color@10.2.2))(@jest/transform@29.7.0(supports-color@10.2.2))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(jest@29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0)(jest@29.7.0)(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.109.0)
@@ -4656,7 +4657,7 @@ importers:
         version: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.6)(webpack@5.109.0)
       webpack-dev-server:
         specifier: ~5.2.6
-        version: 5.2.6(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
+        version: 5.2.6(debug@4.4.3)(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
 
   examples/service-clients/odsp-client/shared-tree-demo:
     dependencies:
@@ -4699,7 +4700,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@types/node':
         specifier: ~22.19.17
         version: 22.19.17
@@ -4729,7 +4730,7 @@ importers:
         version: 6.1.3
       tailwindcss:
         specifier: ^3.3.2
-        version: 3.4.16(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))
+        version: 3.4.16(ts-node@10.9.2)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.109.0)
@@ -4744,7 +4745,7 @@ importers:
         version: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.6)(webpack@5.109.0)
       webpack-dev-server:
         specifier: ~5.2.6
-        version: 5.2.6(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
+        version: 5.2.6(debug@4.4.3)(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
 
   examples/utils/bundle-size-tests:
     dependencies:
@@ -4832,7 +4833,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@mixer/webpack-bundle-compare':
         specifier: ^0.1.0
         version: 0.1.1
@@ -4932,7 +4933,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       copyfiles:
         specifier: ^2.4.1
         version: 2.4.1
@@ -5050,7 +5051,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.58.1
         version: 7.58.1(patch_hash=949a26f6cec9ac4e37522f178b8e4982136ccfeb8c6d0835130ef2aa6788f4fa)(@types/node@22.19.17)
@@ -5086,7 +5087,7 @@ importers:
         version: 5.109.0(clean-css@5.3.3)(html-minifier-terser@7.2.0)(postcss@8.5.16)(uglify-js@3.19.3)(webpack-cli@5.1.4)
       webpack-dev-server:
         specifier: ~5.2.6
-        version: 5.2.6(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
+        version: 5.2.6(debug@4.4.3)(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.18.2
@@ -5105,7 +5106,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@types/node':
         specifier: ~22.19.17
         version: 22.19.17
@@ -5160,7 +5161,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
@@ -5257,7 +5258,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.58.1
         version: 7.58.1(patch_hash=949a26f6cec9ac4e37522f178b8e4982136ccfeb8c6d0835130ef2aa6788f4fa)(@types/node@22.19.17)
@@ -5365,7 +5366,7 @@ importers:
         version: link:../../../packages/utils/tool-utils
       axios:
         specifier: 1.18.1
-        version: 1.18.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 1.18.1(debug@4.4.3)(supports-color@10.2.2)
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
@@ -5392,7 +5393,7 @@ importers:
         version: 11.1.1
       webpack-dev-server:
         specifier: ~5.2.6
-        version: 5.2.6(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
+        version: 5.2.6(debug@4.4.3)(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.18.2
@@ -5414,7 +5415,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@types/express':
         specifier: ^4.17.21
         version: 4.17.21
@@ -5523,7 +5524,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/test-tools':
         specifier: ^2.0.0
         version: 2.0.1
@@ -5550,16 +5551,16 @@ importers:
         version: 5.6.3(webpack@5.109.0)
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))
+        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2)
       jest-environment-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(supports-color@10.2.2)(typescript@5.4.5)
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
       jest-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(puppeteer@23.10.3(supports-color@10.2.2)(typescript@5.4.5))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(puppeteer@23.10.3)(supports-color@10.2.2)(typescript@5.4.5)
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
@@ -5574,10 +5575,10 @@ importers:
         version: 6.1.3
       tinylicious:
         specifier: ^7.0.1
-        version: 7.0.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 7.0.1(debug@4.4.3)(supports-color@10.2.2)
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.29.7(supports-color@10.2.2))(@jest/transform@29.7.0(supports-color@10.2.2))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(jest@29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0)(jest@29.7.0)(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.109.0)
@@ -5592,7 +5593,7 @@ importers:
         version: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.6)(webpack@5.109.0)
       webpack-dev-server:
         specifier: ~5.2.6
-        version: 5.2.6(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
+        version: 5.2.6(debug@4.4.3)(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
 
   examples/version-migration/same-container:
     dependencies:
@@ -5677,7 +5678,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/test-tools':
         specifier: ^2.0.0
         version: 2.0.1
@@ -5707,7 +5708,7 @@ importers:
         version: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
       eslint-config-prettier:
         specifier: catalog:eslint
-        version: 10.1.8(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))
+        version: 10.1.8(eslint@9.39.1)
       expect-puppeteer:
         specifier: ^9.0.2
         version: 9.0.2
@@ -5716,16 +5717,16 @@ importers:
         version: 5.6.3(webpack@5.109.0)
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))
+        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2)
       jest-environment-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(supports-color@10.2.2)(typescript@5.4.5)
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
       jest-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(puppeteer@23.10.3(supports-color@10.2.2)(typescript@5.4.5))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(puppeteer@23.10.3)(supports-color@10.2.2)(typescript@5.4.5)
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
@@ -5743,10 +5744,10 @@ importers:
         version: 4.0.0(webpack@5.109.0)
       tinylicious:
         specifier: ^7.0.1
-        version: 7.0.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 7.0.1(debug@4.4.3)(supports-color@10.2.2)
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.29.7(supports-color@10.2.2))(@jest/transform@29.7.0(supports-color@10.2.2))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(jest@29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0)(jest@29.7.0)(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.109.0)
@@ -5761,7 +5762,7 @@ importers:
         version: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.6)(webpack@5.109.0)
       webpack-dev-server:
         specifier: ~5.2.6
-        version: 5.2.6(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
+        version: 5.2.6(debug@4.4.3)(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
 
   examples/version-migration/separate-container:
     dependencies:
@@ -5858,7 +5859,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/test-tools':
         specifier: ^2.0.0
         version: 2.0.1
@@ -5888,7 +5889,7 @@ importers:
         version: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
       eslint-config-prettier:
         specifier: catalog:eslint
-        version: 10.1.8(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))
+        version: 10.1.8(eslint@9.39.1)
       expect-puppeteer:
         specifier: ^9.0.2
         version: 9.0.2
@@ -5897,16 +5898,16 @@ importers:
         version: 5.6.3(webpack@5.109.0)
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))
+        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2)
       jest-environment-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(supports-color@10.2.2)(typescript@5.4.5)
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
       jest-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(puppeteer@23.10.3(supports-color@10.2.2)(typescript@5.4.5))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(puppeteer@23.10.3)(supports-color@10.2.2)(typescript@5.4.5)
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
@@ -5924,10 +5925,10 @@ importers:
         version: 4.0.0(webpack@5.109.0)
       tinylicious:
         specifier: ^7.0.1
-        version: 7.0.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 7.0.1(debug@4.4.3)(supports-color@10.2.2)
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.29.7(supports-color@10.2.2))(@jest/transform@29.7.0(supports-color@10.2.2))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(jest@29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0)(jest@29.7.0)(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.109.0)
@@ -5942,7 +5943,7 @@ importers:
         version: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.6)(webpack@5.109.0)
       webpack-dev-server:
         specifier: ~5.2.6
-        version: 5.2.6(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
+        version: 5.2.6(debug@4.4.3)(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
 
   examples/version-migration/tree-shim:
     dependencies:
@@ -6021,7 +6022,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/test-tools':
         specifier: ^2.0.0
         version: 2.0.1
@@ -6054,16 +6055,16 @@ importers:
         version: 5.6.3(webpack@5.109.0)
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))
+        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2)
       jest-environment-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(supports-color@10.2.2)(typescript@5.4.5)
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
       jest-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(puppeteer@23.10.3(supports-color@10.2.2)(typescript@5.4.5))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(puppeteer@23.10.3)(supports-color@10.2.2)(typescript@5.4.5)
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
@@ -6084,10 +6085,10 @@ importers:
         version: 4.0.0(webpack@5.109.0)
       tinylicious:
         specifier: ^7.0.1
-        version: 7.0.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 7.0.1(debug@4.4.3)(supports-color@10.2.2)
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.29.7(supports-color@10.2.2))(@jest/transform@29.7.0(supports-color@10.2.2))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(jest@29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0)(jest@29.7.0)(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.109.0)
@@ -6102,7 +6103,7 @@ importers:
         version: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.6)(webpack@5.109.0)
       webpack-dev-server:
         specifier: ~5.2.6
-        version: 5.2.6(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
+        version: 5.2.6(debug@4.4.3)(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
 
   examples/view-integration/container-views:
     dependencies:
@@ -6160,7 +6161,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/test-tools':
         specifier: ^2.0.0
         version: 2.0.1
@@ -6190,16 +6191,16 @@ importers:
         version: 5.6.3(webpack@5.109.0)
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))
+        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2)
       jest-environment-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(supports-color@10.2.2)(typescript@5.4.5)
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
       jest-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(puppeteer@23.10.3(supports-color@10.2.2)(typescript@5.4.5))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(puppeteer@23.10.3)(supports-color@10.2.2)(typescript@5.4.5)
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
@@ -6211,10 +6212,10 @@ importers:
         version: 6.1.3
       tinylicious:
         specifier: ^7.0.1
-        version: 7.0.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 7.0.1(debug@4.4.3)(supports-color@10.2.2)
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.29.7(supports-color@10.2.2))(@jest/transform@29.7.0(supports-color@10.2.2))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(jest@29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0)(jest@29.7.0)(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.109.0)
@@ -6229,7 +6230,7 @@ importers:
         version: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.6)(webpack@5.109.0)
       webpack-dev-server:
         specifier: ~5.2.6
-        version: 5.2.6(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
+        version: 5.2.6(debug@4.4.3)(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
 
   examples/view-integration/external-views:
     dependencies:
@@ -6296,7 +6297,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/test-tools':
         specifier: ^2.0.0
         version: 2.0.1
@@ -6329,16 +6330,16 @@ importers:
         version: 5.6.3(webpack@5.109.0)
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))
+        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2)
       jest-environment-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(supports-color@10.2.2)(typescript@5.4.5)
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
       jest-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(puppeteer@23.10.3(supports-color@10.2.2)(typescript@5.4.5))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(puppeteer@23.10.3)(supports-color@10.2.2)(typescript@5.4.5)
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
@@ -6350,10 +6351,10 @@ importers:
         version: 6.1.3
       tinylicious:
         specifier: ^7.0.1
-        version: 7.0.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 7.0.1(debug@4.4.3)(supports-color@10.2.2)
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.29.7(supports-color@10.2.2))(@jest/transform@29.7.0(supports-color@10.2.2))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(jest@29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0)(jest@29.7.0)(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.109.0)
@@ -6368,7 +6369,7 @@ importers:
         version: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.6)(webpack@5.109.0)
       webpack-dev-server:
         specifier: ~5.2.6
-        version: 5.2.6(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
+        version: 5.2.6(debug@4.4.3)(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
 
   examples/view-integration/view-framework-sampler:
     dependencies:
@@ -6417,7 +6418,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/test-tools':
         specifier: ^2.0.0
         version: 2.0.1
@@ -6450,16 +6451,16 @@ importers:
         version: 5.6.3(webpack@5.109.0)
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))
+        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2)
       jest-environment-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(supports-color@10.2.2)(typescript@5.4.5)
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
       jest-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(puppeteer@23.10.3(supports-color@10.2.2)(typescript@5.4.5))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(puppeteer@23.10.3)(supports-color@10.2.2)(typescript@5.4.5)
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
@@ -6474,10 +6475,10 @@ importers:
         version: 6.1.3
       tinylicious:
         specifier: ^7.0.1
-        version: 7.0.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 7.0.1(debug@4.4.3)(supports-color@10.2.2)
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.29.7(supports-color@10.2.2))(@jest/transform@29.7.0(supports-color@10.2.2))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(jest@29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0)(jest@29.7.0)(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.109.0)
@@ -6492,7 +6493,7 @@ importers:
         version: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.6)(webpack@5.109.0)
       webpack-dev-server:
         specifier: ~5.2.6
-        version: 5.2.6(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
+        version: 5.2.6(debug@4.4.3)(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
 
   experimental/PropertyDDS/packages/property-changeset:
     dependencies:
@@ -6722,7 +6723,7 @@ importers:
         version: link:../../../../packages/dds/shared-object-base
       axios:
         specifier: 1.18.1
-        version: 1.18.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 1.18.1(debug@4.4.3)(supports-color@10.2.2)
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
@@ -6968,7 +6969,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../../../packages/runtime/test-runtime-utils
@@ -7062,7 +7063,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../../../../packages/runtime/test-runtime-utils
@@ -7153,7 +7154,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../../packages/runtime/test-runtime-utils
@@ -7289,7 +7290,7 @@ importers:
         version: link:../../../packages/runtime/container-runtime
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../../packages/runtime/test-runtime-utils
@@ -7337,7 +7338,7 @@ importers:
         version: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
       eslint-config-prettier:
         specifier: catalog:eslint
-        version: 10.1.8(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))
+        version: 10.1.8(eslint@9.39.1)
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
@@ -7398,7 +7399,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.58.1
         version: 7.58.1(patch_hash=949a26f6cec9ac4e37522f178b8e4982136ccfeb8c6d0835130ef2aa6788f4fa)(@types/node@22.19.17)
@@ -7468,7 +7469,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.58.1
         version: 7.58.1(patch_hash=949a26f6cec9ac4e37522f178b8e4982136ccfeb8c6d0835130ef2aa6788f4fa)(@types/node@22.19.17)
@@ -7541,7 +7542,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.58.1
         version: 7.58.1(patch_hash=949a26f6cec9ac4e37522f178b8e4982136ccfeb8c6d0835130ef2aa6788f4fa)(@types/node@22.19.17)
@@ -7586,19 +7587,19 @@ importers:
         version: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
       eslint-config-prettier:
         specifier: catalog:eslint
-        version: 10.1.8(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))
+        version: 10.1.8(eslint@9.39.1)
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))
+        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2)
       jest-environment-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(supports-color@10.2.2)(typescript@5.4.5)
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
       jest-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(puppeteer@23.10.3(supports-color@10.2.2)(typescript@5.4.5))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(puppeteer@23.10.3)(supports-color@10.2.2)(typescript@5.4.5)
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
@@ -7622,7 +7623,7 @@ importers:
         version: 18.0.1
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.29.7(supports-color@10.2.2))(@jest/transform@29.7.0(supports-color@10.2.2))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(jest@29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0)(jest@29.7.0)(typescript@5.4.5)
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@22.19.17)(typescript@5.4.5)
@@ -7659,7 +7660,7 @@ importers:
         version: '@fluidframework/container-definitions@2.111.0'
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.58.1
         version: 7.58.1(patch_hash=949a26f6cec9ac4e37522f178b8e4982136ccfeb8c6d0835130ef2aa6788f4fa)(@types/node@22.19.17)
@@ -7704,7 +7705,7 @@ importers:
         version: '@fluidframework/core-interfaces@2.111.0'
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.58.1
         version: 7.58.1(patch_hash=949a26f6cec9ac4e37522f178b8e4982136ccfeb8c6d0835130ef2aa6788f4fa)(@types/node@22.19.17)
@@ -7773,7 +7774,7 @@ importers:
         version: '@fluidframework/core-utils@2.111.0'
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.58.1
         version: 7.58.1(patch_hash=949a26f6cec9ac4e37522f178b8e4982136ccfeb8c6d0835130ef2aa6788f4fa)(@types/node@22.19.17)
@@ -7803,7 +7804,7 @@ importers:
         version: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
       eslint-config-prettier:
         specifier: catalog:eslint
-        version: 10.1.8(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))
+        version: 10.1.8(eslint@9.39.1)
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
@@ -7849,7 +7850,7 @@ importers:
         version: '@fluidframework/driver-definitions@2.111.0'
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.58.1
         version: 7.58.1(patch_hash=949a26f6cec9ac4e37522f178b8e4982136ccfeb8c6d0835130ef2aa6788f4fa)(@types/node@22.19.17)
@@ -7925,7 +7926,7 @@ importers:
         version: link:../../common/container-definitions
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -8022,7 +8023,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -8122,7 +8123,7 @@ importers:
         version: '@fluidframework/counter@2.111.0(supports-color@10.2.2)'
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -8213,7 +8214,7 @@ importers:
         version: link:../../common/container-definitions
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -8319,7 +8320,7 @@ importers:
         version: link:../../common/container-definitions
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -8434,7 +8435,7 @@ importers:
         version: link:../../common/container-definitions
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/map-previous':
         specifier: npm:@fluidframework/map@2.111.0
         version: '@fluidframework/map@2.111.0(supports-color@10.2.2)'
@@ -8558,7 +8559,7 @@ importers:
         version: link:../../common/container-definitions
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/matrix-previous':
         specifier: npm:@fluidframework/matrix@2.111.0
         version: '@fluidframework/matrix@2.111.0(supports-color@10.2.2)'
@@ -8682,7 +8683,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/merge-tree-previous':
         specifier: npm:@fluidframework/merge-tree@2.111.0
         version: '@fluidframework/merge-tree@2.111.0(supports-color@10.2.2)'
@@ -8794,7 +8795,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/ordered-collection-previous':
         specifier: npm:@fluidframework/ordered-collection@2.111.0
         version: '@fluidframework/ordered-collection@2.111.0(supports-color@10.2.2)'
@@ -8891,7 +8892,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -8988,7 +8989,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/register-collection-previous':
         specifier: npm:@fluidframework/register-collection@2.111.0
         version: '@fluidframework/register-collection@2.111.0(supports-color@10.2.2)'
@@ -9106,7 +9107,7 @@ importers:
         version: link:../../common/container-definitions
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/sequence-previous':
         specifier: npm:@fluidframework/sequence@2.111.0
         version: '@fluidframework/sequence@2.111.0(supports-color@10.2.2)'
@@ -9230,7 +9231,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/shared-object-base-previous':
         specifier: npm:@fluidframework/shared-object-base@2.111.0
         version: '@fluidframework/shared-object-base@2.111.0(supports-color@10.2.2)'
@@ -9330,7 +9331,7 @@ importers:
         version: link:../../common/container-definitions
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/shared-summary-block-previous':
         specifier: npm:@fluidframework/shared-summary-block@2.111.0
         version: '@fluidframework/shared-summary-block@2.111.0(supports-color@10.2.2)'
@@ -9436,7 +9437,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/task-manager-previous':
         specifier: npm:@fluidframework/task-manager@2.111.0
         version: '@fluidframework/task-manager@2.111.0(supports-color@10.2.2)'
@@ -9548,7 +9549,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.58.1
         version: 7.58.1(patch_hash=949a26f6cec9ac4e37522f178b8e4982136ccfeb8c6d0835130ef2aa6788f4fa)(@types/node@22.19.17)
@@ -9681,7 +9682,7 @@ importers:
         version: link:../../loader/container-loader
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/local-driver':
         specifier: workspace:~
         version: link:../../drivers/local-driver
@@ -9741,7 +9742,7 @@ importers:
         version: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
       eslint-config-prettier:
         specifier: catalog:eslint
-        version: 10.1.8(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))
+        version: 10.1.8(eslint@9.39.1)
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
@@ -9796,7 +9797,7 @@ importers:
         version: '@fluidframework/debugger@2.111.0(supports-color@10.2.2)'
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.58.1
         version: 7.58.1(patch_hash=949a26f6cec9ac4e37522f178b8e4982136ccfeb8c6d0835130ef2aa6788f4fa)(@types/node@22.19.17)
@@ -9866,7 +9867,7 @@ importers:
         version: '@fluidframework/driver-base@2.111.0(supports-color@10.2.2)'
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.58.1
         version: 7.58.1(patch_hash=949a26f6cec9ac4e37522f178b8e4982136ccfeb8c6d0835130ef2aa6788f4fa)(@types/node@22.19.17)
@@ -9954,7 +9955,7 @@ importers:
         version: '@fluidframework/driver-web-cache@2.111.0(supports-color@10.2.2)'
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.58.1
         version: 7.58.1(patch_hash=949a26f6cec9ac4e37522f178b8e4982136ccfeb8c6d0835130ef2aa6788f4fa)(@types/node@22.19.17)
@@ -10036,7 +10037,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/file-driver-previous':
         specifier: npm:@fluidframework/file-driver@2.111.0
         version: '@fluidframework/file-driver@2.111.0(supports-color@10.2.2)'
@@ -10148,7 +10149,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/local-driver-previous':
         specifier: npm:@fluidframework/local-driver@2.111.0
         version: '@fluidframework/local-driver@2.111.0(supports-color@10.2.2)'
@@ -10257,7 +10258,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/odsp-driver-previous':
         specifier: npm:@fluidframework/odsp-driver@2.111.0
         version: '@fluidframework/odsp-driver@2.111.0(supports-color@10.2.2)'
@@ -10330,7 +10331,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/odsp-driver-definitions-previous':
         specifier: npm:@fluidframework/odsp-driver-definitions@2.111.0
         version: '@fluidframework/odsp-driver-definitions@2.111.0'
@@ -10400,7 +10401,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/odsp-urlresolver-previous':
         specifier: npm:@fluidframework/odsp-urlresolver@2.111.0
         version: '@fluidframework/odsp-urlresolver@2.111.0(supports-color@10.2.2)'
@@ -10479,7 +10480,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/replay-driver-previous':
         specifier: npm:@fluidframework/replay-driver@2.111.0
         version: '@fluidframework/replay-driver@2.111.0(supports-color@10.2.2)'
@@ -10567,7 +10568,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/routerlicious-driver-previous':
         specifier: npm:@fluidframework/routerlicious-driver@2.111.0
         version: '@fluidframework/routerlicious-driver@2.111.0(supports-color@10.2.2)'
@@ -10655,7 +10656,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/routerlicious-urlresolver-previous':
         specifier: npm:@fluidframework/routerlicious-urlresolver@2.111.0
         version: '@fluidframework/routerlicious-urlresolver@2.111.0'
@@ -10743,7 +10744,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/tinylicious-driver-previous':
         specifier: npm:@fluidframework/tinylicious-driver@2.111.0
         version: '@fluidframework/tinylicious-driver@2.111.0(supports-color@10.2.2)'
@@ -10843,7 +10844,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.58.1
         version: 7.58.1(patch_hash=949a26f6cec9ac4e37522f178b8e4982136ccfeb8c6d0835130ef2aa6788f4fa)(@types/node@22.19.17)
@@ -10943,7 +10944,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.58.1
         version: 7.58.1(patch_hash=949a26f6cec9ac4e37522f178b8e4982136ccfeb8c6d0835130ef2aa6788f4fa)(@types/node@22.19.17)
@@ -11049,7 +11050,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/merge-tree':
         specifier: workspace:~
         version: link:../../dds/merge-tree
@@ -11155,16 +11156,16 @@ importers:
         version: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
       eslint-config-prettier:
         specifier: catalog:eslint
-        version: 10.1.8(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))
+        version: 10.1.8(eslint@9.39.1)
       eslint-plugin-jest:
         specifier: ~29.5.0
-        version: 29.5.0(@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(jest@29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 29.5.0(@typescript-eslint/eslint-plugin@8.54.0)(eslint@9.39.1)(jest@29.7.0)(supports-color@10.2.2)(typescript@5.4.5)
       eslint-plugin-react:
         specifier: ~7.37.5
-        version: 7.37.5(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))
+        version: 7.37.5(eslint@9.39.1)
       eslint-plugin-react-hooks:
         specifier: ~7.0.1
-        version: 7.0.1(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 7.0.1(eslint@9.39.1)(supports-color@10.2.2)
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
@@ -11273,7 +11274,7 @@ importers:
         version: 2.0.8(supports-color@10.2.2)
       tinylicious:
         specifier: ^7.0.1
-        version: 7.0.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 7.0.1(debug@4.4.3)(supports-color@10.2.2)
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
@@ -11337,7 +11338,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.58.1
         version: 7.58.1(patch_hash=949a26f6cec9ac4e37522f178b8e4982136ccfeb8c6d0835130ef2aa6788f4fa)(@types/node@22.19.17)
@@ -11401,7 +11402,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -11504,7 +11505,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.58.1
         version: 7.58.1(patch_hash=949a26f6cec9ac4e37522f178b8e4982136ccfeb8c6d0835130ef2aa6788f4fa)(@types/node@22.19.17)
@@ -11613,7 +11614,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/fluid-static-previous':
         specifier: npm:@fluidframework/fluid-static@2.111.0
         version: '@fluidframework/fluid-static@2.111.0(supports-color@10.2.2)'
@@ -11701,7 +11702,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.58.1
         version: 7.58.1(patch_hash=949a26f6cec9ac4e37522f178b8e4982136ccfeb8c6d0835130ef2aa6788f4fa)(@types/node@22.19.17)
@@ -11765,7 +11766,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.58.1
         version: 7.58.1(patch_hash=949a26f6cec9ac4e37522f178b8e4982136ccfeb8c6d0835130ef2aa6788f4fa)(@types/node@22.19.17)
@@ -11820,7 +11821,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.58.1
         version: 7.58.1(patch_hash=949a26f6cec9ac4e37522f178b8e4982136ccfeb8c6d0835130ef2aa6788f4fa)(@types/node@22.19.17)
@@ -11899,7 +11900,7 @@ importers:
         version: link:../../common/driver-definitions
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -11993,7 +11994,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/react':
         specifier: workspace:~
         version: link:../react
@@ -12005,7 +12006,7 @@ importers:
         version: 7.58.1(patch_hash=949a26f6cec9ac4e37522f178b8e4982136ccfeb8c6d0835130ef2aa6788f4fa)(@types/node@22.19.17)
       '@testing-library/react':
         specifier: ^16.3.0
-        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
@@ -12035,10 +12036,10 @@ importers:
         version: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
       eslint-config-prettier:
         specifier: catalog:eslint
-        version: 10.1.8(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))
+        version: 10.1.8(eslint@9.39.1)
       global-jsdom:
         specifier: ^26.0.0
-        version: 26.0.0(jsdom@26.1.0(supports-color@10.2.2))
+        version: 26.0.0(jsdom@26.1.0)
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
@@ -12114,7 +12115,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -12126,7 +12127,7 @@ importers:
         version: 7.58.1(patch_hash=949a26f6cec9ac4e37522f178b8e4982136ccfeb8c6d0835130ef2aa6788f4fa)(@types/node@22.19.17)
       '@testing-library/react':
         specifier: ^16.3.0
-        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
@@ -12156,10 +12157,10 @@ importers:
         version: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
       eslint-config-prettier:
         specifier: catalog:eslint
-        version: 10.1.8(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))
+        version: 10.1.8(eslint@9.39.1)
       global-jsdom:
         specifier: ^26.0.0
-        version: 26.0.0(jsdom@26.1.0(supports-color@10.2.2))
+        version: 26.0.0(jsdom@26.1.0)
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
@@ -12217,7 +12218,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/request-handler-previous':
         specifier: npm:@fluidframework/request-handler@2.111.0
         version: '@fluidframework/request-handler@2.111.0(supports-color@10.2.2)'
@@ -12299,7 +12300,7 @@ importers:
         version: link:../../runtime/datastore
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/runtime-utils
@@ -12390,7 +12391,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/id-compressor':
         specifier: workspace:~
         version: link:../../runtime/id-compressor
@@ -12399,16 +12400,16 @@ importers:
         version: link:../../runtime/test-runtime-utils
       '@langchain/anthropic':
         specifier: ^1.3.28
-        version: 1.3.28(@langchain/core@1.1.44(openai@6.36.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))
+        version: 1.3.28(@langchain/core@1.1.44)
       '@langchain/core':
         specifier: ^1.1.44
-        version: 1.1.44(openai@6.36.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
+        version: 1.1.44(openai@6.36.0)(ws@8.21.0)
       '@langchain/google-genai':
         specifier: ^2.1.30
-        version: 2.1.30(@langchain/core@1.1.44(openai@6.36.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))
+        version: 2.1.30(@langchain/core@1.1.44)
       '@langchain/openai':
         specifier: ^1.4.5
-        version: 1.4.5(@langchain/core@1.1.44(openai@6.36.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(ws@8.21.0)
+        version: 1.4.5(@langchain/core@1.1.44)(ws@8.21.0)
       '@microsoft/api-extractor':
         specifier: 7.58.1
         version: 7.58.1(patch_hash=949a26f6cec9ac4e37522f178b8e4982136ccfeb8c6d0835130ef2aa6788f4fa)(@types/node@22.19.17)
@@ -12438,7 +12439,7 @@ importers:
         version: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
       eslint-config-prettier:
         specifier: catalog:eslint
-        version: 10.1.8(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))
+        version: 10.1.8(eslint@9.39.1)
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
@@ -12471,7 +12472,7 @@ importers:
         version: link:../type-factory
       '@langchain/core':
         specifier: ^1.1.44
-        version: 1.1.44(openai@6.36.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
+        version: 1.1.44(openai@6.36.0)(ws@8.21.0)
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.18.2
@@ -12496,7 +12497,7 @@ importers:
         version: link:../../common/core-utils
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/runtime-utils
@@ -12505,13 +12506,13 @@ importers:
         version: link:../../dds/tree
       '@langchain/anthropic':
         specifier: ^1.3.28
-        version: 1.3.28(@langchain/core@1.1.44(openai@6.36.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))
+        version: 1.3.28(@langchain/core@1.1.44)
       '@langchain/google-genai':
         specifier: ^2.1.30
-        version: 2.1.30(@langchain/core@1.1.44(openai@6.36.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))
+        version: 2.1.30(@langchain/core@1.1.44)
       '@langchain/openai':
         specifier: ^1.4.5
-        version: 1.4.5(@langchain/core@1.1.44(openai@6.36.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(ws@8.21.0)
+        version: 1.4.5(@langchain/core@1.1.44)(ws@8.21.0)
       '@microsoft/api-extractor':
         specifier: 7.58.1
         version: 7.58.1(patch_hash=949a26f6cec9ac4e37522f178b8e4982136ccfeb8c6d0835130ef2aa6788f4fa)(@types/node@22.19.17)
@@ -12538,7 +12539,7 @@ importers:
         version: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
       eslint-config-prettier:
         specifier: catalog:eslint
-        version: 10.1.8(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))
+        version: 10.1.8(eslint@9.39.1)
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
@@ -12584,7 +12585,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/tree':
         specifier: workspace:~
         version: link:../../dds/tree
@@ -12614,7 +12615,7 @@ importers:
         version: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
       eslint-config-prettier:
         specifier: catalog:eslint
-        version: 10.1.8(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))
+        version: 10.1.8(eslint@9.39.1)
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
@@ -12657,7 +12658,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.58.1
         version: 7.58.1(patch_hash=949a26f6cec9ac4e37522f178b8e4982136ccfeb8c6d0835130ef2aa6788f4fa)(@types/node@22.19.17)
@@ -12684,7 +12685,7 @@ importers:
         version: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
       eslint-config-prettier:
         specifier: catalog:eslint
-        version: 10.1.8(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))
+        version: 10.1.8(eslint@9.39.1)
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
@@ -12739,7 +12740,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -12854,7 +12855,7 @@ importers:
         version: '@fluidframework/container-loader@2.111.0(supports-color@10.2.2)'
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.58.1
         version: 7.58.1(patch_hash=949a26f6cec9ac4e37522f178b8e4982136ccfeb8c6d0835130ef2aa6788f4fa)(@types/node@22.19.17)
@@ -12957,7 +12958,7 @@ importers:
         version: '@fluidframework/driver-utils@2.111.0(supports-color@10.2.2)'
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.58.1
         version: 7.58.1(patch_hash=949a26f6cec9ac4e37522f178b8e4982136ccfeb8c6d0835130ef2aa6788f4fa)(@types/node@22.19.17)
@@ -13039,7 +13040,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.58.1
         version: 7.58.1(patch_hash=949a26f6cec9ac4e37522f178b8e4982136ccfeb8c6d0835130ef2aa6788f4fa)(@types/node@22.19.17)
@@ -13148,7 +13149,7 @@ importers:
         version: '@fluidframework/container-runtime@2.111.0(supports-color@10.2.2)'
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../test-runtime-utils
@@ -13245,7 +13246,7 @@ importers:
         version: '@fluidframework/container-runtime-definitions@2.111.0(supports-color@10.2.2)'
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.58.1
         version: 7.58.1(patch_hash=949a26f6cec9ac4e37522f178b8e4982136ccfeb8c6d0835130ef2aa6788f4fa)(@types/node@22.19.17)
@@ -13330,7 +13331,7 @@ importers:
         version: '@fluidframework/datastore@2.111.0(supports-color@10.2.2)'
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../test-runtime-utils
@@ -13421,7 +13422,7 @@ importers:
         version: '@fluidframework/datastore-definitions@2.111.0(supports-color@10.2.2)'
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.58.1
         version: 7.58.1(patch_hash=949a26f6cec9ac4e37522f178b8e4982136ccfeb8c6d0835130ef2aa6788f4fa)(@types/node@22.19.17)
@@ -13491,7 +13492,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/id-compressor-previous':
         specifier: npm:@fluidframework/id-compressor@2.111.0
         version: '@fluidframework/id-compressor@2.111.0(supports-color@10.2.2)'
@@ -13573,7 +13574,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/runtime-definitions-previous':
         specifier: npm:@fluidframework/runtime-definitions@2.111.0
         version: '@fluidframework/runtime-definitions@2.111.0(supports-color@10.2.2)'
@@ -13655,7 +13656,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/runtime-utils-previous':
         specifier: npm:@fluidframework/runtime-utils@2.111.0
         version: '@fluidframework/runtime-utils@2.111.0(supports-color@10.2.2)'
@@ -13776,7 +13777,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/test-runtime-utils-previous':
         specifier: npm:@fluidframework/test-runtime-utils@2.111.0
         version: '@fluidframework/test-runtime-utils@2.111.0(supports-color@10.2.2)'
@@ -13879,7 +13880,7 @@ importers:
         version: link:../../runtime/container-runtime
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/test-runtime-utils':
         specifier: workspace:~
         version: link:../../runtime/test-runtime-utils
@@ -13909,7 +13910,7 @@ importers:
         version: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
       eslint-config-prettier:
         specifier: catalog:eslint
-        version: 10.1.8(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))
+        version: 10.1.8(eslint@9.39.1)
       fluid-framework:
         specifier: workspace:~
         version: link:../../framework/fluid-framework
@@ -13954,7 +13955,7 @@ importers:
         version: link:../../azure-client
       '@fluidframework/azure-client-legacy':
         specifier: npm:@fluidframework/azure-client@^1.2.0
-        version: '@fluidframework/azure-client@1.2.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)'
+        version: '@fluidframework/azure-client@1.2.0(debug@4.4.3)(supports-color@10.2.2)'
       '@fluidframework/container-definitions':
         specifier: workspace:~
         version: link:../../../common/container-definitions
@@ -13978,7 +13979,7 @@ importers:
         version: link:../../../dds/map
       '@fluidframework/map-legacy':
         specifier: npm:@fluidframework/map@^1.4.0
-        version: '@fluidframework/map@1.4.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)'
+        version: '@fluidframework/map@1.4.0(debug@4.4.3)(supports-color@10.2.2)'
       '@fluidframework/matrix':
         specifier: workspace:~
         version: link:../../../dds/matrix
@@ -14020,7 +14021,7 @@ importers:
         version: 2.0.8(supports-color@10.2.2)
       tinylicious:
         specifier: ^7.0.1
-        version: 7.0.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 7.0.1(debug@4.4.3)(supports-color@10.2.2)
       uuid:
         specifier: ^11.1.1
         version: 11.1.1
@@ -14039,7 +14040,7 @@ importers:
         version: link:../../../common/driver-definitions
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
@@ -14145,7 +14146,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
@@ -14245,7 +14246,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/test-utils':
         specifier: workspace:~
         version: link:../../test/test-utils
@@ -14354,7 +14355,7 @@ importers:
         version: link:../../runtime/container-runtime-definitions
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/test-utils':
         specifier: workspace:~
         version: link:../../test/test-utils
@@ -14396,7 +14397,7 @@ importers:
         version: 2.0.8(supports-color@10.2.2)
       tinylicious:
         specifier: ^7.0.1
-        version: 7.0.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 7.0.1(debug@4.4.3)(supports-color@10.2.2)
       typescript:
         specifier: ~5.4.5
         version: 5.4.5
@@ -14450,7 +14451,7 @@ importers:
         version: link:../../common/driver-definitions
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/id-compressor':
         specifier: workspace:~
         version: link:../../runtime/id-compressor
@@ -14600,7 +14601,7 @@ importers:
         version: link:../../loader/driver-utils
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/id-compressor':
         specifier: workspace:~
         version: link:../../runtime/id-compressor
@@ -14748,7 +14749,7 @@ importers:
         version: link:../../loader/driver-utils
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/id-compressor':
         specifier: workspace:~
         version: link:../../runtime/id-compressor
@@ -14851,7 +14852,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.58.1
         version: 7.58.1(patch_hash=949a26f6cec9ac4e37522f178b8e4982136ccfeb8c6d0835130ef2aa6788f4fa)(@types/node@22.19.17)
@@ -14966,7 +14967,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/server-local-server':
         specifier: ^7.0.1
         version: 7.0.1(supports-color@10.2.2)
@@ -15036,7 +15037,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.58.1
         version: 7.58.1(patch_hash=949a26f6cec9ac4e37522f178b8e4982136ccfeb8c6d0835130ef2aa6788f4fa)(@types/node@22.19.17)
@@ -15109,7 +15110,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.58.1
         version: 7.58.1(patch_hash=949a26f6cec9ac4e37522f178b8e4982136ccfeb8c6d0835130ef2aa6788f4fa)(@types/node@22.19.17)
@@ -15209,7 +15210,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.58.1
         version: 7.58.1(patch_hash=949a26f6cec9ac4e37522f178b8e4982136ccfeb8c6d0835130ef2aa6788f4fa)(@types/node@22.19.17)
@@ -15395,7 +15396,7 @@ importers:
         version: 2.0.8(supports-color@10.2.2)
       tinylicious:
         specifier: ^7.0.1
-        version: 7.0.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 7.0.1(debug@4.4.3)(supports-color@10.2.2)
       uuid:
         specifier: ^11.1.1
         version: 11.1.1
@@ -15414,7 +15415,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/protocol-definitions':
         specifier: ^3.2.0
         version: 3.2.0
@@ -15478,7 +15479,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.58.1
         version: 7.58.1(patch_hash=949a26f6cec9ac4e37522f178b8e4982136ccfeb8c6d0835130ef2aa6788f4fa)(@types/node@22.19.17)
@@ -15595,7 +15596,7 @@ importers:
         version: 2.0.8(supports-color@10.2.2)
       tinylicious:
         specifier: ^7.0.1
-        version: 7.0.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 7.0.1(debug@4.4.3)(supports-color@10.2.2)
     devDependencies:
       '@biomejs/biome':
         specifier: ~2.4.5
@@ -15614,7 +15615,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10
@@ -15741,7 +15742,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/test-utils-previous':
         specifier: npm:@fluidframework/test-utils@2.111.0
         version: '@fluidframework/test-utils@2.111.0(supports-color@10.2.2)'
@@ -15919,7 +15920,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.58.1
         version: 7.58.1(patch_hash=949a26f6cec9ac4e37522f178b8e4982136ccfeb8c6d0835130ef2aa6788f4fa)(@types/node@22.19.17)
@@ -15991,7 +15992,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       jest-environment-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(supports-color@10.2.2)(typescript@5.4.5)
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
@@ -16006,7 +16007,7 @@ importers:
         version: 5.4.5
       webpack-dev-server:
         specifier: ~5.2.6
-        version: 5.2.6(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
+        version: 5.2.6(debug@4.4.3)(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
 
   packages/tools/changelog-generator-wrapper:
     dependencies:
@@ -16018,7 +16019,7 @@ importers:
         version: 6.1.0
       changesets-format-with-issue-links:
         specifier: ^0.3.0
-        version: 0.3.0(@changesets/cli@2.29.8(@types/node@22.19.17))(supports-color@10.2.2)
+        version: 0.3.0(@changesets/cli@2.29.8)(supports-color@10.2.2)
       typescript:
         specifier: ~5.4.5
         version: 5.4.5
@@ -16031,7 +16032,7 @@ importers:
         version: 2.0.3
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       concurrently:
         specifier: ^10.0.3
         version: 10.0.3
@@ -16083,7 +16084,7 @@ importers:
         version: '@fluidframework/devtools@2.111.0(supports-color@10.2.2)'
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@microsoft/api-extractor':
         specifier: 7.58.1
         version: 7.58.1(patch_hash=949a26f6cec9ac4e37522f178b8e4982136ccfeb8c6d0835130ef2aa6788f4fa)(@types/node@22.19.17)
@@ -16107,7 +16108,7 @@ importers:
         version: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
       eslint-config-prettier:
         specifier: catalog:eslint
-        version: 10.1.8(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))
+        version: 10.1.8(eslint@9.39.1)
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
@@ -16189,7 +16190,7 @@ importers:
         version: link:../../../runtime/container-runtime-definitions
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/runtime-utils':
         specifier: workspace:~
         version: link:../../../runtime/runtime-utils
@@ -16261,16 +16262,16 @@ importers:
         version: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
       eslint-config-prettier:
         specifier: catalog:eslint
-        version: 10.1.8(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))
+        version: 10.1.8(eslint@9.39.1)
       eslint-plugin-chai-expect:
         specifier: ~3.1.0
-        version: 3.1.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))
+        version: 3.1.0(eslint@9.39.1)
       expect-puppeteer:
         specifier: ^9.0.2
         version: 9.0.2
       global-jsdom:
         specifier: ^26.0.0
-        version: 26.0.0(jsdom@26.1.0(supports-color@10.2.2))
+        version: 26.0.0(jsdom@26.1.0)
       good-fences:
         specifier: ^1.1.1
         version: 1.2.0
@@ -16279,16 +16280,16 @@ importers:
         version: 5.6.3(webpack@5.109.0)
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))
+        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2)
       jest-environment-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(supports-color@10.2.2)(typescript@5.4.5)
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
       jest-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(puppeteer@23.10.3(supports-color@10.2.2)(typescript@5.4.5))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(puppeteer@23.10.3)(supports-color@10.2.2)(typescript@5.4.5)
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
@@ -16312,7 +16313,7 @@ importers:
         version: 3.0.1
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.29.7(supports-color@10.2.2))(@jest/transform@29.7.0(supports-color@10.2.2))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(jest@29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0)(jest@29.7.0)(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.109.0)
@@ -16409,7 +16410,7 @@ importers:
         version: '@fluidframework/devtools-core@2.111.0(supports-color@10.2.2)'
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/id-compressor':
         specifier: workspace:~
         version: link:../../../runtime/id-compressor
@@ -16445,10 +16446,10 @@ importers:
         version: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
       eslint-config-prettier:
         specifier: catalog:eslint
-        version: 10.1.8(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))
+        version: 10.1.8(eslint@9.39.1)
       eslint-plugin-chai-expect:
         specifier: ~3.1.0
-        version: 3.1.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))
+        version: 3.1.0(eslint@9.39.1)
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
@@ -16469,7 +16470,7 @@ importers:
     dependencies:
       '@fluentui/react-components':
         specifier: ^9.47.5
-        version: 9.56.5(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
+        version: 9.56.5(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
       '@fluentui/react-icons':
         specifier: ^2.0.233
         version: 2.0.266(react@18.3.1)
@@ -16541,7 +16542,7 @@ importers:
         version: link:../../../dds/tree
       re-resizable:
         specifier: ^6.9.9
-        version: 6.10.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 6.10.3(react-dom@18.3.1)(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -16566,7 +16567,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/test-utils':
         specifier: workspace:~
         version: link:../../../test/test-utils
@@ -16578,7 +16579,7 @@ importers:
         version: 5.17.0
       '@testing-library/react':
         specifier: ^16.3.0
-        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@testing-library/user-event':
         specifier: ^14.4.3
         version: 14.5.2(@testing-library/dom@10.4.1)
@@ -16608,28 +16609,28 @@ importers:
         version: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
       eslint-config-prettier:
         specifier: catalog:eslint
-        version: 10.1.8(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))
+        version: 10.1.8(eslint@9.39.1)
       eslint-plugin-jest:
         specifier: ~29.5.0
-        version: 29.5.0(@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(jest@29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 29.5.0(@typescript-eslint/eslint-plugin@8.54.0)(eslint@9.39.1)(jest@29.7.0)(supports-color@10.2.2)(typescript@5.4.5)
       eslint-plugin-react:
         specifier: ~7.37.5
-        version: 7.37.5(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))
+        version: 7.37.5(eslint@9.39.1)
       eslint-plugin-react-hooks:
         specifier: ~7.0.1
-        version: 7.0.1(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 7.0.1(eslint@9.39.1)(supports-color@10.2.2)
       html-webpack-plugin:
         specifier: ^5.6.0
         version: 5.6.3(webpack@5.109.0)
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))
+        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2)
       jest-environment-jsdom:
         specifier: ^29.6.2
         version: 29.7.0(supports-color@10.2.2)
       jest-environment-puppeteer:
         specifier: ^10.1.3
-        version: 10.1.4(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 10.1.4(debug@4.4.3)(supports-color@10.2.2)(typescript@5.4.5)
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
@@ -16644,7 +16645,7 @@ importers:
         version: 6.1.3
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.29.7(supports-color@10.2.2))(@jest/transform@29.7.0(supports-color@10.2.2))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(jest@29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0)(jest@29.7.0)(typescript@5.4.5)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.4.5)(webpack@5.109.0)
@@ -16659,7 +16660,7 @@ importers:
         version: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.6)(webpack@5.109.0)
       webpack-dev-server:
         specifier: ~5.2.6
-        version: 5.2.6(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
+        version: 5.2.6(debug@4.4.3)(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
       webpack-merge:
         specifier: ^6.0.1
         version: 6.0.1
@@ -16668,10 +16669,10 @@ importers:
     dependencies:
       '@fluentui/react':
         specifier: ^8.109.4
-        version: 8.121.13(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 8.121.13(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-components':
         specifier: ^9.47.5
-        version: 9.56.5(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
+        version: 9.56.5(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
       '@fluentui/react-hooks':
         specifier: ^8.6.24
         version: 8.8.16(@types/react@18.3.15)(react@18.3.1)
@@ -16710,10 +16711,10 @@ importers:
         version: 18.3.1(react@18.3.1)
       react-split-pane:
         specifier: ^0.1.92
-        version: 0.1.92(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 0.1.92(react-dom@18.3.1)(react@18.3.1)
       recharts:
         specifier: ^2.7.2
-        version: 2.14.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 2.14.1(react-dom@18.3.1)(react@18.3.1)
       scheduler:
         specifier: ^0.20.0
         version: 0.20.2
@@ -16738,7 +16739,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/shared-object-base':
         specifier: workspace:~
         version: link:../../../dds/shared-object-base
@@ -16753,7 +16754,7 @@ importers:
         version: 5.17.0
       '@testing-library/react':
         specifier: ^16.3.0
-        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@testing-library/user-event':
         specifier: ^14.4.3
         version: 14.5.2(@testing-library/dom@10.4.1)
@@ -16798,22 +16799,22 @@ importers:
         version: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
       eslint-config-prettier:
         specifier: catalog:eslint
-        version: 10.1.8(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))
+        version: 10.1.8(eslint@9.39.1)
       eslint-plugin-jest:
         specifier: ~29.5.0
-        version: 29.5.0(@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(jest@29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 29.5.0(@typescript-eslint/eslint-plugin@8.54.0)(eslint@9.39.1)(jest@29.7.0)(supports-color@10.2.2)(typescript@5.4.5)
       eslint-plugin-react:
         specifier: ~7.37.5
-        version: 7.37.5(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))
+        version: 7.37.5(eslint@9.39.1)
       eslint-plugin-react-hooks:
         specifier: ~7.0.1
-        version: 7.0.1(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 7.0.1(eslint@9.39.1)(supports-color@10.2.2)
       globby:
         specifier: ^13.2.2
         version: 13.2.2
       jest:
         specifier: ^29.6.2
-        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))
+        version: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2)
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
@@ -16840,7 +16841,7 @@ importers:
         version: 3.36.0(supports-color@10.2.2)
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.29.7(supports-color@10.2.2))(@jest/transform@29.7.0(supports-color@10.2.2))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(jest@29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0)(jest@29.7.0)(typescript@5.4.5)
       typescript:
         specifier: ~5.4.5
         version: 5.4.5
@@ -16910,7 +16911,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@types/node':
         specifier: ~22.19.17
         version: 22.19.17
@@ -16983,7 +16984,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/fluid-runner-previous':
         specifier: npm:@fluidframework/fluid-runner@2.111.0
         version: '@fluidframework/fluid-runner@2.111.0(supports-color@10.2.2)'
@@ -17134,7 +17135,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@types/json-stable-stringify':
         specifier: ^1.0.32
         version: 1.1.0
@@ -17201,7 +17202,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/odsp-doclib-utils-previous':
         specifier: npm:@fluidframework/odsp-doclib-utils@2.111.0
         version: '@fluidframework/odsp-doclib-utils@2.111.0(supports-color@10.2.2)'
@@ -17286,7 +17287,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/telemetry-utils-previous':
         specifier: npm:@fluidframework/telemetry-utils@2.111.0
         version: '@fluidframework/telemetry-utils@2.111.0(supports-color@10.2.2)'
@@ -17383,7 +17384,7 @@ importers:
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
-        version: 13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+        version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/tool-utils-previous':
         specifier: npm:@fluidframework/tool-utils@2.111.0
         version: '@fluidframework/tool-utils@2.111.0(supports-color@10.2.2)'
@@ -17446,7 +17447,7 @@ importers:
         version: 4.1.2
       markdown-magic-package-scripts:
         specifier: ^1.2.2
-        version: 1.2.2(markdown-magic@2.6.1(supports-color@10.2.2))
+        version: 1.2.2(markdown-magic@2.6.1)
       yargs:
         specifier: 17.7.2
         version: 17.7.2
@@ -28643,8 +28644,8 @@ snapshots:
 
   '@asamuzakjp/css-color@3.2.0':
     dependencies:
-      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
-      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5)(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5)(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 10.4.3
@@ -28773,7 +28774,7 @@ snapshots:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
       '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@10.2.2)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)(supports-color@10.2.2)
       '@babel/helpers': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
@@ -28793,7 +28794,7 @@ snapshots:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
       '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)
       '@babel/helpers': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
@@ -28848,7 +28849,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@10.2.2)':
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)(supports-color@10.2.2)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-module-imports': 7.29.7(supports-color@10.2.2)
@@ -28857,7 +28858,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)(supports-color@8.1.1)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-module-imports': 7.29.7(supports-color@8.1.1)
@@ -28891,172 +28892,87 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
-  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.29.7(supports-color@10.2.2))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-plugin-utils': 7.25.9
-
-  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.29.7(supports-color@10.2.2))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-plugin-utils': 7.25.9
-
-  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.29.7(supports-color@10.2.2))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-plugin-utils': 7.25.9
-
-  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.29.7(supports-color@10.2.2))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-plugin-utils': 7.25.9
-
-  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-import-attributes@7.26.0(@babel/core@7.29.7(supports-color@10.2.2))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-plugin-utils': 7.25.9
-
-  '@babel/plugin-syntax-import-attributes@7.26.0(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-import-attributes@7.26.0(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.29.7(supports-color@10.2.2))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-plugin-utils': 7.25.9
-
-  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.29.7(supports-color@10.2.2))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-plugin-utils': 7.25.9
-
-  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-jsx@7.25.9(@babel/core@7.29.7(supports-color@10.2.2))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-plugin-utils': 7.25.9
-
-  '@babel/plugin-syntax-jsx@7.25.9(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-jsx@7.25.9(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.29.7(supports-color@10.2.2))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-plugin-utils': 7.25.9
-
-  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.29.7(supports-color@10.2.2))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-plugin-utils': 7.25.9
-
-  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.29.7(supports-color@10.2.2))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-plugin-utils': 7.25.9
-
-  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.29.7(supports-color@10.2.2))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-plugin-utils': 7.25.9
-
-  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.29.7(supports-color@10.2.2))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-plugin-utils': 7.25.9
-
-  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.29.7(supports-color@10.2.2))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-plugin-utils': 7.25.9
-
-  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.29.7(supports-color@10.2.2))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-plugin-utils': 7.25.9
-
-  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.29.7(supports-color@10.2.2))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-plugin-utils': 7.25.9
-
-  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-typescript@7.25.9(@babel/core@7.29.7(supports-color@10.2.2))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-plugin-utils': 7.25.9
-
-  '@babel/plugin-syntax-typescript@7.25.9(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/plugin-syntax-typescript@7.25.9(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.25.9
@@ -29309,15 +29225,15 @@ snapshots:
 
   '@csstools/color-helpers@5.1.0': {}
 
-  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5)(@csstools/css-tokenizer@3.0.4)':
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
 
-  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5)(@csstools/css-tokenizer@3.0.4)':
     dependencies:
       '@csstools/color-helpers': 5.1.0
-      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5)(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
 
@@ -29371,78 +29287,67 @@ snapshots:
 
   '@es-joy/resolve.exports@1.2.0': {}
 
-  '@eslint-community/eslint-plugin-eslint-comments@4.5.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))':
-    dependencies:
-      escape-string-regexp: 4.0.0
-      eslint: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
-      ignore: 5.3.2
-
-  '@eslint-community/eslint-plugin-eslint-comments@4.5.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))':
+  '@eslint-community/eslint-plugin-eslint-comments@4.5.0(eslint@9.39.1)':
     dependencies:
       escape-string-regexp: 4.0.0
       eslint: 9.39.1(jiti@2.6.1)(supports-color@8.1.1)
       ignore: 5.3.2
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))':
-    dependencies:
-      eslint: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
-      eslint-visitor-keys: 3.4.3
-
-  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.1)':
     dependencies:
       eslint: 9.39.1(jiti@2.6.1)(supports-color@8.1.1)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint-react/ast@2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)':
+  '@eslint-react/ast@2.13.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)':
     dependencies:
       '@eslint-react/eff': 2.13.0
       '@typescript-eslint/types': 8.61.0
       '@typescript-eslint/typescript-estree': 8.61.0(supports-color@10.2.2)(typescript@5.4.5)
-      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       eslint: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
       string-ts: 2.3.1
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint-react/ast@2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)':
+  '@eslint-react/ast@2.13.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)':
     dependencies:
       '@eslint-react/eff': 2.13.0
       '@typescript-eslint/types': 8.61.0
       '@typescript-eslint/typescript-estree': 8.61.0(supports-color@8.1.1)(typescript@5.4.5)
-      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
       eslint: 9.39.1(jiti@2.6.1)(supports-color@8.1.1)
       string-ts: 2.3.1
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint-react/core@2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)':
+  '@eslint-react/core@2.13.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)':
     dependencies:
-      '@eslint-react/ast': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+      '@eslint-react/ast': 2.13.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@eslint-react/eff': 2.13.0
-      '@eslint-react/shared': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
-      '@eslint-react/var': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+      '@eslint-react/shared': 2.13.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
+      '@eslint-react/var': 2.13.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@typescript-eslint/scope-manager': 8.61.0
       '@typescript-eslint/types': 8.61.0
-      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       eslint: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
       ts-pattern: 5.9.0
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint-react/core@2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)':
+  '@eslint-react/core@2.13.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)':
     dependencies:
-      '@eslint-react/ast': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
+      '@eslint-react/ast': 2.13.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
       '@eslint-react/eff': 2.13.0
-      '@eslint-react/shared': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
-      '@eslint-react/var': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
+      '@eslint-react/shared': 2.13.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
+      '@eslint-react/var': 2.13.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
       '@typescript-eslint/scope-manager': 8.61.0
       '@typescript-eslint/types': 8.61.0
-      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
       eslint: 9.39.1(jiti@2.6.1)(supports-color@8.1.1)
       ts-pattern: 5.9.0
       typescript: 5.4.5
@@ -29451,50 +29356,50 @@ snapshots:
 
   '@eslint-react/eff@2.13.0': {}
 
-  '@eslint-react/eslint-plugin@2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)':
+  '@eslint-react/eslint-plugin@2.13.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)':
     dependencies:
       '@eslint-react/eff': 2.13.0
-      '@eslint-react/shared': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+      '@eslint-react/shared': 2.13.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@typescript-eslint/scope-manager': 8.61.0
-      '@typescript-eslint/type-utils': 8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+      '@typescript-eslint/type-utils': 8.61.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@typescript-eslint/types': 8.61.0
-      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       eslint: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
-      eslint-plugin-react-dom: 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
-      eslint-plugin-react-hooks-extra: 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
-      eslint-plugin-react-naming-convention: 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
-      eslint-plugin-react-rsc: 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
-      eslint-plugin-react-web-api: 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
-      eslint-plugin-react-x: 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+      eslint-plugin-react-dom: 2.13.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
+      eslint-plugin-react-hooks-extra: 2.13.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
+      eslint-plugin-react-naming-convention: 2.13.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
+      eslint-plugin-react-rsc: 2.13.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
+      eslint-plugin-react-web-api: 2.13.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
+      eslint-plugin-react-x: 2.13.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       ts-api-utils: 2.5.0(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint-react/eslint-plugin@2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)':
+  '@eslint-react/eslint-plugin@2.13.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)':
     dependencies:
       '@eslint-react/eff': 2.13.0
-      '@eslint-react/shared': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
+      '@eslint-react/shared': 2.13.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
       '@typescript-eslint/scope-manager': 8.61.0
-      '@typescript-eslint/type-utils': 8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
+      '@typescript-eslint/type-utils': 8.61.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
       '@typescript-eslint/types': 8.61.0
-      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
       eslint: 9.39.1(jiti@2.6.1)(supports-color@8.1.1)
-      eslint-plugin-react-dom: 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
-      eslint-plugin-react-hooks-extra: 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
-      eslint-plugin-react-naming-convention: 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
-      eslint-plugin-react-rsc: 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
-      eslint-plugin-react-web-api: 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
-      eslint-plugin-react-x: 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
+      eslint-plugin-react-dom: 2.13.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
+      eslint-plugin-react-hooks-extra: 2.13.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
+      eslint-plugin-react-naming-convention: 2.13.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
+      eslint-plugin-react-rsc: 2.13.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
+      eslint-plugin-react-web-api: 2.13.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
+      eslint-plugin-react-x: 2.13.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
       ts-api-utils: 2.5.0(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint-react/shared@2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)':
+  '@eslint-react/shared@2.13.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)':
     dependencies:
       '@eslint-react/eff': 2.13.0
-      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       eslint: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
       ts-pattern: 5.9.0
       typescript: 5.4.5
@@ -29502,10 +29407,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint-react/shared@2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)':
+  '@eslint-react/shared@2.13.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)':
     dependencies:
       '@eslint-react/eff': 2.13.0
-      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
       eslint: 9.39.1(jiti@2.6.1)(supports-color@8.1.1)
       ts-pattern: 5.9.0
       typescript: 5.4.5
@@ -29513,28 +29418,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint-react/var@2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)':
+  '@eslint-react/var@2.13.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)':
     dependencies:
-      '@eslint-react/ast': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+      '@eslint-react/ast': 2.13.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@eslint-react/eff': 2.13.0
-      '@eslint-react/shared': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+      '@eslint-react/shared': 2.13.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@typescript-eslint/scope-manager': 8.61.0
       '@typescript-eslint/types': 8.61.0
-      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       eslint: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
       ts-pattern: 5.9.0
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint-react/var@2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)':
+  '@eslint-react/var@2.13.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)':
     dependencies:
-      '@eslint-react/ast': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
+      '@eslint-react/ast': 2.13.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
       '@eslint-react/eff': 2.13.0
-      '@eslint-react/shared': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
+      '@eslint-react/shared': 2.13.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
       '@typescript-eslint/scope-manager': 8.61.0
       '@typescript-eslint/types': 8.61.0
-      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
       eslint: 9.39.1(jiti@2.6.1)(supports-color@8.1.1)
       ts-pattern: 5.9.0
       typescript: 5.4.5
@@ -29666,16 +29571,16 @@ snapshots:
     dependencies:
       '@swc/helpers': 0.5.15
 
-  '@fluentui/react-accordion@9.5.11(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)':
+  '@fluentui/react-accordion@9.5.11(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)':
     dependencies:
-      '@fluentui/react-aria': 9.13.11(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-context-selector': 9.1.70(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-aria': 9.13.11(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-context-selector': 9.1.70(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
       '@fluentui/react-icons': 2.0.266(react@18.3.1)
       '@fluentui/react-jsx-runtime': 9.0.47(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-motion': 9.6.4(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-motion-components-preview': 0.4.0(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-motion': 9.6.4(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-motion-components-preview': 0.4.0(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-shared-contexts': 9.21.1(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-theme': 9.1.23
       '@fluentui/react-utilities': 9.18.18(@types/react@18.3.15)(react@18.3.1)
       '@griffel/react': 1.5.27(react@18.3.1)
@@ -29687,13 +29592,13 @@ snapshots:
     transitivePeerDependencies:
       - scheduler
 
-  '@fluentui/react-alert@9.0.0-beta.124(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)':
+  '@fluentui/react-alert@9.0.0-beta.124(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)':
     dependencies:
-      '@fluentui/react-avatar': 9.6.45(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
-      '@fluentui/react-button': 9.3.97(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-avatar': 9.6.45(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-button': 9.3.97(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-icons': 2.0.266(react@18.3.1)
       '@fluentui/react-jsx-runtime': 9.0.47(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-theme': 9.1.23
       '@fluentui/react-utilities': 9.18.18(@types/react@18.3.15)(react@18.3.1)
       '@griffel/react': 1.5.27(react@18.3.1)
@@ -29705,12 +29610,12 @@ snapshots:
     transitivePeerDependencies:
       - scheduler
 
-  '@fluentui/react-aria@9.13.11(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@fluentui/react-aria@9.13.11(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)':
     dependencies:
       '@fluentui/keyboard-keys': 9.0.8
       '@fluentui/react-jsx-runtime': 9.0.47(@types/react@18.3.15)(react@18.3.1)
       '@fluentui/react-shared-contexts': 9.21.1(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-utilities': 9.18.18(@types/react@18.3.15)(react@18.3.1)
       '@swc/helpers': 0.5.15
       '@types/react': 18.3.15
@@ -29718,17 +29623,17 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@fluentui/react-avatar@9.6.45(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)':
+  '@fluentui/react-avatar@9.6.45(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)':
     dependencies:
-      '@fluentui/react-badge': 9.2.47(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-context-selector': 9.1.70(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-badge': 9.2.47(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-context-selector': 9.1.70(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
       '@fluentui/react-icons': 2.0.266(react@18.3.1)
       '@fluentui/react-jsx-runtime': 9.0.47(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-popover': 9.9.27(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-popover': 9.9.27(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
       '@fluentui/react-shared-contexts': 9.21.1(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-theme': 9.1.23
-      '@fluentui/react-tooltip': 9.5.1(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-tooltip': 9.5.1(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-utilities': 9.18.18(@types/react@18.3.15)(react@18.3.1)
       '@griffel/react': 1.5.27(react@18.3.1)
       '@swc/helpers': 0.5.15
@@ -29739,7 +29644,7 @@ snapshots:
     transitivePeerDependencies:
       - scheduler
 
-  '@fluentui/react-badge@9.2.47(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@fluentui/react-badge@9.2.47(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)':
     dependencies:
       '@fluentui/react-icons': 2.0.266(react@18.3.1)
       '@fluentui/react-jsx-runtime': 9.0.47(@types/react@18.3.15)(react@18.3.1)
@@ -29753,15 +29658,15 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@fluentui/react-breadcrumb@9.0.45(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@fluentui/react-breadcrumb@9.0.45(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)':
     dependencies:
-      '@fluentui/react-aria': 9.13.11(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-button': 9.3.97(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-aria': 9.13.11(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-button': 9.3.97(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-icons': 2.0.266(react@18.3.1)
       '@fluentui/react-jsx-runtime': 9.0.47(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-link': 9.3.4(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-link': 9.3.4(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-shared-contexts': 9.21.1(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-theme': 9.1.23
       '@fluentui/react-utilities': 9.18.18(@types/react@18.3.15)(react@18.3.1)
       '@griffel/react': 1.5.27(react@18.3.1)
@@ -29771,14 +29676,14 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@fluentui/react-button@9.3.97(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@fluentui/react-button@9.3.97(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)':
     dependencies:
       '@fluentui/keyboard-keys': 9.0.8
-      '@fluentui/react-aria': 9.13.11(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-aria': 9.13.11(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-icons': 2.0.266(react@18.3.1)
       '@fluentui/react-jsx-runtime': 9.0.47(@types/react@18.3.15)(react@18.3.1)
       '@fluentui/react-shared-contexts': 9.21.1(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-theme': 9.1.23
       '@fluentui/react-utilities': 9.18.18(@types/react@18.3.15)(react@18.3.1)
       '@griffel/react': 1.5.27(react@18.3.1)
@@ -29788,12 +29693,12 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@fluentui/react-card@9.0.99(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@fluentui/react-card@9.0.99(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)':
     dependencies:
       '@fluentui/keyboard-keys': 9.0.8
       '@fluentui/react-jsx-runtime': 9.0.47(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-text': 9.4.29(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-text': 9.4.29(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-theme': 9.1.23
       '@fluentui/react-utilities': 9.18.18(@types/react@18.3.15)(react@18.3.1)
       '@griffel/react': 1.5.27(react@18.3.1)
@@ -29803,15 +29708,15 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@fluentui/react-carousel@9.4.2(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)':
+  '@fluentui/react-carousel@9.4.2(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)':
     dependencies:
-      '@fluentui/react-aria': 9.13.11(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-button': 9.3.97(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-context-selector': 9.1.70(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-aria': 9.13.11(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-button': 9.3.97(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-context-selector': 9.1.70(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
       '@fluentui/react-icons': 2.0.266(react@18.3.1)
       '@fluentui/react-jsx-runtime': 9.0.47(@types/react@18.3.15)(react@18.3.1)
       '@fluentui/react-shared-contexts': 9.21.1(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-theme': 9.1.23
       '@fluentui/react-utilities': 9.18.18(@types/react@18.3.15)(react@18.3.1)
       '@griffel/react': 1.5.27(react@18.3.1)
@@ -29826,14 +29731,14 @@ snapshots:
     transitivePeerDependencies:
       - scheduler
 
-  '@fluentui/react-checkbox@9.2.43(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)':
+  '@fluentui/react-checkbox@9.2.43(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)':
     dependencies:
-      '@fluentui/react-field': 9.1.82(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-field': 9.1.82(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
       '@fluentui/react-icons': 2.0.266(react@18.3.1)
       '@fluentui/react-jsx-runtime': 9.0.47(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-label': 9.1.80(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-label': 9.1.80(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-shared-contexts': 9.21.1(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-theme': 9.1.23
       '@fluentui/react-utilities': 9.18.18(@types/react@18.3.15)(react@18.3.1)
       '@griffel/react': 1.5.27(react@18.3.1)
@@ -29845,18 +29750,18 @@ snapshots:
     transitivePeerDependencies:
       - scheduler
 
-  '@fluentui/react-combobox@9.13.14(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)':
+  '@fluentui/react-combobox@9.13.14(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)':
     dependencies:
       '@fluentui/keyboard-keys': 9.0.8
-      '@fluentui/react-aria': 9.13.11(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-context-selector': 9.1.70(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
-      '@fluentui/react-field': 9.1.82(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-aria': 9.13.11(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-context-selector': 9.1.70(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-field': 9.1.82(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
       '@fluentui/react-icons': 2.0.266(react@18.3.1)
       '@fluentui/react-jsx-runtime': 9.0.47(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-portal': 9.4.39(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-positioning': 9.15.14(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-portal': 9.4.39(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-positioning': 9.15.14(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-shared-contexts': 9.21.1(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-theme': 9.1.23
       '@fluentui/react-utilities': 9.18.18(@types/react@18.3.15)(react@18.3.1)
       '@griffel/react': 1.5.27(react@18.3.1)
@@ -29868,65 +29773,65 @@ snapshots:
     transitivePeerDependencies:
       - scheduler
 
-  '@fluentui/react-components@9.56.5(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)':
+  '@fluentui/react-components@9.56.5(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)':
     dependencies:
-      '@fluentui/react-accordion': 9.5.11(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
-      '@fluentui/react-alert': 9.0.0-beta.124(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
-      '@fluentui/react-aria': 9.13.11(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-avatar': 9.6.45(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
-      '@fluentui/react-badge': 9.2.47(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-breadcrumb': 9.0.45(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-button': 9.3.97(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-card': 9.0.99(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-carousel': 9.4.2(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
-      '@fluentui/react-checkbox': 9.2.43(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
-      '@fluentui/react-combobox': 9.13.14(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
-      '@fluentui/react-dialog': 9.11.24(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
-      '@fluentui/react-divider': 9.2.79(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-drawer': 9.6.4(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
-      '@fluentui/react-field': 9.1.82(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
-      '@fluentui/react-image': 9.1.77(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-infobutton': 9.0.0-beta.102(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
-      '@fluentui/react-infolabel': 9.0.52(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
-      '@fluentui/react-input': 9.4.95(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
-      '@fluentui/react-label': 9.1.80(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-link': 9.3.4(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-menu': 9.14.22(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
-      '@fluentui/react-message-bar': 9.2.17(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-motion': 9.6.4(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-overflow': 9.2.3(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
-      '@fluentui/react-persona': 9.2.104(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
-      '@fluentui/react-popover': 9.9.27(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
-      '@fluentui/react-portal': 9.4.39(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-positioning': 9.15.14(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-progress': 9.1.93(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
-      '@fluentui/react-provider': 9.18.1(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-radio': 9.2.38(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
-      '@fluentui/react-rating': 9.0.24(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-search': 9.0.25(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
-      '@fluentui/react-select': 9.1.93(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-accordion': 9.5.11(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-alert': 9.0.0-beta.124(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-aria': 9.13.11(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-avatar': 9.6.45(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-badge': 9.2.47(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-breadcrumb': 9.0.45(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-button': 9.3.97(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-card': 9.0.99(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-carousel': 9.4.2(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-checkbox': 9.2.43(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-combobox': 9.13.14(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-dialog': 9.11.24(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-divider': 9.2.79(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-drawer': 9.6.4(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-field': 9.1.82(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-image': 9.1.77(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-infobutton': 9.0.0-beta.102(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-infolabel': 9.0.52(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-input': 9.4.95(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-label': 9.1.80(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-link': 9.3.4(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-menu': 9.14.22(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-message-bar': 9.2.17(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-motion': 9.6.4(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-overflow': 9.2.3(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-persona': 9.2.104(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-popover': 9.9.27(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-portal': 9.4.39(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-positioning': 9.15.14(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-progress': 9.1.93(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-provider': 9.18.1(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-radio': 9.2.38(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-rating': 9.0.24(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-search': 9.0.25(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-select': 9.1.93(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
       '@fluentui/react-shared-contexts': 9.21.1(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-skeleton': 9.1.22(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
-      '@fluentui/react-slider': 9.2.2(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
-      '@fluentui/react-spinbutton': 9.2.94(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
-      '@fluentui/react-spinner': 9.5.4(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-swatch-picker': 9.1.16(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
-      '@fluentui/react-switch': 9.1.100(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
-      '@fluentui/react-table': 9.15.24(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
-      '@fluentui/react-tabs': 9.6.4(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
-      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-tag-picker': 9.3.11(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
-      '@fluentui/react-tags': 9.3.25(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
-      '@fluentui/react-teaching-popover': 9.1.24(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
-      '@fluentui/react-text': 9.4.29(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-textarea': 9.3.94(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-skeleton': 9.1.22(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-slider': 9.2.2(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-spinbutton': 9.2.94(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-spinner': 9.5.4(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-swatch-picker': 9.1.16(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-switch': 9.1.100(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-table': 9.15.24(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-tabs': 9.6.4(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-tag-picker': 9.3.11(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-tags': 9.3.25(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-teaching-popover': 9.1.24(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-text': 9.4.29(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-textarea': 9.3.94(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
       '@fluentui/react-theme': 9.1.23
-      '@fluentui/react-toast': 9.3.62(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-toolbar': 9.2.12(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
-      '@fluentui/react-tooltip': 9.5.1(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-tree': 9.8.9(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-toast': 9.3.62(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-toolbar': 9.2.12(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-tooltip': 9.5.1(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-tree': 9.8.9(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
       '@fluentui/react-utilities': 9.18.18(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-virtualizer': 9.0.0-alpha.88(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-virtualizer': 9.0.0-alpha.88(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@griffel/react': 1.5.27(react@18.3.1)
       '@swc/helpers': 0.5.15
       '@types/react': 18.3.15
@@ -29936,7 +29841,7 @@ snapshots:
     transitivePeerDependencies:
       - scheduler
 
-  '@fluentui/react-context-selector@9.1.70(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)':
+  '@fluentui/react-context-selector@9.1.70(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)':
     dependencies:
       '@fluentui/react-utilities': 9.18.18(@types/react@18.3.15)(react@18.3.1)
       '@swc/helpers': 0.5.15
@@ -29946,18 +29851,18 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       scheduler: 0.20.2
 
-  '@fluentui/react-dialog@9.11.24(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)':
+  '@fluentui/react-dialog@9.11.24(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)':
     dependencies:
       '@fluentui/keyboard-keys': 9.0.8
-      '@fluentui/react-aria': 9.13.11(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-context-selector': 9.1.70(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-aria': 9.13.11(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-context-selector': 9.1.70(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
       '@fluentui/react-icons': 2.0.266(react@18.3.1)
       '@fluentui/react-jsx-runtime': 9.0.47(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-motion': 9.6.4(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-motion-components-preview': 0.4.0(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-portal': 9.4.39(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-motion': 9.6.4(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-motion-components-preview': 0.4.0(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-portal': 9.4.39(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-shared-contexts': 9.21.1(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-theme': 9.1.23
       '@fluentui/react-utilities': 9.18.18(@types/react@18.3.15)(react@18.3.1)
       '@griffel/react': 1.5.27(react@18.3.1)
@@ -29969,7 +29874,7 @@ snapshots:
     transitivePeerDependencies:
       - scheduler
 
-  '@fluentui/react-divider@9.2.79(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@fluentui/react-divider@9.2.79(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)':
     dependencies:
       '@fluentui/react-jsx-runtime': 9.0.47(@types/react@18.3.15)(react@18.3.1)
       '@fluentui/react-shared-contexts': 9.21.1(@types/react@18.3.15)(react@18.3.1)
@@ -29982,14 +29887,14 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@fluentui/react-drawer@9.6.4(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)':
+  '@fluentui/react-drawer@9.6.4(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)':
     dependencies:
-      '@fluentui/react-dialog': 9.11.24(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-dialog': 9.11.24(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
       '@fluentui/react-jsx-runtime': 9.0.47(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-motion': 9.6.4(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-portal': 9.4.39(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-motion': 9.6.4(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-portal': 9.4.39(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-shared-contexts': 9.21.1(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-theme': 9.1.23
       '@fluentui/react-utilities': 9.18.18(@types/react@18.3.15)(react@18.3.1)
       '@griffel/react': 1.5.27(react@18.3.1)
@@ -30001,12 +29906,12 @@ snapshots:
     transitivePeerDependencies:
       - scheduler
 
-  '@fluentui/react-field@9.1.82(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)':
+  '@fluentui/react-field@9.1.82(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)':
     dependencies:
-      '@fluentui/react-context-selector': 9.1.70(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-context-selector': 9.1.70(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
       '@fluentui/react-icons': 2.0.266(react@18.3.1)
       '@fluentui/react-jsx-runtime': 9.0.47(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-label': 9.1.80(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-label': 9.1.80(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-theme': 9.1.23
       '@fluentui/react-utilities': 9.18.18(@types/react@18.3.15)(react@18.3.1)
       '@griffel/react': 1.5.27(react@18.3.1)
@@ -30044,7 +29949,7 @@ snapshots:
       react: 18.3.1
       tslib: 2.8.1
 
-  '@fluentui/react-image@9.1.77(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@fluentui/react-image@9.1.77(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)':
     dependencies:
       '@fluentui/react-jsx-runtime': 9.0.47(@types/react@18.3.15)(react@18.3.1)
       '@fluentui/react-shared-contexts': 9.21.1(@types/react@18.3.15)(react@18.3.1)
@@ -30057,13 +29962,13 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@fluentui/react-infobutton@9.0.0-beta.102(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)':
+  '@fluentui/react-infobutton@9.0.0-beta.102(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)':
     dependencies:
       '@fluentui/react-icons': 2.0.266(react@18.3.1)
       '@fluentui/react-jsx-runtime': 9.0.47(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-label': 9.1.80(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-popover': 9.9.27(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
-      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-label': 9.1.80(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-popover': 9.9.27(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-theme': 9.1.23
       '@fluentui/react-utilities': 9.18.18(@types/react@18.3.15)(react@18.3.1)
       '@griffel/react': 1.5.27(react@18.3.1)
@@ -30075,13 +29980,13 @@ snapshots:
     transitivePeerDependencies:
       - scheduler
 
-  '@fluentui/react-infolabel@9.0.52(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)':
+  '@fluentui/react-infolabel@9.0.52(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)':
     dependencies:
       '@fluentui/react-icons': 2.0.266(react@18.3.1)
       '@fluentui/react-jsx-runtime': 9.0.47(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-label': 9.1.80(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-popover': 9.9.27(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
-      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-label': 9.1.80(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-popover': 9.9.27(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-theme': 9.1.23
       '@fluentui/react-utilities': 9.18.18(@types/react@18.3.15)(react@18.3.1)
       '@griffel/react': 1.5.27(react@18.3.1)
@@ -30093,9 +29998,9 @@ snapshots:
     transitivePeerDependencies:
       - scheduler
 
-  '@fluentui/react-input@9.4.95(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)':
+  '@fluentui/react-input@9.4.95(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)':
     dependencies:
-      '@fluentui/react-field': 9.1.82(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-field': 9.1.82(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
       '@fluentui/react-jsx-runtime': 9.0.47(@types/react@18.3.15)(react@18.3.1)
       '@fluentui/react-shared-contexts': 9.21.1(@types/react@18.3.15)(react@18.3.1)
       '@fluentui/react-theme': 9.1.23
@@ -30117,7 +30022,7 @@ snapshots:
       react: 18.3.1
       react-is: 17.0.2
 
-  '@fluentui/react-label@9.1.80(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@fluentui/react-label@9.1.80(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)':
     dependencies:
       '@fluentui/react-jsx-runtime': 9.0.47(@types/react@18.3.15)(react@18.3.1)
       '@fluentui/react-shared-contexts': 9.21.1(@types/react@18.3.15)(react@18.3.1)
@@ -30130,12 +30035,12 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@fluentui/react-link@9.3.4(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@fluentui/react-link@9.3.4(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)':
     dependencies:
       '@fluentui/keyboard-keys': 9.0.8
       '@fluentui/react-jsx-runtime': 9.0.47(@types/react@18.3.15)(react@18.3.1)
       '@fluentui/react-shared-contexts': 9.21.1(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-theme': 9.1.23
       '@fluentui/react-utilities': 9.18.18(@types/react@18.3.15)(react@18.3.1)
       '@griffel/react': 1.5.27(react@18.3.1)
@@ -30145,17 +30050,17 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@fluentui/react-menu@9.14.22(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)':
+  '@fluentui/react-menu@9.14.22(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)':
     dependencies:
       '@fluentui/keyboard-keys': 9.0.8
-      '@fluentui/react-aria': 9.13.11(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-context-selector': 9.1.70(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-aria': 9.13.11(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-context-selector': 9.1.70(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
       '@fluentui/react-icons': 2.0.266(react@18.3.1)
       '@fluentui/react-jsx-runtime': 9.0.47(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-portal': 9.4.39(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-positioning': 9.15.14(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-portal': 9.4.39(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-positioning': 9.15.14(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-shared-contexts': 9.21.1(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-theme': 9.1.23
       '@fluentui/react-utilities': 9.18.18(@types/react@18.3.15)(react@18.3.1)
       '@griffel/react': 1.5.27(react@18.3.1)
@@ -30167,12 +30072,12 @@ snapshots:
     transitivePeerDependencies:
       - scheduler
 
-  '@fluentui/react-message-bar@9.2.17(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@fluentui/react-message-bar@9.2.17(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)':
     dependencies:
-      '@fluentui/react-button': 9.3.97(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-button': 9.3.97(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-icons': 2.0.266(react@18.3.1)
       '@fluentui/react-jsx-runtime': 9.0.47(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-link': 9.3.4(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-link': 9.3.4(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-shared-contexts': 9.21.1(@types/react@18.3.15)(react@18.3.1)
       '@fluentui/react-theme': 9.1.23
       '@fluentui/react-utilities': 9.18.18(@types/react@18.3.15)(react@18.3.1)
@@ -30182,18 +30087,18 @@ snapshots:
       '@types/react-dom': 18.3.3(@types/react@18.3.15)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      react-transition-group: 4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-transition-group: 4.4.5(react-dom@18.3.1)(react@18.3.1)
 
-  '@fluentui/react-motion-components-preview@0.4.0(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@fluentui/react-motion-components-preview@0.4.0(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)':
     dependencies:
-      '@fluentui/react-motion': 9.6.4(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-motion': 9.6.4(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@swc/helpers': 0.5.15
       '@types/react': 18.3.15
       '@types/react-dom': 18.3.3(@types/react@18.3.15)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@fluentui/react-motion@9.6.4(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@fluentui/react-motion@9.6.4(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)':
     dependencies:
       '@fluentui/react-shared-contexts': 9.21.1(@types/react@18.3.15)(react@18.3.1)
       '@fluentui/react-utilities': 9.18.18(@types/react@18.3.15)(react@18.3.1)
@@ -30204,10 +30109,10 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       react-is: 17.0.2
 
-  '@fluentui/react-overflow@9.2.3(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)':
+  '@fluentui/react-overflow@9.2.3(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)':
     dependencies:
       '@fluentui/priority-overflow': 9.1.14
-      '@fluentui/react-context-selector': 9.1.70(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-context-selector': 9.1.70(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
       '@fluentui/react-theme': 9.1.23
       '@fluentui/react-utilities': 9.18.18(@types/react@18.3.15)(react@18.3.1)
       '@griffel/react': 1.5.27(react@18.3.1)
@@ -30219,10 +30124,10 @@ snapshots:
     transitivePeerDependencies:
       - scheduler
 
-  '@fluentui/react-persona@9.2.104(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)':
+  '@fluentui/react-persona@9.2.104(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)':
     dependencies:
-      '@fluentui/react-avatar': 9.6.45(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
-      '@fluentui/react-badge': 9.2.47(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-avatar': 9.6.45(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-badge': 9.2.47(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-jsx-runtime': 9.0.47(@types/react@18.3.15)(react@18.3.1)
       '@fluentui/react-shared-contexts': 9.21.1(@types/react@18.3.15)(react@18.3.1)
       '@fluentui/react-theme': 9.1.23
@@ -30236,16 +30141,16 @@ snapshots:
     transitivePeerDependencies:
       - scheduler
 
-  '@fluentui/react-popover@9.9.27(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)':
+  '@fluentui/react-popover@9.9.27(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)':
     dependencies:
       '@fluentui/keyboard-keys': 9.0.8
-      '@fluentui/react-aria': 9.13.11(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-context-selector': 9.1.70(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-aria': 9.13.11(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-context-selector': 9.1.70(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
       '@fluentui/react-jsx-runtime': 9.0.47(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-portal': 9.4.39(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-positioning': 9.15.14(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-portal': 9.4.39(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-positioning': 9.15.14(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-shared-contexts': 9.21.1(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-theme': 9.1.23
       '@fluentui/react-utilities': 9.18.18(@types/react@18.3.15)(react@18.3.1)
       '@griffel/react': 1.5.27(react@18.3.1)
@@ -30263,10 +30168,10 @@ snapshots:
       '@types/react': 18.3.15
       react: 18.3.1
 
-  '@fluentui/react-portal@9.4.39(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@fluentui/react-portal@9.4.39(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)':
     dependencies:
       '@fluentui/react-shared-contexts': 9.21.1(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-utilities': 9.18.18(@types/react@18.3.15)(react@18.3.1)
       '@griffel/react': 1.5.27(react@18.3.1)
       '@swc/helpers': 0.5.15
@@ -30274,9 +30179,9 @@ snapshots:
       '@types/react-dom': 18.3.3(@types/react@18.3.15)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      use-disposable: 1.0.4(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      use-disposable: 1.0.4(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
 
-  '@fluentui/react-positioning@9.15.14(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@fluentui/react-positioning@9.15.14(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)':
     dependencies:
       '@floating-ui/devtools': 0.2.1(@floating-ui/dom@1.5.4)
       '@floating-ui/dom': 1.5.4
@@ -30290,9 +30195,9 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@fluentui/react-progress@9.1.93(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)':
+  '@fluentui/react-progress@9.1.93(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)':
     dependencies:
-      '@fluentui/react-field': 9.1.82(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-field': 9.1.82(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
       '@fluentui/react-jsx-runtime': 9.0.47(@types/react@18.3.15)(react@18.3.1)
       '@fluentui/react-shared-contexts': 9.21.1(@types/react@18.3.15)(react@18.3.1)
       '@fluentui/react-theme': 9.1.23
@@ -30306,12 +30211,12 @@ snapshots:
     transitivePeerDependencies:
       - scheduler
 
-  '@fluentui/react-provider@9.18.1(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@fluentui/react-provider@9.18.1(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)':
     dependencies:
       '@fluentui/react-icons': 2.0.266(react@18.3.1)
       '@fluentui/react-jsx-runtime': 9.0.47(@types/react@18.3.15)(react@18.3.1)
       '@fluentui/react-shared-contexts': 9.21.1(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-theme': 9.1.23
       '@fluentui/react-utilities': 9.18.18(@types/react@18.3.15)(react@18.3.1)
       '@griffel/core': 1.18.2
@@ -30322,13 +30227,13 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@fluentui/react-radio@9.2.38(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)':
+  '@fluentui/react-radio@9.2.38(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)':
     dependencies:
-      '@fluentui/react-field': 9.1.82(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-field': 9.1.82(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
       '@fluentui/react-jsx-runtime': 9.0.47(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-label': 9.1.80(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-label': 9.1.80(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-shared-contexts': 9.21.1(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-theme': 9.1.23
       '@fluentui/react-utilities': 9.18.18(@types/react@18.3.15)(react@18.3.1)
       '@griffel/react': 1.5.27(react@18.3.1)
@@ -30340,11 +30245,11 @@ snapshots:
     transitivePeerDependencies:
       - scheduler
 
-  '@fluentui/react-rating@9.0.24(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@fluentui/react-rating@9.0.24(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)':
     dependencies:
       '@fluentui/react-icons': 2.0.266(react@18.3.1)
       '@fluentui/react-jsx-runtime': 9.0.47(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-theme': 9.1.23
       '@fluentui/react-utilities': 9.18.18(@types/react@18.3.15)(react@18.3.1)
       '@griffel/react': 1.5.27(react@18.3.1)
@@ -30354,10 +30259,10 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@fluentui/react-search@9.0.25(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)':
+  '@fluentui/react-search@9.0.25(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)':
     dependencies:
       '@fluentui/react-icons': 2.0.266(react@18.3.1)
-      '@fluentui/react-input': 9.4.95(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-input': 9.4.95(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
       '@fluentui/react-jsx-runtime': 9.0.47(@types/react@18.3.15)(react@18.3.1)
       '@fluentui/react-theme': 9.1.23
       '@fluentui/react-utilities': 9.18.18(@types/react@18.3.15)(react@18.3.1)
@@ -30370,9 +30275,9 @@ snapshots:
     transitivePeerDependencies:
       - scheduler
 
-  '@fluentui/react-select@9.1.93(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)':
+  '@fluentui/react-select@9.1.93(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)':
     dependencies:
-      '@fluentui/react-field': 9.1.82(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-field': 9.1.82(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
       '@fluentui/react-icons': 2.0.266(react@18.3.1)
       '@fluentui/react-jsx-runtime': 9.0.47(@types/react@18.3.15)(react@18.3.1)
       '@fluentui/react-shared-contexts': 9.21.1(@types/react@18.3.15)(react@18.3.1)
@@ -30394,9 +30299,9 @@ snapshots:
       '@types/react': 18.3.15
       react: 18.3.1
 
-  '@fluentui/react-skeleton@9.1.22(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)':
+  '@fluentui/react-skeleton@9.1.22(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)':
     dependencies:
-      '@fluentui/react-field': 9.1.82(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-field': 9.1.82(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
       '@fluentui/react-jsx-runtime': 9.0.47(@types/react@18.3.15)(react@18.3.1)
       '@fluentui/react-shared-contexts': 9.21.1(@types/react@18.3.15)(react@18.3.1)
       '@fluentui/react-theme': 9.1.23
@@ -30410,12 +30315,12 @@ snapshots:
     transitivePeerDependencies:
       - scheduler
 
-  '@fluentui/react-slider@9.2.2(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)':
+  '@fluentui/react-slider@9.2.2(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)':
     dependencies:
-      '@fluentui/react-field': 9.1.82(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-field': 9.1.82(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
       '@fluentui/react-jsx-runtime': 9.0.47(@types/react@18.3.15)(react@18.3.1)
       '@fluentui/react-shared-contexts': 9.21.1(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-theme': 9.1.23
       '@fluentui/react-utilities': 9.18.18(@types/react@18.3.15)(react@18.3.1)
       '@griffel/react': 1.5.27(react@18.3.1)
@@ -30427,10 +30332,10 @@ snapshots:
     transitivePeerDependencies:
       - scheduler
 
-  '@fluentui/react-spinbutton@9.2.94(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)':
+  '@fluentui/react-spinbutton@9.2.94(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)':
     dependencies:
       '@fluentui/keyboard-keys': 9.0.8
-      '@fluentui/react-field': 9.1.82(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-field': 9.1.82(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
       '@fluentui/react-icons': 2.0.266(react@18.3.1)
       '@fluentui/react-jsx-runtime': 9.0.47(@types/react@18.3.15)(react@18.3.1)
       '@fluentui/react-shared-contexts': 9.21.1(@types/react@18.3.15)(react@18.3.1)
@@ -30445,10 +30350,10 @@ snapshots:
     transitivePeerDependencies:
       - scheduler
 
-  '@fluentui/react-spinner@9.5.4(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@fluentui/react-spinner@9.5.4(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)':
     dependencies:
       '@fluentui/react-jsx-runtime': 9.0.47(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-label': 9.1.80(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-label': 9.1.80(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-shared-contexts': 9.21.1(@types/react@18.3.15)(react@18.3.1)
       '@fluentui/react-theme': 9.1.23
       '@fluentui/react-utilities': 9.18.18(@types/react@18.3.15)(react@18.3.1)
@@ -30459,14 +30364,14 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@fluentui/react-swatch-picker@9.1.16(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)':
+  '@fluentui/react-swatch-picker@9.1.16(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)':
     dependencies:
-      '@fluentui/react-context-selector': 9.1.70(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
-      '@fluentui/react-field': 9.1.82(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-context-selector': 9.1.70(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-field': 9.1.82(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
       '@fluentui/react-icons': 2.0.266(react@18.3.1)
       '@fluentui/react-jsx-runtime': 9.0.47(@types/react@18.3.15)(react@18.3.1)
       '@fluentui/react-shared-contexts': 9.21.1(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-theme': 9.1.23
       '@fluentui/react-utilities': 9.18.18(@types/react@18.3.15)(react@18.3.1)
       '@griffel/react': 1.5.27(react@18.3.1)
@@ -30478,14 +30383,14 @@ snapshots:
     transitivePeerDependencies:
       - scheduler
 
-  '@fluentui/react-switch@9.1.100(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)':
+  '@fluentui/react-switch@9.1.100(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)':
     dependencies:
-      '@fluentui/react-field': 9.1.82(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-field': 9.1.82(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
       '@fluentui/react-icons': 2.0.266(react@18.3.1)
       '@fluentui/react-jsx-runtime': 9.0.47(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-label': 9.1.80(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-label': 9.1.80(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-shared-contexts': 9.21.1(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-theme': 9.1.23
       '@fluentui/react-utilities': 9.18.18(@types/react@18.3.15)(react@18.3.1)
       '@griffel/react': 1.5.27(react@18.3.1)
@@ -30497,18 +30402,18 @@ snapshots:
     transitivePeerDependencies:
       - scheduler
 
-  '@fluentui/react-table@9.15.24(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)':
+  '@fluentui/react-table@9.15.24(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)':
     dependencies:
       '@fluentui/keyboard-keys': 9.0.8
-      '@fluentui/react-aria': 9.13.11(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-avatar': 9.6.45(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
-      '@fluentui/react-checkbox': 9.2.43(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
-      '@fluentui/react-context-selector': 9.1.70(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-aria': 9.13.11(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-avatar': 9.6.45(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-checkbox': 9.2.43(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-context-selector': 9.1.70(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
       '@fluentui/react-icons': 2.0.266(react@18.3.1)
       '@fluentui/react-jsx-runtime': 9.0.47(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-radio': 9.2.38(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-radio': 9.2.38(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
       '@fluentui/react-shared-contexts': 9.21.1(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-theme': 9.1.23
       '@fluentui/react-utilities': 9.18.18(@types/react@18.3.15)(react@18.3.1)
       '@griffel/react': 1.5.27(react@18.3.1)
@@ -30520,12 +30425,12 @@ snapshots:
     transitivePeerDependencies:
       - scheduler
 
-  '@fluentui/react-tabs@9.6.4(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)':
+  '@fluentui/react-tabs@9.6.4(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)':
     dependencies:
-      '@fluentui/react-context-selector': 9.1.70(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-context-selector': 9.1.70(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
       '@fluentui/react-jsx-runtime': 9.0.47(@types/react@18.3.15)(react@18.3.1)
       '@fluentui/react-shared-contexts': 9.21.1(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-theme': 9.1.23
       '@fluentui/react-utilities': 9.18.18(@types/react@18.3.15)(react@18.3.1)
       '@griffel/react': 1.5.27(react@18.3.1)
@@ -30537,7 +30442,7 @@ snapshots:
     transitivePeerDependencies:
       - scheduler
 
-  '@fluentui/react-tabster@9.23.1(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@fluentui/react-tabster@9.23.1(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)':
     dependencies:
       '@fluentui/react-shared-contexts': 9.21.1(@types/react@18.3.15)(react@18.3.1)
       '@fluentui/react-theme': 9.1.23
@@ -30551,20 +30456,20 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       tabster: 8.2.0
 
-  '@fluentui/react-tag-picker@9.3.11(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)':
+  '@fluentui/react-tag-picker@9.3.11(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)':
     dependencies:
       '@fluentui/keyboard-keys': 9.0.8
-      '@fluentui/react-aria': 9.13.11(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-combobox': 9.13.14(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
-      '@fluentui/react-context-selector': 9.1.70(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
-      '@fluentui/react-field': 9.1.82(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-aria': 9.13.11(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-combobox': 9.13.14(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-context-selector': 9.1.70(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-field': 9.1.82(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
       '@fluentui/react-icons': 2.0.266(react@18.3.1)
       '@fluentui/react-jsx-runtime': 9.0.47(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-portal': 9.4.39(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-positioning': 9.15.14(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-portal': 9.4.39(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-positioning': 9.15.14(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-shared-contexts': 9.21.1(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-tags': 9.3.25(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-tags': 9.3.25(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
       '@fluentui/react-theme': 9.1.23
       '@fluentui/react-utilities': 9.18.18(@types/react@18.3.15)(react@18.3.1)
       '@griffel/react': 1.5.27(react@18.3.1)
@@ -30576,15 +30481,15 @@ snapshots:
     transitivePeerDependencies:
       - scheduler
 
-  '@fluentui/react-tags@9.3.25(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)':
+  '@fluentui/react-tags@9.3.25(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)':
     dependencies:
       '@fluentui/keyboard-keys': 9.0.8
-      '@fluentui/react-aria': 9.13.11(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-avatar': 9.6.45(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-aria': 9.13.11(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-avatar': 9.6.45(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
       '@fluentui/react-icons': 2.0.266(react@18.3.1)
       '@fluentui/react-jsx-runtime': 9.0.47(@types/react@18.3.15)(react@18.3.1)
       '@fluentui/react-shared-contexts': 9.21.1(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-theme': 9.1.23
       '@fluentui/react-utilities': 9.18.18(@types/react@18.3.15)(react@18.3.1)
       '@griffel/react': 1.5.27(react@18.3.1)
@@ -30596,16 +30501,16 @@ snapshots:
     transitivePeerDependencies:
       - scheduler
 
-  '@fluentui/react-teaching-popover@9.1.24(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)':
+  '@fluentui/react-teaching-popover@9.1.24(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)':
     dependencies:
-      '@fluentui/react-aria': 9.13.11(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-button': 9.3.97(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-context-selector': 9.1.70(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-aria': 9.13.11(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-button': 9.3.97(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-context-selector': 9.1.70(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
       '@fluentui/react-icons': 2.0.266(react@18.3.1)
       '@fluentui/react-jsx-runtime': 9.0.47(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-popover': 9.9.27(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-popover': 9.9.27(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
       '@fluentui/react-shared-contexts': 9.21.1(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-theme': 9.1.23
       '@fluentui/react-utilities': 9.18.18(@types/react@18.3.15)(react@18.3.1)
       '@griffel/react': 1.5.27(react@18.3.1)
@@ -30618,7 +30523,7 @@ snapshots:
     transitivePeerDependencies:
       - scheduler
 
-  '@fluentui/react-text@9.4.29(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@fluentui/react-text@9.4.29(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)':
     dependencies:
       '@fluentui/react-jsx-runtime': 9.0.47(@types/react@18.3.15)(react@18.3.1)
       '@fluentui/react-shared-contexts': 9.21.1(@types/react@18.3.15)(react@18.3.1)
@@ -30631,9 +30536,9 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@fluentui/react-textarea@9.3.94(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)':
+  '@fluentui/react-textarea@9.3.94(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)':
     dependencies:
-      '@fluentui/react-field': 9.1.82(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-field': 9.1.82(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
       '@fluentui/react-jsx-runtime': 9.0.47(@types/react@18.3.15)(react@18.3.1)
       '@fluentui/react-shared-contexts': 9.21.1(@types/react@18.3.15)(react@18.3.1)
       '@fluentui/react-theme': 9.1.23
@@ -30652,17 +30557,17 @@ snapshots:
       '@fluentui/tokens': 1.0.0-alpha.20
       '@swc/helpers': 0.5.15
 
-  '@fluentui/react-toast@9.3.62(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@fluentui/react-toast@9.3.62(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)':
     dependencies:
       '@fluentui/keyboard-keys': 9.0.8
-      '@fluentui/react-aria': 9.13.11(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-aria': 9.13.11(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-icons': 2.0.266(react@18.3.1)
       '@fluentui/react-jsx-runtime': 9.0.47(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-motion': 9.6.4(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-motion-components-preview': 0.4.0(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-portal': 9.4.39(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-motion': 9.6.4(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-motion-components-preview': 0.4.0(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-portal': 9.4.39(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-shared-contexts': 9.21.1(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-theme': 9.1.23
       '@fluentui/react-utilities': 9.18.18(@types/react@18.3.15)(react@18.3.1)
       '@griffel/react': 1.5.27(react@18.3.1)
@@ -30672,15 +30577,15 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@fluentui/react-toolbar@9.2.12(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)':
+  '@fluentui/react-toolbar@9.2.12(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)':
     dependencies:
-      '@fluentui/react-button': 9.3.97(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-context-selector': 9.1.70(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
-      '@fluentui/react-divider': 9.2.79(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-button': 9.3.97(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-context-selector': 9.1.70(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-divider': 9.2.79(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-jsx-runtime': 9.0.47(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-radio': 9.2.38(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-radio': 9.2.38(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
       '@fluentui/react-shared-contexts': 9.21.1(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-theme': 9.1.23
       '@fluentui/react-utilities': 9.18.18(@types/react@18.3.15)(react@18.3.1)
       '@griffel/react': 1.5.27(react@18.3.1)
@@ -30692,14 +30597,14 @@ snapshots:
     transitivePeerDependencies:
       - scheduler
 
-  '@fluentui/react-tooltip@9.5.1(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@fluentui/react-tooltip@9.5.1(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)':
     dependencies:
       '@fluentui/keyboard-keys': 9.0.8
       '@fluentui/react-jsx-runtime': 9.0.47(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-portal': 9.4.39(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-positioning': 9.15.14(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-portal': 9.4.39(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-positioning': 9.15.14(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-shared-contexts': 9.21.1(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-theme': 9.1.23
       '@fluentui/react-utilities': 9.18.18(@types/react@18.3.15)(react@18.3.1)
       '@griffel/react': 1.5.27(react@18.3.1)
@@ -30709,21 +30614,21 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@fluentui/react-tree@9.8.9(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)':
+  '@fluentui/react-tree@9.8.9(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)':
     dependencies:
       '@fluentui/keyboard-keys': 9.0.8
-      '@fluentui/react-aria': 9.13.11(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-avatar': 9.6.45(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
-      '@fluentui/react-button': 9.3.97(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-checkbox': 9.2.43(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
-      '@fluentui/react-context-selector': 9.1.70(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-aria': 9.13.11(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-avatar': 9.6.45(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-button': 9.3.97(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-checkbox': 9.2.43(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-context-selector': 9.1.70(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
       '@fluentui/react-icons': 2.0.266(react@18.3.1)
       '@fluentui/react-jsx-runtime': 9.0.47(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-motion': 9.6.4(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-motion-components-preview': 0.4.0(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@fluentui/react-radio': 9.2.38(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.20.2)
+      '@fluentui/react-motion': 9.6.4(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-motion-components-preview': 0.4.0(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
+      '@fluentui/react-radio': 9.2.38(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)(scheduler@0.20.2)
       '@fluentui/react-shared-contexts': 9.21.1(@types/react@18.3.15)(react@18.3.1)
-      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fluentui/react-tabster': 9.23.1(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)
       '@fluentui/react-theme': 9.1.23
       '@fluentui/react-utilities': 9.18.18(@types/react@18.3.15)(react@18.3.1)
       '@griffel/react': 1.5.27(react@18.3.1)
@@ -30743,7 +30648,7 @@ snapshots:
       '@types/react': 18.3.15
       react: 18.3.1
 
-  '@fluentui/react-virtualizer@9.0.0-alpha.88(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@fluentui/react-virtualizer@9.0.0-alpha.88(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)':
     dependencies:
       '@fluentui/react-jsx-runtime': 9.0.47(@types/react@18.3.15)(react@18.3.1)
       '@fluentui/react-shared-contexts': 9.21.1(@types/react@18.3.15)(react@18.3.1)
@@ -30762,7 +30667,7 @@ snapshots:
       react: 18.3.1
       tslib: 2.8.1
 
-  '@fluentui/react@8.121.13(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@fluentui/react@8.121.13(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)':
     dependencies:
       '@fluentui/date-time-utilities': 8.6.9
       '@fluentui/font-icons-mdl2': 8.5.55(@types/react@18.3.15)(react@18.3.1)
@@ -30832,22 +30737,22 @@ snapshots:
       events_pkg: events@3.3.0
       sha.js: 2.4.12
 
-  '@fluid-internal/eslint-plugin-fluid@0.4.1(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)':
+  '@fluid-internal/eslint-plugin-fluid@0.4.1(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)':
     dependencies:
       '@microsoft/tsdoc': 0.15.1
-      '@typescript-eslint/parser': 8.46.4(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
-      '@typescript-eslint/utils': 8.46.4(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+      '@typescript-eslint/parser': 8.46.4(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.46.4(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       eslint: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
       ts-morph: 22.0.0
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@fluid-internal/eslint-plugin-fluid@0.4.1(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)':
+  '@fluid-internal/eslint-plugin-fluid@0.4.1(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)':
     dependencies:
       '@microsoft/tsdoc': 0.15.1
-      '@typescript-eslint/parser': 8.46.4(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
-      '@typescript-eslint/utils': 8.46.4(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
+      '@typescript-eslint/parser': 8.46.4(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.46.4(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
       eslint: 9.39.1(jiti@2.6.1)(supports-color@8.1.1)
       ts-morph: 22.0.0
     transitivePeerDependencies:
@@ -31166,18 +31071,18 @@ snapshots:
     transitivePeerDependencies:
       - tslib
 
-  '@fluidframework/aqueduct@1.4.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@fluidframework/aqueduct@1.4.0(debug@4.4.3)(supports-color@10.2.2)':
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 0.32.2
       '@fluidframework/container-definitions': 1.4.0
-      '@fluidframework/container-loader': 1.4.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
-      '@fluidframework/container-runtime': 1.4.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+      '@fluidframework/container-loader': 1.4.0(debug@4.4.3)(supports-color@10.2.2)
+      '@fluidframework/container-runtime': 1.4.0(debug@4.4.3)(supports-color@10.2.2)
       '@fluidframework/container-runtime-definitions': 1.4.0
       '@fluidframework/core-interfaces': 1.4.0
-      '@fluidframework/datastore': 1.4.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+      '@fluidframework/datastore': 1.4.0(debug@4.4.3)(supports-color@10.2.2)
       '@fluidframework/datastore-definitions': 1.4.0
-      '@fluidframework/map': 1.4.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+      '@fluidframework/map': 1.4.0(debug@4.4.3)(supports-color@10.2.2)
       '@fluidframework/request-handler': 1.4.0(supports-color@10.2.2)
       '@fluidframework/runtime-definitions': 1.4.0
       '@fluidframework/runtime-utils': 1.4.0(supports-color@10.2.2)
@@ -31209,22 +31114,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@fluidframework/azure-client@1.2.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@fluidframework/azure-client@1.2.0(debug@4.4.3)(supports-color@10.2.2)':
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 1.1.1
       '@fluidframework/container-definitions': 1.4.0
-      '@fluidframework/container-loader': 1.4.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+      '@fluidframework/container-loader': 1.4.0(debug@4.4.3)(supports-color@10.2.2)
       '@fluidframework/core-interfaces': 1.4.0
       '@fluidframework/driver-definitions': 1.4.0
-      '@fluidframework/driver-utils': 1.4.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
-      '@fluidframework/fluid-static': 1.4.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
-      '@fluidframework/map': 1.4.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+      '@fluidframework/driver-utils': 1.4.0(debug@4.4.3)(supports-color@10.2.2)
+      '@fluidframework/fluid-static': 1.4.0(debug@4.4.3)(supports-color@10.2.2)
+      '@fluidframework/map': 1.4.0(debug@4.4.3)(supports-color@10.2.2)
       '@fluidframework/protocol-definitions': 1.2.0
-      '@fluidframework/routerlicious-driver': 1.4.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+      '@fluidframework/routerlicious-driver': 1.4.0(debug@4.4.3)(supports-color@10.2.2)
       '@fluidframework/runtime-utils': 1.4.0(supports-color@10.2.2)
       '@fluidframework/server-services-client': 0.1036.5002(supports-color@10.2.2)
-      axios: 0.33.0(debug@4.4.3(supports-color@10.2.2))
+      axios: 0.33.0(debug@4.4.3)
       uuid: 11.1.1
     transitivePeerDependencies:
       - bufferutil
@@ -31407,7 +31312,7 @@ snapshots:
       '@fluidframework/core-interfaces': 2.111.0
       '@fluidframework/driver-definitions': 2.111.0
 
-  '@fluidframework/container-loader@1.4.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@fluidframework/container-loader@1.4.0(debug@4.4.3)(supports-color@10.2.2)':
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 0.32.2
@@ -31415,7 +31320,7 @@ snapshots:
       '@fluidframework/container-utils': 1.4.0(supports-color@10.2.2)
       '@fluidframework/core-interfaces': 1.4.0
       '@fluidframework/driver-definitions': 1.4.0
-      '@fluidframework/driver-utils': 1.4.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+      '@fluidframework/driver-utils': 1.4.0(debug@4.4.3)(supports-color@10.2.2)
       '@fluidframework/protocol-base': 0.1036.5002
       '@fluidframework/protocol-definitions': 0.1028.2000
       '@fluidframework/telemetry-utils': 1.4.0(supports-color@10.2.2)
@@ -31464,7 +31369,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@fluidframework/container-runtime@1.4.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@fluidframework/container-runtime@1.4.0(debug@4.4.3)(supports-color@10.2.2)':
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 0.32.2
@@ -31472,9 +31377,9 @@ snapshots:
       '@fluidframework/container-runtime-definitions': 1.4.0
       '@fluidframework/container-utils': 1.4.0(supports-color@10.2.2)
       '@fluidframework/core-interfaces': 1.4.0
-      '@fluidframework/datastore': 1.4.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+      '@fluidframework/datastore': 1.4.0(debug@4.4.3)(supports-color@10.2.2)
       '@fluidframework/driver-definitions': 1.4.0
-      '@fluidframework/driver-utils': 1.4.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+      '@fluidframework/driver-utils': 1.4.0(debug@4.4.3)(supports-color@10.2.2)
       '@fluidframework/garbage-collector': 1.4.0
       '@fluidframework/protocol-base': 0.1036.5002
       '@fluidframework/protocol-definitions': 0.1028.2000
@@ -31557,7 +31462,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@fluidframework/datastore@1.4.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@fluidframework/datastore@1.4.0(debug@4.4.3)(supports-color@10.2.2)':
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 0.32.2
@@ -31566,7 +31471,7 @@ snapshots:
       '@fluidframework/core-interfaces': 1.4.0
       '@fluidframework/datastore-definitions': 1.4.0
       '@fluidframework/driver-definitions': 1.4.0
-      '@fluidframework/driver-utils': 1.4.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+      '@fluidframework/driver-utils': 1.4.0(debug@4.4.3)(supports-color@10.2.2)
       '@fluidframework/garbage-collector': 1.4.0
       '@fluidframework/protocol-base': 0.1036.5002
       '@fluidframework/protocol-definitions': 0.1028.2000
@@ -31639,12 +31544,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@fluidframework/driver-base@1.4.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@fluidframework/driver-base@1.4.0(debug@4.4.3)(supports-color@10.2.2)':
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 0.32.2
       '@fluidframework/driver-definitions': 1.4.0
-      '@fluidframework/driver-utils': 1.4.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+      '@fluidframework/driver-utils': 1.4.0(debug@4.4.3)(supports-color@10.2.2)
       '@fluidframework/protocol-definitions': 0.1028.2000
       '@fluidframework/telemetry-utils': 1.4.0(supports-color@10.2.2)
     transitivePeerDependencies:
@@ -31672,7 +31577,7 @@ snapshots:
     dependencies:
       '@fluidframework/core-interfaces': 2.111.0
 
-  '@fluidframework/driver-utils@1.4.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@fluidframework/driver-utils@1.4.0(debug@4.4.3)(supports-color@10.2.2)':
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 0.32.2
@@ -31682,7 +31587,7 @@ snapshots:
       '@fluidframework/protocol-base': 0.1036.5002
       '@fluidframework/protocol-definitions': 0.1028.2000
       '@fluidframework/telemetry-utils': 1.4.0(supports-color@10.2.2)
-      axios: 0.33.0(debug@4.4.3(supports-color@10.2.2))
+      axios: 0.33.0(debug@4.4.3)
       uuid: 11.1.1
     transitivePeerDependencies:
       - debug
@@ -31711,29 +31616,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@fluidframework/eslint-config-fluid@13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)':
+  '@fluidframework/eslint-config-fluid@13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)':
     dependencies:
-      '@eslint-community/eslint-plugin-eslint-comments': 4.5.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))
-      '@eslint-react/eslint-plugin': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+      '@eslint-community/eslint-plugin-eslint-comments': 4.5.0(eslint@9.39.1)
+      '@eslint-react/eslint-plugin': 2.13.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@eslint/js': 9.39.4
-      '@fluid-internal/eslint-plugin-fluid': 0.4.1(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
-      '@rushstack/eslint-plugin': 0.22.1(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
-      '@typescript-eslint/eslint-plugin': 8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
-      '@typescript-eslint/parser': 8.54.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+      '@fluid-internal/eslint-plugin-fluid': 0.4.1(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
+      '@rushstack/eslint-plugin': 0.22.1(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
+      '@typescript-eslint/eslint-plugin': 8.54.0(@typescript-eslint/parser@8.54.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
+      '@typescript-eslint/parser': 8.54.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       eslint-config-biome: 2.1.3
-      eslint-config-prettier: 10.1.8(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))
-      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)
+      eslint-config-prettier: 10.1.8(eslint@9.39.1)
+      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import-x@4.16.2)(eslint@9.39.1)(supports-color@10.2.2)
       eslint-plugin-depend: 1.4.0
-      eslint-plugin-import-x: 4.16.2(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)
-      eslint-plugin-jsdoc: 61.4.2(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)
+      eslint-plugin-import-x: 4.16.2(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)
+      eslint-plugin-jsdoc: 61.4.2(eslint@9.39.1)(supports-color@10.2.2)
       eslint-plugin-no-only-tests: 3.3.0
-      eslint-plugin-promise: 7.2.1(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))
-      eslint-plugin-react-hooks: 7.0.1(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)
-      eslint-plugin-tsdoc: 0.5.2(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
-      eslint-plugin-unicorn: 54.0.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)
-      eslint-plugin-unused-imports: 4.3.0(@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))
+      eslint-plugin-promise: 7.2.1(eslint@9.39.1)
+      eslint-plugin-react-hooks: 7.0.1(eslint@9.39.1)(supports-color@10.2.2)
+      eslint-plugin-tsdoc: 0.5.2(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
+      eslint-plugin-unicorn: 54.0.0(eslint@9.39.1)(supports-color@10.2.2)
+      eslint-plugin-unused-imports: 4.3.0(@typescript-eslint/eslint-plugin@8.54.0)(eslint@9.39.1)
       globals: 14.0.0
-      typescript-eslint: 8.54.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+      typescript-eslint: 8.54.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
     transitivePeerDependencies:
       - '@typescript-eslint/utils'
       - eslint
@@ -31742,29 +31647,29 @@ snapshots:
       - supports-color
       - typescript
 
-  '@fluidframework/eslint-config-fluid@13.0.0(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)':
+  '@fluidframework/eslint-config-fluid@13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)':
     dependencies:
-      '@eslint-community/eslint-plugin-eslint-comments': 4.5.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))
-      '@eslint-react/eslint-plugin': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
+      '@eslint-community/eslint-plugin-eslint-comments': 4.5.0(eslint@9.39.1)
+      '@eslint-react/eslint-plugin': 2.13.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
       '@eslint/js': 9.39.4
-      '@fluid-internal/eslint-plugin-fluid': 0.4.1(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
-      '@rushstack/eslint-plugin': 0.22.1(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
-      '@typescript-eslint/eslint-plugin': 8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
-      '@typescript-eslint/parser': 8.54.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
+      '@fluid-internal/eslint-plugin-fluid': 0.4.1(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
+      '@rushstack/eslint-plugin': 0.22.1(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
+      '@typescript-eslint/eslint-plugin': 8.54.0(@typescript-eslint/parser@8.54.0)(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
+      '@typescript-eslint/parser': 8.54.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
       eslint-config-biome: 2.1.3
-      eslint-config-prettier: 10.1.8(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))
-      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1))(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)
+      eslint-config-prettier: 10.1.8(eslint@9.39.1)
+      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import-x@4.16.2)(eslint@9.39.1)(supports-color@8.1.1)
       eslint-plugin-depend: 1.4.0
-      eslint-plugin-import-x: 4.16.2(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)
-      eslint-plugin-jsdoc: 61.4.2(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)
+      eslint-plugin-import-x: 4.16.2(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@8.1.1)
+      eslint-plugin-jsdoc: 61.4.2(eslint@9.39.1)(supports-color@8.1.1)
       eslint-plugin-no-only-tests: 3.3.0
-      eslint-plugin-promise: 7.2.1(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))
-      eslint-plugin-react-hooks: 7.0.1(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)
-      eslint-plugin-tsdoc: 0.5.2(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
-      eslint-plugin-unicorn: 54.0.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)
-      eslint-plugin-unused-imports: 4.3.0(@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))
+      eslint-plugin-promise: 7.2.1(eslint@9.39.1)
+      eslint-plugin-react-hooks: 7.0.1(eslint@9.39.1)(supports-color@8.1.1)
+      eslint-plugin-tsdoc: 0.5.2(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
+      eslint-plugin-unicorn: 54.0.0(eslint@9.39.1)(supports-color@8.1.1)
+      eslint-plugin-unused-imports: 4.3.0(@typescript-eslint/eslint-plugin@8.54.0)(eslint@9.39.1)
       globals: 14.0.0
-      typescript-eslint: 8.54.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
+      typescript-eslint: 8.54.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
     transitivePeerDependencies:
       - '@typescript-eslint/utils'
       - eslint
@@ -31801,13 +31706,13 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/fluid-static@1.4.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@fluidframework/fluid-static@1.4.0(debug@4.4.3)(supports-color@10.2.2)':
     dependencies:
-      '@fluidframework/aqueduct': 1.4.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+      '@fluidframework/aqueduct': 1.4.0(debug@4.4.3)(supports-color@10.2.2)
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 0.32.2
       '@fluidframework/container-definitions': 1.4.0
-      '@fluidframework/container-loader': 1.4.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+      '@fluidframework/container-loader': 1.4.0(debug@4.4.3)(supports-color@10.2.2)
       '@fluidframework/container-runtime-definitions': 1.4.0
       '@fluidframework/core-interfaces': 1.4.0
       '@fluidframework/datastore-definitions': 1.4.0
@@ -31886,18 +31791,18 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/map@1.4.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@fluidframework/map@1.4.0(debug@4.4.3)(supports-color@10.2.2)':
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 0.32.2
       '@fluidframework/container-utils': 1.4.0(supports-color@10.2.2)
       '@fluidframework/core-interfaces': 1.4.0
       '@fluidframework/datastore-definitions': 1.4.0
-      '@fluidframework/driver-utils': 1.4.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+      '@fluidframework/driver-utils': 1.4.0(debug@4.4.3)(supports-color@10.2.2)
       '@fluidframework/protocol-definitions': 0.1028.2000
       '@fluidframework/runtime-definitions': 1.4.0
       '@fluidframework/runtime-utils': 1.4.0(supports-color@10.2.2)
-      '@fluidframework/shared-object-base': 1.4.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+      '@fluidframework/shared-object-base': 1.4.0(debug@4.4.3)(supports-color@10.2.2)
       path-browserify: 1.0.1
     transitivePeerDependencies:
       - debug
@@ -32082,13 +31987,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@fluidframework/routerlicious-driver@1.4.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@fluidframework/routerlicious-driver@1.4.0(debug@4.4.3)(supports-color@10.2.2)':
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 0.32.2
-      '@fluidframework/driver-base': 1.4.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+      '@fluidframework/driver-base': 1.4.0(debug@4.4.3)(supports-color@10.2.2)
       '@fluidframework/driver-definitions': 1.4.0
-      '@fluidframework/driver-utils': 1.4.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+      '@fluidframework/driver-utils': 1.4.0(debug@4.4.3)(supports-color@10.2.2)
       '@fluidframework/gitresources': 0.1036.5002
       '@fluidframework/protocol-base': 0.1036.5002
       '@fluidframework/protocol-definitions': 0.1028.2000
@@ -32215,7 +32120,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@fluidframework/server-lambdas@7.0.1(debug@4.3.7(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@fluidframework/server-lambdas@7.0.1(debug@4.3.7)(supports-color@10.2.2)':
     dependencies:
       '@fluidframework/common-utils': 3.1.0
       '@fluidframework/gitresources': 7.0.1
@@ -32228,7 +32133,7 @@ snapshots:
       '@types/semver': 7.7.0
       assert: 2.1.0
       async: 3.2.6
-      axios: 1.18.1(debug@4.3.7(supports-color@10.2.2))(supports-color@10.2.2)
+      axios: 1.18.1(debug@4.3.7)(supports-color@10.2.2)
       buffer: 6.0.3
       double-ended-queue: 2.1.0-0
       events: 3.3.0
@@ -32244,7 +32149,7 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/server-lambdas@7.0.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@fluidframework/server-lambdas@7.0.1(debug@4.4.3)(supports-color@10.2.2)':
     dependencies:
       '@fluidframework/common-utils': 3.1.0
       '@fluidframework/gitresources': 7.0.1
@@ -32257,7 +32162,7 @@ snapshots:
       '@types/semver': 7.7.0
       assert: 2.1.0
       async: 3.2.6
-      axios: 1.18.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+      axios: 1.18.1(debug@4.4.3)(supports-color@10.2.2)
       buffer: 6.0.3
       double-ended-queue: 2.1.0-0
       events: 3.3.0
@@ -32277,7 +32182,7 @@ snapshots:
     dependencies:
       '@fluidframework/common-utils': 3.1.0
       '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-lambdas': 7.0.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+      '@fluidframework/server-lambdas': 7.0.1(debug@4.4.3)(supports-color@10.2.2)
       '@fluidframework/server-memory-orderer': 7.0.1(supports-color@10.2.2)
       '@fluidframework/server-services-client': 7.0.1(supports-color@10.2.2)
       '@fluidframework/server-services-core': 7.0.1(supports-color@10.2.2)
@@ -32297,7 +32202,7 @@ snapshots:
       '@fluidframework/common-utils': 3.1.0
       '@fluidframework/protocol-base': 7.0.1
       '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-lambdas': 7.0.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+      '@fluidframework/server-lambdas': 7.0.1(debug@4.4.3)(supports-color@10.2.2)
       '@fluidframework/server-services-client': 7.0.1(supports-color@10.2.2)
       '@fluidframework/server-services-core': 7.0.1(supports-color@10.2.2)
       '@fluidframework/server-services-telemetry': 7.0.1
@@ -32325,7 +32230,7 @@ snapshots:
       '@fluidframework/gitresources': 0.1036.5002
       '@fluidframework/protocol-base': 0.1036.5002
       '@fluidframework/protocol-definitions': 0.1028.2000
-      axios: 0.33.0(debug@4.4.3(supports-color@10.2.2))
+      axios: 0.33.0(debug@4.4.3)
       crc-32: 1.2.0
       debug: 4.4.3(supports-color@10.2.2)
       json-stringify-safe: 5.0.1
@@ -32343,7 +32248,7 @@ snapshots:
       '@fluidframework/gitresources': 7.0.1
       '@fluidframework/protocol-base': 7.0.1
       '@fluidframework/protocol-definitions': 3.2.0
-      axios: 1.18.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+      axios: 1.18.1(debug@4.4.3)(supports-color@10.2.2)
       crc-32: 1.2.0
       debug: 4.4.3(supports-color@10.2.2)
       json-stringify-safe: 5.0.1
@@ -32379,7 +32284,7 @@ snapshots:
       '@fluidframework/server-services-core': 7.0.1(supports-color@10.2.2)
       '@fluidframework/server-services-telemetry': 7.0.1
       '@fluidframework/server-services-utils': 7.0.1(supports-color@10.2.2)
-      '@socket.io/redis-adapter': 8.3.0(socket.io-adapter@2.5.6(supports-color@8.1.1))(supports-color@10.2.2)
+      '@socket.io/redis-adapter': 8.3.0(socket.io-adapter@2.5.6)(supports-color@10.2.2)
       '@socket.io/sticky': 1.0.4
       body-parser: 1.20.3(supports-color@10.2.2)
       debug: 4.4.3(supports-color@8.1.1)
@@ -32440,27 +32345,27 @@ snapshots:
       '@fluidframework/server-services-client': 7.0.1(supports-color@10.2.2)
       '@fluidframework/server-services-core': 7.0.1(supports-color@10.2.2)
       '@fluidframework/server-services-telemetry': 7.0.1
-      '@types/ioredis-mock': 8.2.6(ioredis@5.6.1(supports-color@10.2.2))
+      '@types/ioredis-mock': 8.2.6(ioredis@5.6.1)
       assert: 2.1.0
       debug: 4.4.3(supports-color@10.2.2)
       events: 3.3.0
       ioredis: 5.6.1(supports-color@10.2.2)
-      ioredis-mock: 8.9.0(@types/ioredis-mock@8.2.6(ioredis@5.6.1(supports-color@10.2.2)))(ioredis@5.6.1(supports-color@10.2.2))
+      ioredis-mock: 8.9.0(@types/ioredis-mock@8.2.6)(ioredis@5.6.1)
       lodash: 4.18.1
       string-hash: 1.1.3
       uuid: 11.1.1
     transitivePeerDependencies:
       - supports-color
 
-  '@fluidframework/shared-object-base@1.4.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@fluidframework/shared-object-base@1.4.0(debug@4.4.3)(supports-color@10.2.2)':
     dependencies:
       '@fluidframework/common-definitions': 0.20.1
       '@fluidframework/common-utils': 0.32.2
       '@fluidframework/container-definitions': 1.4.0
-      '@fluidframework/container-runtime': 1.4.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+      '@fluidframework/container-runtime': 1.4.0(debug@4.4.3)(supports-color@10.2.2)
       '@fluidframework/container-utils': 1.4.0(supports-color@10.2.2)
       '@fluidframework/core-interfaces': 1.4.0
-      '@fluidframework/datastore': 1.4.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+      '@fluidframework/datastore': 1.4.0(debug@4.4.3)(supports-color@10.2.2)
       '@fluidframework/datastore-definitions': 1.4.0
       '@fluidframework/protocol-definitions': 0.1028.2000
       '@fluidframework/runtime-definitions': 1.4.0
@@ -33102,7 +33007,7 @@ snapshots:
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))':
+  '@jest/core@29.7.0(supports-color@10.2.2)(ts-node@10.9.2)':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0(supports-color@10.2.2)
@@ -33116,7 +33021,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))
+      jest-config: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2)
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -33137,7 +33042,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@29.7.0(supports-color@8.1.1)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))':
+  '@jest/core@29.7.0(supports-color@8.1.1)(ts-node@10.9.2)':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0(supports-color@8.1.1)
@@ -33151,7 +33056,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@22.19.17)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))
+      jest-config: 29.7.0(@types/node@22.19.17)(supports-color@8.1.1)(ts-node@10.9.2)
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -33550,13 +33455,13 @@ snapshots:
 
   '@kwsites/promise-deferred@1.1.1': {}
 
-  '@langchain/anthropic@1.3.28(@langchain/core@1.1.44(openai@6.36.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))':
+  '@langchain/anthropic@1.3.28(@langchain/core@1.1.44)':
     dependencies:
       '@anthropic-ai/sdk': 0.90.0(zod@4.3.6)
-      '@langchain/core': 1.1.44(openai@6.36.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
+      '@langchain/core': 1.1.44(openai@6.36.0)(ws@8.21.0)
       zod: 4.3.6
 
-  '@langchain/core@1.1.44(openai@6.36.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)':
+  '@langchain/core@1.1.44(openai@6.36.0)(ws@8.21.0)':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       '@standard-schema/spec': 1.1.0
@@ -33564,7 +33469,7 @@ snapshots:
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.20
-      langsmith: 0.6.3(openai@6.36.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
+      langsmith: 0.6.3(openai@6.36.0)(ws@8.21.0)
       mustache: 4.2.0
       p-queue: 6.6.2
       zod: 4.3.6
@@ -33575,14 +33480,14 @@ snapshots:
       - openai
       - ws
 
-  '@langchain/google-genai@2.1.30(@langchain/core@1.1.44(openai@6.36.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))':
+  '@langchain/google-genai@2.1.30(@langchain/core@1.1.44)':
     dependencies:
       '@google/generative-ai': 0.24.1
-      '@langchain/core': 1.1.44(openai@6.36.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
+      '@langchain/core': 1.1.44(openai@6.36.0)(ws@8.21.0)
 
-  '@langchain/openai@1.4.5(@langchain/core@1.1.44(openai@6.36.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(ws@8.21.0)':
+  '@langchain/openai@1.4.5(@langchain/core@1.1.44)(ws@8.21.0)':
     dependencies:
-      '@langchain/core': 1.1.44(openai@6.36.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
+      '@langchain/core': 1.1.44(openai@6.36.0)(ws@8.21.0)
       js-tiktoken: 1.0.20
       openai: 6.36.0(ws@8.21.0)(zod@4.3.6)
       zod: 4.3.6
@@ -34233,7 +34138,7 @@ snapshots:
       async: 2.6.4
       debug: 4.3.7(supports-color@10.2.2)
       eventemitter2: 6.4.9
-      extrareqp2: 1.0.0(debug@4.3.7(supports-color@10.2.2))
+      extrareqp2: 1.0.0(debug@4.3.7)
       ws: 7.5.11
     transitivePeerDependencies:
       - bufferutil
@@ -34288,19 +34193,19 @@ snapshots:
       - bare-buffer
       - supports-color
 
-  '@rushstack/eslint-plugin@0.22.1(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)':
+  '@rushstack/eslint-plugin@0.22.1(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)':
     dependencies:
       '@rushstack/tree-pattern': 0.3.4
-      '@typescript-eslint/utils': 8.46.4(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.46.4(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       eslint: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@rushstack/eslint-plugin@0.22.1(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)':
+  '@rushstack/eslint-plugin@0.22.1(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)':
     dependencies:
       '@rushstack/tree-pattern': 0.3.4
-      '@typescript-eslint/utils': 8.46.4(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.46.4(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
       eslint: 9.39.1(jiti@2.6.1)(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
@@ -34426,7 +34331,7 @@ snapshots:
 
   '@socket.io/component-emitter@3.1.2': {}
 
-  '@socket.io/redis-adapter@8.3.0(socket.io-adapter@2.5.6(supports-color@8.1.1))(supports-color@10.2.2)':
+  '@socket.io/redis-adapter@8.3.0(socket.io-adapter@2.5.6)(supports-color@10.2.2)':
     dependencies:
       debug: 4.3.7(supports-color@10.2.2)
       notepack.io: 3.0.1
@@ -34494,7 +34399,7 @@ snapshots:
       lodash: 4.18.1
       redent: 3.0.0
 
-  '@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.29.2
       '@testing-library/dom': 10.4.1
@@ -34756,7 +34661,7 @@ snapshots:
     dependencies:
       '@types/node': 22.19.17
 
-  '@types/ioredis-mock@8.2.6(ioredis@5.6.1(supports-color@10.2.2))':
+  '@types/ioredis-mock@8.2.6(ioredis@5.6.1)':
     dependencies:
       ioredis: 5.6.1(supports-color@10.2.2)
 
@@ -34979,30 +34884,13 @@ snapshots:
       '@types/node': 22.19.17
     optional: true
 
-  '@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)':
+  '@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.54.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+      '@typescript-eslint/parser': 8.54.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@typescript-eslint/scope-manager': 8.54.0
-      '@typescript-eslint/type-utils': 8.54.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
-      '@typescript-eslint/utils': 8.54.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
-      '@typescript-eslint/visitor-keys': 8.54.0
-      eslint: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
-      ignore: 7.0.5
-      natural-compare: 1.4.0
-      ts-api-utils: 2.5.0(typescript@5.4.5)
-      typescript: 5.4.5
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
-  '@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)':
-    dependencies:
-      '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.54.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
-      '@typescript-eslint/scope-manager': 8.54.0
-      '@typescript-eslint/type-utils': 8.54.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
-      '@typescript-eslint/utils': 8.54.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+      '@typescript-eslint/type-utils': 8.54.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.54.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@typescript-eslint/visitor-keys': 8.54.0
       eslint: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
       ignore: 7.0.5
@@ -35012,13 +34900,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)':
+  '@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0)(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.54.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
+      '@typescript-eslint/parser': 8.54.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
       '@typescript-eslint/scope-manager': 8.54.0
-      '@typescript-eslint/type-utils': 8.54.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
-      '@typescript-eslint/utils': 8.54.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
+      '@typescript-eslint/type-utils': 8.54.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.54.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
       '@typescript-eslint/visitor-keys': 8.54.0
       eslint: 9.39.1(jiti@2.6.1)(supports-color@8.1.1)
       ignore: 7.0.5
@@ -35028,7 +34916,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.46.4(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)':
+  '@typescript-eslint/parser@8.46.4(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.46.4
       '@typescript-eslint/types': 8.46.4
@@ -35040,7 +34928,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.46.4(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)':
+  '@typescript-eslint/parser@8.46.4(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.46.4
       '@typescript-eslint/types': 8.46.4
@@ -35052,7 +34940,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.54.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)':
+  '@typescript-eslint/parser@8.54.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.54.0
       '@typescript-eslint/types': 8.54.0
@@ -35064,7 +34952,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.54.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)':
+  '@typescript-eslint/parser@8.54.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.54.0
       '@typescript-eslint/types': 8.54.0
@@ -35184,11 +35072,11 @@ snapshots:
     dependencies:
       typescript: 5.4.5
 
-  '@typescript-eslint/type-utils@8.54.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)':
+  '@typescript-eslint/type-utils@8.54.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)':
     dependencies:
       '@typescript-eslint/types': 8.54.0
       '@typescript-eslint/typescript-estree': 8.54.0(supports-color@10.2.2)(typescript@5.4.5)
-      '@typescript-eslint/utils': 8.54.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.54.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       debug: 4.4.3(supports-color@10.2.2)
       eslint: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
       ts-api-utils: 2.5.0(typescript@5.4.5)
@@ -35196,11 +35084,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@8.54.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)':
+  '@typescript-eslint/type-utils@8.54.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)':
     dependencies:
       '@typescript-eslint/types': 8.54.0
       '@typescript-eslint/typescript-estree': 8.54.0(supports-color@8.1.1)(typescript@5.4.5)
-      '@typescript-eslint/utils': 8.54.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.54.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
       debug: 4.4.3(supports-color@8.1.1)
       eslint: 9.39.1(jiti@2.6.1)(supports-color@8.1.1)
       ts-api-utils: 2.5.0(typescript@5.4.5)
@@ -35208,11 +35096,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)':
+  '@typescript-eslint/type-utils@8.61.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)':
     dependencies:
       '@typescript-eslint/types': 8.61.0
       '@typescript-eslint/typescript-estree': 8.61.0(supports-color@10.2.2)(typescript@5.4.5)
-      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       debug: 4.4.3(supports-color@10.2.2)
       eslint: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
       ts-api-utils: 2.5.0(typescript@5.4.5)
@@ -35220,11 +35108,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)':
+  '@typescript-eslint/type-utils@8.61.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)':
     dependencies:
       '@typescript-eslint/types': 8.61.0
       '@typescript-eslint/typescript-estree': 8.61.0(supports-color@8.1.1)(typescript@5.4.5)
-      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
       debug: 4.4.3(supports-color@8.1.1)
       eslint: 9.39.1(jiti@2.6.1)(supports-color@8.1.1)
       ts-api-utils: 2.5.0(typescript@5.4.5)
@@ -35362,9 +35250,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.46.4(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)':
+  '@typescript-eslint/utils@8.46.4(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.1)
       '@typescript-eslint/scope-manager': 8.46.4
       '@typescript-eslint/types': 8.46.4
       '@typescript-eslint/typescript-estree': 8.46.4(supports-color@10.2.2)(typescript@5.4.5)
@@ -35373,9 +35261,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.46.4(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)':
+  '@typescript-eslint/utils@8.46.4(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.1)
       '@typescript-eslint/scope-manager': 8.46.4
       '@typescript-eslint/types': 8.46.4
       '@typescript-eslint/typescript-estree': 8.46.4(supports-color@8.1.1)(typescript@5.4.5)
@@ -35384,9 +35272,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.54.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)':
+  '@typescript-eslint/utils@8.54.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.1)
       '@typescript-eslint/scope-manager': 8.54.0
       '@typescript-eslint/types': 8.54.0
       '@typescript-eslint/typescript-estree': 8.54.0(supports-color@10.2.2)(typescript@5.4.5)
@@ -35395,9 +35283,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.54.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)':
+  '@typescript-eslint/utils@8.54.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.1)
       '@typescript-eslint/scope-manager': 8.54.0
       '@typescript-eslint/types': 8.54.0
       '@typescript-eslint/typescript-estree': 8.54.0(supports-color@8.1.1)(typescript@5.4.5)
@@ -35406,9 +35294,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.56.1(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)':
+  '@typescript-eslint/utils@8.56.1(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.1)
       '@typescript-eslint/scope-manager': 8.56.1
       '@typescript-eslint/types': 8.56.1
       '@typescript-eslint/typescript-estree': 8.56.1(supports-color@10.2.2)(typescript@5.4.5)
@@ -35417,9 +35305,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.56.1(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)':
+  '@typescript-eslint/utils@8.56.1(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.1)
       '@typescript-eslint/scope-manager': 8.56.1
       '@typescript-eslint/types': 8.56.1
       '@typescript-eslint/typescript-estree': 8.56.1(supports-color@8.1.1)(typescript@5.4.5)
@@ -35428,9 +35316,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)':
+  '@typescript-eslint/utils@8.61.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.1)
       '@typescript-eslint/scope-manager': 8.61.0
       '@typescript-eslint/types': 8.61.0
       '@typescript-eslint/typescript-estree': 8.61.0(supports-color@10.2.2)(typescript@5.4.5)
@@ -35439,9 +35327,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)':
+  '@typescript-eslint/utils@8.61.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.1)
       '@typescript-eslint/scope-manager': 8.61.0
       '@typescript-eslint/types': 8.61.0
       '@typescript-eslint/typescript-estree': 8.61.0(supports-color@8.1.1)(typescript@5.4.5)
@@ -35637,7 +35525,7 @@ snapshots:
       '@vue/shared': 3.4.38
       csstype: 3.1.3
 
-  '@vue/server-renderer@3.4.38(vue@3.4.38(typescript@5.4.5))':
+  '@vue/server-renderer@3.4.38(vue@3.4.38)':
     dependencies:
       '@vue/compiler-ssr': 3.4.38
       '@vue/shared': 3.4.38
@@ -35645,9 +35533,9 @@ snapshots:
 
   '@vue/shared@3.4.38': {}
 
-  '@vvago/vale@3.12.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
+  '@vvago/vale@3.12.0(debug@4.4.3)(supports-color@8.1.1)':
     dependencies:
-      axios: 1.18.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      axios: 1.18.1(debug@4.4.3)(supports-color@8.1.1)
       rimraf: 5.0.10
       tar: 7.5.11
       unzipper: 0.10.14
@@ -35746,7 +35634,7 @@ snapshots:
       webpack: 5.109.0(clean-css@5.3.3)(html-minifier-terser@7.2.0)(postcss@8.5.16)(uglify-js@3.19.3)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.6)(webpack@5.109.0)
     optionalDependencies:
-      webpack-dev-server: 5.2.6(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
+      webpack-dev-server: 5.2.6(debug@4.4.3)(supports-color@8.1.1)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
 
   '@xtuc/ieee754@1.2.0': {}
 
@@ -36063,17 +35951,17 @@ snapshots:
 
   axe-core@4.10.2: {}
 
-  axios@0.33.0(debug@4.4.3(supports-color@10.2.2)):
+  axios@0.33.0(debug@4.4.3):
     dependencies:
-      follow-redirects: 1.16.0(debug@4.4.3(supports-color@10.2.2))
+      follow-redirects: 1.16.0(debug@4.4.3)
       form-data: 4.0.6
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
 
-  axios@1.18.1(debug@4.3.7(supports-color@10.2.2))(supports-color@10.2.2):
+  axios@1.18.1(debug@4.3.7)(supports-color@10.2.2):
     dependencies:
-      follow-redirects: 1.16.0(debug@4.3.7(supports-color@10.2.2))
+      follow-redirects: 1.16.0(debug@4.3.7)
       form-data: 4.0.6
       https-proxy-agent: 5.0.1(supports-color@10.2.2)
       proxy-from-env: 2.1.0
@@ -36081,9 +35969,9 @@ snapshots:
       - debug
       - supports-color
 
-  axios@1.18.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2):
+  axios@1.18.1(debug@4.4.3)(supports-color@10.2.2):
     dependencies:
-      follow-redirects: 1.16.0(debug@4.4.3(supports-color@10.2.2))
+      follow-redirects: 1.16.0(debug@4.4.3)
       form-data: 4.0.6
       https-proxy-agent: 5.0.1(supports-color@10.2.2)
       proxy-from-env: 2.1.0
@@ -36091,9 +35979,9 @@ snapshots:
       - debug
       - supports-color
 
-  axios@1.18.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1):
+  axios@1.18.1(debug@4.4.3)(supports-color@8.1.1):
     dependencies:
-      follow-redirects: 1.16.0(debug@4.4.3(supports-color@8.1.1))
+      follow-redirects: 1.16.0(debug@4.4.3)
       form-data: 4.0.6
       https-proxy-agent: 5.0.1(supports-color@8.1.1)
       proxy-from-env: 2.1.0
@@ -36108,26 +35996,26 @@ snapshots:
 
   b4a@1.6.7: {}
 
-  babel-jest@29.7.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2):
+  babel-jest@29.7.0(@babel/core@7.29.7)(supports-color@10.2.2):
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
       '@jest/transform': 29.7.0(supports-color@10.2.2)
       '@types/babel__core': 7.20.5
       babel-plugin-istanbul: 6.1.1(supports-color@10.2.2)
-      babel-preset-jest: 29.6.3(@babel/core@7.29.7(supports-color@10.2.2))
+      babel-preset-jest: 29.6.3(@babel/core@7.29.7)
       chalk: 4.1.2
       graceful-fs: 4.2.11
       slash: 3.0.0
     transitivePeerDependencies:
       - supports-color
 
-  babel-jest@29.7.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1):
+  babel-jest@29.7.0(@babel/core@7.29.7)(supports-color@8.1.1):
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@jest/transform': 29.7.0(supports-color@8.1.1)
       '@types/babel__core': 7.20.5
       babel-plugin-istanbul: 6.1.1(supports-color@8.1.1)
-      babel-preset-jest: 29.6.3(@babel/core@7.29.7(supports-color@8.1.1))
+      babel-preset-jest: 29.6.3(@babel/core@7.29.7)
       chalk: 4.1.2
       graceful-fs: 4.2.11
       slash: 3.0.0
@@ -36161,55 +36049,30 @@ snapshots:
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.20.6
 
-  babel-preset-current-node-syntax@1.1.0(@babel/core@7.29.7(supports-color@10.2.2)):
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-syntax-import-attributes': 7.26.0(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.29.7(supports-color@10.2.2))
-
-  babel-preset-current-node-syntax@1.1.0(@babel/core@7.29.7(supports-color@8.1.1)):
+  babel-preset-current-node-syntax@1.1.0(@babel/core@7.29.7):
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-import-attributes': 7.26.0(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.29.7)
+      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.29.7)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.29.7)
+      '@babel/plugin-syntax-import-attributes': 7.26.0(@babel/core@7.29.7)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.29.7)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.29.7)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.29.7)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.29.7)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.29.7)
 
-  babel-preset-jest@29.6.3(@babel/core@7.29.7(supports-color@10.2.2)):
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      babel-plugin-jest-hoist: 29.6.3
-      babel-preset-current-node-syntax: 1.1.0(@babel/core@7.29.7(supports-color@10.2.2))
-
-  babel-preset-jest@29.6.3(@babel/core@7.29.7(supports-color@8.1.1)):
+  babel-preset-jest@29.6.3(@babel/core@7.29.7):
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       babel-plugin-jest-hoist: 29.6.3
-      babel-preset-current-node-syntax: 1.1.0(@babel/core@7.29.7(supports-color@8.1.1))
+      babel-preset-current-node-syntax: 1.1.0(@babel/core@7.29.7)
 
   bail@1.0.5: {}
 
@@ -36561,7 +36424,7 @@ snapshots:
 
   change-case@5.4.4: {}
 
-  changesets-format-with-issue-links@0.3.0(@changesets/cli@2.29.8(@types/node@22.19.17))(supports-color@10.2.2):
+  changesets-format-with-issue-links@0.3.0(@changesets/cli@2.29.8)(supports-color@10.2.2):
     dependencies:
       '@changesets/cli': 2.29.8(@types/node@22.19.17)
       gitlog: 4.0.8(supports-color@10.2.2)
@@ -36569,7 +36432,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  changesets-format-with-issue-links@0.3.0(@changesets/cli@2.29.8(@types/node@22.19.17))(supports-color@8.1.1):
+  changesets-format-with-issue-links@0.3.0(@changesets/cli@2.29.8)(supports-color@8.1.1):
     dependencies:
       '@changesets/cli': 2.29.8(@types/node@22.19.17)
       gitlog: 4.0.8(supports-color@8.1.1)
@@ -36973,13 +36836,13 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
-  create-jest@29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)):
+  create-jest@29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))
+      jest-config: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -36988,13 +36851,13 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@22.19.17)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)):
+  create-jest@29.7.0(@types/node@22.19.17)(supports-color@8.1.1)(ts-node@10.9.2):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@22.19.17)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))
+      jest-config: 29.7.0(@types/node@22.19.17)(supports-color@8.1.1)(ts-node@10.9.2)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -37781,11 +37644,7 @@ snapshots:
 
   eslint-config-biome@2.1.3: {}
 
-  eslint-config-prettier@10.1.8(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2)):
-    dependencies:
-      eslint: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
-
-  eslint-config-prettier@10.1.8(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1)):
+  eslint-config-prettier@10.1.8(eslint@9.39.1):
     dependencies:
       eslint: 9.39.1(jiti@2.6.1)(supports-color@8.1.1)
 
@@ -37796,7 +37655,7 @@ snapshots:
     optionalDependencies:
       unrs-resolver: 1.11.1
 
-  eslint-import-resolver-typescript@4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2):
+  eslint-import-resolver-typescript@4.4.4(eslint-plugin-import-x@4.16.2)(eslint@9.39.1)(supports-color@10.2.2):
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
       eslint: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
@@ -37807,11 +37666,11 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import-x: 4.16.2(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)
+      eslint-plugin-import-x: 4.16.2(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1))(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1):
+  eslint-import-resolver-typescript@4.4.4(eslint-plugin-import-x@4.16.2)(eslint@9.39.1)(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       eslint: 9.39.1(jiti@2.6.1)(supports-color@8.1.1)
@@ -37822,11 +37681,11 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import-x: 4.16.2(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)
+      eslint-plugin-import-x: 4.16.2(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-chai-expect@3.1.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2)):
+  eslint-plugin-chai-expect@3.1.0(eslint@9.39.1):
     dependencies:
       eslint: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
 
@@ -37836,7 +37695,7 @@ snapshots:
       module-replacements: 2.11.0
       semver: 7.7.4
 
-  eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2):
+  eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2):
     dependencies:
       '@package-json/types': 0.0.12
       '@typescript-eslint/types': 8.61.0
@@ -37850,11 +37709,11 @@ snapshots:
       stable-hash-x: 0.2.0
       unrs-resolver: 1.11.1
     optionalDependencies:
-      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1):
+  eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@8.1.1):
     dependencies:
       '@package-json/types': 0.0.12
       '@typescript-eslint/types': 8.61.0
@@ -37868,22 +37727,22 @@ snapshots:
       stable-hash-x: 0.2.0
       unrs-resolver: 1.11.1
     optionalDependencies:
-      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-jest@29.5.0(@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(jest@29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(supports-color@10.2.2)(typescript@5.4.5):
+  eslint-plugin-jest@29.5.0(@typescript-eslint/eslint-plugin@8.54.0)(eslint@9.39.1)(jest@29.7.0)(supports-color@10.2.2)(typescript@5.4.5):
     dependencies:
-      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       eslint: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
-      jest: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))
+      '@typescript-eslint/eslint-plugin': 8.54.0(@typescript-eslint/parser@8.54.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
+      jest: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  eslint-plugin-jsdoc@61.4.2(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2):
+  eslint-plugin-jsdoc@61.4.2(eslint@9.39.1)(supports-color@10.2.2):
     dependencies:
       '@es-joy/jsdoccomment': 0.76.0
       '@es-joy/resolve.exports': 1.2.0
@@ -37903,7 +37762,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-jsdoc@61.4.2(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1):
+  eslint-plugin-jsdoc@61.4.2(eslint@9.39.1)(supports-color@8.1.1):
     dependencies:
       '@es-joy/jsdoccomment': 0.76.0
       '@es-joy/resolve.exports': 1.2.0
@@ -37925,26 +37784,21 @@ snapshots:
 
   eslint-plugin-no-only-tests@3.3.0: {}
 
-  eslint-plugin-promise@7.2.1(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2)):
+  eslint-plugin-promise@7.2.1(eslint@9.39.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))
-      eslint: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
-
-  eslint-plugin-promise@7.2.1(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1)):
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.1)
       eslint: 9.39.1(jiti@2.6.1)(supports-color@8.1.1)
 
-  eslint-plugin-react-dom@2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5):
+  eslint-plugin-react-dom@2.13.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5):
     dependencies:
-      '@eslint-react/ast': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
-      '@eslint-react/core': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+      '@eslint-react/ast': 2.13.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
+      '@eslint-react/core': 2.13.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@eslint-react/eff': 2.13.0
-      '@eslint-react/shared': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
-      '@eslint-react/var': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+      '@eslint-react/shared': 2.13.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
+      '@eslint-react/var': 2.13.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@typescript-eslint/scope-manager': 8.61.0
       '@typescript-eslint/types': 8.61.0
-      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       compare-versions: 6.1.1
       eslint: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
       ts-pattern: 5.9.0
@@ -37952,16 +37806,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-dom@2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5):
+  eslint-plugin-react-dom@2.13.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5):
     dependencies:
-      '@eslint-react/ast': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
-      '@eslint-react/core': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
+      '@eslint-react/ast': 2.13.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
+      '@eslint-react/core': 2.13.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
       '@eslint-react/eff': 2.13.0
-      '@eslint-react/shared': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
-      '@eslint-react/var': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
+      '@eslint-react/shared': 2.13.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
+      '@eslint-react/var': 2.13.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
       '@typescript-eslint/scope-manager': 8.61.0
       '@typescript-eslint/types': 8.61.0
-      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
       compare-versions: 6.1.1
       eslint: 9.39.1(jiti@2.6.1)(supports-color@8.1.1)
       ts-pattern: 5.9.0
@@ -37969,41 +37823,41 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-hooks-extra@2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5):
+  eslint-plugin-react-hooks-extra@2.13.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5):
     dependencies:
-      '@eslint-react/ast': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
-      '@eslint-react/core': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+      '@eslint-react/ast': 2.13.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
+      '@eslint-react/core': 2.13.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@eslint-react/eff': 2.13.0
-      '@eslint-react/shared': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
-      '@eslint-react/var': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+      '@eslint-react/shared': 2.13.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
+      '@eslint-react/var': 2.13.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@typescript-eslint/scope-manager': 8.61.0
-      '@typescript-eslint/type-utils': 8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+      '@typescript-eslint/type-utils': 8.61.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@typescript-eslint/types': 8.61.0
-      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       eslint: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
       ts-pattern: 5.9.0
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-hooks-extra@2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5):
+  eslint-plugin-react-hooks-extra@2.13.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5):
     dependencies:
-      '@eslint-react/ast': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
-      '@eslint-react/core': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
+      '@eslint-react/ast': 2.13.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
+      '@eslint-react/core': 2.13.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
       '@eslint-react/eff': 2.13.0
-      '@eslint-react/shared': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
-      '@eslint-react/var': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
+      '@eslint-react/shared': 2.13.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
+      '@eslint-react/var': 2.13.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
       '@typescript-eslint/scope-manager': 8.61.0
-      '@typescript-eslint/type-utils': 8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
+      '@typescript-eslint/type-utils': 8.61.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
       '@typescript-eslint/types': 8.61.0
-      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
       eslint: 9.39.1(jiti@2.6.1)(supports-color@8.1.1)
       ts-pattern: 5.9.0
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-hooks@7.0.1(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2):
+  eslint-plugin-react-hooks@7.0.1(eslint@9.39.1)(supports-color@10.2.2):
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/parser': 7.28.4
@@ -38014,7 +37868,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-hooks@7.0.1(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1):
+  eslint-plugin-react-hooks@7.0.1(eslint@9.39.1)(supports-color@8.1.1):
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/parser': 7.28.4
@@ -38025,17 +37879,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-naming-convention@2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5):
+  eslint-plugin-react-naming-convention@2.13.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5):
     dependencies:
-      '@eslint-react/ast': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
-      '@eslint-react/core': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+      '@eslint-react/ast': 2.13.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
+      '@eslint-react/core': 2.13.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@eslint-react/eff': 2.13.0
-      '@eslint-react/shared': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
-      '@eslint-react/var': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+      '@eslint-react/shared': 2.13.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
+      '@eslint-react/var': 2.13.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@typescript-eslint/scope-manager': 8.61.0
-      '@typescript-eslint/type-utils': 8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+      '@typescript-eslint/type-utils': 8.61.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@typescript-eslint/types': 8.61.0
-      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       compare-versions: 6.1.1
       eslint: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
       string-ts: 2.3.1
@@ -38044,17 +37898,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-naming-convention@2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5):
+  eslint-plugin-react-naming-convention@2.13.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5):
     dependencies:
-      '@eslint-react/ast': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
-      '@eslint-react/core': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
+      '@eslint-react/ast': 2.13.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
+      '@eslint-react/core': 2.13.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
       '@eslint-react/eff': 2.13.0
-      '@eslint-react/shared': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
-      '@eslint-react/var': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
+      '@eslint-react/shared': 2.13.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
+      '@eslint-react/var': 2.13.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
       '@typescript-eslint/scope-manager': 8.61.0
-      '@typescript-eslint/type-utils': 8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
+      '@typescript-eslint/type-utils': 8.61.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
       '@typescript-eslint/types': 8.61.0
-      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
       compare-versions: 6.1.1
       eslint: 9.39.1(jiti@2.6.1)(supports-color@8.1.1)
       string-ts: 2.3.1
@@ -38063,42 +37917,42 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-rsc@2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5):
+  eslint-plugin-react-rsc@2.13.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5):
     dependencies:
-      '@eslint-react/ast': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
-      '@eslint-react/shared': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
-      '@eslint-react/var': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+      '@eslint-react/ast': 2.13.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
+      '@eslint-react/shared': 2.13.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
+      '@eslint-react/var': 2.13.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@typescript-eslint/types': 8.61.0
-      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       eslint: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
       ts-pattern: 5.9.0
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-rsc@2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5):
+  eslint-plugin-react-rsc@2.13.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5):
     dependencies:
-      '@eslint-react/ast': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
-      '@eslint-react/shared': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
-      '@eslint-react/var': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
+      '@eslint-react/ast': 2.13.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
+      '@eslint-react/shared': 2.13.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
+      '@eslint-react/var': 2.13.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
       '@typescript-eslint/types': 8.61.0
-      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
       eslint: 9.39.1(jiti@2.6.1)(supports-color@8.1.1)
       ts-pattern: 5.9.0
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-web-api@2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5):
+  eslint-plugin-react-web-api@2.13.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5):
     dependencies:
-      '@eslint-react/ast': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
-      '@eslint-react/core': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+      '@eslint-react/ast': 2.13.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
+      '@eslint-react/core': 2.13.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@eslint-react/eff': 2.13.0
-      '@eslint-react/shared': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
-      '@eslint-react/var': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+      '@eslint-react/shared': 2.13.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
+      '@eslint-react/var': 2.13.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@typescript-eslint/scope-manager': 8.61.0
       '@typescript-eslint/types': 8.61.0
-      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       birecord: 0.1.1
       eslint: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
       ts-pattern: 5.9.0
@@ -38106,16 +37960,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-web-api@2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5):
+  eslint-plugin-react-web-api@2.13.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5):
     dependencies:
-      '@eslint-react/ast': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
-      '@eslint-react/core': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
+      '@eslint-react/ast': 2.13.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
+      '@eslint-react/core': 2.13.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
       '@eslint-react/eff': 2.13.0
-      '@eslint-react/shared': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
-      '@eslint-react/var': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
+      '@eslint-react/shared': 2.13.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
+      '@eslint-react/var': 2.13.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
       '@typescript-eslint/scope-manager': 8.61.0
       '@typescript-eslint/types': 8.61.0
-      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
       birecord: 0.1.1
       eslint: 9.39.1(jiti@2.6.1)(supports-color@8.1.1)
       ts-pattern: 5.9.0
@@ -38123,47 +37977,47 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-x@2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5):
+  eslint-plugin-react-x@2.13.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5):
     dependencies:
-      '@eslint-react/ast': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
-      '@eslint-react/core': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+      '@eslint-react/ast': 2.13.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
+      '@eslint-react/core': 2.13.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@eslint-react/eff': 2.13.0
-      '@eslint-react/shared': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
-      '@eslint-react/var': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+      '@eslint-react/shared': 2.13.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
+      '@eslint-react/var': 2.13.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@typescript-eslint/scope-manager': 8.61.0
-      '@typescript-eslint/type-utils': 8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+      '@typescript-eslint/type-utils': 8.61.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@typescript-eslint/types': 8.61.0
-      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       compare-versions: 6.1.1
       eslint: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
-      is-immutable-type: 5.0.4(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+      is-immutable-type: 5.0.4(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       ts-api-utils: 2.5.0(typescript@5.4.5)
       ts-pattern: 5.9.0
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-x@2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5):
+  eslint-plugin-react-x@2.13.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5):
     dependencies:
-      '@eslint-react/ast': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
-      '@eslint-react/core': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
+      '@eslint-react/ast': 2.13.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
+      '@eslint-react/core': 2.13.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
       '@eslint-react/eff': 2.13.0
-      '@eslint-react/shared': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
-      '@eslint-react/var': 2.13.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
+      '@eslint-react/shared': 2.13.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
+      '@eslint-react/var': 2.13.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
       '@typescript-eslint/scope-manager': 8.61.0
-      '@typescript-eslint/type-utils': 8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
+      '@typescript-eslint/type-utils': 8.61.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
       '@typescript-eslint/types': 8.61.0
-      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.61.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
       compare-versions: 6.1.1
       eslint: 9.39.1(jiti@2.6.1)(supports-color@8.1.1)
-      is-immutable-type: 5.0.4(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
+      is-immutable-type: 5.0.4(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
       ts-api-utils: 2.5.0(typescript@5.4.5)
       ts-pattern: 5.9.0
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react@7.37.5(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2)):
+  eslint-plugin-react@7.37.5(eslint@9.39.1):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlast: 1.2.5
@@ -38185,30 +38039,30 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-tsdoc@0.5.2(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5):
+  eslint-plugin-tsdoc@0.5.2(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5):
     dependencies:
       '@microsoft/tsdoc': 0.16.0
       '@microsoft/tsdoc-config': 0.18.1
-      '@typescript-eslint/utils': 8.56.1(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.56.1(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
     transitivePeerDependencies:
       - eslint
       - supports-color
       - typescript
 
-  eslint-plugin-tsdoc@0.5.2(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5):
+  eslint-plugin-tsdoc@0.5.2(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5):
     dependencies:
       '@microsoft/tsdoc': 0.16.0
       '@microsoft/tsdoc-config': 0.18.1
-      '@typescript-eslint/utils': 8.56.1(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.56.1(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
     transitivePeerDependencies:
       - eslint
       - supports-color
       - typescript
 
-  eslint-plugin-unicorn@54.0.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2):
+  eslint-plugin-unicorn@54.0.0(eslint@9.39.1)(supports-color@10.2.2):
     dependencies:
       '@babel/helper-validator-identifier': 7.27.1
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.1)
       '@eslint/eslintrc': 3.3.3(supports-color@10.2.2)
       ci-info: 4.4.0
       clean-regexp: 1.0.0
@@ -38227,10 +38081,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-unicorn@54.0.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1):
+  eslint-plugin-unicorn@54.0.0(eslint@9.39.1)(supports-color@8.1.1):
     dependencies:
       '@babel/helper-validator-identifier': 7.27.1
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.1)
       '@eslint/eslintrc': 3.3.3(supports-color@8.1.1)
       ci-info: 4.4.0
       clean-regexp: 1.0.0
@@ -38249,17 +38103,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-unused-imports@4.3.0(@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2)):
-    dependencies:
-      eslint: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
-    optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
-
-  eslint-plugin-unused-imports@4.3.0(@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1)):
+  eslint-plugin-unused-imports@4.3.0(@typescript-eslint/eslint-plugin@8.54.0)(eslint@9.39.1):
     dependencies:
       eslint: 9.39.1(jiti@2.6.1)(supports-color@8.1.1)
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
+      '@typescript-eslint/eslint-plugin': 8.54.0(@typescript-eslint/parser@8.54.0)(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
 
   eslint-scope@5.1.1:
     dependencies:
@@ -38279,7 +38127,7 @@ snapshots:
 
   eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.1)
       '@eslint-community/regexpp': 4.12.2
       '@eslint/config-array': 0.21.1(supports-color@10.2.2)
       '@eslint/config-helpers': 0.4.2
@@ -38320,7 +38168,7 @@ snapshots:
 
   eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.1)
       '@eslint-community/regexpp': 4.12.2
       '@eslint/config-array': 0.21.1(supports-color@8.1.1)
       '@eslint/config-helpers': 0.4.2
@@ -38554,9 +38402,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  extrareqp2@1.0.0(debug@4.3.7(supports-color@10.2.2)):
+  extrareqp2@1.0.0(debug@4.3.7):
     dependencies:
-      follow-redirects: 1.16.0(debug@4.3.7(supports-color@10.2.2))
+      follow-redirects: 1.16.0(debug@4.3.7)
     transitivePeerDependencies:
       - debug
 
@@ -38760,15 +38608,11 @@ snapshots:
 
   fn.name@1.1.0: {}
 
-  follow-redirects@1.16.0(debug@4.3.7(supports-color@10.2.2)):
+  follow-redirects@1.16.0(debug@4.3.7):
     optionalDependencies:
       debug: 4.3.7(supports-color@10.2.2)
 
-  follow-redirects@1.16.0(debug@4.4.3(supports-color@10.2.2)):
-    optionalDependencies:
-      debug: 4.4.3(supports-color@10.2.2)
-
-  follow-redirects@1.16.0(debug@4.4.3(supports-color@8.1.1)):
+  follow-redirects@1.16.0(debug@4.4.3):
     optionalDependencies:
       debug: 4.4.3(supports-color@8.1.1)
 
@@ -39006,7 +38850,7 @@ snapshots:
     dependencies:
       ini: 4.1.1
 
-  global-jsdom@26.0.0(jsdom@26.1.0(supports-color@10.2.2)):
+  global-jsdom@26.0.0(jsdom@26.1.0):
     dependencies:
       jsdom: 26.1.0(supports-color@10.2.2)
 
@@ -39338,10 +39182,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  http-proxy-middleware@2.0.10(@types/express@4.17.25)(debug@4.4.3(supports-color@10.2.2)):
+  http-proxy-middleware@2.0.10(@types/express@4.17.25)(debug@4.4.3):
     dependencies:
       '@types/http-proxy': 1.17.15
-      http-proxy: 1.18.1(debug@4.4.3(supports-color@10.2.2))
+      http-proxy: 1.18.1(debug@4.4.3)
       is-glob: 4.0.3
       is-plain-obj: 3.0.0
       micromatch: 4.0.8
@@ -39350,30 +39194,10 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  http-proxy-middleware@2.0.10(@types/express@4.17.25)(debug@4.4.3(supports-color@8.1.1)):
-    dependencies:
-      '@types/http-proxy': 1.17.15
-      http-proxy: 1.18.1(debug@4.4.3(supports-color@8.1.1))
-      is-glob: 4.0.3
-      is-plain-obj: 3.0.0
-      micromatch: 4.0.8
-    optionalDependencies:
-      '@types/express': 4.17.25
-    transitivePeerDependencies:
-      - debug
-
-  http-proxy@1.18.1(debug@4.4.3(supports-color@10.2.2)):
+  http-proxy@1.18.1(debug@4.4.3):
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.16.0(debug@4.4.3(supports-color@10.2.2))
-      requires-port: 1.0.0
-    transitivePeerDependencies:
-      - debug
-
-  http-proxy@1.18.1(debug@4.4.3(supports-color@8.1.1)):
-    dependencies:
-      eventemitter3: 4.0.7
-      follow-redirects: 1.16.0(debug@4.4.3(supports-color@8.1.1))
+      follow-redirects: 1.16.0(debug@4.4.3)
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -39546,11 +39370,11 @@ snapshots:
 
   interpret@3.1.1: {}
 
-  ioredis-mock@8.9.0(@types/ioredis-mock@8.2.6(ioredis@5.6.1(supports-color@10.2.2)))(ioredis@5.6.1(supports-color@10.2.2)):
+  ioredis-mock@8.9.0(@types/ioredis-mock@8.2.6)(ioredis@5.6.1):
     dependencies:
       '@ioredis/as-callback': 3.0.0
       '@ioredis/commands': 1.2.0
-      '@types/ioredis-mock': 8.2.6(ioredis@5.6.1(supports-color@10.2.2))
+      '@types/ioredis-mock': 8.2.6(ioredis@5.6.1)
       fengari: 0.1.4
       fengari-interop: 0.1.3(fengari@0.1.4)
       ioredis: 5.6.1(supports-color@10.2.2)
@@ -39683,9 +39507,9 @@ snapshots:
 
   is-hexadecimal@1.0.4: {}
 
-  is-immutable-type@5.0.4(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5):
+  is-immutable-type@5.0.4(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5):
     dependencies:
-      '@typescript-eslint/type-utils': 8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+      '@typescript-eslint/type-utils': 8.61.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       eslint: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
       ts-api-utils: 2.5.0(typescript@5.4.5)
       ts-declaration-location: 1.0.7(typescript@5.4.5)
@@ -39693,9 +39517,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  is-immutable-type@5.0.4(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5):
+  is-immutable-type@5.0.4(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5):
     dependencies:
-      '@typescript-eslint/type-utils': 8.61.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
+      '@typescript-eslint/type-utils': 8.61.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
       eslint: 9.39.1(jiti@2.6.1)(supports-color@8.1.1)
       ts-api-utils: 2.5.0(typescript@5.4.5)
       ts-declaration-location: 1.0.7(typescript@5.4.5)
@@ -39998,16 +39822,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)):
+  jest-cli@29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2):
     dependencies:
-      '@jest/core': 29.7.0(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))
+      '@jest/core': 29.7.0(supports-color@10.2.2)(ts-node@10.9.2)
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))
+      create-jest: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2)
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))
+      jest-config: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -40017,16 +39841,16 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@22.19.17)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)):
+  jest-cli@29.7.0(@types/node@22.19.17)(supports-color@8.1.1)(ts-node@10.9.2):
     dependencies:
-      '@jest/core': 29.7.0(supports-color@8.1.1)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))
+      '@jest/core': 29.7.0(supports-color@8.1.1)(ts-node@10.9.2)
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@22.19.17)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))
+      create-jest: 29.7.0(@types/node@22.19.17)(supports-color@8.1.1)(ts-node@10.9.2)
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@22.19.17)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))
+      jest-config: 29.7.0(@types/node@22.19.17)(supports-color@8.1.1)(ts-node@10.9.2)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -40036,12 +39860,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)):
+  jest-config@29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2):
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
       '@jest/test-sequencer': 29.7.0
       '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      babel-jest: 29.7.0(@babel/core@7.29.7)(supports-color@10.2.2)
       chalk: 4.1.2
       ci-info: 3.9.0
       deepmerge: 4.3.1
@@ -40067,12 +39891,12 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@22.19.17)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)):
+  jest-config@29.7.0(@types/node@22.19.17)(supports-color@8.1.1)(ts-node@10.9.2):
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@jest/test-sequencer': 29.7.0
       '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      babel-jest: 29.7.0(@babel/core@7.29.7)(supports-color@8.1.1)
       chalk: 4.1.2
       ci-info: 3.9.0
       deepmerge: 4.3.1
@@ -40098,7 +39922,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-dev-server@10.1.4(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2):
+  jest-dev-server@10.1.4(debug@4.4.3)(supports-color@10.2.2):
     dependencies:
       chalk: 4.1.2
       cwd: 0.10.0
@@ -40106,7 +39930,7 @@ snapshots:
       prompts: 2.4.2
       spawnd: 10.1.4
       tree-kill: 1.2.2
-      wait-on: 8.0.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+      wait-on: 8.0.1(debug@4.4.3)(supports-color@10.2.2)
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -40154,12 +39978,12 @@ snapshots:
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
-  jest-environment-puppeteer@10.1.4(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5):
+  jest-environment-puppeteer@10.1.4(debug@4.4.3)(supports-color@10.2.2)(typescript@5.4.5):
     dependencies:
       chalk: 4.1.2
       cosmiconfig: 8.3.6(typescript@5.4.5)
       deepmerge: 4.3.1
-      jest-dev-server: 10.1.4(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+      jest-dev-server: 10.1.4(debug@4.4.3)(supports-color@10.2.2)
       jest-environment-node: 29.7.0
     transitivePeerDependencies:
       - debug
@@ -40225,10 +40049,10 @@ snapshots:
     optionalDependencies:
       jest-resolve: 29.7.0
 
-  jest-puppeteer@10.1.4(debug@4.4.3(supports-color@10.2.2))(puppeteer@23.10.3(supports-color@10.2.2)(typescript@5.4.5))(supports-color@10.2.2)(typescript@5.4.5):
+  jest-puppeteer@10.1.4(debug@4.4.3)(puppeteer@23.10.3)(supports-color@10.2.2)(typescript@5.4.5):
     dependencies:
       expect-puppeteer: 10.1.4
-      jest-environment-puppeteer: 10.1.4(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+      jest-environment-puppeteer: 10.1.4(debug@4.4.3)(supports-color@10.2.2)(typescript@5.4.5)
       puppeteer: 23.10.3(supports-color@10.2.2)(typescript@5.4.5)
     transitivePeerDependencies:
       - debug
@@ -40373,13 +40197,13 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/generator': 7.26.3
-      '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-syntax-typescript': 7.25.9(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.29.7)
+      '@babel/plugin-syntax-typescript': 7.25.9(@babel/core@7.29.7)
       '@babel/types': 7.28.4
       '@jest/expect-utils': 29.7.0
       '@jest/transform': 29.7.0(supports-color@10.2.2)
       '@jest/types': 29.6.3
-      babel-preset-current-node-syntax: 1.1.0(@babel/core@7.29.7(supports-color@10.2.2))
+      babel-preset-current-node-syntax: 1.1.0(@babel/core@7.29.7)
       chalk: 4.1.2
       expect: 29.7.0
       graceful-fs: 4.2.11
@@ -40398,13 +40222,13 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/generator': 7.26.3
-      '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.29.7(supports-color@8.1.1))
-      '@babel/plugin-syntax-typescript': 7.25.9(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.29.7)
+      '@babel/plugin-syntax-typescript': 7.25.9(@babel/core@7.29.7)
       '@babel/types': 7.28.4
       '@jest/expect-utils': 29.7.0
       '@jest/transform': 29.7.0(supports-color@8.1.1)
       '@jest/types': 29.6.3
-      babel-preset-current-node-syntax: 1.1.0(@babel/core@7.29.7(supports-color@8.1.1))
+      babel-preset-current-node-syntax: 1.1.0(@babel/core@7.29.7)
       chalk: 4.1.2
       expect: 29.7.0
       graceful-fs: 4.2.11
@@ -40461,24 +40285,24 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)):
+  jest@29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2):
     dependencies:
-      '@jest/core': 29.7.0(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))
+      '@jest/core': 29.7.0(supports-color@10.2.2)(ts-node@10.9.2)
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))
+      jest-cli: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
       - supports-color
       - ts-node
 
-  jest@29.7.0(@types/node@22.19.17)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)):
+  jest@29.7.0(@types/node@22.19.17)(supports-color@8.1.1)(ts-node@10.9.2):
     dependencies:
-      '@jest/core': 29.7.0(supports-color@8.1.1)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))
+      '@jest/core': 29.7.0(supports-color@8.1.1)(ts-node@10.9.2)
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@22.19.17)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))
+      jest-cli: 29.7.0(@types/node@22.19.17)(supports-color@8.1.1)(ts-node@10.9.2)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -40716,7 +40540,7 @@ snapshots:
 
   ky@1.7.3: {}
 
-  langsmith@0.6.3(openai@6.36.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0):
+  langsmith@0.6.3(openai@6.36.0)(ws@8.21.0):
     dependencies:
       p-queue: 6.6.2
     optionalDependencies:
@@ -40978,7 +40802,7 @@ snapshots:
 
   map-stream@0.1.0: {}
 
-  markdown-magic-package-scripts@1.2.2(markdown-magic@2.6.1(supports-color@10.2.2)):
+  markdown-magic-package-scripts@1.2.2(markdown-magic@2.6.1):
     dependencies:
       findup: 0.1.5
       markdown-magic: 2.6.1(supports-color@10.2.2)
@@ -42503,7 +42327,7 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.5.16
 
-  postcss-load-config@4.0.2(postcss@8.5.16)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)):
+  postcss-load-config@4.0.2(postcss@8.5.16)(ts-node@10.9.2):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.8.3
@@ -42936,12 +42760,12 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
-  re-resizable@6.10.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  re-resizable@6.10.3(react-dom@18.3.1)(react@18.3.1):
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  react-collapsible@2.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-collapsible@2.10.0(react-dom@18.3.1)(react@18.3.1):
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -42952,22 +42776,22 @@ snapshots:
       react: 18.3.1
       scheduler: 0.23.2
 
-  react-draggable@4.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-draggable@4.4.6(react-dom@18.3.1)(react@18.3.1):
     dependencies:
       clsx: 1.2.1
       prop-types: 15.8.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  react-grid-layout@1.5.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-grid-layout@1.5.1(react-dom@18.3.1)(react@18.3.1):
     dependencies:
       clsx: 2.1.1
       fast-equals: 4.0.3
       prop-types: 15.8.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      react-draggable: 4.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react-resizable: 3.0.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-draggable: 4.4.6(react-dom@18.3.1)(react@18.3.1)
+      react-resizable: 3.0.5(react-dom@18.3.1)(react@18.3.1)
       resize-observer-polyfill: 1.5.1
 
   react-is@16.13.1: {}
@@ -42984,23 +42808,23 @@ snapshots:
       react: 18.3.1
       scheduler: 0.23.2
 
-  react-resizable@3.0.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-resizable@3.0.5(react-dom@18.3.1)(react@18.3.1):
     dependencies:
       prop-types: 15.8.1
       react: 18.3.1
-      react-draggable: 4.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-draggable: 4.4.6(react-dom@18.3.1)(react@18.3.1)
     transitivePeerDependencies:
       - react-dom
 
-  react-smooth@4.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-smooth@4.0.3(react-dom@18.3.1)(react@18.3.1):
     dependencies:
       fast-equals: 5.0.1
       prop-types: 15.8.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      react-transition-group: 4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-transition-group: 4.4.5(react-dom@18.3.1)(react@18.3.1)
 
-  react-split-pane@0.1.92(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-split-pane@0.1.92(react-dom@18.3.1)(react@18.3.1):
     dependencies:
       prop-types: 15.8.1
       react: 18.3.1
@@ -43012,7 +42836,7 @@ snapshots:
     dependencies:
       prop-types: 15.8.1
 
-  react-transition-group@4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-transition-group@4.4.5(react-dom@18.3.1)(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.29.2
       dom-helpers: 5.2.1
@@ -43101,7 +42925,7 @@ snapshots:
     dependencies:
       decimal.js-light: 2.5.1
 
-  recharts@2.14.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  recharts@2.14.1(react-dom@18.3.1)(react@18.3.1):
     dependencies:
       clsx: 2.1.1
       eventemitter3: 4.0.7
@@ -43109,7 +42933,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-is: 18.3.1
-      react-smooth: 4.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-smooth: 4.0.3(react-dom@18.3.1)(react@18.3.1)
       recharts-scale: 0.4.5
       tiny-invariant: 1.3.3
       victory-vendor: 36.9.2
@@ -44066,7 +43890,7 @@ snapshots:
       execa: 5.1.1
       lazy-ass: 1.6.0
       ps-tree: 1.2.0
-      wait-on: 8.0.1(debug@4.3.7(supports-color@10.2.2))(supports-color@10.2.2)
+      wait-on: 8.0.1(debug@4.3.7)(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -44346,7 +44170,7 @@ snapshots:
       keyborg: 2.6.0
       tslib: 2.8.1
 
-  tailwindcss@3.4.16(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)):
+  tailwindcss@3.4.16(ts-node@10.9.2):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -44365,7 +44189,7 @@ snapshots:
       postcss: 8.5.16
       postcss-import: 15.1.0(postcss@8.5.16)
       postcss-js: 4.0.1(postcss@8.5.16)
-      postcss-load-config: 4.0.2(postcss@8.5.16)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))
+      postcss-load-config: 4.0.2(postcss@8.5.16)(ts-node@10.9.2)
       postcss-nested: 6.2.0(postcss@8.5.16)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.12
@@ -44505,13 +44329,13 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
-  tinylicious@7.0.1(debug@4.3.7(supports-color@10.2.2))(supports-color@10.2.2):
+  tinylicious@7.0.1(debug@4.3.7)(supports-color@10.2.2):
     dependencies:
       '@fluidframework/common-utils': 3.1.0
       '@fluidframework/gitresources': 7.0.1
       '@fluidframework/protocol-base': 7.0.1
       '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-lambdas': 7.0.1(debug@4.3.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@fluidframework/server-lambdas': 7.0.1(debug@4.3.7)(supports-color@10.2.2)
       '@fluidframework/server-local-server': 7.0.1(supports-color@10.2.2)
       '@fluidframework/server-memory-orderer': 7.0.1(supports-color@10.2.2)
       '@fluidframework/server-services-client': 7.0.1(supports-color@10.2.2)
@@ -44521,7 +44345,7 @@ snapshots:
       '@fluidframework/server-services-utils': 7.0.1(supports-color@10.2.2)
       '@fluidframework/server-test-utils': 7.0.1(supports-color@10.2.2)
       agentkeepalive: 4.6.0
-      axios: 1.18.1(debug@4.3.7(supports-color@10.2.2))(supports-color@10.2.2)
+      axios: 1.18.1(debug@4.3.7)(supports-color@10.2.2)
       body-parser: 1.20.3(supports-color@10.2.2)
       charwise: 3.0.1
       compression: 1.7.5(supports-color@10.2.2)
@@ -44546,13 +44370,13 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  tinylicious@7.0.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2):
+  tinylicious@7.0.1(debug@4.4.3)(supports-color@10.2.2):
     dependencies:
       '@fluidframework/common-utils': 3.1.0
       '@fluidframework/gitresources': 7.0.1
       '@fluidframework/protocol-base': 7.0.1
       '@fluidframework/protocol-definitions': 3.2.0
-      '@fluidframework/server-lambdas': 7.0.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+      '@fluidframework/server-lambdas': 7.0.1(debug@4.4.3)(supports-color@10.2.2)
       '@fluidframework/server-local-server': 7.0.1(supports-color@10.2.2)
       '@fluidframework/server-memory-orderer': 7.0.1(supports-color@10.2.2)
       '@fluidframework/server-services-client': 7.0.1(supports-color@10.2.2)
@@ -44562,7 +44386,7 @@ snapshots:
       '@fluidframework/server-services-utils': 7.0.1(supports-color@10.2.2)
       '@fluidframework/server-test-utils': 7.0.1(supports-color@10.2.2)
       agentkeepalive: 4.6.0
-      axios: 1.18.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+      axios: 1.18.1(debug@4.4.3)(supports-color@10.2.2)
       body-parser: 1.20.3(supports-color@10.2.2)
       charwise: 3.0.1
       compression: 1.7.5(supports-color@10.2.2)
@@ -44684,12 +44508,12 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-jest@29.2.5(@babel/core@7.29.7(supports-color@10.2.2))(@jest/transform@29.7.0(supports-color@10.2.2))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(jest@29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5)))(typescript@5.4.5):
+  ts-jest@29.2.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0)(jest@29.7.0)(typescript@5.4.5):
     dependencies:
       bs-logger: 0.2.6
       ejs: 3.1.10
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.4.5))
+      jest: 29.7.0(@types/node@22.19.17)(supports-color@10.2.2)(ts-node@10.9.2)
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -44701,7 +44525,7 @@ snapshots:
       '@babel/core': 7.29.7(supports-color@10.2.2)
       '@jest/transform': 29.7.0(supports-color@10.2.2)
       '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      babel-jest: 29.7.0(@babel/core@7.29.7)(supports-color@10.2.2)
 
   ts-loader@9.5.1(typescript@5.4.5)(webpack@5.109.0):
     dependencies:
@@ -44860,23 +44684,23 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typescript-eslint@8.54.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5):
+  typescript-eslint@8.54.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
-      '@typescript-eslint/parser': 8.54.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+      '@typescript-eslint/eslint-plugin': 8.54.0(@typescript-eslint/parser@8.54.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
+      '@typescript-eslint/parser': 8.54.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@typescript-eslint/typescript-estree': 8.54.0(supports-color@10.2.2)(typescript@5.4.5)
-      '@typescript-eslint/utils': 8.54.0(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.54.0(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       eslint: 9.39.1(jiti@2.6.1)(supports-color@10.2.2)
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
 
-  typescript-eslint@8.54.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5):
+  typescript-eslint@8.54.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5))(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
-      '@typescript-eslint/parser': 8.54.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
+      '@typescript-eslint/eslint-plugin': 8.54.0(@typescript-eslint/parser@8.54.0)(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
+      '@typescript-eslint/parser': 8.54.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
       '@typescript-eslint/typescript-estree': 8.54.0(supports-color@8.1.1)(typescript@5.4.5)
-      '@typescript-eslint/utils': 8.54.0(eslint@9.39.1(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.54.0(eslint@9.39.1)(supports-color@8.1.1)(typescript@5.4.5)
       eslint: 9.39.1(jiti@2.6.1)(supports-color@8.1.1)
       typescript: 5.4.5
     transitivePeerDependencies:
@@ -45095,7 +44919,7 @@ snapshots:
 
   urijs@1.19.11: {}
 
-  url-loader@4.1.1(file-loader@6.2.0(webpack@5.109.0))(webpack@5.109.0):
+  url-loader@4.1.1(file-loader@6.2.0)(webpack@5.109.0):
     dependencies:
       loader-utils: 2.0.4
       mime-types: 2.1.35
@@ -45116,14 +44940,14 @@ snapshots:
 
   urlpattern-polyfill@10.0.0: {}
 
-  use-disposable@1.0.4(@types/react-dom@18.3.3(@types/react@18.3.15))(@types/react@18.3.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  use-disposable@1.0.4(@types/react-dom@18.3.3)(@types/react@18.3.15)(react-dom@18.3.1)(react@18.3.1):
     dependencies:
       '@types/react': 18.3.15
       '@types/react-dom': 18.3.3(@types/react@18.3.15)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  use-resize-observer@7.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  use-resize-observer@7.1.0(react-dom@18.3.1)(react@18.3.1):
     dependencies:
       '@juggle/resize-observer': 3.4.0
       react: 18.3.1
@@ -45223,7 +45047,7 @@ snapshots:
       '@vue/compiler-dom': 3.4.38
       '@vue/compiler-sfc': 3.4.38
       '@vue/runtime-dom': 3.4.38
-      '@vue/server-renderer': 3.4.38(vue@3.4.38(typescript@5.4.5))
+      '@vue/server-renderer': 3.4.38(vue@3.4.38)
       '@vue/shared': 3.4.38
     optionalDependencies:
       typescript: 5.4.5
@@ -45238,9 +45062,9 @@ snapshots:
     dependencies:
       xml-name-validator: 5.0.0
 
-  wait-on@8.0.1(debug@4.3.7(supports-color@10.2.2))(supports-color@10.2.2):
+  wait-on@8.0.1(debug@4.3.7)(supports-color@10.2.2):
     dependencies:
-      axios: 1.18.1(debug@4.3.7(supports-color@10.2.2))(supports-color@10.2.2)
+      axios: 1.18.1(debug@4.3.7)(supports-color@10.2.2)
       joi: 17.13.3
       lodash: 4.18.1
       minimist: 1.2.8
@@ -45249,9 +45073,9 @@ snapshots:
       - debug
       - supports-color
 
-  wait-on@8.0.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2):
+  wait-on@8.0.1(debug@4.4.3)(supports-color@10.2.2):
     dependencies:
-      axios: 1.18.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
+      axios: 1.18.1(debug@4.4.3)(supports-color@10.2.2)
       joi: 17.13.3
       lodash: 4.18.1
       minimist: 1.2.8
@@ -45325,7 +45149,7 @@ snapshots:
       webpack-merge: 5.10.0
     optionalDependencies:
       webpack-bundle-analyzer: 4.10.2
-      webpack-dev-server: 5.2.6(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
+      webpack-dev-server: 5.2.6(debug@4.4.3)(supports-color@8.1.1)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0)
 
   webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.109.0):
     dependencies:
@@ -45340,7 +45164,7 @@ snapshots:
     transitivePeerDependencies:
       - tslib
 
-  webpack-dev-server@5.2.6(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0):
+  webpack-dev-server@5.2.6(debug@4.4.3)(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -45358,7 +45182,7 @@ snapshots:
       connect-history-api-fallback: 2.0.0
       express: 4.22.1(supports-color@10.2.2)
       graceful-fs: 4.2.11
-      http-proxy-middleware: 2.0.10(@types/express@4.17.25)(debug@4.4.3(supports-color@10.2.2))
+      http-proxy-middleware: 2.0.10(@types/express@4.17.25)(debug@4.4.3)
       ipaddr.js: 2.2.0
       launch-editor: 2.14.1
       open: 10.2.0
@@ -45380,47 +45204,7 @@ snapshots:
       - tslib
       - utf-8-validate
 
-  webpack-dev-server@5.2.6(debug@4.4.3(supports-color@8.1.1))(supports-color@10.2.2)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0):
-    dependencies:
-      '@types/bonjour': 3.5.13
-      '@types/connect-history-api-fallback': 1.5.4
-      '@types/express': 4.17.25
-      '@types/express-serve-static-core': 4.19.6
-      '@types/serve-index': 1.9.4
-      '@types/serve-static': 1.15.7
-      '@types/sockjs': 0.3.36
-      '@types/ws': 8.5.13
-      ansi-html-community: 0.0.8
-      bonjour-service: 1.3.0
-      chokidar: 3.6.0
-      colorette: 2.0.20
-      compression: 1.8.1(supports-color@10.2.2)
-      connect-history-api-fallback: 2.0.0
-      express: 4.22.1(supports-color@10.2.2)
-      graceful-fs: 4.2.11
-      http-proxy-middleware: 2.0.10(@types/express@4.17.25)(debug@4.4.3(supports-color@8.1.1))
-      ipaddr.js: 2.2.0
-      launch-editor: 2.14.1
-      open: 10.2.0
-      p-retry: 6.2.1
-      schema-utils: 4.3.3
-      selfsigned: 5.5.0
-      serve-index: 1.9.1(supports-color@10.2.2)
-      sockjs: 0.3.24
-      spdy: 4.0.2(supports-color@10.2.2)
-      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.109.0)
-      ws: 8.21.0
-    optionalDependencies:
-      webpack: 5.109.0(clean-css@5.3.3)(html-minifier-terser@7.2.0)(postcss@8.5.16)(uglify-js@3.19.3)(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.6)(webpack@5.109.0)
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - supports-color
-      - tslib
-      - utf-8-validate
-
-  webpack-dev-server@5.2.6(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0):
+  webpack-dev-server@5.2.6(debug@4.4.3)(supports-color@8.1.1)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.109.0):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -45438,7 +45222,7 @@ snapshots:
       connect-history-api-fallback: 2.0.0
       express: 4.22.1(supports-color@8.1.1)
       graceful-fs: 4.2.11
-      http-proxy-middleware: 2.0.10(@types/express@4.17.25)(debug@4.4.3(supports-color@8.1.1))
+      http-proxy-middleware: 2.0.10(@types/express@4.17.25)(debug@4.4.3)
       ipaddr.js: 2.2.0
       launch-editor: 2.14.1
       open: 10.2.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,6 +26,15 @@ allowBuilds:
 
 blockExoticSubdeps: true
 
+# Shortens peer-dependency identifiers in the lockfile from fully-nested paths to flat name@version keys.
+# Example:
+#   before: eslint-config-prettier 10.1.8(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))
+#   after:  eslint-config-prettier 10.1.8(eslint@9.39.1)
+# The nested peers of `eslint@9.39.1` still live on eslint's own lockfile entry; they're just not
+# re-encoded into every consumer's identifier. Smaller lockfile, same resolved graph.
+# See https://pnpm.io/settings#dedupepeers
+dedupePeers: true
+
 catalogs:
   # Build-tools packages
   buildTools:


### PR DESCRIPTION
## Description

Sets `dedupePeers: true` in `pnpm-workspace.yaml` and regenerates the lockfile.

`dedupePeers` (added in pnpm v10.33.0) changes the format of peer-dependency identifiers in the lockfile from fully-nested paths to flat `name@version` keys. Example:

- Before: `eslint-config-prettier 10.1.8(eslint@9.39.1(jiti@2.6.1)(supports-color@10.2.2))`
- After:  `eslint-config-prettier 10.1.8(eslint@9.39.1)`

The nested peer information still lives on each peer's own lockfile entry; it's just no longer re-encoded into every consumer's identifier. Same resolved graph, smaller lockfile.

### Impact on this repo

- `pnpm-lock.yaml`: **40,068 -> 39,881 lines** (-187), **1.69 MB -> 1.62 MB** (-72 KB, ~4.3%).
- No `package.json` changes, no dependency version changes, no changes to what actually lands in `node_modules`.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Main things to sanity-check:
- The lockfile diff should be almost entirely peer-suffix flattening on existing entries - no unexpected version bumps or removed packages.
- Anyone with a stale local `pnpm-lock.yaml` on an in-flight branch will need to rebase (or accept a lockfile-config-mismatch on `--frozen-lockfile`) once this merges. Worth calling out in the merge announcement.
