### PR TITLE
Respect publishAsPartOfBuild in pipeline templates

### DIFF
--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -662,14 +662,14 @@ extends:
     # This is also true if the releaseKind is 'npm' (meaning we only want to publish the npm packages).
     # But if the releaseKind is 'docker' (meaning we only want to publish the docker images, not the npm packages),
     # then those steps should tag the repo.
-    - ${{ if and(eq(parameters.shouldPublishNpmPackages, true), ne(parameters.releaseKind, 'docker')) }}:
+    - ${{ if and(eq(parameters.publishAsPartOfBuild, true), eq(parameters.shouldPublishNpmPackages, true), ne(parameters.releaseKind, 'docker')) }}:
       - template: /tools/pipelines/templates/include-publish-npm-package.yml@self
         parameters:
           tagName: ${{ parameters.tagName }}
           isReleaseGroup: ${{ parameters.isReleaseGroup }}
           buildDirectory: ${{ parameters.buildDirectory }}
 
-    - ${{ if eq(parameters.shouldReleaseDockerImage, true) }}:
+    - ${{ if and(eq(parameters.publishAsPartOfBuild, true), eq(parameters.shouldReleaseDockerImage, true)) }}:
       - stage: publish_docker_official
         dependsOn: build
         displayName: Publish Official Docker Image

--- a/tools/pipelines/templates/build-npm-client-package.yml
+++ b/tools/pipelines/templates/build-npm-client-package.yml
@@ -913,7 +913,7 @@ extends:
                   condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
 
       # Publish stage
-      - ${{ if eq(parameters.publish, true) }}:
+      - ${{ if and(eq(parameters.publish, true), eq(parameters.publishAsPartOfBuild, true)) }}:
         - template: /tools/pipelines/templates/include-publish-npm-package.yml@self
           parameters:
             tagName: ${{ parameters.tagName }}
@@ -927,18 +927,19 @@ extends:
           parameters:
             dependsOn:
               - build
-              # Note: the publish stages are created in include-publish-npm-package.yml. We need to match the ids exactly.
-              - publish_npm_internal_test
-              - publish_npm_internal_build
-              - publish_npm_public
-              # NOTE: This is brittle; since the publish_npm_internal_dev stage is added to the pipeline conditionally,
-              # we create a dependency on it based on the same condition.
-              # So this needs to be kept in sync with the logic that include-publish-npm-package.yml uses to create the stage.
-              # At some point it might be preferable to always create the stage, control its execution solely with
-              # 'condition:', and update this bit to always depend on publish_npm_internal_dev, since it will always exist.
-              - ${{ if eq(parameters.isReleaseGroup, true) }}:
-                - publish_npm_internal_dev
-              - upload_manifests
+              - ${{ if and(eq(parameters.publish, true), eq(parameters.publishAsPartOfBuild, true)) }}:
+                # Note: the publish stages are created in include-publish-npm-package.yml. We need to match the ids exactly.
+                - publish_npm_internal_test
+                - publish_npm_internal_build
+                - publish_npm_public
+                # NOTE: This is brittle; since the publish_npm_internal_dev stage is added to the pipeline conditionally,
+                # we create a dependency on it based on the same condition.
+                # So this needs to be kept in sync with the logic that include-publish-npm-package.yml uses to create the stage.
+                # At some point it might be preferable to always create the stage, control its execution solely with
+                # 'condition:', and update this bit to always depend on publish_npm_internal_dev, since it will always exist.
+                - ${{ if eq(parameters.isReleaseGroup, true) }}:
+                  - publish_npm_internal_dev
+                - upload_manifests
             telemetryDescription: 'stage_timing'
             telemetry_upload_steps:
               - template: /tools/pipelines/templates/upload-telemetry/include-steps-upload-stage-timing.yml@self

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -637,7 +637,7 @@ extends:
                       publishLocation: pipeline
 
       # Publish stage
-      - ${{ if eq(parameters.publish, true) }}:
+      - ${{ if and(eq(parameters.publish, true), eq(parameters.publishAsPartOfBuild, true)) }}:
         - template: /tools/pipelines/templates/include-publish-npm-package.yml@self
           parameters:
             tagName: ${{ parameters.tagName }}
@@ -650,17 +650,18 @@ extends:
           parameters:
             dependsOn:
               - build
-              # Note: the publish stages are created in include-publish-npm-package.yml. We need to match the ids exactly.
-              - publish_npm_internal_test
-              - publish_npm_internal_build
-              - publish_npm_public
-              # NOTE: This is brittle; since the publish_npm_internal_dev stage is added to the pipeline conditionally,
-              # we create a dependency on it based on the same condition.
-              # So this needs to be kept in sync with the logic that include-publish-npm-package.yml uses to create the stage.
-              # At some point it might be preferable to always create the stage, control its execution solely with
-              # 'condition:', and update this bit to always depend on publish_npm_internal_dev, since it will always exist.
-              - ${{ if eq(parameters.isReleaseGroup, true) }}:
-                - publish_npm_internal_dev
+              - ${{ if and(eq(parameters.publish, true), eq(parameters.publishAsPartOfBuild, true)) }}:
+                # Note: the publish stages are created in include-publish-npm-package.yml. We need to match the ids exactly.
+                - publish_npm_internal_test
+                - publish_npm_internal_build
+                - publish_npm_public
+                # NOTE: This is brittle; since the publish_npm_internal_dev stage is added to the pipeline conditionally,
+                # we create a dependency on it based on the same condition.
+                # So this needs to be kept in sync with the logic that include-publish-npm-package.yml uses to create the stage.
+                # At some point it might be preferable to always create the stage, control its execution solely with
+                # 'condition:', and update this bit to always depend on publish_npm_internal_dev, since it will always exist.
+                - ${{ if eq(parameters.isReleaseGroup, true) }}:
+                  - publish_npm_internal_dev
             telemetryDescription: 'stage_timing'
             telemetry_upload_steps:
               - template: /tools/pipelines/templates/upload-telemetry/include-steps-upload-stage-timing.yml@self


### PR DESCRIPTION
## Description

Publish stages should only run for pipelines that declare `publishAsPartOfBuild: true`.

Test run to avoid regressions: https://dev.azure.com/fluidframework/internal/_build/results?buildId=413198&view=results