### PR TITLE
feat(tree): getConstraintStatus

### DIFF
--- a/packages/dds/tree/src/shared-tree/sharedTreeChangeFamily.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTreeChangeFamily.ts
@@ -358,15 +358,17 @@ export enum ConstraintStatus {
 	Satisfied,
 	/**
 	 * At least one implicit constraint has been violated.
+	 * @remarks
 	 * Implicit constraints are those that are automatically enforced by SharedTree on all changes.
 	 *
 	 * Such a violation typically arises in one of two scenarios:
-	 * 1. A schema change conflicts with a concurrent data or schema that was sequenced before it.
+	 * 1. A schema change conflicts with a concurrent data or schema change that was sequenced before it.
 	 * 2. A data change conflicts with a concurrent schema change that was sequenced before it.
 	 */
 	ImplicitViolation,
 	/**
 	 * At least one explicit constraint has been violated.
+	 * @remarks
 	 * Explicit constraints are those that are explicitly added
 	 * through {@link RunTransactionParamsAlpha.preconditions | preconditions}
 	 * or {@link TransactionCallbackStatusAlpha.preconditionsOnRevert | preconditionsOnRevert}.

--- a/packages/dds/tree/src/shared-tree/sharedTreeChangeFamily.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTreeChangeFamily.ts
@@ -347,3 +347,57 @@ export function updateRefreshers(
 		}
 	});
 }
+
+/**
+ * The status of a {@link SharedTreeChange} with respect to its constraints.
+ */
+export enum ConstraintStatus {
+	/**
+	 * All constraints are satisfied.
+	 */
+	Satisfied,
+	/**
+	 * At least one implicit constraint has been violated.
+	 * Implicit constraints are those that are automatically enforced by SharedTree on all changes.
+	 *
+	 * Such a violation typically arises in one of two scenarios:
+	 * 1. A schema change conflicts with a concurrent data or schema that was sequenced before it.
+	 * 2. A data change conflicts with a concurrent schema change that was sequenced before it.
+	 */
+	ImplicitViolation,
+	/**
+	 * At least one explicit constraint has been violated.
+	 * Explicit constraints are those that are explicitly added
+	 * through {@link RunTransactionParamsAlpha.preconditions | preconditions}
+	 * or {@link TransactionCallbackStatusAlpha.preconditionsOnRevert | preconditionsOnRevert}.
+	 */
+	ExplicitViolation,
+}
+
+/**
+ * Gets the constraint status of a shared tree change.
+ * @param change - The shared tree change to evaluate.
+ * @returns The constraint status of the change.
+ */
+export function getConstraintStatus(change: SharedTreeChange): ConstraintStatus {
+	if (change.changes.length === 0) {
+		// The SharedTreeChange format (both in memory and over the wire) has no way to convey implicit constraint violation.
+		// Instead, the current rebase implementation in SharedTreeChangeFamily produces an empty change.
+		// This is not ideal because there is no guarantee that an empty change didn't just start out that way.
+		// There is currently only one way to generate an empty change that isn't a result of an implicit constraint violation:
+		// when the SharedTreeChangeFamily is wrapped in makeMitigatedChangeFamily, an empty change is produced when an error occurs.
+		// This is unlikely to cause problems for this logic for two reasons:
+		// 1. Such an error will put SharedTree into a broken state, halting further operations.
+		// 2. It is reasonable to treat a changeset whose production triggered an error as having violated the implicit constraints in our code.
+		return ConstraintStatus.ImplicitViolation;
+	}
+	if (
+		change.changes.some(
+			({ type, innerChange }) =>
+				type === "data" && (innerChange.constraintViolationCount ?? 0) > 0,
+		)
+	) {
+		return ConstraintStatus.ExplicitViolation;
+	}
+	return ConstraintStatus.Satisfied;
+}

--- a/packages/dds/tree/src/test/shared-tree/sharedTreeChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTreeChangeFamily.spec.ts
@@ -31,6 +31,8 @@ import {
 	FieldBatchFormatVersion,
 } from "../../feature-libraries/index.js";
 import {
+	ConstraintStatus,
+	getConstraintStatus,
 	SharedTreeChangeFamily,
 	updateRefreshers,
 	// eslint-disable-next-line import-x/no-internal-modules
@@ -77,11 +79,13 @@ defaultEditor.exitTransaction();
 defaultEditor.valueField(rootField).set(chunkFromJsonTrees(["Y"]));
 defaultEditor.sequenceField(rootField).remove(0, 1);
 defaultEditor.move(rootField, 0, 1, rootField, 0);
+defaultEditor.addNoChangeConstraint();
 
 const dataChange1 = dataChanges[0];
 const dataChange2 = dataChanges[1];
 const dataChange3 = dataChanges[2];
 const dataChange4 = dataChanges[3];
+const constraint = dataChanges[4];
 // This rebased change now refers to an ID introduced in dataChange3
 const rebasedDataChange4 = modularFamily.rebaser.rebase(
 	makeAnonChange(dataChange4),
@@ -94,6 +98,9 @@ const stDataChange1: SharedTreeChange = {
 };
 const stDataChange2: SharedTreeChange = {
 	changes: [{ type: "data", innerChange: dataChange2 }],
+};
+const stConstraint: SharedTreeChange = {
+	changes: [{ type: "data", innerChange: constraint }],
 };
 const emptySchema: TreeStoredSchema = {
 	nodeSchema: new Map(),
@@ -463,6 +470,62 @@ describe("SharedTreeChangeFamily", () => {
 				new DefaultRevisionReplacer(newRevision, sharedTreeFamily.getRevisions(input)),
 			);
 			checkConsistency(updated);
+		});
+	});
+	describe("getConstraintStatus", () => {
+		it("returns Satisfied for a change that has no constraint violations", () => {
+			const status = getConstraintStatus(stDataChange1);
+			assert.equal(status, ConstraintStatus.Satisfied);
+		});
+		it("returns ExplicitViolation for a change that has explicit constraint violations", () => {
+			const hasViolatedExplicitConstraint = sharedTreeFamily.rebaser.rebase(
+				makeAnonChange(stConstraint),
+				makeAnonChange(stDataChange1),
+				revisionMetadataSourceFromInfo([]),
+			);
+			const status = getConstraintStatus(hasViolatedExplicitConstraint);
+			assert.equal(status, ConstraintStatus.ExplicitViolation);
+		});
+		it("returns ImplicitViolation for a data change rebased over a schema change", () => {
+			const dataOverSchema = sharedTreeFamily.rebaser.rebase(
+				makeAnonChange(stDataChange1),
+				makeAnonChange(stSchemaChange),
+				revisionMetadataSourceFromInfo([]),
+			);
+			const status = getConstraintStatus(dataOverSchema);
+			assert.equal(status, ConstraintStatus.ImplicitViolation);
+		});
+		it("returns ImplicitViolation for a schema change rebased over a data change", () => {
+			const schemaOverData = sharedTreeFamily.rebaser.rebase(
+				makeAnonChange(stSchemaChange),
+				makeAnonChange(stDataChange1),
+				revisionMetadataSourceFromInfo([]),
+			);
+			const status = getConstraintStatus(schemaOverData);
+			assert.equal(status, ConstraintStatus.ImplicitViolation);
+		});
+		it("returns ImplicitViolation for a schema change rebased over a schema change", () => {
+			const schemaOverSchema = sharedTreeFamily.rebaser.rebase(
+				makeAnonChange(stSchemaChange),
+				makeAnonChange(stSchemaChange),
+				revisionMetadataSourceFromInfo([]),
+			);
+			const status = getConstraintStatus(schemaOverSchema);
+			assert.equal(status, ConstraintStatus.ImplicitViolation);
+		});
+		it("returns ImplicitViolation for a data change with a violated constraint that is rebased over a schema change", () => {
+			const hasViolatedExplicitConstraint = sharedTreeFamily.rebaser.rebase(
+				makeAnonChange(stConstraint),
+				makeAnonChange(stDataChange1),
+				revisionMetadataSourceFromInfo([]),
+			);
+			const hasBothKindsOfViolations = sharedTreeFamily.rebaser.rebase(
+				makeAnonChange(hasViolatedExplicitConstraint),
+				makeAnonChange(stSchemaChange),
+				revisionMetadataSourceFromInfo([]),
+			);
+			const status = getConstraintStatus(hasBothKindsOfViolations);
+			assert.equal(status, ConstraintStatus.ImplicitViolation);
 		});
 	});
 });


### PR DESCRIPTION
## Description

Adds a `getConstraintStatus` free function that reports on the status of a SharedTreeChange.
This is a prerequisite for reporting this information to the application when a change is sequenced.

## Breaking Changes

None