### PR TITLE
Include final retain in tree deltas

### DIFF
--- a/.changeset/complete-array-deltas.md
+++ b/.changeset/complete-array-deltas.md
@@ -1,0 +1,12 @@
+---
+"@fluidframework/tree": minor
+"fluid-framework": minor
+"__section": tree
+---
+Array node deltas now cover the complete array
+
+`ArrayNodeDeltaOp` and `ArrayNodeTreeChangedDeltaOp` sequences now include a final retain operation for an unchanged trailing portion of the array. Consumers can process the operations as a complete delta without separately retaining an omitted suffix.
+
+Text deltas inherit the same complete-coverage behavior.
+
+This should not break any existing users as this behavior was allowed under the old specification, but may allow some users to simplify their processing of the delta.

--- a/.changeset/fix-quill-terminal-newline.md
+++ b/.changeset/fix-quill-terminal-newline.md
@@ -1,0 +1,7 @@
+---
+"@fluidframework/quill-react": minor
+"__section": fix
+---
+Fix extra blank lines in collaborating Quill editors
+
+Quill React bindings now distinguish Quill's required terminal newline from user-authored content. Remote editors no longer render an extra blank paragraph after text or line-formatting changes, while intentional trailing line breaks remain synchronized.

--- a/packages/dds/tree/src/simple-tree/api/index.ts
+++ b/packages/dds/tree/src/simple-tree/api/index.ts
@@ -67,7 +67,6 @@ export {
 	createCustomizedFluidFrameworkScopedFactory,
 } from "./schemaCreationUtilities.js";
 export {
-	deltaMarksToArrayOps,
 	getIdentifierFromNode,
 	getPropertyKeyFromStoredKey,
 	getStoredKey,

--- a/packages/dds/tree/src/simple-tree/api/treeNodeApi.ts
+++ b/packages/dds/tree/src/simple-tree/api/treeNodeApi.ts
@@ -25,6 +25,7 @@ import {
 	type ImplicitAllowedTypes,
 	type TreeNodeFromImplicitAllowedTypes,
 	normalizeAllowedTypes,
+	type TreeNodeKernel,
 } from "../core/index.js";
 import { type ImplicitFieldSchema, FieldSchema } from "../fieldSchema.js";
 import { tryGetTreeNodeForField } from "../getTreeNodeForField.js";
@@ -114,6 +115,10 @@ export interface ArrayNodeRemoveOp {
  * When an element is moved across two different arrays, the source array's delta contains a
  * `"remove"` and the destination array's delta contains an `"insert"` — they cannot be
  * correlated without additional bookkeeping on the caller's side.
+ *
+ * The operations cover the complete array: trailing elements that were not changed are included
+ * in a final `"retain"` op. Applying every operation therefore consumes the entire pre-edit array
+ * and produces the entire post-edit array.
  *
  * @sealed @alpha
  */
@@ -296,7 +301,13 @@ export const treeNodeApi: TreeNodeApi = {
 						// unavailable rather than receiving stale marks from only the first batch.
 						// TODO: Once the eventing stack is rewritten to walk the composed delta at
 						// flush time, `marks` will always be defined. Remove the `undefined` fallback.
-						const delta = marks === undefined ? undefined : deltaMarksToArrayOps(marks);
+						const delta =
+							marks === undefined
+								? undefined
+								: deltaMarksToArrayOpsWithRetain(marks, getArrayLength(kernel), (count) => ({
+										type: "retain",
+										count,
+									}));
 						listener({ delta });
 					});
 				} else {
@@ -314,7 +325,17 @@ export const treeNodeApi: TreeNodeApi = {
 					return kernel.events.on("childrenChangedAfterBatch", ({ fieldMarks }) => {
 						const marks = fieldMarks.get(EmptyKey);
 						const delta =
-							marks === undefined ? undefined : deltaMarksToArrayOpsForTreeChanged(marks);
+							marks === undefined
+								? undefined
+								: deltaMarksToArrayOpsWithRetain(
+										marks,
+										getArrayLength(kernel),
+										(count, subtreeChanged) => ({
+											type: "retain",
+											count,
+											subtreeChanged,
+										}),
+									);
 						(listener as (data: { readonly delta: typeof delta }) => void)({ delta });
 					});
 				}
@@ -351,73 +372,59 @@ export const treeNodeApi: TreeNodeApi = {
 };
 
 /**
- * Converts an array of internal {@link DeltaMark}s for a sequence field into sequential
- * array delta ops suitable for inclusion in {@link NodeChangedDataDelta.delta}.
+ * Converts internal {@link DeltaMark}s for an array's sequence field into sequential array delta
+ * operations.
  *
- * Each mark in the delta describes a contiguous run of positions in the original array:
- * - A mark with only `count` (no attach/detach) → `"retain"` with no subtree information
- * - A mark with only `attach` → `"insert"` (new elements added)
- * - A mark with only `detach` → `"remove"` (elements removed)
- * - A mark with both `attach` and `detach` → `"remove"` + `"insert"`
+ * @remarks
+ * Each mark describes a contiguous run:
+ * - A mark with only `count` becomes a retain.
+ * - A mark with only `attach` becomes an insert.
+ * - A mark with only `detach` becomes a remove.
+ * - A mark with both `attach` and `detach` becomes a remove followed by an insert.
+ *
+ * Internal mark arrays may omit an unchanged suffix. The returned operations always cover the
+ * complete array, so this function uses the array's post-edit length to append a trailing retain
+ * when needed.
  *
  * @param marks - The low-level delta marks for the array's sequence field.
+ * @param postEditLength - The array's length after the edit.
+ * @param buildRetainOp - Builds a retain operation. Its second argument indicates whether the
+ * retained element's subtree changed; it is `false` for a synthesized trailing retain.
  *
  * @privateRemarks
  * The case where both `attach` and `detach` are set is unreachable today: the sequence-field
- * encoder never emits such marks for array (EmptyKey) fields. It is handled defensively.
+ * encoder never emits such marks for array (`EmptyKey`) fields. It is handled defensively.
  */
-export function deltaMarksToArrayOps(marks: readonly DeltaMark[]): ArrayNodeDeltaOp[] {
-	const ops: ArrayNodeDeltaOp[] = [];
+export function deltaMarksToArrayOpsWithRetain<TRetain extends ArrayNodeRetainOp>(
+	marks: readonly DeltaMark[],
+	postEditLength: number,
+	buildRetainOp: (count: number, subtreeChanged: boolean) => TRetain,
+): (TRetain | ArrayNodeInsertOp | ArrayNodeRemoveOp)[] {
+	const ops: (TRetain | ArrayNodeInsertOp | ArrayNodeRemoveOp)[] = [];
+	let processedLength = 0;
 	for (const mark of marks) {
 		if (mark.detach !== undefined) {
 			ops.push({ type: "remove", count: mark.count });
 		}
 		if (mark.attach !== undefined) {
 			ops.push({ type: "insert", count: mark.count });
+			processedLength += mark.count;
 		} else if (mark.detach === undefined) {
-			// Retain: elements were not added or removed.
-			ops.push({ type: "retain", count: mark.count });
+			// When `fields` is set, `count` is guaranteed to be 1 (DeltaMark invariant).
+			ops.push(buildRetainOp(mark.count, mark.fields !== undefined));
+			processedLength += mark.count;
 		}
+	}
+	// DeltaMark arrays are allowed to omit the trailing retain, while our user facing array equivalents are not, so add it if necessary.
+	assert(processedLength <= postEditLength, "Array delta exceeds post-edit array length");
+	if (processedLength < postEditLength) {
+		ops.push(buildRetainOp(postEditLength - processedLength, false));
 	}
 	return ops;
 }
 
-/**
- * Converts an array of internal {@link DeltaMark}s for a sequence field into sequential
- * {@link ArrayNodeTreeChangedDeltaOp}s suitable for inclusion in
- * {@link NodeChangedDataTreeDelta.delta} (delivered to {@link TreeChangeEventsAlpha.treeChanged}).
- *
- * Same conversion rules as {@link deltaMarksToArrayOps}, but retain ops additionally carry a
- * {@link ArrayNodeTreeChangedRetainOp.subtreeChanged} flag derived from whether the mark has
- * a `fields` property (indicating a descendant changed).
- *
- * @param marks - The low-level delta marks for the array's sequence field.
- *
- * @privateRemarks
- * The case where both `attach` and `detach` are set is unreachable today: the sequence-field
- * encoder never emits such marks for array (EmptyKey) fields. It is handled defensively.
- */
-export function deltaMarksToArrayOpsForTreeChanged(
-	marks: readonly DeltaMark[],
-): ArrayNodeTreeChangedDeltaOp[] {
-	const ops: ArrayNodeTreeChangedDeltaOp[] = [];
-	for (const mark of marks) {
-		if (mark.detach !== undefined) {
-			ops.push({ type: "remove", count: mark.count });
-		}
-		if (mark.attach !== undefined) {
-			ops.push({ type: "insert", count: mark.count });
-		} else if (mark.detach === undefined) {
-			// Retain: elements were not added or removed (but may have deep changes).
-			// When `fields` is set, `count` is guaranteed to be 1 (DeltaMark invariant).
-			ops.push({
-				type: "retain",
-				count: mark.count,
-				subtreeChanged: mark.fields !== undefined,
-			});
-		}
-	}
-	return ops;
+function getArrayLength(arrayNodeKernel: TreeNodeKernel): number {
+	return arrayNodeKernel.getInnerNode().getBoxed(EmptyKey).length;
 }
 
 /**

--- a/packages/dds/tree/src/simple-tree/api/treeNodeApi.ts
+++ b/packages/dds/tree/src/simple-tree/api/treeNodeApi.ts
@@ -423,6 +423,12 @@ export function deltaMarksToArrayOpsWithRetain<TRetain extends ArrayNodeRetainOp
 	return ops;
 }
 
+/**
+ * Returns the length of the `EmptyKey` field under the provided node kernel.
+ * @remarks
+ * Use this with the kernel of an array node to get the current length of the array.
+ * This is the same as `.length` on the array node, but is usable without having to get (and possible create) the node and narrow to the proper type to access that.
+ */
 function getArrayLength(arrayNodeKernel: TreeNodeKernel): number {
 	return arrayNodeKernel.getInnerNode().getBoxed(EmptyKey).length;
 }

--- a/packages/dds/tree/src/simple-tree/index.ts
+++ b/packages/dds/tree/src/simple-tree/index.ts
@@ -100,7 +100,6 @@ export {
 	type ArrayNodeRetainOp,
 	type ArrayNodeTreeChangedDeltaOp,
 	type ArrayNodeTreeChangedRetainOp,
-	deltaMarksToArrayOps,
 	type NodeChangedData,
 	type NodeChangedDataAlpha,
 	type NodeChangedDataDelta,

--- a/packages/dds/tree/src/test/simple-tree/api/treeNodeApi.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/treeNodeApi.spec.ts
@@ -13,7 +13,7 @@ import {
 } from "@fluidframework/test-runtime-utils/internal";
 
 import { FluidClientVersion } from "../../../codec/index.js";
-import { type NormalizedUpPath, rootFieldKey } from "../../../core/index.js";
+import { type DeltaMark, type NormalizedUpPath, rootFieldKey } from "../../../core/index.js";
 import {
 	currentObserver,
 	defaultSchemaPolicy,
@@ -28,8 +28,12 @@ import {
 	TreeAlpha,
 	type TreeCheckout,
 } from "../../../shared-tree/index.js";
-// eslint-disable-next-line import-x/no-internal-modules
-import { tryGetSchema } from "../../../simple-tree/api/treeNodeApi.js";
+/* eslint-disable import-x/no-internal-modules */
+import {
+	deltaMarksToArrayOpsWithRetain,
+	tryGetSchema,
+} from "../../../simple-tree/api/treeNodeApi.js";
+/* eslint-enable import-x/no-internal-modules */
 // eslint-disable-next-line import-x/no-internal-modules
 import { fieldCursorFromVerbose } from "../../../simple-tree/api/verboseTree.js";
 import {
@@ -2741,13 +2745,117 @@ describe("treeNodeApi", () => {
 			assert.equal(eventCount, 1);
 		});
 
+		describe("deltaMarksToArrayOpsWithRetain", () => {
+			const detachedNodeId = { minor: 0 };
+			const buildRetain = (count: number, subtreeChanged: boolean) => ({
+				type: "retain" as const,
+				count,
+				subtreeChanged,
+			});
+
+			const cases: readonly {
+				name: string;
+				marks: readonly DeltaMark[];
+				postEditLength: number;
+				expected: readonly ArrayNodeTreeChangedDeltaOp[];
+			}[] = [
+				{
+					name: "empty array",
+					marks: [],
+					postEditLength: 0,
+					expected: [],
+				},
+				{
+					name: "omitted unchanged suffix",
+					marks: [],
+					postEditLength: 3,
+					expected: [{ type: "retain", count: 3, subtreeChanged: false }],
+				},
+				{
+					name: "explicit full retain",
+					marks: [{ count: 3 }],
+					postEditLength: 3,
+					expected: [{ type: "retain", count: 3, subtreeChanged: false }],
+				},
+				{
+					name: "middle insert",
+					marks: [{ count: 1 }, { count: 2, attach: detachedNodeId }],
+					postEditLength: 5,
+					expected: [
+						{ type: "retain", count: 1, subtreeChanged: false },
+						{ type: "insert", count: 2 },
+						{ type: "retain", count: 2, subtreeChanged: false },
+					],
+				},
+				{
+					name: "middle remove",
+					marks: [{ count: 1 }, { count: 2, detach: detachedNodeId }],
+					postEditLength: 3,
+					expected: [
+						{ type: "retain", count: 1, subtreeChanged: false },
+						{ type: "remove", count: 2 },
+						{ type: "retain", count: 2, subtreeChanged: false },
+					],
+				},
+				{
+					name: "replacement",
+					marks: [{ count: 2, attach: detachedNodeId, detach: { minor: 1 } }],
+					postEditLength: 4,
+					expected: [
+						{ type: "remove", count: 2 },
+						{ type: "insert", count: 2 },
+						{ type: "retain", count: 2, subtreeChanged: false },
+					],
+				},
+				{
+					name: "deep change",
+					marks: [{ count: 1 }, { count: 1, fields: new Map() }],
+					postEditLength: 3,
+					expected: [
+						{ type: "retain", count: 1, subtreeChanged: false },
+						{ type: "retain", count: 1, subtreeChanged: true },
+						{ type: "retain", count: 1, subtreeChanged: false },
+					],
+				},
+			];
+
+			for (const { name, marks, postEditLength, expected } of cases) {
+				it(name, () => {
+					assert.deepEqual(
+						deltaMarksToArrayOpsWithRetain(marks, postEditLength, buildRetain),
+						expected,
+					);
+				});
+			}
+
+			it("supports retain ops without subtree metadata", () => {
+				assert.deepEqual(
+					deltaMarksToArrayOpsWithRetain([{ count: 1, fields: new Map() }], 2, (count) => ({
+						type: "retain",
+						count,
+					})),
+					[
+						{ type: "retain", count: 1 },
+						{ type: "retain", count: 1 },
+					],
+				);
+			});
+
+			it("rejects operations beyond the post-edit length", () => {
+				assert.throws(
+					() => deltaMarksToArrayOpsWithRetain([{ count: 2 }], 1, buildRetain),
+					/Array delta exceeds post-edit array length/,
+				);
+			});
+		});
+
 		describe(`'nodeChanged' delta payload for array operations`, () => {
 			// These tests verify the concrete ArrayNodeDeltaOp values emitted for specific
 			// array mutations.  The delta follows Quill-style semantics:
-			//   retain  – elements that remain in place (leading unchanged elements)
+			//   retain  – elements that remain in place
 			//   insert  – elements added to the array
 			//   remove  – elements removed from the array
-			// Trailing unchanged elements are NOT represented by a trailing retain op.
+			// The operations cover the complete array, including trailing unchanged elements.
 			const sf = new SchemaFactory("nodeChanged-delta-content");
 			class TestArray extends sf.array("TestArray", [sf.number]) {}
 
@@ -2769,7 +2877,7 @@ describe("treeNodeApi", () => {
 				]);
 			});
 
-			it(`insertAt(0) emits only an insert op (no leading retain)`, () => {
+			it(`insertAt(0) retains the unchanged suffix`, () => {
 				const view = getView(new TreeViewConfiguration({ schema: TestArray }));
 				view.initialize([1, 2, 3]);
 				const root = view.root;
@@ -2779,10 +2887,15 @@ describe("treeNodeApi", () => {
 
 				root.insertAt(0, 0);
 
-				assert.deepEqual(deltas, [[{ type: "insert", count: 1 }]]);
+				assert.deepEqual(deltas, [
+					[
+						{ type: "insert", count: 1 },
+						{ type: "retain", count: 3 },
+					],
+				]);
 			});
 
-			it(`removeAt(0) emits only a remove op (no leading retain)`, () => {
+			it(`removeAt(0) retains the unchanged suffix`, () => {
 				const view = getView(new TreeViewConfiguration({ schema: TestArray }));
 				view.initialize([1, 2, 3]);
 				const root = view.root;
@@ -2792,7 +2905,12 @@ describe("treeNodeApi", () => {
 
 				root.removeAt(0);
 
-				assert.deepEqual(deltas, [[{ type: "remove", count: 1 }]]);
+				assert.deepEqual(deltas, [
+					[
+						{ type: "remove", count: 1 },
+						{ type: "retain", count: 2 },
+					],
+				]);
 			});
 
 			it(`removeAt(end) emits a leading retain followed by a remove`, () => {
@@ -2853,7 +2971,7 @@ describe("treeNodeApi", () => {
 				// Use a fork to compose two changes into a single delta: modify
 				// element 0's nested property and remove element 1. The merged
 				// delta's marks are [{count:1,fields:{...}}, {count:1,detach:id}].
-				// For nodeChanged (no subtreeChanged), this produces [retain, remove 1].
+				// For nodeChanged (no subtreeChanged), this produces [retain, remove 1, retain].
 				const { forkView, forkCheckout } = getViewForForkedBranch(view);
 				forkView.root[0].value = 99;
 				forkView.root.removeAt(1);
@@ -2863,6 +2981,7 @@ describe("treeNodeApi", () => {
 					[
 						{ type: "retain", count: 1 },
 						{ type: "remove", count: 1 },
+						{ type: "retain", count: 1 },
 					],
 				]);
 			});
@@ -2886,7 +3005,12 @@ describe("treeNodeApi", () => {
 					const deltas: (readonly ArrayNodeDeltaOp[] | undefined)[] = [];
 					TreeAlpha.on(root, "nodeChanged", ({ delta }) => deltas.push(delta));
 					root.removeAt(0);
-					assert.deepEqual(deltas, [[{ type: "remove", count: 1 }]]);
+					assert.deepEqual(deltas, [
+						[
+							{ type: "remove", count: 1 },
+							{ type: "retain", count: 2 },
+						],
+					]);
 				});
 
 				it(`moveToEnd fires nodeChanged with correct delta`, () => {
@@ -2933,7 +3057,10 @@ describe("treeNodeApi", () => {
 						"nodeChanged should not fire for deep change",
 					);
 					assert.deepEqual(treeChangedDeltas, [
-						[{ type: "retain", count: 1, subtreeChanged: true }],
+						[
+							{ type: "retain", count: 1, subtreeChanged: true },
+							{ type: "retain", count: 2, subtreeChanged: false },
+						],
 					]);
 				});
 
@@ -3071,7 +3198,7 @@ describe("treeNodeApi", () => {
 					]);
 				});
 
-				it(`insertAt(0) emits only an insert op (no spurious leading retain)`, () => {
+				it(`insertAt(0) retains the unchanged suffix`, () => {
 					const view = getView(new TreeViewConfiguration({ schema: ItemArray }));
 					view.initialize([{ v: 1 }, { v: 2 }]);
 					const root = view.root;
@@ -3081,7 +3208,12 @@ describe("treeNodeApi", () => {
 
 					root.insertAt(0, { v: 0 });
 
-					assert.deepEqual(treeChangedDeltas, [[{ type: "insert", count: 1 }]]);
+					assert.deepEqual(treeChangedDeltas, [
+						[
+							{ type: "insert", count: 1 },
+							{ type: "retain", count: 2, subtreeChanged: false },
+						],
+					]);
 				});
 
 				describe(`unhydrated array`, () => {
@@ -3110,7 +3242,10 @@ describe("treeNodeApi", () => {
 							"nodeChanged should not fire for deep change",
 						);
 						assert.deepEqual(treeChangedDeltas, [
-							[{ type: "retain", count: 1, subtreeChanged: true }],
+							[
+								{ type: "retain", count: 1, subtreeChanged: true },
+								{ type: "retain", count: 2, subtreeChanged: false },
+							],
 						]);
 					});
 
@@ -3129,6 +3264,7 @@ describe("treeNodeApi", () => {
 							[
 								{ type: "retain", count: 1, subtreeChanged: false },
 								{ type: "retain", count: 1, subtreeChanged: true },
+								{ type: "retain", count: 1, subtreeChanged: false },
 							],
 						]);
 					});

--- a/packages/dds/tree/src/test/simple-tree/core/treeNodeKernel.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/core/treeNodeKernel.spec.ts
@@ -387,9 +387,6 @@ describe("array node delta in nodeChanged", () => {
 	});
 
 	it("delta contains retain before insert for insert at middle position", () => {
-		// The sequence-field encoder strips trailing no-op marks, so elements after the
-		// insertion point are not included as a trailing retain — consumers should treat
-		// the remainder of the array as implicitly retained.
 		const myArray = hydrate(MyArray, [1, 2, 3]);
 
 		const deltas: (readonly ArrayNodeDeltaOp[] | undefined)[] = [];
@@ -403,12 +400,11 @@ describe("array node delta in nodeChanged", () => {
 		assert.deepEqual(deltas[0], [
 			{ type: "retain", count: 1 },
 			{ type: "insert", count: 1 },
+			{ type: "retain", count: 2 },
 		]);
 	});
 
 	it("delta contains retain and remove for removeAt from middle of array", () => {
-		// The sequence-field encoder strips trailing no-op marks, so the element after the
-		// removed position is not included as a trailing retain.
 		const myArray = hydrate(MyArray, [1, 2, 3]);
 
 		const deltas: (readonly ArrayNodeDeltaOp[] | undefined)[] = [];
@@ -422,11 +418,11 @@ describe("array node delta in nodeChanged", () => {
 		assert.deepEqual(deltas[0], [
 			{ type: "retain", count: 1 },
 			{ type: "remove", count: 1 },
+			{ type: "retain", count: 1 },
 		]);
 	});
 
-	it("insert at position 0 produces no leading retain", () => {
-		// Sparse encoding: no retain is emitted before the insert when operating at the start.
+	it("insert at position 0 retains the unchanged suffix", () => {
 		const myArray = hydrate(MyArray, [1, 2, 3]);
 
 		const deltas: (readonly ArrayNodeDeltaOp[] | undefined)[] = [];
@@ -437,11 +433,13 @@ describe("array node delta in nodeChanged", () => {
 		myArray.insertAt(0, 99);
 
 		assert.equal(deltas.length, 1);
-		assert.deepEqual(deltas[0], [{ type: "insert", count: 1 }]);
+		assert.deepEqual(deltas[0], [
+			{ type: "insert", count: 1 },
+			{ type: "retain", count: 3 },
+		]);
 	});
 
-	it("remove at position 0 produces no leading retain", () => {
-		// Sparse encoding: no retain is emitted before the remove when operating at the start.
+	it("remove at position 0 retains the unchanged suffix", () => {
 		const myArray = hydrate(MyArray, [1, 2, 3]);
 
 		const deltas: (readonly ArrayNodeDeltaOp[] | undefined)[] = [];
@@ -452,7 +450,10 @@ describe("array node delta in nodeChanged", () => {
 		myArray.removeAt(0);
 
 		assert.equal(deltas.length, 1);
-		assert.deepEqual(deltas[0], [{ type: "remove", count: 1 }]);
+		assert.deepEqual(deltas[0], [
+			{ type: "remove", count: 1 },
+			{ type: "retain", count: 2 },
+		]);
 	});
 
 	it("object node nodeChanged does not include delta", () => {
@@ -534,6 +535,7 @@ describe("array node delta in nodeChanged", () => {
 		assert.deepEqual(deltas[0], [
 			{ type: "retain", count: 1 },
 			{ type: "insert", count: 3 },
+			{ type: "retain", count: 1 },
 		]);
 	});
 
@@ -551,6 +553,7 @@ describe("array node delta in nodeChanged", () => {
 		assert.deepEqual(deltas[0], [
 			{ type: "retain", count: 1 },
 			{ type: "remove", count: 3 },
+			{ type: "retain", count: 1 },
 		]);
 	});
 
@@ -715,8 +718,13 @@ describe("array move events", () => {
 					{ type: "insert", count: 1 },
 				],
 			]);
-			// Source: the moved element is removed from position 0.
-			assert.deepEqual(delta2, [[{ type: "remove", count: 1 }]]);
+			// Source: remove the moved element, then retain the remaining element.
+			assert.deepEqual(delta2, [
+				[
+					{ type: "remove", count: 1 },
+					{ type: "retain", count: 1 },
+				],
+			]);
 		});
 
 		it("moveRangeToEnd emits correct count in remove and insert ops", () => {

--- a/packages/dds/tree/src/test/text/textDomain.spec.ts
+++ b/packages/dds/tree/src/test/text/textDomain.spec.ts
@@ -121,6 +121,7 @@ describe("textDomain", () => {
 			assert.deepEqual(received[0], [
 				{ type: "retain", count: 1 },
 				{ type: "insert", text: "xy" },
+				{ type: "retain", count: 1 },
 			]);
 		});
 
@@ -139,6 +140,7 @@ describe("textDomain", () => {
 			assert.deepEqual(received[0], [
 				{ type: "retain", count: 1 },
 				{ type: "remove", count: 2 },
+				{ type: "retain", count: 2 },
 			]);
 		});
 
@@ -159,10 +161,12 @@ describe("textDomain", () => {
 			assert.deepEqual(received[0], [
 				{ type: "retain", count: 1 },
 				{ type: "remove", count: 2 },
+				{ type: "retain", count: 2 },
 			]);
 			assert.deepEqual(received[1], [
 				{ type: "retain", count: 1 },
 				{ type: "insert", text: "XY" },
+				{ type: "retain", count: 2 },
 			]);
 		});
 
@@ -178,7 +182,10 @@ describe("textDomain", () => {
 			});
 			text.insertAt(0, "X");
 			assert.equal(received.length, 1);
-			assert.deepEqual(received[0], [{ type: "insert", text: "X" }]);
+			assert.deepEqual(received[0], [
+				{ type: "insert", text: "X" },
+				{ type: "retain", count: 3 },
+			]);
 		});
 
 		it("fires for insert at end", () => {

--- a/packages/dds/tree/src/test/text/textDomainFormatted.spec.ts
+++ b/packages/dds/tree/src/test/text/textDomainFormatted.spec.ts
@@ -394,6 +394,7 @@ describe("textDomainFormatted", () => {
 			assert.deepEqual(received[0], [
 				{ type: "retain", count: 1, formattingChanged: false },
 				{ type: "insert", text: "xy" },
+				{ type: "retain", count: 1, formattingChanged: false },
 			]);
 		});
 
@@ -409,7 +410,10 @@ describe("textDomainFormatted", () => {
 			});
 			text.insertAt(0, "X");
 			assert.equal(received.length, 1);
-			assert.deepEqual(received[0], [{ type: "insert", text: "X" }]);
+			assert.deepEqual(received[0], [
+				{ type: "insert", text: "X" },
+				{ type: "retain", count: 3, formattingChanged: false },
+			]);
 		});
 
 		it("fires for insert at end", () => {
@@ -445,6 +449,7 @@ describe("textDomainFormatted", () => {
 			assert.deepEqual(received[0], [
 				{ type: "retain", count: 1, formattingChanged: false },
 				{ type: "remove", count: 2 },
+				{ type: "retain", count: 2, formattingChanged: false },
 			]);
 		});
 
@@ -480,10 +485,12 @@ describe("textDomainFormatted", () => {
 			assert.deepEqual(received[0], [
 				{ type: "retain", count: 1, formattingChanged: false },
 				{ type: "remove", count: 2 },
+				{ type: "retain", count: 2, formattingChanged: false },
 			]);
 			assert.deepEqual(received[1], [
 				{ type: "retain", count: 1, formattingChanged: false },
 				{ type: "insert", text: "XY" },
+				{ type: "retain", count: 2, formattingChanged: false },
 			]);
 		});
 
@@ -506,10 +513,12 @@ describe("textDomainFormatted", () => {
 			assert.deepEqual(received[0], [
 				{ type: "retain", count: 1, formattingChanged: false },
 				{ type: "retain", count: 1, formattingChanged: true },
+				{ type: "retain", count: 3, formattingChanged: false },
 			]);
 			assert.deepEqual(received[1], [
 				{ type: "retain", count: 2, formattingChanged: false },
 				{ type: "retain", count: 1, formattingChanged: true },
+				{ type: "retain", count: 2, formattingChanged: false },
 			]);
 		});
 

--- a/packages/framework/quill-react/src/formatted/quillFormattedView.tsx
+++ b/packages/framework/quill-react/src/formatted/quillFormattedView.tsx
@@ -243,7 +243,7 @@ function contentOpsToQuillDelta(
 	}
 
 	// Fixup required new line: quill requires one at the end, so we add an extra if needed.
-	// This simple deletes the old one if there was one, then adds a new one if needed.
+	// This simply deletes the old one if there was one, then adds a new one if needed.
 	// Such an approach was deemed slightly simpler and less error prone than reusing one if preexisting,
 	// since it avoids any potential for the extra new line to accidentally be reused when it has formatting applied.
 	const remainingQuillContent = preEditContent.slice(quillPos);

--- a/packages/framework/quill-react/src/formatted/quillFormattedView.tsx
+++ b/packages/framework/quill-react/src/formatted/quillFormattedView.tsx
@@ -242,15 +242,22 @@ function contentOpsToQuillDelta(
 		}
 	}
 
+	// Fixup required new line: quill requires one at the end, so we add an extra if needed.
+	// This simple deletes the old one if there was one, then adds a new one if needed.
+	// Such an approach was deemed slightly simpler and less error prone than reusing one if preexisting,
+	// since it avoids any potential for the extra new line to accidentally be reused when it has formatting applied.
 	const remainingQuillContent = preEditContent.slice(quillPos);
 	if (remainingQuillContent.length > 0) {
 		assert(
 			remainingQuillContent === "\n",
 			"Expected only Quill's mandatory terminal newline to remain",
 		);
+		// Delete the extra new line which is required by quill.
 		quillOps.push({ delete: 1 });
 	}
+
 	if (!root.fullString().endsWith("\n")) {
+		// If needed add the extra new line which is required by quill.
 		quillOps.push({ insert: "\n" });
 	}
 

--- a/packages/framework/quill-react/src/formatted/quillFormattedView.tsx
+++ b/packages/framework/quill-react/src/formatted/quillFormattedView.tsx
@@ -299,7 +299,7 @@ export function applyQuillDeltaToTree(
 			if (op.retain !== undefined) {
 				// The docs for retain imply this is always a number, but the type definitions allow a record here.
 				// It is unknown why the type definitions allow a record as they have no doc comments.
-				// For now this assert seems to be passing, so we just assume its always a number.
+				// For now this assert seems to be passing, so we just assume it's always a number.
 				assert(
 					typeof op.retain === "number",
 					0xcdf /* Expected retain count to be a number */,

--- a/packages/framework/quill-react/src/formatted/quillFormattedView.tsx
+++ b/packages/framework/quill-react/src/formatted/quillFormattedView.tsx
@@ -105,6 +105,18 @@ function createLineAtom(
 	};
 }
 
+function lineAtomToQuillAttributes(
+	lineAtom: FormattedTextAsTreeDefault.StringLineAtom,
+): Record<string, unknown> {
+	const attributes: Record<string, unknown> = {
+		...lineTagToQuillAttributes[lineAtom.tag.value],
+	};
+	if (lineAtom.indent) {
+		attributes.indent = lineAtom.indent;
+	}
+	return attributes;
+}
+
 /**
  * Convert {@link TextAsTree.TextOp}s from `onContentChanged` into Quill delta ops
  * that can be applied via `Quill.updateContents()`.
@@ -134,7 +146,7 @@ function contentOpsToQuillDelta(
 	const quillOps: QuillDeltaOp[] = [];
 	// treePos: atom index in the post-edit tree. Advances for retain and insert, not remove.
 	let treePos = 0;
-	// quillPos: UTF-16 index in preEditContent. Advances for retain and remove, not insert.
+	// quillPos: UTF-16 index in preEditContent. Advances when existing Quill content is consumed.
 	let quillPos = 0;
 	// Cache the atoms array so we don't pay tree-traversal cost on every index read.
 	const atoms = root.charactersWithFormatting();
@@ -198,17 +210,10 @@ function contentOpsToQuillDelta(
 
 				if (atom.content instanceof FormattedTextAsTreeDefault.StringLineAtom) {
 					// Line atom: insert newline with line tag attributes.
-					const attributes: Record<string, unknown> = {};
-					const lineTag = atom.content.tag.value;
-					Object.assign(attributes, lineTagToQuillAttributes[lineTag]);
-					if (atom.content.indent) {
-						attributes.indent = atom.content.indent;
-					}
-					const quillOp: QuillDeltaOp = { insert: "\n" };
-					if (Object.keys(attributes).length > 0) {
-						quillOp.attributes = attributes;
-					}
-					quillOps.push(quillOp);
+					quillOps.push({
+						insert: "\n",
+						attributes: lineAtomToQuillAttributes(atom.content),
+					});
 					i++;
 				} else {
 					// Text atom: group consecutive atoms with the same formatting.
@@ -224,7 +229,6 @@ function contentOpsToQuillDelta(
 				}
 			}
 			treePos = insertEnd;
-			// quillPos does not advance: inserts are new content not in preEditContent.
 		} else {
 			// remove: atoms are gone from the tree; use preEditContent to get UTF-16 width.
 			const utf16Count = utf16LengthForCodePoints(preEditContent, quillPos, op.count);
@@ -232,6 +236,18 @@ function contentOpsToQuillDelta(
 			quillPos += utf16Count;
 			// treePos does not advance — removed atoms are not in the new tree.
 		}
+	}
+
+	const remainingQuillContent = preEditContent.slice(quillPos);
+	if (remainingQuillContent.length > 0) {
+		assert(
+			remainingQuillContent === "\n",
+			"Expected only Quill's mandatory terminal newline to remain",
+		);
+		quillOps.push({ delete: 1 });
+	}
+	if (!root.fullString().endsWith("\n")) {
+		quillOps.push({ insert: "\n" });
 	}
 
 	return quillOps;

--- a/packages/framework/quill-react/src/formatted/quillFormattedView.tsx
+++ b/packages/framework/quill-react/src/formatted/quillFormattedView.tsx
@@ -105,12 +105,16 @@ function createLineAtom(
 	};
 }
 
+/**
+ * Convert a line atom's tag and indentation to Quill block attributes.
+ */
 function lineAtomToQuillAttributes(
 	lineAtom: FormattedTextAsTreeDefault.StringLineAtom,
 ): Record<string, unknown> {
 	const attributes: Record<string, unknown> = {
 		...lineTagToQuillAttributes[lineAtom.tag.value],
 	};
+	// Omitting an indentation of zero uses Quill's default unindented representation.
 	if (lineAtom.indent) {
 		attributes.indent = lineAtom.indent;
 	}

--- a/packages/framework/quill-react/src/plain/quillView.tsx
+++ b/packages/framework/quill-react/src/plain/quillView.tsx
@@ -112,13 +112,14 @@ const TextEditorView: FC<MainViewPropsInner> = ({ root, undoRedo, editLabel }) =
 		const handleTextChange = (_delta: unknown, _oldDelta: unknown, source: string): void => {
 			if (source !== "user") return;
 			runGuarded(isUpdatingRef, () => {
+				const text = quill.getText(0, quill.getLength() - 1);
 				const context = TreeAlpha.context(root);
 				if (context.isBranch()) {
-					context.runTransaction(() => syncTextToTree(root, quill.getText()), {
+					context.runTransaction(() => syncTextToTree(root, text), {
 						label: editLabelRef.current,
 					});
 				} else {
-					syncTextToTree(root, quill.getText());
+					syncTextToTree(root, text);
 				}
 			});
 		};

--- a/packages/framework/quill-react/src/test/textEditor.test.tsx
+++ b/packages/framework/quill-react/src/test/textEditor.test.tsx
@@ -15,6 +15,7 @@ import {
 } from "@fluidframework/tree/internal";
 import { render } from "@testing-library/react";
 import globalJsdom from "global-jsdom";
+import Quill from "quill";
 import DeltaPackage from "quill-delta";
 
 import {
@@ -89,6 +90,39 @@ describe("textEditor", () => {
 			for (const reactStrictMode of [false, true]) {
 				describe(`StrictMode: ${reactStrictMode}`, () => {
 					const ViewComponent = QuillMainView;
+
+					it("keeps remote editor DOM in sync after a user edit", () => {
+						const text = TextAsTree.Tree.fromString("");
+						const root = toPropTreeNode(text);
+						const rendered = render(
+							<>
+								<ViewComponent root={root} />
+								<ViewComponent root={root} />
+							</>,
+							{ reactStrictMode },
+						);
+						const sourceContainer =
+							rendered.container.querySelector<HTMLElement>(".ql-container");
+						const editors = rendered.container.querySelectorAll<HTMLElement>(".ql-editor");
+						const sourceEditor = editors[0];
+						const remoteEditor = editors[1];
+						assert.ok(
+							sourceContainer !== null &&
+								sourceEditor !== undefined &&
+								remoteEditor !== undefined,
+						);
+						const source = Quill.find(sourceContainer) as Quill;
+
+						source.setText("Hello", "user");
+
+						assert.equal(sourceEditor.innerHTML, "<p>Hello</p>");
+						assert.equal(remoteEditor.innerHTML, sourceEditor.innerHTML);
+
+						source.setText("Hello\nWorld", "user");
+
+						assert.equal(sourceEditor.innerHTML, "<p>Hello</p><p>World</p>");
+						assert.equal(remoteEditor.innerHTML, sourceEditor.innerHTML);
+					});
 
 					it("renders MainView with editor container", () => {
 						const text = TextAsTree.Tree.fromString("");
@@ -260,6 +294,39 @@ describe("textEditor", () => {
 		describe("dom tests", () => {
 			for (const reactStrictMode of [false, true]) {
 				describe(`StrictMode: ${reactStrictMode}`, () => {
+					it("keeps remote editor DOM in sync after a user edit", () => {
+						const { tree } = createFormattedTreeView();
+						const root = toPropTreeNode(tree);
+						const rendered = render(
+							<>
+								<FormattedMainView root={root} />
+								<FormattedMainView root={root} />
+							</>,
+							{ reactStrictMode },
+						);
+						const sourceContainer =
+							rendered.container.querySelector<HTMLElement>(".ql-container");
+						const editors = rendered.container.querySelectorAll<HTMLElement>(".ql-editor");
+						const sourceEditor = editors[0];
+						const remoteEditor = editors[1];
+						assert.ok(
+							sourceContainer !== null &&
+								sourceEditor !== undefined &&
+								remoteEditor !== undefined,
+						);
+						const source = Quill.find(sourceContainer) as Quill;
+
+						source.setText("Hello", "user");
+
+						assert.equal(sourceEditor.innerHTML, "<p>Hello</p>");
+						assert.equal(remoteEditor.innerHTML, sourceEditor.innerHTML);
+
+						source.formatLine(0, source.getLength(), "list", "bullet", "user");
+
+						assert.match(sourceEditor.innerHTML, /^<ol>/);
+						assert.equal(remoteEditor.innerHTML, sourceEditor.innerHTML);
+					});
+
 					it("renders FormattedMainView with editor container", () => {
 						const { tree } = createFormattedTreeView();
 						const content = <FormattedMainView root={toPropTreeNode(tree)} />;

--- a/packages/framework/quill-react/src/test/textEditor.test.tsx
+++ b/packages/framework/quill-react/src/test/textEditor.test.tsx
@@ -116,11 +116,17 @@ describe("textEditor", () => {
 						source.setText("Hello", "user");
 
 						assert.equal(sourceEditor.innerHTML, "<p>Hello</p>");
+						// Check that the editors have the same content: they should be kept in sync
 						assert.equal(remoteEditor.innerHTML, sourceEditor.innerHTML);
 
 						source.setText("Hello\nWorld", "user");
 
+						// Check the edit did not cause the views to de-sync.
 						assert.equal(sourceEditor.innerHTML, "<p>Hello</p><p>World</p>");
+						assert.equal(remoteEditor.innerHTML, sourceEditor.innerHTML);
+
+						// Check a trailing new line also does not cause de-sync.
+						source.setText("Hello\nWorld\n", "user");
 						assert.equal(remoteEditor.innerHTML, sourceEditor.innerHTML);
 					});
 
@@ -319,11 +325,18 @@ describe("textEditor", () => {
 						source.setText("Hello", "user");
 
 						assert.equal(sourceEditor.innerHTML, "<p>Hello</p>");
+						// Check that the editors have the same content: they should be kept in sync
 						assert.equal(remoteEditor.innerHTML, sourceEditor.innerHTML);
 
+						// Do a formatting operation which adds a line atom to the end of the string.
+						// This hits an edge case in the quill integration since quill requires such a trailing line end,
+						// so our integration replaces its extra one it had to add to support will with the real one added by this change.
 						source.formatLine(0, source.getLength(), "list", "bullet", "user");
-
+						// Check the the above format operation added the expected list item.
 						assert.match(sourceEditor.innerHTML, /^<ol>/);
+
+						// Check that the editors have the same content, ensuring they didn't get out of sync.
+						// This validates, among other things, that the fix for handling of the trailing new line doesn't regress.
 						assert.equal(remoteEditor.innerHTML, sourceEditor.innerHTML);
 					});
 

--- a/packages/framework/quill-react/src/test/textEditor.test.tsx
+++ b/packages/framework/quill-react/src/test/textEditor.test.tsx
@@ -328,11 +328,11 @@ describe("textEditor", () => {
 						// Check that the editors have the same content: they should be kept in sync
 						assert.equal(remoteEditor.innerHTML, sourceEditor.innerHTML);
 
-						// Do a formatting operation which adds a line atom to the end of the string.
-						// This hits an edge case in the quill integration since quill requires such a trailing line end,
-						// so our integration replaces its extra one it had to add to support will with the real one added by this change.
+						// Do a formatting operation that adds a line atom to the end of the string.
+						// This hits an edge case in the Quill integration because Quill requires a trailing newline,
+						// so our integration replaces its synthetic newline with the real line atom added by this change.
 						source.formatLine(0, source.getLength(), "list", "bullet", "user");
-						// Check the the above format operation added the expected list item.
+						// Check that the above format operation added the expected list item.
 						assert.match(sourceEditor.innerHTML, /^<ol>/);
 
 						// Check that the editors have the same content, ensuring they didn't get out of sync.


### PR DESCRIPTION
## Description

Previously our array node deltas were not required to include the final retain. This is now alwayse included.

Addationally handling of the extra new line required to make quill a happe is now more robust, fixing a buig where remote copllaborators should end up with extra new lines.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
