### PR TITLE
fix(client-devtools): recognize internal React components

### DIFF
--- a/packages/tools/devtools/devtools-view/src/DevtoolsView.tsx
+++ b/packages/tools/devtools/devtools-view/src/DevtoolsView.tsx
@@ -208,14 +208,14 @@ export function DevtoolsView(props: DevtoolsViewProps): ReactElement {
 							{modalVisible && (
 								<TelemetryConsentModal onClose={(): void => setModalVisible(false)} />
 							)}
-							<_DevtoolsView supportedFeatures={{}} />
+							<DevtoolsViewInternal supportedFeatures={{}} />
 						</>
 					) : (
 						<>
 							{modalVisible && (
 								<TelemetryConsentModal onClose={(): void => setModalVisible(false)} />
 							)}
-							<_DevtoolsView supportedFeatures={supportedFeatures} />
+							<DevtoolsViewInternal supportedFeatures={supportedFeatures} />
 						</>
 					)}
 				</FluentProvider>
@@ -224,7 +224,7 @@ export function DevtoolsView(props: DevtoolsViewProps): ReactElement {
 	);
 }
 
-interface _DevtoolsViewProps {
+interface DevtoolsViewInternalProps {
 	/**
 	 * Set of features supported by the Devtools.
 	 */
@@ -234,7 +234,7 @@ interface _DevtoolsViewProps {
 /**
  * Internal {@link DevtoolsView}, displayed once the supported feature set has been acquired from the webpage.
  */
-function _DevtoolsView(props: _DevtoolsViewProps): ReactElement {
+function DevtoolsViewInternal(props: DevtoolsViewInternalProps): ReactElement {
 	const { supportedFeatures } = props;
 
 	const [containers, setContainers] = useState<ContainerKey[] | undefined>();

--- a/packages/tools/devtools/devtools-view/src/components/ContainerDevtoolsView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/ContainerDevtoolsView.tsx
@@ -131,7 +131,7 @@ export function ContainerDevtoolsView(props: ContainerDevtoolsViewProps): ReactE
 	return supportedFeatures === undefined ? (
 		<Waiting />
 	) : (
-		<_ContainerDevtoolsView
+		<ContainerDevtoolsViewInternal
 			containerKey={containerKey}
 			supportedFeatures={supportedFeatures}
 		/>
@@ -139,9 +139,9 @@ export function ContainerDevtoolsView(props: ContainerDevtoolsViewProps): ReactE
 }
 
 /**
- * {@link _ContainerDevtoolsView} input props.
+ * {@link ContainerDevtoolsViewInternal} input props.
  */
-interface _ContainerDevtoolsViewProps extends HasContainerKey {
+interface ContainerDevtoolsViewInternalProps extends HasContainerKey {
 	/**
 	 * Set of features supported by the corresponding Container-level devtools instance.
 	 */
@@ -151,7 +151,9 @@ interface _ContainerDevtoolsViewProps extends HasContainerKey {
 /**
  * Internal {@link ContainerDevtoolsView}, displayed after supported feature set has been acquired from the webpage.
  */
-function _ContainerDevtoolsView(props: _ContainerDevtoolsViewProps): ReactElement {
+function ContainerDevtoolsViewInternal(
+	props: ContainerDevtoolsViewInternalProps,
+): ReactElement {
 	const { containerKey, supportedFeatures } = props;
 
 	const styles = useStyles();


### PR DESCRIPTION
Rename internal Devtools view components and their props so React hook linting identifies them as function components.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

Copilot-Session: 62172399-447d-4b34-a88c-1fbb53b94268