### PR TITLE
chore(publish): require publishAsPartOfBuild to be passed explicitly

### DIFF
--- a/tools/pipelines/build-api-markdown-documenter.yml
+++ b/tools/pipelines/build-api-markdown-documenter.yml
@@ -86,6 +86,7 @@ extends:
   parameters:
     publish: ${{ variables.publish }}
     publishOverride: ${{ parameters.publishOverride }}
+    publishAsPartOfBuild: true
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     buildDirectory: ${{ variables.FluidFrameworkDirectory }}/tools/api-markdown-documenter
     testCoverage: ${{ variables.testCoverage }}

--- a/tools/pipelines/build-benchmark-tool.yml
+++ b/tools/pipelines/build-benchmark-tool.yml
@@ -88,6 +88,7 @@ extends:
   parameters:
     publish: ${{ variables.publish }}
     publishOverride: ${{ parameters.publishOverride }}
+    publishAsPartOfBuild: true
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     testCoverage: ${{ variables.testCoverage }}

--- a/tools/pipelines/build-build-common.yml
+++ b/tools/pipelines/build-build-common.yml
@@ -88,6 +88,7 @@ extends:
   parameters:
     publish: ${{ variables.publish }}
     publishOverride: ${{ parameters.publishOverride }}
+    publishAsPartOfBuild: true
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     buildDirectory: ${{ variables.FluidFrameworkDirectory }}/common/build/build-common

--- a/tools/pipelines/build-build-tools.yml
+++ b/tools/pipelines/build-build-tools.yml
@@ -101,6 +101,7 @@ extends:
   parameters:
     publish: ${{ variables.publish }}
     publishOverride: ${{ parameters.publishOverride }}
+    publishAsPartOfBuild: true
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     interdependencyRange: ${{ parameters.interdependencyRange }}

--- a/tools/pipelines/build-bundle-size-artifacts.yml
+++ b/tools/pipelines/build-bundle-size-artifacts.yml
@@ -36,3 +36,4 @@ extends:
     checkoutSubmodules: true
     releaseBuildOverride: none
     publishOverride: default
+    publishAsPartOfBuild: true

--- a/tools/pipelines/build-common-utils.yml
+++ b/tools/pipelines/build-common-utils.yml
@@ -96,6 +96,7 @@ extends:
   parameters:
     publish: ${{ variables.publish }}
     publishOverride: ${{ parameters.publishOverride }}
+    publishAsPartOfBuild: true
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     buildDirectory: ${{ variables.FluidFrameworkDirectory }}/common/lib/common-utils

--- a/tools/pipelines/build-eslint-config-fluid.yml
+++ b/tools/pipelines/build-eslint-config-fluid.yml
@@ -90,6 +90,7 @@ extends:
   parameters:
     publish: ${{ variables.publish }}
     publishOverride: ${{ parameters.publishOverride }}
+    publishAsPartOfBuild: true
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     buildDirectory: ${{ variables.FluidFrameworkDirectory }}/common/build/eslint-config-fluid

--- a/tools/pipelines/build-eslint-plugin-fluid.yml
+++ b/tools/pipelines/build-eslint-plugin-fluid.yml
@@ -90,6 +90,7 @@ extends:
   parameters:
     publish: ${{ variables.publish }}
     publishOverride: ${{ parameters.publishOverride }}
+    publishAsPartOfBuild: true
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     buildDirectory: ${{ variables.FluidFrameworkDirectory }}/common/build/eslint-plugin-fluid

--- a/tools/pipelines/build-protocol-definitions.yml
+++ b/tools/pipelines/build-protocol-definitions.yml
@@ -97,6 +97,7 @@ extends:
   parameters:
     publish: ${{ variables.publish }}
     publishOverride: ${{ parameters.publishOverride }}
+    publishAsPartOfBuild: true
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     buildDirectory: ${{ variables.FluidFrameworkDirectory }}/common/lib/protocol-definitions

--- a/tools/pipelines/build-test-tools.yml
+++ b/tools/pipelines/build-test-tools.yml
@@ -84,6 +84,7 @@ extends:
   parameters:
     publish: ${{ variables.publish }}
     publishOverride: ${{ parameters.publishOverride }}
+    publishAsPartOfBuild: true
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     buildDirectory: ${{ variables.FluidFrameworkDirectory }}/tools/test-tools

--- a/tools/pipelines/server-gitrest.yml
+++ b/tools/pipelines/server-gitrest.yml
@@ -101,6 +101,7 @@ extends:
     shouldPublishNpmPackages: ${{ variables.publish }}
     releaseKind: ${{ parameters.releaseKind }}
     publishOverride: ${{ parameters.publishOverride }}
+    publishAsPartOfBuild: true
     buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     dockerBuildBumpsVersion: true
     # Root-only install: gitrest has native deps that don't install in CI; the real build runs in Docker.

--- a/tools/pipelines/server-gitssh.yml
+++ b/tools/pipelines/server-gitssh.yml
@@ -87,3 +87,4 @@ extends:
     installPackages: false
     enableDockerImagePull: false
     tagName: gitssh
+    publishAsPartOfBuild: true

--- a/tools/pipelines/server-historian.yml
+++ b/tools/pipelines/server-historian.yml
@@ -100,6 +100,7 @@ extends:
     shouldPublishNpmPackages: ${{ variables.publish }}
     releaseKind: ${{ parameters.releaseKind }}
     publishOverride: ${{ parameters.publishOverride }}
+    publishAsPartOfBuild: true
     buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     buildDirectory: ${{ variables.FluidFrameworkDirectory }}/server/historian
     containerName: fluidframework/routerlicious/historian

--- a/tools/pipelines/server-routerlicious.yml
+++ b/tools/pipelines/server-routerlicious.yml
@@ -118,6 +118,7 @@ extends:
     shouldPublishNpmPackages: ${{ variables.publish }}
     releaseKind: ${{ parameters.releaseKind }}
     publishOverride: ${{ parameters.publishOverride }}
+    publishAsPartOfBuild: true
     buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     interdependencyRange: ${{ parameters.interdependencyRange }}
     buildDirectory: ${{ variables.FluidFrameworkDirectory }}/server/routerlicious

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -53,6 +53,16 @@ parameters:
     type: string
     default: default
 
+  # Indicates who owns the publish step for this build:
+  #   true  - publishing happens as part of this build pipeline's own publish stages.
+  #   false - publishing is delegated to the dedicated publish pipeline, which consumes the packed tarballs
+  #           and publish-metadata.json produced here.
+  # This is recorded in publish-metadata.json so the publish pipeline can tell which runs it owns.
+  # Deliberately has no default: every pipeline must state which side owns its publishing, so that a search
+  # for `publishAsPartOfBuild: true` is an accurate list of what has not been migrated yet.
+  - name: publishAsPartOfBuild
+    type: boolean
+
   - name: tagName
     type: string
     default:
@@ -478,6 +488,7 @@ extends:
                   publishOverride: skip
                 ${{ else }}:
                   publishOverride: ${{ parameters.publishOverride }}
+                publishAsPartOfBuild: ${{ parameters.publishAsPartOfBuild }}
 
           # At this point we want to publish the artifact with npm-packed packages, but as part of 1ES migration that's
           # now part of templateContext.outputs below.

--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -121,13 +121,14 @@ parameters:
   default: false
 
 # Indicates who owns the publish step for this build:
-#   true  - publishing happens as part of this build pipeline's own publish stages (current behavior).
+#   true  - publishing happens as part of this build pipeline's own publish stages.
 #   false - publishing is delegated to the dedicated publish pipeline, which consumes the packed tarballs
 #           and publish-metadata.json produced here.
 # This is recorded in publish-metadata.json so the publish pipeline can tell which runs it owns.
+# Deliberately has no default: every pipeline must state which side owns its publishing, so that a search
+# for `publishAsPartOfBuild: true` is an accurate list of what has not been migrated yet.
 - name: publishAsPartOfBuild
   type: boolean
-  default: true
 
 # Indicates if tests should be run with code coverage analysis.
 - name: testCoverage

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -61,6 +61,16 @@ parameters:
 - name: publishOverride
   type: string
 
+# Indicates who owns the publish step for this build:
+#   true  - publishing happens as part of this build pipeline's own publish stages.
+#   false - publishing is delegated to the dedicated publish pipeline, which consumes the packed tarballs
+#           and publish-metadata.json produced here.
+# This is recorded in publish-metadata.json so the publish pipeline can tell which runs it owns.
+# Deliberately has no default: every pipeline must state which side owns its publishing, so that a search
+# for `publishAsPartOfBuild: true` is an accurate list of what has not been migrated yet.
+- name: publishAsPartOfBuild
+  type: boolean
+
 - name: releaseBuildOverride
   type: string
 
@@ -457,6 +467,7 @@ extends:
                   - template: /tools/pipelines/templates/include-generate-publish-metadata.yml@self
                     parameters:
                       publishOverride: ${{ parameters.publishOverride }}
+                      publishAsPartOfBuild: ${{ parameters.publishAsPartOfBuild }}
 
                   # At this point we want to publish the artifact with npm-packed packages, and the one with test files,
                   # but as part of 1ES migration that's now part of templateContext.outputs below.

--- a/tools/pipelines/templates/include-generate-publish-metadata.yml
+++ b/tools/pipelines/templates/include-generate-publish-metadata.yml
@@ -6,13 +6,14 @@ parameters:
   type: string
 
 # Indicates who owns the publish step for this build:
-#   true  - publishing happens as part of this build pipeline's own publish stages (current behavior).
+#   true  - publishing happens as part of this build pipeline's own publish stages.
 #   false - publishing is delegated to the dedicated publish pipeline, which consumes the packed tarballs
 #           and publish-metadata.json produced here.
 # This is recorded in publish-metadata.json so the publish pipeline can tell which runs it owns.
+# Deliberately has no default: every pipeline must state which side owns its publishing, so that a search
+# for `publishAsPartOfBuild: true` is an accurate list of what has not been migrated yet.
 - name: publishAsPartOfBuild
   type: boolean
-  default: true
 
 steps:
 - task: Bash@3


### PR DESCRIPTION
## Description

Follow-up to #27795, addressing [Abe27342's review comment](https://github.com/microsoft/FluidFramework/pull/27795#pullrequestreview-4822009785):

> this looks fine as-is, but can you make a follow-up that drops the default on `publishAsPartOfBuild` and makes everyone explicitly pass true? It will make auditing "what's left" easier.

`publishAsPartOfBuild` shipped with `default: true`, which made a pipeline nobody had considered for migration look identical to one deliberately left publishing from the build. That defeats the point of the flag, since there was no reliable way to tell what was left to migrate.

This drops the default and makes all fifteen top-level pipelines pass the value explicitly, so `grep -r "publishAsPartOfBuild: true" tools/pipelines` is now an accurate list of what has not been migrated. To get there, the parameter is also threaded through the two intermediate templates that did not have it yet, `build-npm-package.yml` and `build-docker-service.yml`.

Every pipeline is set to `true`, which is what the default already resolved to, so this is a no-op at runtime.

## Reviewer Guidance

Mostly mechanical: 14 pipelines get a one-line addition (`build-client.yml` already passed it explicitly). The parts worth actual review:

- **`build-docker-service.yml`** is the only non-obvious call site. Its `include-generate-publish-metadata.yml` invocation already used a `${{ if }}` / `${{ else }}` pair to select `publishOverride`, so the new parameter is added as a sibling key after that conditional block rather than inside either branch.
- **`server-gitssh.yml`** was the only pipeline not already passing `publishOverride`, so its line went at the end of the parameter block instead of next to a related one.
- **`build-bundle-size-artifacts.yml`** does not pack packages, so it never actually emits publish metadata. It still has to pass the parameter, since ADO requires values for defaultless parameters at template expansion time regardless of whether the step runs.

Since dropping a default turns a missing value into a hard expansion failure, I verified programmatically that every pipeline reaching the metadata template passes it: all 15 resolve to `true`, 0 missing, and no template in the chain still declares a default. All 60 YAML files under `tools/pipelines` still parse.
