### PR TITLE
build(client): fix depend on everything for build:entrypoints:node10

### DIFF
--- a/fluidBuild.config.cjs
+++ b/fluidBuild.config.cjs
@@ -157,6 +157,7 @@ module.exports = {
 		},
 		"build:entrypoints:esm": ["build:esnext"],
 		"build:entrypoints:cjs": ["tsc"],
+		"build:entrypoints:node10": [],
 		// Generic build:test script should be replaced by :esm or :cjs specific versions.
 		// "tsc" would be nice to eliminate from here, but plenty of packages still focus
 		// on CommonJS.


### PR DESCRIPTION
Without any dependency config, `build:entrypoints:node10` task depended on all tasks before (default of `after: ["^*"]`).