### PR TITLE
build(examples): declare stylesheet modules

### DIFF
--- a/examples/apps/data-object-grid/src/styles.d.ts
+++ b/examples/apps/data-object-grid/src/styles.d.ts
@@ -1,0 +1,6 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+declare module "*.css";

--- a/examples/data-objects/canvas/src/styles.d.ts
+++ b/examples/data-objects/canvas/src/styles.d.ts
@@ -1,0 +1,6 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+declare module "*.less";

--- a/examples/data-objects/codemirror/src/styles.d.ts
+++ b/examples/data-objects/codemirror/src/styles.d.ts
@@ -1,0 +1,6 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+declare module "*.css";

--- a/examples/data-objects/multiview/constellation-view/src/styles.d.ts
+++ b/examples/data-objects/multiview/constellation-view/src/styles.d.ts
@@ -1,0 +1,6 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+declare module "*.css";

--- a/examples/data-objects/multiview/container/src/styles.d.ts
+++ b/examples/data-objects/multiview/container/src/styles.d.ts
@@ -1,0 +1,6 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+declare module "*.css";

--- a/examples/data-objects/multiview/plot-coordinate-view/src/styles.d.ts
+++ b/examples/data-objects/multiview/plot-coordinate-view/src/styles.d.ts
@@ -1,0 +1,6 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+declare module "*.css";

--- a/examples/data-objects/multiview/slider-coordinate-view/src/styles.d.ts
+++ b/examples/data-objects/multiview/slider-coordinate-view/src/styles.d.ts
@@ -1,0 +1,6 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+declare module "*.css";

--- a/examples/data-objects/multiview/triangle-view/src/styles.d.ts
+++ b/examples/data-objects/multiview/triangle-view/src/styles.d.ts
@@ -1,0 +1,6 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+declare module "*.css";

--- a/examples/data-objects/prosemirror/src/styles.d.ts
+++ b/examples/data-objects/prosemirror/src/styles.d.ts
@@ -1,0 +1,6 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+declare module "*.css";

--- a/examples/data-objects/smde/src/styles.d.ts
+++ b/examples/data-objects/smde/src/styles.d.ts
@@ -1,0 +1,6 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+declare module "*.css";

--- a/examples/data-objects/table-tree/src/styles.d.ts
+++ b/examples/data-objects/table-tree/src/styles.d.ts
@@ -1,0 +1,6 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+declare module "*.css";

--- a/examples/data-objects/text-editor/src/styles.d.ts
+++ b/examples/data-objects/text-editor/src/styles.d.ts
@@ -1,0 +1,6 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+declare module "*.css";

--- a/examples/data-objects/todo/src/styles.d.ts
+++ b/examples/data-objects/todo/src/styles.d.ts
@@ -1,0 +1,6 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+declare module "*.css";

--- a/examples/data-objects/webflow/src/styles.d.ts
+++ b/examples/data-objects/webflow/src/styles.d.ts
@@ -1,0 +1,6 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+declare module "*.css";

--- a/examples/service-clients/azure-client/todo-list/src/styles.d.ts
+++ b/examples/service-clients/azure-client/todo-list/src/styles.d.ts
@@ -1,0 +1,6 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+declare module "*.css";

--- a/examples/service-clients/odsp-client/shared-tree-demo/src/styles.d.ts
+++ b/examples/service-clients/odsp-client/shared-tree-demo/src/styles.d.ts
@@ -1,0 +1,6 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+declare module "*.css";


### PR DESCRIPTION
Add ambient CSS and LESS module declarations for example packages whose stylesheet imports are checked by TypeScript 6.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

Copilot-Session: 62172399-447d-4b34-a88c-1fbb53b94268