### PR TITLE
feat(tree): better formatted text insertion APIs

### DIFF
--- a/packages/dds/tree/src/test/text/textDomainFormatted.spec.ts
+++ b/packages/dds/tree/src/test/text/textDomainFormatted.spec.ts
@@ -26,6 +26,7 @@ import { describeHydration, hydrateNode } from "../simple-tree/index.js";
 import { testSchemaCompatibilitySnapshots } from "../snapshots/index.js";
 import { suitesWithAndWithoutProduction } from "../utils.js";
 import { FormattedTextAsTreeDefault } from "../../text/index.js";
+import { oneFromIterable } from "../../util/index.js";
 
 // Custom formatted-text schemas used to exercise `formatRange` edge cases which the default schema cannot express.
 
@@ -103,6 +104,30 @@ describe("textDomainFormatted", () => {
 		assert.equal(text.fullString(), "hello world");
 		text.removeRange(0, 6);
 		assert.equal(text.fullString(), "world");
+	});
+
+	it("default formatting", () => {
+		class Custom extends FormattedTextAsTree.createSchema(
+			new SchemaFactoryBeta("test.formatted.custom"),
+			[SchemaFactory.null, SchemaFactory.number],
+			[],
+			5,
+		) {}
+		{
+			const text = Custom.fromString("x");
+			const atom = oneFromIterable(text.charactersWithFormatting()) ?? assert.fail();
+			assert.equal(atom.format, 5);
+			atom.format = 4;
+			assert.equal(atom.format, 4);
+			text.reformat();
+			assert.equal(atom.format, 5);
+			text.insertAt(1, "y", null); // Ensure this overrides default correctly, even when null.
+			text.insertAt(2, "z"); // Uses default
+			assert.deepEqual(
+				[...text.charactersWithFormatting()].map((atom2) => atom2.format),
+				[5, null, 5],
+			);
+		}
 	});
 
 	it("fromString applies the provided format", () => {

--- a/packages/dds/tree/src/test/text/textDomainFormatted.spec.ts
+++ b/packages/dds/tree/src/test/text/textDomainFormatted.spec.ts
@@ -243,9 +243,6 @@ describe("textDomainFormatted", () => {
 		it("uses the default format when no format is provided", () => {
 			const text = FormattedTextAsTreeDefault.Tree.fromString("hello");
 			text.formatRange(0, 5, { bold: true, italic: true });
-			// Customize the default format so we can distinguish it from a fresh default.
-			text.defaultFormat.underline = true;
-			// Reformat a sub-range without providing a format: the default format should be used.
 			text.reformat(1, 4);
 			assert.deepEqual(
 				[...text.charactersWithFormatting()].map((atom) => [
@@ -253,13 +250,15 @@ describe("textDomainFormatted", () => {
 					atom.format.bold,
 					atom.format.italic,
 					atom.format.underline,
+					atom.format.size,
+					atom.format.font,
 				]),
 				[
-					["h", true, true, false],
-					["e", false, false, true],
-					["l", false, false, true],
-					["l", false, false, true],
-					["o", true, true, false],
+					["h", true, true, false, 12, "Arial"],
+					["e", false, false, false, 12, "Arial"],
+					["l", false, false, false, 12, "Arial"],
+					["l", false, false, false, 12, "Arial"],
+					["o", true, true, false, 12, "Arial"],
 				],
 			);
 		});
@@ -283,7 +282,16 @@ describe("textDomainFormatted", () => {
 	it("insertWithFormattingAt", () => {
 		const text = FormattedTextAsTreeDefault.Tree.fromString("ab");
 		text.insertWithFormattingAt(1, [
-			{ content: { content: "c" }, format: { ...text.defaultFormat, italic: true } },
+			{
+				content: { content: "c" },
+				format: {
+					bold: false,
+					italic: true,
+					underline: false,
+					size: 12,
+					font: "Arial",
+				},
+			},
 		]);
 		assert.equal(text.fullString(), "acb");
 		assert.deepEqual(
@@ -299,10 +307,15 @@ describe("textDomainFormatted", () => {
 		);
 	});
 
-	it("defaultFormat", () => {
+	it("insertAt applies the provided format", () => {
 		const text = FormattedTextAsTreeDefault.Tree.fromString("ab");
-		text.defaultFormat.underline = true;
-		text.insertAt(2, "cd");
+		text.insertAt(2, "cd", {
+			bold: false,
+			italic: false,
+			underline: true,
+			size: 12,
+			font: "Arial",
+		});
 		assert.deepEqual(
 			[...text.charactersWithFormatting()].map((atom) => [
 				atom.content.content,
@@ -317,12 +330,49 @@ describe("textDomainFormatted", () => {
 		);
 	});
 
+	it("insertAt accepts text atoms", () => {
+		const text = FormattedTextAsTreeDefault.Tree.fromString("ab");
+		text.insertAt(
+			1,
+			[
+				new FormattedTextAsTreeDefault.StringLineAtom({
+					tag: FormattedTextAsTreeDefault.LineTag("h1"),
+					indent: 0,
+				}),
+				new FormattedTextAsTree.StringTextAtom({ content: "c" }),
+			],
+			{
+				bold: true,
+				italic: false,
+				underline: false,
+				size: 12,
+				font: "Arial",
+			},
+		);
+
+		assert.equal(text.fullString(), "a\ncb");
+		assert.deepEqual(
+			[...text.charactersWithFormatting()].map((atom) => atom.format.bold),
+			[false, true, true, false],
+		);
+	});
+
 	it("getUniformRun", () => {
 		const text = FormattedTextAsTreeDefault.Tree.fromString("abc");
-		text.defaultFormat.underline = true;
-		text.insertAt(3, "de");
-		text.defaultFormat.italic = true;
-		text.insertAt(5, "f");
+		text.insertAt(3, "de", {
+			bold: false,
+			italic: false,
+			underline: true,
+			size: 12,
+			font: "Arial",
+		});
+		text.insertAt(5, "f", {
+			bold: false,
+			italic: true,
+			underline: true,
+			size: 12,
+			font: "Arial",
+		});
 		assert.equal(text.getUniformRun(0, 5), 3);
 		assert.equal(text.getUniformRun(0), 3);
 		assert.equal(text.getUniformRun(3, 5), 2);
@@ -333,10 +383,20 @@ describe("textDomainFormatted", () => {
 
 	it("getString with getUniformRun", () => {
 		const text = FormattedTextAsTreeDefault.Tree.fromString("abc");
-		text.defaultFormat.underline = true;
-		text.insertAt(3, "de");
-		text.defaultFormat.italic = true;
-		text.insertAt(5, "f");
+		text.insertAt(3, "de", {
+			bold: false,
+			italic: false,
+			underline: true,
+			size: 12,
+			font: "Arial",
+		});
+		text.insertAt(5, "f", {
+			bold: false,
+			italic: true,
+			underline: true,
+			size: 12,
+			font: "Arial",
+		});
 		let index = 0;
 		let currentRun = text.getUniformRun(index, text.characterCount());
 		assert.equal(text.getString(index, index + currentRun), "abc");

--- a/packages/dds/tree/src/text/textDomainFormatted.ts
+++ b/packages/dds/tree/src/text/textDomainFormatted.ts
@@ -665,7 +665,7 @@ export namespace FormattedTextAsTree {
 		>[],
 	> extends TextAsTree.Members {
 		/**
-		 * {@link FormattedTextAsTree.Members.insertAt} with optional formatting to apply to all additional characters,
+		 * {@link TextAsTree.Members.insertAt} with optional formatting to apply to all additional characters,
 		 * and allowing an array of atoms instead of a string.
 		 * @param format - Optional formatting to apply to all additional characters. If not specified, the default formatting (from {@link FormattedTextAsTree.createSchema}) will be used.
 		 * @remarks

--- a/packages/dds/tree/src/text/textDomainFormatted.ts
+++ b/packages/dds/tree/src/text/textDomainFormatted.ts
@@ -92,8 +92,7 @@ export namespace FormattedTextAsTree {
 	 * @param extraAtoms - Additional atom schema to allow as text content beyond the built-in {@link FormattedTextAsTree.StringTextAtom}.
 	 * Use this to embed richer content (for example line breaks or inline objects) alongside plain characters.
 	 * @param defaultFormatInsertable - The formatting applied to text inserted via non-formatted APIs
-	 * (for example {@link TextAsTree.Members.insertAt} and {@link FormattedTextAsTree.Statics.fromString} when no explicit format is provided).
-	 * This is the initial value used for {@link FormattedTextAsTree.Members.defaultFormat}, but it can be reassigned on a per instance basis if desired.
+	 * (for example {@link FormattedTextAsTree.Members.insertAt} and {@link FormattedTextAsTree.Statics.fromString} when no explicit format is provided).
 	 * @returns The schema for the formatted text node, whose nodes implement {@link FormattedTextAsTree.Members} and whose statics implement {@link FormattedTextAsTree.Statics}.
 	 * @remarks
 	 * See {@link FormattedTextAsTreeDefault} for a default parameterization of this factory.
@@ -113,11 +112,38 @@ export namespace FormattedTextAsTree {
 		defaultFormatInsertable: InsertableTreeFieldFromImplicitField<FormatSchema>,
 	): FormattedTextSchema<TUserScope, FormatSchema, ExtraAtomsSchema> {
 		const atoms = [StringTextAtom, ...extraAtoms] as const;
+		/**
+		 * The type of a text atom node, which goes in a StringAtom.
+		 */
+		type TextAtomNode = TreeNodeFromImplicitAllowedTypes<TextAtomSchemas<ExtraAtomsSchema>>;
 
 		const sf = createFormattedScopedFactory(inputSchemaFactory);
 
 		const defaultFormat: TreeFieldFromImplicitField<FormatSchema> =
 			TreeBeta.create<FormatSchema>(formatSchema, defaultFormatInsertable);
+
+		/**
+		 * Gets a format node, which must be cloned before being inserted.
+		 */
+		function getFormatNode(
+			format?: InsertableTreeFieldFromImplicitField<FormatSchema>,
+		): TreeFieldFromImplicitField<FormatSchema> {
+			// Note we cannot use the `format ?? defaultFormat` syntax as format is allowed to be `null`.
+			return format === undefined
+				? defaultFormat
+				: TreeBeta.create<FormatSchema>(formatSchema, format);
+		}
+
+		function cloneFormat(
+			format: TreeFieldFromImplicitField<FormatSchema>,
+		): TreeFieldFromImplicitField<FormatSchema> &
+			TreeNodeFromImplicitAllowedTypes<FormatSchema> {
+			const clone: TreeFieldFromImplicitField<FormatSchema> =
+				TreeBeta.clone<FormatSchema>(format);
+			// TypeScript fails to prove that cloning a node gives a node, and not possible undefined (like cloning a empty field could).
+			// This cast helps users of this function get the types they need.
+			return clone as typeof clone & TreeNodeFromImplicitAllowedTypes<FormatSchema>;
+		}
 
 		class TextNode
 			extends sf.object("Text", {
@@ -125,14 +151,21 @@ export namespace FormattedTextAsTree {
 			})
 			implements Members<FormatSchema, ExtraAtomsSchema>
 		{
-			// This can get modified, so give each node its own clone.
-			public defaultFormat: TreeFieldFromImplicitField<FormatSchema> =
-				TreeBeta.clone(defaultFormat);
-
-			public insertAt(index: number, additionalCharacters: string): void {
+			public insertAt(
+				index: number,
+				additionalCharacters:
+					| string
+					| Iterable<TreeNodeFromImplicitAllowedTypes<TextAtomSchemas<ExtraAtomsSchema>>>,
+				format?: InsertableTreeFieldFromImplicitField<FormatSchema>,
+			): void {
+				const newAtoms: Iterable<TextAtomNode> =
+					typeof additionalCharacters === "string"
+						? stringTextAtomsFromString(additionalCharacters)
+						: additionalCharacters;
+				const formatNode = getFormatNode(format);
 				this.content.insertAt(
 					index,
-					TreeArrayNode.spread(textAtomsFromString(additionalCharacters, this.defaultFormat)),
+					TreeArrayNode.spread(stringAtomsFromTextAtoms(newAtoms, formatNode)),
 				);
 			}
 
@@ -184,10 +217,7 @@ export namespace FormattedTextAsTree {
 				value: string,
 				format?: InsertableTreeFieldFromImplicitField<FormatSchema>,
 			): TextNode {
-				const formatNode =
-					format === undefined
-						? defaultFormat
-						: TreeBeta.create<FormatSchema>(formatSchema, format);
+				const formatNode = getFormatNode(format);
 				// Use `this` rather than `TextNode` so the more derived schema class is constructed when using this as a static on a subclass.
 				return new this({
 					content: [
@@ -260,13 +290,11 @@ export namespace FormattedTextAsTree {
 			public reformat(
 				start: number | undefined,
 				end: number | undefined,
-				format: TreeFieldFromImplicitField<FormatSchema> = this.defaultFormat,
+				format?: InsertableTreeFieldFromImplicitField<FormatSchema>,
 			): void {
-				const node = TreeBeta.create<FormatSchema>(formatSchema, format as never);
+				const node = getFormatNode(format);
 				this.#editRange(start, end, "FormattedTextAsTree.reformat", (atom) => {
-					const formatNode: TreeFieldFromImplicitField<FormatSchema> = TreeBeta.clone(node);
-					// Generics can't prove TreeFieldFromImplicitField is valid as TreeNodeFromImplicitAllowedTypes, so we have to cast:
-					atom.format = formatNode as TreeNodeFromImplicitAllowedTypes<FormatSchema>;
+					atom.format = cloneFormat(node);
 				});
 			}
 
@@ -343,19 +371,37 @@ export namespace FormattedTextAsTree {
 			}
 		}
 
-		function textAtomsFromString(
+		function stringTextAtomsFromString(
 			value: string,
+		): Iterable<StringTextAtom & TextAtomNode> {
+			return mapIterable(
+				charactersFromString(value),
+				// TypeScript can't prove in this Generic context that StringTextAtom is assignable to TextAtomNode, so we have to cast.
+				// Since TextAtomSchemas unconditionally includes StringTextAtom, this cast is safe.
+				(char) => new StringTextAtom({ content: char }) as StringTextAtom & TextAtomNode,
+			);
+		}
+
+		function stringAtomsFromTextAtoms(
+			value: Iterable<TreeNodeFromImplicitAllowedTypes<TextAtomSchemas<ExtraAtomsSchema>>>,
 			format: TreeFieldFromImplicitField<FormatSchema>,
 		): Iterable<StringAtom> {
-			const result = mapIterable(charactersFromString(value), (char) => {
-				const textAtom = new StringTextAtom({ content: char });
+			const result = mapIterable(value, (content) => {
 				const data = {
-					content: textAtom,
-					format: TreeBeta.clone<FormatSchema>(format),
+					content,
+					format: cloneFormat(format),
 				};
 				return new StringAtom(data as never); // Generic break type safety here. TODO: try and make safer.
 			});
 			return result;
+		}
+
+		function textAtomsFromString(
+			value: string,
+			format: TreeFieldFromImplicitField<FormatSchema>,
+		): Iterable<StringAtom> {
+			const textAtoms = stringTextAtomsFromString(value);
+			return stringAtomsFromTextAtoms(textAtoms, format);
 		}
 
 		class StringArray extends sf.array("StringArray", [() => StringAtom]) {
@@ -619,14 +665,20 @@ export namespace FormattedTextAsTree {
 		>[],
 	> extends TextAsTree.Members {
 		/**
-		 * Format to use by default for text inserted with non-formatted APIs.
+		 * {@link FormattedTextAsTree.Members.insertAt} with optional formatting to apply to all additional characters,
+		 * and allowing an array of atoms instead of a string.
+		 * @param format - Optional formatting to apply to all additional characters. If not specified, the default formatting (from {@link FormattedTextAsTree.createSchema}) will be used.
 		 * @remarks
-		 * This is not persisted in the tree, and observation of it is not tracked by the tree observation tracking.
-		 * @privateRemarks
-		 * Opt this into observation tracking.
-		 * TODO: This being a mutable instance property is not required, and might not be the best API design choice.
+		 * Use {@link FormattedTextAsTree.Members.insertWithFormattingAt} if you need to specify formatting for atom independently.
+		 * @override
 		 */
-		defaultFormat: TreeFieldFromImplicitField<FormatSchema>;
+		insertAt(
+			index: number,
+			additionalCharacters:
+				| string
+				| Iterable<TreeNodeFromImplicitAllowedTypes<TextAtomSchemas<ExtraAtomsSchema>>>,
+			format?: InsertableTreeFieldFromImplicitField<FormatSchema>,
+		): void;
 
 		/**
 		 * Gets an array type view of the characters currently in the text.
@@ -642,7 +694,7 @@ export namespace FormattedTextAsTree {
 		 */
 		charactersWithFormatting(): readonly FormattedAtom<
 			TreeNodeFromImplicitAllowedTypes<FormatSchema>,
-			TreeNodeFromImplicitAllowedTypes<FormattedTextAtoms<ExtraAtomsSchema>>
+			TreeNodeFromImplicitAllowedTypes<TextAtomSchemas<ExtraAtomsSchema>>
 		>[];
 
 		/**
@@ -663,7 +715,7 @@ export namespace FormattedTextAsTree {
 			additionalCharacters: Iterable<
 				FormattedAtomInsertable<
 					InsertableTreeNodeFromImplicitAllowedTypes<FormatSchema>,
-					InsertableTreeNodeFromImplicitAllowedTypes<FormattedTextAtoms<ExtraAtomsSchema>>
+					InsertableTreeNodeFromImplicitAllowedTypes<TextAtomSchemas<ExtraAtomsSchema>>
 				>
 			>,
 		): void;
@@ -699,7 +751,7 @@ export namespace FormattedTextAsTree {
 		 * @param endIndex - The ending index (exclusive) of the range to format.
 		 * @param format - The formatting to replace the formatting of the indicated range with.
 		 * For each atom, `format` will be cloned and assigned to the atom's format, overwriting any existing formatting.
-		 * If not specified the {@link FormattedTextAsTree.Members.defaultFormat} will be used.
+		 * If not specified the `defaultFormat` from {@link FormattedTextAsTree.createSchema} will be used.
 		 * @remarks
 		 * The start and end behave the same as in {@link (TreeArrayNode:interface).removeRange}.
 		 *
@@ -710,7 +762,7 @@ export namespace FormattedTextAsTree {
 		reformat(
 			startIndex?: number | undefined,
 			endIndex?: number | undefined,
-			format?: TreeFieldFromImplicitField<FormatSchema>,
+			format?: InsertableTreeFieldFromImplicitField<FormatSchema>,
 		): void;
 
 		/**
@@ -770,12 +822,14 @@ export namespace FormattedTextAsTree {
 	>;
 
 	/**
-	 * Helper for expressing the full set of formatted text atoms for a given schema.
-	 * @privateRemarks
-	 * Eventually this should probably be given a better name and/or made a system type in a system namespace.
+	 * Helper for expressing the full set of text atoms for a given schema.
+	 * @remarks
+	 * This is just schema for the text atom {@link AllowedTypes},
+	 * and does not include the actual formatting (which is higher up in the tree).
+	 * @sealed
 	 * @internal
 	 */
-	export type FormattedTextAtoms<
+	export type TextAtomSchemas<
 		ExtraAtomsSchema extends readonly LazyItem<
 			TreeNodeSchema<string, NodeKind, TextAtom & TreeNode>
 		>[],

--- a/packages/dds/tree/src/text/textDomainFormattedDefault.ts
+++ b/packages/dds/tree/src/text/textDomainFormattedDefault.ts
@@ -132,7 +132,7 @@ export namespace FormattedTextAsTreeDefault {
 	 */
 	export type FormattedAtomInsertable = FormattedTextAsTree.FormattedAtom<
 		InsertableTreeNodeFromImplicitAllowedTypes<typeof CharacterFormat>,
-		InsertableTreeNodeFromImplicitAllowedTypes<FormattedTextAtoms>
+		InsertableTreeNodeFromImplicitAllowedTypes<TextAtomSchemas>
 	>;
 
 	/**
@@ -142,9 +142,7 @@ export namespace FormattedTextAsTreeDefault {
 	 * @sealed
 	 * @internal
 	 */
-	export type FormattedTextAtoms = FormattedTextAsTree.FormattedTextAtoms<
-		[typeof StringLineAtom]
-	>;
+	export type TextAtomSchemas = FormattedTextAsTree.TextAtomSchemas<[typeof StringLineAtom]>;
 
 	/**
 	 * The schema produced using {@link FormattedTextAsTree.createSchema} with hard-coded assumptions

--- a/packages/framework/quill-react/src/formatted/quillFormattedView.tsx
+++ b/packages/framework/quill-react/src/formatted/quillFormattedView.tsx
@@ -348,10 +348,7 @@ export function applyQuillDeltaToTree(
 					root.insertWithFormattingAt(cpPos, [createLineAtom(lineTag, indent)]);
 				} else {
 					// Insert: add new text with formatting at current position
-					root.defaultFormat = new FormattedTextAsTreeDefault.CharacterFormat(
-						quillAttributesToFormat(op.attributes),
-					);
-					root.insertAt(cpPos, op.insert);
+					root.insertAt(cpPos, op.insert, quillAttributesToFormat(op.attributes));
 				}
 				// Update content to reflect insertion
 				content = content.slice(0, utf16Pos) + op.insert + content.slice(utf16Pos);

--- a/packages/framework/quill-react/src/test/textEditor.test.tsx
+++ b/packages/framework/quill-react/src/test/textEditor.test.tsx
@@ -434,6 +434,13 @@ describe("textEditor", () => {
 
 						it("deletes bold text and removes <strong> tag", () => {
 							const { tree: text } = createFormattedTreeView();
+							text.insertAt(0, "BOLD", {
+								bold: true,
+								italic: false,
+								underline: false,
+								size: 12,
+								font: "Arial",
+							});
 							text.insertAt(4, "plain", createPlainFormat());
 
 							const content = <FormattedMainView root={toPropTreeNode(text)} />;

--- a/packages/framework/quill-react/src/test/textEditor.test.tsx
+++ b/packages/framework/quill-react/src/test/textEditor.test.tsx
@@ -418,14 +418,13 @@ describe("textEditor", () => {
 
 							assert.ok(!rendered.container.querySelector("strong"), "Initially: no <strong>");
 
-							text.defaultFormat = new FormattedTextAsTreeDefault.CharacterFormat({
+							text.insertAt(2, "BOLD", {
 								bold: true,
 								italic: false,
 								underline: false,
 								size: 12,
 								font: "Arial",
 							});
-							text.insertAt(2, "BOLD");
 
 							rendered.rerender(content);
 							const el = rendered.container.querySelector("strong");
@@ -435,16 +434,7 @@ describe("textEditor", () => {
 
 						it("deletes bold text and removes <strong> tag", () => {
 							const { tree: text } = createFormattedTreeView();
-							text.defaultFormat = new FormattedTextAsTreeDefault.CharacterFormat({
-								bold: true,
-								italic: false,
-								underline: false,
-								size: 12,
-								font: "Arial",
-							});
-							text.insertAt(0, "BOLD");
-							text.defaultFormat = createPlainFormat();
-							text.insertAt(4, "plain");
+							text.insertAt(4, "plain", createPlainFormat());
 
 							const content = <FormattedMainView root={toPropTreeNode(text)} />;
 							const rendered = render(content, { reactStrictMode });
@@ -482,14 +472,13 @@ describe("textEditor", () => {
 
 							assert.ok(!rendered.container.querySelector("em"), "Initially: no <em>");
 
-							text.defaultFormat = new FormattedTextAsTreeDefault.CharacterFormat({
+							text.insertAt(2, "ITAL", {
 								bold: false,
 								italic: true,
 								underline: false,
 								size: 12,
 								font: "Arial",
 							});
-							text.insertAt(2, "ITAL");
 
 							rendered.rerender(content);
 							const el = rendered.container.querySelector("em");
@@ -499,16 +488,14 @@ describe("textEditor", () => {
 
 						it("deletes italic text and removes <em> tag", () => {
 							const { tree: text } = createFormattedTreeView();
-							text.defaultFormat = new FormattedTextAsTreeDefault.CharacterFormat({
+							text.insertAt(0, "ITAL", {
 								bold: false,
 								italic: true,
 								underline: false,
 								size: 12,
 								font: "Arial",
 							});
-							text.insertAt(0, "ITAL");
-							text.defaultFormat = createPlainFormat();
-							text.insertAt(4, "plain");
+							text.insertAt(4, "plain", createPlainFormat());
 
 							const content = <FormattedMainView root={toPropTreeNode(text)} />;
 							const rendered = render(content, { reactStrictMode });
@@ -543,14 +530,13 @@ describe("textEditor", () => {
 
 							assert.ok(!rendered.container.querySelector("u"), "Initially: no <u>");
 
-							text.defaultFormat = new FormattedTextAsTreeDefault.CharacterFormat({
+							text.insertAt(2, "UNDER", {
 								bold: false,
 								italic: false,
 								underline: true,
 								size: 12,
 								font: "Arial",
 							});
-							text.insertAt(2, "UNDER");
 
 							rendered.rerender(content);
 							const el = rendered.container.querySelector("u");
@@ -560,16 +546,14 @@ describe("textEditor", () => {
 
 						it("deletes underlined text and removes <u> tag", () => {
 							const { tree: text } = createFormattedTreeView();
-							text.defaultFormat = new FormattedTextAsTreeDefault.CharacterFormat({
+							text.insertAt(0, "UNDER", {
 								bold: false,
 								italic: false,
 								underline: true,
 								size: 12,
 								font: "Arial",
 							});
-							text.insertAt(0, "UNDER");
-							text.defaultFormat = createPlainFormat();
-							text.insertAt(5, "plain");
+							text.insertAt(5, "plain", createPlainFormat());
 
 							const content = <FormattedMainView root={toPropTreeNode(text)} />;
 							const rendered = render(content, { reactStrictMode });
@@ -607,14 +591,13 @@ describe("textEditor", () => {
 								"Initially: no .ql-size-huge",
 							);
 
-							text.defaultFormat = new FormattedTextAsTreeDefault.CharacterFormat({
+							text.insertAt(2, "HUGE", {
 								bold: false,
 								italic: false,
 								underline: false,
 								size: 24,
 								font: "Arial",
 							});
-							text.insertAt(2, "HUGE");
 
 							rendered.rerender(content);
 							const el = rendered.container.querySelector(".ql-size-huge");
@@ -624,16 +607,14 @@ describe("textEditor", () => {
 
 						it("deletes huge size text and removes .ql-size-huge", () => {
 							const { tree: text } = createFormattedTreeView();
-							text.defaultFormat = new FormattedTextAsTreeDefault.CharacterFormat({
+							text.insertAt(0, "HUGE", {
 								bold: false,
 								italic: false,
 								underline: false,
 								size: 24,
 								font: "Arial",
 							});
-							text.insertAt(0, "HUGE");
-							text.defaultFormat = createPlainFormat();
-							text.insertAt(4, "plain");
+							text.insertAt(4, "plain", createPlainFormat());
 
 							const content = <FormattedMainView root={toPropTreeNode(text)} />;
 							const rendered = render(content, { reactStrictMode });
@@ -677,14 +658,13 @@ describe("textEditor", () => {
 								"Initially: no .ql-font-monospace",
 							);
 
-							text.defaultFormat = new FormattedTextAsTreeDefault.CharacterFormat({
+							text.insertAt(2, "MONO", {
 								bold: false,
 								italic: false,
 								underline: false,
 								size: 12,
 								font: "monospace",
 							});
-							text.insertAt(2, "MONO");
 
 							rendered.rerender(content);
 							const el = rendered.container.querySelector(".ql-font-monospace");
@@ -694,16 +674,14 @@ describe("textEditor", () => {
 
 						it("deletes monospace font text and removes .ql-font-monospace", () => {
 							const { tree: text } = createFormattedTreeView();
-							text.defaultFormat = new FormattedTextAsTreeDefault.CharacterFormat({
+							text.insertAt(0, "MONO", {
 								bold: false,
 								italic: false,
 								underline: false,
 								size: 12,
 								font: "monospace",
 							});
-							text.insertAt(0, "MONO");
-							text.defaultFormat = createPlainFormat();
-							text.insertAt(4, "plain");
+							text.insertAt(4, "plain", createPlainFormat());
 
 							const content = <FormattedMainView root={toPropTreeNode(text)} />;
 							const rendered = render(content, { reactStrictMode });


### PR DESCRIPTION
## Description

Remove `defaultFormat` property from FormattedTextAsTree.Members.
Extend `insertAt` so it can insert either strings or typed text atoms with optional formatting.

## Breaking Changes

APIs are internal only (so no changeset).

Callers using `FormattedTextAsTree.Members.defaultFormat` must pass formatting directly to `insertAt` or `reformat`. References to `FormattedTextAtoms` must use `TextAtomSchemas`.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
