### PR TITLE
Type erase the details of StringTextAtom to prevent implicit construction with invalid strings

### DIFF
--- a/packages/dds/tree/src/test/text/textDomainFormatted.spec.ts
+++ b/packages/dds/tree/src/test/text/textDomainFormatted.spec.ts
@@ -170,6 +170,8 @@ describe("textDomainFormatted", () => {
 				atoms.map((atom) => atom.content),
 				["a", "😀", "b"],
 			);
+			const empty = FormattedTextAsTree.StringTextAtom.fromString("");
+			assert.deepEqual(empty, []);
 		});
 	});
 

--- a/packages/dds/tree/src/test/text/textDomainFormatted.spec.ts
+++ b/packages/dds/tree/src/test/text/textDomainFormatted.spec.ts
@@ -20,6 +20,7 @@ import { setEnableExpensiveDebugAsserts } from "../../text/textDomain.js";
 import type { TextAsTree } from "../../text/textDomain.js";
 import {
 	FormattedTextAsTree,
+	StringTextAtomNode,
 	// eslint-disable-next-line import-x/no-internal-modules -- Importing code being tested
 } from "../../text/textDomainFormatted.js";
 import { describeHydration, hydrateNode } from "../simple-tree/index.js";
@@ -146,6 +147,32 @@ describe("textDomainFormatted", () => {
 		);
 	});
 
+	describe("StringTextAtom", () => {
+		it("fromCharacter creates one atom", () => {
+			assert.equal(FormattedTextAsTree.StringTextAtom.fromCharacter("a").content, "a");
+			assert.equal(FormattedTextAsTree.StringTextAtom.fromCharacter("😀").content, "😀");
+		});
+
+		it("fromCharacter rejects values which are not one character", () => {
+			assert.throws(
+				() => FormattedTextAsTree.StringTextAtom.fromCharacter(""),
+				validateUsageError(/exactly one Unicode character/),
+			);
+			assert.throws(
+				() => FormattedTextAsTree.StringTextAtom.fromCharacter("ab"),
+				validateUsageError(/exactly one Unicode character/),
+			);
+		});
+
+		it("fromString creates one atom per character", () => {
+			const atoms = FormattedTextAsTree.StringTextAtom.fromString("a😀b");
+			assert.deepEqual(
+				atoms.map((atom) => atom.content),
+				["a", "😀", "b"],
+			);
+		});
+	});
+
 	describe("formatRange", () => {
 		it("basic use", () => {
 			const text = FormattedTextAsTreeDefault.Tree.fromString("hello");
@@ -185,7 +212,9 @@ describe("textDomainFormatted", () => {
 		it("throws when an atom's format is a non-object node", () => {
 			const text = UnionFormatText.fromString("b");
 			// Prepend an atom whose format is a non-object (number) node.
-			text.insertWithFormattingAt(0, [{ content: { content: "a" }, format: 5 }]);
+			text.insertWithFormattingAt(0, [
+				{ content: FormattedTextAsTree.StringTextAtom.fromCharacter("a"), format: 5 },
+			]);
 			assert.throws(
 				() => text.formatRange(0, 2, { bold: true }),
 				validateUsageError(/formatRange currently only supports object nodes for the format./),
@@ -195,7 +224,9 @@ describe("textDomainFormatted", () => {
 		it("throws when a non-object node format occurs in the middle of a range", () => {
 			const text = UnionFormatText.fromString("ac");
 			// Insert an atom with a non-object (number) format between the two object-formatted atoms.
-			text.insertWithFormattingAt(1, [{ content: { content: "b" }, format: 5 }]);
+			text.insertWithFormattingAt(1, [
+				{ content: FormattedTextAsTree.StringTextAtom.fromCharacter("b"), format: 5 },
+			]);
 			// The range spans object formats at either end with a non-object format in the middle.
 			assert.throws(
 				() => text.formatRange(0, 3, { bold: true }),
@@ -308,7 +339,7 @@ describe("textDomainFormatted", () => {
 		const text = FormattedTextAsTreeDefault.Tree.fromString("ab");
 		text.insertWithFormattingAt(1, [
 			{
-				content: { content: "c" },
+				content: FormattedTextAsTree.StringTextAtom.fromCharacter("c"),
 				format: {
 					bold: false,
 					italic: true,
@@ -364,7 +395,7 @@ describe("textDomainFormatted", () => {
 					tag: FormattedTextAsTreeDefault.LineTag("h1"),
 					indent: 0,
 				}),
-				new FormattedTextAsTree.StringTextAtom({ content: "c" }),
+				FormattedTextAsTree.StringTextAtom.fromCharacter("c"),
 			],
 			{
 				bold: true,
@@ -724,7 +755,7 @@ describe("textDomainFormatted", () => {
 			it("edit character text", () => {
 				const [text, log] = setupObservations();
 				const char = text.charactersWithFormatting()[2].content;
-				assert(char instanceof FormattedTextAsTree.StringTextAtom);
+				assert(char instanceof StringTextAtomNode);
 				char.content = "X";
 				checkLog(log, ["fullString", "characters", "charactersCopy"], overInvalidated);
 			});

--- a/packages/dds/tree/src/text/textDomainFormatted.ts
+++ b/packages/dds/tree/src/text/textDomainFormatted.ts
@@ -22,6 +22,7 @@ import {
 	TreeArrayNode,
 	TreeBeta,
 	createCustomizedFluidFrameworkScopedFactory,
+	eraseSchemaDetails,
 	isObjectNodeSchema,
 	eraseSchemaDetailsSubclassable,
 } from "../simple-tree/index.js";
@@ -41,7 +42,13 @@ import type {
 	ErasedNode,
 	SchemaFactoryBeta,
 } from "../simple-tree/index.js";
-import { brand, mapIterable, validateIndex, validateIndexRange } from "../util/index.js";
+import {
+	brand,
+	mapIterable,
+	oneFromIterable,
+	validateIndex,
+	validateIndexRange,
+} from "../util/index.js";
 
 import {
 	charactersFromString,
@@ -69,6 +76,44 @@ const sfStatic = new SchemaFactoryAlpha("com.fluidframework.text.formatted");
 const formatKey: FieldKey = brand("format");
 
 /**
+ * Atom in the string containing a single character.
+ * @privateRemarks
+ * This is outside the namespace so it can be exported for testing, but not package exported.
+ */
+export class StringTextAtomNode
+	extends sfStatic.object("StringTextAtom", {
+		/**
+		 * The underlying text content of this atom.
+		 * @remarks
+		 * This is typically a single Unicode code point, and thus may contain multiple UTF-16 surrogate pair code units.
+		 * Using longer strings is still valid. For example, so users might store whole grapheme clusters here, or even longer sections of text.
+		 * Anything combined into a single atom will be treated atomically, and can not be partially selected or formatted.
+		 * Using larger atoms and splitting them as needed is NOT a recommended approach, since this will result in poor merge behavior for concurrent edits.
+		 * Instead atoms should always be the smallest unit of text which will be independently selected, moved or formatted.
+		 * @privateRemarks
+		 * This content logically represents the whole atom's content, so using {@link EmptyKey} makes sense to help indicate that.
+		 */
+		content: SchemaFactory.required([SchemaFactory.string], { key: EmptyKey }),
+	})
+	implements FormattedTextAsTree.TextAtom
+{
+	public static fromCharacter(value: string): StringTextAtomNode {
+		const character = oneFromIterable(charactersFromString(value));
+		if (character === undefined) {
+			throw new UsageError("value must contain exactly one Unicode character.");
+		}
+		return new StringTextAtomNode({ content: character });
+	}
+
+	public static fromString(value: string): StringTextAtomNode[] {
+		return Array.from(
+			charactersFromString(value),
+			(character) => new StringTextAtomNode({ content: character }),
+		);
+	}
+}
+
+/**
  * A collection of text related types, schema and utilities for working with text beyond the basic {@link SchemaStatics.string}.
  * @remarks
  * This is generic over formatting an embedded object/atom types.
@@ -89,7 +134,7 @@ export namespace FormattedTextAsTree {
 	 * It must be different to distinguish different formatted text schema within the same document.
 	 * @param formatSchema - Schema describing the formatting associated with each atom of text.
 	 * Use an {@link NodeKind.Object|Object node} to support {@link FormattedTextAsTree.Members.formatRange}.
-	 * @param extraAtoms - Additional atom schema to allow as text content beyond the built-in {@link FormattedTextAsTree.StringTextAtom}.
+	 * @param extraAtoms - Additional atom schema to allow as text content beyond the built-in {@link FormattedTextAsTree.(StringTextAtom:variable)}.
 	 * Use this to embed richer content (for example line breaks or inline objects) alongside plain characters.
 	 * @param defaultFormatInsertable - The formatting applied to text inserted via non-formatted APIs
 	 * (for example {@link FormattedTextAsTree.Members.insertAt} and {@link FormattedTextAsTree.Statics.fromString} when no explicit format is provided).
@@ -97,7 +142,7 @@ export namespace FormattedTextAsTree {
 	 * @remarks
 	 * See {@link FormattedTextAsTreeDefault} for a default parameterization of this factory.
 	 * @privateRemarks
-	 * TODO: The choice to always include the built-in `StringTextAtom` is a design decision that should be re-evaluated before stabilizing.
+	 * TODO: The choice to always include the built-in {@link FormattedTextAsTree.(StringTextAtom:variable)} is a design decision that should be re-evaluated before stabilizing.
 	 */
 	export function createSchema<
 		const TUserScope extends string,
@@ -374,12 +419,9 @@ export namespace FormattedTextAsTree {
 		function stringTextAtomsFromString(
 			value: string,
 		): Iterable<StringTextAtom & TextAtomNode> {
-			return mapIterable(
-				charactersFromString(value),
-				// TypeScript can't prove in this Generic context that StringTextAtom is assignable to TextAtomNode, so we have to cast.
-				// Since TextAtomSchemas unconditionally includes StringTextAtom, this cast is safe.
-				(char) => new StringTextAtom({ content: char }) as StringTextAtom & TextAtomNode,
-			);
+			// TypeScript can't prove in this Generic context that StringTextAtom is assignable to TextAtomNode, so we have to cast.
+			// Since TextAtomSchemas unconditionally includes StringTextAtom, this cast is safe.
+			return StringTextAtom.fromString(value) as (StringTextAtom & TextAtomNode)[];
 		}
 
 		function stringAtomsFromTextAtoms(
@@ -583,16 +625,30 @@ export namespace FormattedTextAsTree {
 
 	/**
 	 * Portion of a string with formatting.
+	 * @privateRemarks
+	 * This is implemented {@link StringAtom}, but we avoid leaking the fact this is a TreeNode in the API surface to
+	 * preserve more future flexibility.
 	 * @sealed
 	 * @internal
 	 */
 	export interface FormattedAtom<TFormat, TText> {
+		/**
+		 * Content which is formatted.
+		 */
 		readonly content: TText;
+		/**
+		 * Formatting which is applied to the content.
+		 * @remarks
+		 * Can be reassigned of deeply mutated to edit the formatting of the content.
+		 */
 		format: TFormat;
 	}
 
 	/**
 	 * Portion of a string.
+	 * @remarks
+	 * Additional kinds text atoms (also known as embedded objects) which can occur inside a string can implement this.
+	 * The schema for them can then be provided to {@link FormattedTextAsTree.createSchema}.
 	 * @internal
 	 */
 	export interface TextAtom {
@@ -603,26 +659,46 @@ export namespace FormattedTextAsTree {
 	}
 
 	/**
-	 * Unit in the string representing a single character.
+	 * Static factory functions for {@link FormattedTextAsTree.(StringTextAtom:variable)}.
+	 * @privateRemarks
+	 * We type erase StringTextAtom and only provide these static factories for construction
+	 * to reduce the chance of someone accidentally creating a text atom for a string other than a single unicode code point.
+	 * Other strings should work, but our intention is to provide no type safe API which can produce them, so an application can take their lack of existence as an invariant if they want.
+	 * It is still however possible to produce them, like export/import round trips with editing in the middle of the process, of collaboration with an equivalent schema which doesn't enforce this invariant.
 	 * @sealed
 	 * @internal
 	 */
-	export class StringTextAtom
-		extends sfStatic.object("StringTextAtom", {
-			/**
-			 * The underlying text content of this atom.
-			 * @remarks
-			 * This is typically a single Unicode code point, and thus may contain multiple UTF-16 surrogate pair code units.
-			 * Using longer strings is still valid. For example, so users might store whole grapheme clusters here, or even longer sections of text.
-			 * Anything combined into a single atom will be treated atomically, and can not be partially selected or formatted.
-			 * Using larger atoms and splitting them as needed is NOT a recommended approach, since this will result in poor merge behavior for concurrent edits.
-			 * Instead atoms should always be the smallest unit of text which will be independently selected, moved or formatted.
-			 * @privateRemarks
-			 * This content logically represents the whole atom's content, so using {@link EmptyKey} makes sense to help indicate that.
-			 */
-			content: SchemaFactory.required([SchemaFactory.string], { key: EmptyKey }),
-		})
-		implements TextAtom {}
+	export interface StringTextAtomStatics {
+		/**
+		 * Creates an atom from exactly one Unicode code point.
+		 * @throws A {@link @fluidframework/telemetry-utils#UsageError} if `value` does not contain exactly one Unicode code character.
+		 */
+		fromCharacter(value: string): StringTextAtom;
+
+		/**
+		 * Creates one atom for each Unicode code point in `value`.
+		 */
+		fromString(value: string): StringTextAtom[];
+	}
+
+	/**
+	 * Schema for a {@link FormattedTextAsTree.(StringTextAtom:variable)} node.
+	 * @sealed
+	 * @internal
+	 */
+	export const StringTextAtom = eraseSchemaDetails<TextAtom, StringTextAtomStatics>()(
+		StringTextAtomNode,
+	);
+
+	/**
+	 * Node for the {@link FormattedTextAsTree.(StringTextAtom:variable)} schema.
+	 * @sealed
+	 * @internal
+	 */
+	export type StringTextAtom = ErasedNode<
+		TextAtom,
+		"com.fluidframework.text.formatted.StringTextAtom"
+	>;
 
 	/**
 	 * Statics for formatted text nodes.

--- a/packages/dds/tree/src/text/textDomainFormatted.ts
+++ b/packages/dds/tree/src/text/textDomainFormatted.ts
@@ -86,10 +86,10 @@ export class StringTextAtomNode
 		 * The underlying text content of this atom.
 		 * @remarks
 		 * This is typically a single Unicode code point, and thus may contain multiple UTF-16 surrogate pair code units.
-		 * Using longer strings is still valid. For example, so users might store whole grapheme clusters here, or even longer sections of text.
+		 * Longer strings are still valid. For example, users might store whole grapheme clusters here, or even longer sections of text.
 		 * Anything combined into a single atom will be treated atomically, and can not be partially selected or formatted.
 		 * Using larger atoms and splitting them as needed is NOT a recommended approach, since this will result in poor merge behavior for concurrent edits.
-		 * Instead atoms should always be the smallest unit of text which will be independently selected, moved or formatted.
+		 * Instead, atoms should always be the smallest unit of text which will be independently selected, moved or formatted.
 		 * @privateRemarks
 		 * This content logically represents the whole atom's content, so using {@link EmptyKey} makes sense to help indicate that.
 		 */
@@ -639,7 +639,7 @@ export namespace FormattedTextAsTree {
 		/**
 		 * Formatting which is applied to the content.
 		 * @remarks
-		 * Can be reassigned of deeply mutated to edit the formatting of the content.
+		 * Can be reassigned or deeply mutated to edit the formatting of the content.
 		 */
 		format: TFormat;
 	}
@@ -647,7 +647,7 @@ export namespace FormattedTextAsTree {
 	/**
 	 * Portion of a string.
 	 * @remarks
-	 * Additional kinds text atoms (also known as embedded objects) which can occur inside a string can implement this.
+	 * Additional kinds of text atoms (also known as embedded objects) which can occur inside a string can implement this.
 	 * The schema for them can then be provided to {@link FormattedTextAsTree.createSchema}.
 	 * @internal
 	 */
@@ -661,10 +661,10 @@ export namespace FormattedTextAsTree {
 	/**
 	 * Static factory functions for {@link FormattedTextAsTree.(StringTextAtom:variable)}.
 	 * @privateRemarks
-	 * We type erase StringTextAtom and only provide these static factories for construction
+	 * We type-erase `StringTextAtom` and only provide these static factories for construction
 	 * to reduce the chance of someone accidentally creating a text atom for a string other than a single unicode code point.
-	 * Other strings should work, but our intention is to provide no type safe API which can produce them, so an application can take their lack of existence as an invariant if they want.
-	 * It is still however possible to produce them, like export/import round trips with editing in the middle of the process, of collaboration with an equivalent schema which doesn't enforce this invariant.
+	 * Other strings should work, but our intention is to provide no type-safe API which can produce them, so an application can take their lack of existence as an invariant if they want.
+	 * It is still however possible to produce them, like export/import round trips with editing in the middle of the process, or collaboration with an equivalent schema which doesn't enforce this invariant.
 	 * @sealed
 	 * @internal
 	 */

--- a/packages/framework/quill-react/src/test/applyQuillDeltaToTree.test.ts
+++ b/packages/framework/quill-react/src/test/applyQuillDeltaToTree.test.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "node:assert";
 
-import { TreeViewConfiguration } from "@fluidframework/tree";
+import { Tree, TreeViewConfiguration } from "@fluidframework/tree";
 import {
 	independentView,
 	FormattedTextAsTreeDefault,
@@ -134,11 +134,10 @@ describe("applyQuillDeltaToTree", () => {
 
 	it("clears line formatting (case 4: line atom -> plain newline)", () => {
 		const tree = lineAtomTree("h1");
-		// Quill emits header: null when clearing line formatting.
-		// eslint-disable-next-line unicorn/no-null
+		// eslint-disable-next-line unicorn/no-null -- Quill emits header: null when clearing line formatting.
 		applyQuillDeltaToTree(tree, new Delta().retain(1, { header: null }));
 		const atom = tree.charactersWithFormatting()[0]?.content;
-		assert(atom instanceof FormattedTextAsTree.StringTextAtom);
+		assert(Tree.is(atom, FormattedTextAsTree.StringTextAtom));
 		assert.equal(tree.fullString(), "\n");
 	});
 


### PR DESCRIPTION
## Description

Type erase the details of StringTextAtom to prevent implicit construction with invalid strings.
This also erases its schema from the API, making schema evolution practical and property key renames non-breaking.

## Breaking Changes

These are all internal, so no changeset, and should not break any apps:

1. Users of StringTextAtomNode's constructor have to move to the static factories.
2. Users of instanceof can use Tree.is instead.
3. Users modifiying the content of a StringTextAtom must repalce the whole node now.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
