### PR TITLE
fix (Skills): Remove incorrect brackets from yaml frontmatter in trigger-pipelines-for-copilot-pr

### DIFF
--- a/.claude/skills/trigger-pipelines-for-copilot-pr/SKILL.md
+++ b/.claude/skills/trigger-pipelines-for-copilot-pr/SKILL.md
@@ -4,7 +4,7 @@ description: Trigger ADO pipelines for a Copilot-created PR by posting /azp run 
 allowed-tools: Bash(gh pr comment *)
 context: fork
 model: claude-haiku-4-5-20251001
-argument-hint: [pr-number-or-url]
+argument-hint: pr-number-or-url
 ---
 
 Post the following two comments to the PR specified by the user ($ARGUMENTS), in the `microsoft/FluidFramework` repository on GitHub.


### PR DESCRIPTION
## Description

The `trigger-pipelines-for-copilot-pr` skill failed to load with the error "argument-hint must be a string". The frontmatter value `[pr-number-or-url]` was being parsed as a YAML flow sequence (a one-element array) rather than a string. This removes the square brackets so the value is a plain string.
