### PR TITLE
build: tag untagged asserts for 2.114.0 release

### DIFF
--- a/packages/dds/tree/src/feature-libraries/treeTextCursor.ts
+++ b/packages/dds/tree/src/feature-libraries/treeTextCursor.ts
@@ -194,6 +194,6 @@ export function forestsEqual(a: IForestSubscription, b: IForestSubscription): bo
  */
 export function assertForestsEqual(a: IForestSubscription, b: IForestSubscription): void {
 	if (!forestsEqual(a, b)) {
-		fail("Forests are not equal");
+		fail(0xd10 /* Forests are not equal */);
 	}
 }

--- a/packages/drivers/local-driver/src/ephemeralService.ts
+++ b/packages/drivers/local-driver/src/ephemeralService.ts
@@ -362,7 +362,10 @@ class EphemeralServiceImplementation
 	 * @remarks Internal helper for {@link EphemeralServiceContainer}; not part of the public {@link EphemeralService} API.
 	 */
 	public getDocumentServiceFactory(): LocalDocumentServiceFactory {
-		assert(!this.closed, "Cannot create or load containers on a closed EphemeralService");
+		assert(
+			!this.closed,
+			0xd11 /* Cannot create or load containers on a closed EphemeralService */,
+		);
 		return this.documentServiceFactory;
 	}
 
@@ -420,11 +423,14 @@ const containerRuntimeLoader: ContainerRuntimeLoader = async (
 	if (!parameters.existing) {
 		assert(
 			parameters.newContainerRootType !== undefined,
-			"Root data store kind must be provided for new containers",
+			0xd12 /* Root data store kind must be provided for new containers */,
 		);
 		const dataStore = await runtime.createDataStore(parameters.newContainerRootType);
 		const aliasResult = await dataStore.trySetAlias(rootDataStoreId);
-		assert(aliasResult === "Success", "Should be able to set alias on new data store");
+		assert(
+			aliasResult === "Success",
+			0xd13 /* Should be able to set alias on new data store */,
+		);
 	}
 	return runtime;
 };
@@ -511,7 +517,10 @@ export class EphemeralServiceContainer<TData>
 			(await containerInner.getEntryPoint()) as T,
 			id,
 		);
-		assert(container.id !== undefined, "id should be defined when loading a container");
+		assert(
+			container.id !== undefined,
+			0xd14 /* id should be defined when loading a container */,
+		);
 		return container as typeof container & { id: string };
 	}
 

--- a/packages/runtime/runtime-utils/src/serviceClientBase.ts
+++ b/packages/runtime/runtime-utils/src/serviceClientBase.ts
@@ -157,7 +157,10 @@ export abstract class ServiceContainerBase<TData, TOptions = unknown>
 			throw new UsageError("Container attach already in progress");
 		}
 
-		assert(this.container.attachState === AttachState.Detached, "Container not detached");
+		assert(
+			this.container.attachState === AttachState.Detached,
+			0xd15 /* Container not detached */,
+		);
 		this.startedAttach = true;
 
 		// TODO: support setting where attach can fail, and leave the container in a valid (non-closed) state.
@@ -167,7 +170,7 @@ export abstract class ServiceContainerBase<TData, TOptions = unknown>
 		// This type cast is needed to work around the fact that TypeScript assumes the "attach" methods can't modify "attachState".
 		assert(
 			this.container.attachState === (AttachState.Attached as AttachState),
-			"Container failed to attach",
+			0xd16 /* Container failed to attach */,
 		);
 		this.id = this.getContainerId();
 		return this as typeof this & { id: string };

--- a/packages/runtime/runtime-utils/src/serviceClientUtils.ts
+++ b/packages/runtime/runtime-utils/src/serviceClientUtils.ts
@@ -71,7 +71,7 @@ export function normalizeRegistry<T>(
 	if (DataStoreKindImplementation.guard(input)) {
 		return async () => input;
 	}
-	assert(typeof input === "function", "Registry must be a function");
+	assert(typeof input === "function", 0xd17 /* Registry must be a function */);
 	return input;
 }
 

--- a/packages/runtime/test-runtime-utils/src/assertionShortCodesMap.ts
+++ b/packages/runtime/test-runtime-utils/src/assertionShortCodesMap.ts
@@ -1538,10 +1538,8 @@ export const shortCodeMap = {
 	"0xb1b": "missing kind",
 	"0xb1c": "missing field kind",
 	"0xb1d": "missing field kind",
-	"0xb1e": "Should not decode nodes during field encoding",
 	"0xb1f": "Encoded change didn't pass schema validation.",
 	"0xb20": "Encoded change didn't pass schema validation.",
-	"0xb21": "Should not encode nodes during field decoding",
 	"0xb22": "Should not compose two undefined nodes",
 	"0xb23": "Should not compose two undefined nodes",
 	"0xb24": "Unknown node ID",
@@ -1951,5 +1949,13 @@ export const shortCodeMap = {
 	"0xd0c": "withIncrementalDecoder can only be called on contexts without an originator session ID",
 	"0xd0d": "incrementalEncoder cannot be used when encoding originator-dependent identifiers",
 	"0xd0e": "Cannot remove detach without also removing attach",
-	"0xd0f": "Attach sequence number should be greater than the parent's last summary reference sequence number"
+	"0xd0f": "Attach sequence number should be greater than the parent's last summary reference sequence number",
+	"0xd10": "Forests are not equal",
+	"0xd11": "Cannot create or load containers on a closed EphemeralService",
+	"0xd12": "Root data store kind must be provided for new containers",
+	"0xd13": "Should be able to set alias on new data store",
+	"0xd14": "id should be defined when loading a container",
+	"0xd15": "Container not detached",
+	"0xd16": "Container failed to attach",
+	"0xd17": "Registry must be a function"
 };


### PR DESCRIPTION
## Description

Tags previously untagged asserts with hex error codes ahead of the 2.114.0 release, per the standard minor release prep process.

Part of the 2.114.0 release prep sequence:
1. **Tag untagged asserts** (this PR)
2. Update compat generation
3. Generate release notes/changelogs
4. Bump main to 2.115.0

This PR must merge before the version bump PR.