### PR TITLE
refactor(tree): Decode ids via IdDecodingContext in change codecs

### DIFF
--- a/packages/dds/tree/src/core/change-family/changeFamily.ts
+++ b/packages/dds/tree/src/core/change-family/changeFamily.ts
@@ -7,7 +7,7 @@ import type { IIdCompressor, SessionId } from "@fluidframework/id-compressor";
 
 import type { ICodecFamily, IJsonCodec } from "../../codec/index.js";
 import type { SchemaAndPolicy } from "../../core/index.js";
-import type { IdentifierHealingConfig, JsonCompatibleReadOnly } from "../../util/index.js";
+import type { IdDecodingContext, JsonCompatibleReadOnly } from "../../util/index.js";
 import type { ChangeRebaser, RevisionTag, TaggedChange } from "../rebase/index.js";
 
 export type ProcessChangeFn<TChange, TChangeProcessingContext> =
@@ -58,17 +58,35 @@ export interface ChangeEncodingContext {
 /**
  * Context provided to change codecs when decoding.
  * @remarks
- * The same as {@link ChangeEncodingContext} except that it omits `schema` (only consulted when
- * *encoding*, for schema-aware compression) and adds `healing` (only consulted when *decoding*, to
- * recover unresolvable identifiers from a summary blob).
+ * Carries two {@link IdDecodingContext}s, both built once at the decode entry point, replacing the
+ * raw `originatorId`/`healing`/`isSummary` fields the encode context still carries for its own
+ * (encode-time) purposes.
+ *
+ * {@link ChangeDecodingContext.idDecodingContext} resolves revision tags (and other change-atom
+ * identifiers) using the originator session that produced the commit (per-commit for summaries, the
+ * message session for ops).
+ *
+ * {@link ChangeDecodingContext.forestIdDecodingContext} resolves identifiers embedded in forest
+ * chunks (detached-node builds/refreshers), which may reference multiple sessions and so use an
+ * originatorless, heal-aware resolver for summaries. For ops the two contexts are identical.
+ *
+ * TODO: Revisit whether this split is still necessary. In particular: confirm revision tags are
+ * decoded with the correct session id (and whether they should gain healing support like forest
+ * identifiers have), and evaluate whether forest identifier decoding could instead use the
+ * originator session id we already have (which would let both contexts collapse back into one).
  */
-export type ChangeDecodingContext = Omit<ChangeEncodingContext, "schema"> & {
+export interface ChangeDecodingContext {
+	readonly revision: RevisionTag | undefined;
+	readonly idCompressor: IIdCompressor;
 	/**
-	 * Heal-on-decode workaround configuration. See {@link IdentifierHealingConfig}.
-	 * Only takes effect when `isSummary` is also `true`.
+	 * Resolves revision tags and other change-atom identifiers (originator-aware).
 	 */
-	readonly healing?: IdentifierHealingConfig;
-};
+	readonly idDecodingContext: IdDecodingContext;
+	/**
+	 * Resolves identifiers embedded in forest chunks (originatorless + heal-aware for summaries).
+	 */
+	readonly forestIdDecodingContext: IdDecodingContext;
+}
 
 export type ChangeFamilyCodec<TChange> = IJsonCodec<
 	TChange,

--- a/packages/dds/tree/src/core/rebase/revisionTagCodec.ts
+++ b/packages/dds/tree/src/core/rebase/revisionTagCodec.ts
@@ -7,12 +7,18 @@ import { assert } from "@fluidframework/core-utils/internal";
 import type { IIdCompressor, SessionId } from "@fluidframework/id-compressor";
 
 import type { JsonCodecPart } from "../../codec/index.js";
-import type { ChangeEncodingContext } from "../change-family/index.js";
+import type { ChangeDecodingContext, ChangeEncodingContext } from "../change-family/index.js";
 
 import { RevisionTagSchema, type EncodedRevisionTag, type RevisionTag } from "./types.js";
 
 export class RevisionTagCodec
-	implements JsonCodecPart<RevisionTag, typeof RevisionTagSchema, ChangeEncodingContext>
+	implements
+		JsonCodecPart<
+			RevisionTag,
+			typeof RevisionTagSchema,
+			ChangeEncodingContext,
+			ChangeDecodingContext
+		>
 {
 	public localSessionId: SessionId;
 	public readonly encodedSchema = RevisionTagSchema;
@@ -26,7 +32,7 @@ export class RevisionTagCodec
 			? tag
 			: (this.idCompressor.normalizeToOpSpace(tag) as EncodedRevisionTag);
 	}
-	public decode(tag: EncodedRevisionTag, context: ChangeEncodingContext): RevisionTag {
+	public decode(tag: EncodedRevisionTag, context: ChangeDecodingContext): RevisionTag {
 		if (tag === "root") {
 			return tag;
 		}
@@ -35,6 +41,14 @@ export class RevisionTagCodec
 			typeof tag === "number",
 			0x88d /* String revision tag must be the literal 'root' */,
 		);
-		return this.idCompressor.normalizeToSessionSpace(tag, context.originatorId);
+		// Revision tags share the unified identifier-resolution path with forest identifiers.
+		// For the finalized identifiers revision tags always are, this produces the same result
+		// as the originator-based normalization did, without needing the originator session id.
+		const resolved = context.idDecodingContext.resolveEncodedId(tag);
+		assert(
+			typeof resolved !== "string",
+			"Revision tag must resolve to a compressed identifier",
+		);
+		return resolved;
 	}
 }

--- a/packages/dds/tree/src/core/tree/detachedFieldIndexCodecV1.ts
+++ b/packages/dds/tree/src/core/tree/detachedFieldIndexCodecV1.ts
@@ -8,7 +8,7 @@ import type { IIdCompressor } from "@fluidframework/id-compressor";
 import { isFinalId } from "@fluidframework/id-compressor/internal";
 
 import type { CodecAndSchema, IJsonCodec } from "../../codec/index.js";
-import { brand } from "../../util/index.js";
+import { IdDecodingContext, brand } from "../../util/index.js";
 import {
 	type EncodedRevisionTag,
 	type RevisionTagCodec,
@@ -58,12 +58,16 @@ class MajorCodec implements IJsonCodec<Major, EncodedRevisionTag> {
 			major === "root" || isFinalId(major),
 			0x890 /* Expected final id on decode of detached field index revision */,
 		);
-		return this.revisionTagCodec.decode(major, {
+		// DetachedFieldIndex codecs are only used by the summarizer, where all ids are final.
+		const idDecodingContext = new IdDecodingContext({
+			idCompressor: this.idCompressor,
 			originatorId: this.revisionTagCodec.localSessionId,
+		});
+		return this.revisionTagCodec.decode(major, {
 			idCompressor: this.idCompressor,
 			revision: undefined,
-			// DetachedFieldIndex codecs are only used by the summarizer.
-			isSummary: true,
+			idDecodingContext,
+			forestIdDecodingContext: idDecodingContext,
 		});
 	}
 }

--- a/packages/dds/tree/src/core/tree/detachedFieldIndexCodecV2.ts
+++ b/packages/dds/tree/src/core/tree/detachedFieldIndexCodecV2.ts
@@ -8,6 +8,7 @@ import type { IIdCompressor, StableId } from "@fluidframework/id-compressor";
 import { isFinalId, isStableId } from "@fluidframework/id-compressor/internal";
 
 import type { CodecAndSchema, IJsonCodec } from "../../codec/index.js";
+import { IdDecodingContext } from "../../util/index.js";
 import type { EncodedRevisionTag, RevisionTagCodec, RevisionTag } from "../rebase/index.js";
 
 import { makeDetachedFieldIndexCodecFromMajorCodec } from "./detachedFieldIndexCodecCommon.js";
@@ -47,12 +48,16 @@ class MajorCodec implements IJsonCodec<Major> {
 		if (typeof major === "string" && isStableId(major)) {
 			return this.idCompressor.recompress(major);
 		}
-		return this.revisionTagCodec.decode(major, {
+		// DetachedFieldIndex codecs are only used by the summarizer, where all ids are final.
+		const idDecodingContext = new IdDecodingContext({
+			idCompressor: this.idCompressor,
 			originatorId: this.revisionTagCodec.localSessionId,
+		});
+		return this.revisionTagCodec.decode(major, {
 			idCompressor: this.idCompressor,
 			revision: undefined,
-			// DetachedFieldIndex codecs are only used by the summarizer.
-			isSummary: true,
+			idDecodingContext,
+			forestIdDecodingContext: idDecodingContext,
 		});
 	}
 }

--- a/packages/dds/tree/src/feature-libraries/changeAtomIdCodec.ts
+++ b/packages/dds/tree/src/feature-libraries/changeAtomIdCodec.ts
@@ -6,6 +6,7 @@
 import type { JsonCodecPart } from "../codec/index.js";
 import type {
 	ChangeAtomId,
+	ChangeDecodingContext,
 	ChangeEncodingContext,
 	RevisionTag,
 	RevisionTagSchema,
@@ -17,16 +18,22 @@ export function makeChangeAtomIdCodec(
 	revisionTagCodec: JsonCodecPart<
 		RevisionTag,
 		typeof RevisionTagSchema,
-		ChangeEncodingContext
+		ChangeEncodingContext,
+		ChangeDecodingContext
 	>,
-): JsonCodecPart<ChangeAtomId, typeof EncodedChangeAtomId, ChangeEncodingContext> {
+): JsonCodecPart<
+	ChangeAtomId,
+	typeof EncodedChangeAtomId,
+	ChangeEncodingContext,
+	ChangeDecodingContext
+> {
 	return {
 		encode(changeAtomId: ChangeAtomId, context: ChangeEncodingContext): EncodedChangeAtomId {
 			return changeAtomId.revision === undefined || changeAtomId.revision === context.revision
 				? changeAtomId.localId
 				: [changeAtomId.localId, revisionTagCodec.encode(changeAtomId.revision, context)];
 		},
-		decode(changeAtomId: EncodedChangeAtomId, context: ChangeEncodingContext): ChangeAtomId {
+		decode(changeAtomId: EncodedChangeAtomId, context: ChangeDecodingContext): ChangeAtomId {
 			return Array.isArray(changeAtomId)
 				? {
 						localId: changeAtomId[0],

--- a/packages/dds/tree/src/feature-libraries/chunked-forest/codec/codecs.ts
+++ b/packages/dds/tree/src/feature-libraries/chunked-forest/codec/codecs.ts
@@ -194,6 +194,19 @@ export class FieldBatchDecodingContext {
 	}
 
 	/**
+	 * Construct a decode context that reuses an existing {@link IdDecodingContext}.
+	 *
+	 * Used by callers that already hold a fully-configured decode context (for example,
+	 * carried on a change codec's decode context) and need a {@link FieldBatchDecodingContext}
+	 * to decode a field batch. Incremental decoding is not available on the result.
+	 */
+	public static fromIdDecodingContext(
+		idDecodingContext: IdDecodingContext,
+	): FieldBatchDecodingContext {
+		return new FieldBatchDecodingContext(idDecodingContext);
+	}
+
+	/**
 	 * Returns a copy of this context with `incrementalDecoder` swapped in. Used by
 	 * the forest summarizer to attach the per-call incremental builder to a base
 	 * decode context.

--- a/packages/dds/tree/src/feature-libraries/modular-schema/fieldChangeHandler.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/fieldChangeHandler.ts
@@ -6,6 +6,7 @@
 import type { ICodecFamily, JsonCodecPart } from "../../codec/index.js";
 import type {
 	ChangeAtomId,
+	ChangeDecodingContext,
 	ChangeEncodingContext,
 	DeltaDetachedNodeChanges,
 	DeltaDetachedNodeId,
@@ -61,7 +62,8 @@ export interface FieldChangeHandler<
 		revisionTagCodec: JsonCodecPart<
 			RevisionTag,
 			typeof RevisionTagSchema,
-			ChangeEncodingContext
+			ChangeEncodingContext,
+			ChangeDecodingContext
 		>,
 	) => ICodecFamily<TChangeset, FieldChangeEncodingContext, FieldChangeDecodingContext>;
 	readonly editor: TEditor;
@@ -310,6 +312,6 @@ export interface FieldChangeEncodingContext {
  * The decode-side counterpart of {@link FieldChangeEncodingContext}.
  */
 export interface FieldChangeDecodingContext {
-	readonly baseContext: ChangeEncodingContext;
+	readonly baseContext: ChangeDecodingContext;
 	decodeNode(encodedNode: EncodedNodeChangeset): NodeId;
 }

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecV1.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecV1.ts
@@ -288,7 +288,8 @@ export function encodeDetachedNodes(
 	revisionTagCodec: JsonCodecPart<
 		RevisionTag,
 		typeof RevisionTagSchema,
-		ChangeEncodingContext
+		ChangeEncodingContext,
+		ChangeDecodingContext
 	>,
 	fieldsCodec: FieldBatchCodec,
 	chunkCompressionStrategy: TreeCompressionStrategy,
@@ -344,7 +345,8 @@ export function decodeDetachedNodes(
 	revisionTagCodec: JsonCodecPart<
 		RevisionTag,
 		typeof RevisionTagSchema,
-		ChangeEncodingContext
+		ChangeEncodingContext,
+		ChangeDecodingContext
 	>,
 	fieldsCodec: FieldBatchCodec,
 	chunkCompressionStrategy: TreeCompressionStrategy,
@@ -355,15 +357,7 @@ export function decodeDetachedNodes(
 
 	const chunks = fieldsCodec.decode(
 		encoded.trees,
-		context.isSummary
-			? FieldBatchDecodingContext.forSummary({
-					idCompressor: context.idCompressor,
-					healing: context.healing,
-				})
-			: FieldBatchDecodingContext.forOp({
-					idCompressor: context.idCompressor,
-					originatorId: context.originatorId,
-				}),
+		FieldBatchDecodingContext.fromIdDecodingContext(context.forestIdDecodingContext),
 	);
 	const getChunk = (index: number): TreeChunk => {
 		assert(index < chunks.length, 0x898 /* out of bounds index for build chunk */);
@@ -399,7 +393,8 @@ export function encodeRevisionInfos(
 	revisionTagCodec: JsonCodecPart<
 		RevisionTag,
 		typeof RevisionTagSchema,
-		ChangeEncodingContext
+		ChangeEncodingContext,
+		ChangeDecodingContext
 	>,
 ): EncodedRevisionInfo[] | undefined {
 	if (context.revision !== undefined) {
@@ -437,7 +432,8 @@ export function decodeRevisionInfos(
 	revisionTagCodec: JsonCodecPart<
 		RevisionTag,
 		typeof RevisionTagSchema,
-		ChangeEncodingContext
+		ChangeEncodingContext,
+		ChangeDecodingContext
 	>,
 ): RevisionInfo[] | undefined {
 	if (revisions === undefined) {
@@ -473,7 +469,8 @@ export function encodeChange(
 	revisionTagCodec: JsonCodecPart<
 		RevisionTag,
 		typeof RevisionTagSchema,
-		ChangeEncodingContext
+		ChangeEncodingContext,
+		ChangeDecodingContext
 	>,
 	fieldsCodec: FieldBatchCodec,
 	chunkCompressionStrategy: TreeCompressionStrategy,
@@ -524,7 +521,8 @@ export function decodeChange(
 	revisionTagCodec: JsonCodecPart<
 		RevisionTag,
 		typeof RevisionTagSchema,
-		ChangeEncodingContext
+		ChangeEncodingContext,
+		ChangeDecodingContext
 	>,
 	fieldsCodec: FieldBatchCodec,
 	chunkCompressionStrategy: TreeCompressionStrategy,
@@ -589,7 +587,8 @@ export function getFieldChangesetCodecs(
 	revisionTagCodec: JsonCodecPart<
 		RevisionTag,
 		typeof RevisionTagSchema,
-		ChangeEncodingContext
+		ChangeEncodingContext,
+		ChangeDecodingContext
 	>,
 	codecOptions: ICodecOptions,
 ): Map<
@@ -637,7 +636,8 @@ export function makeModularChangeCodecV1(
 	revisionTagCodec: JsonCodecPart<
 		RevisionTag,
 		typeof RevisionTagSchema,
-		ChangeEncodingContext
+		ChangeEncodingContext,
+		ChangeDecodingContext
 	>,
 	fieldsCodec: FieldBatchCodec,
 	codecOptions: ICodecOptions,
@@ -696,7 +696,8 @@ function encodeRevisionOpt(
 		RevisionTag,
 		EncodedRevisionTag,
 		EncodedRevisionTag,
-		ChangeEncodingContext
+		ChangeEncodingContext,
+		ChangeDecodingContext
 	>,
 	revision: RevisionTag | undefined,
 	context: ChangeEncodingContext,

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecV2.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecV2.ts
@@ -40,7 +40,8 @@ export function makeModularChangeCodecV2(
 	revisionTagCodec: JsonCodecPart<
 		RevisionTag,
 		typeof RevisionTagSchema,
-		ChangeEncodingContext
+		ChangeEncodingContext,
+		ChangeDecodingContext
 	>,
 	fieldsCodec: FieldBatchCodec,
 	codecOptions: ICodecOptions,

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecs.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeCodecs.ts
@@ -31,7 +31,8 @@ export function makeModularChangeCodecFamily(
 	revisionTagCodec: JsonCodecPart<
 		RevisionTag,
 		typeof RevisionTagSchema,
-		ChangeEncodingContext
+		ChangeEncodingContext,
+		ChangeDecodingContext
 	>,
 	fieldsCodec: FieldBatchCodec,
 	codecOptions: ICodecOptions,

--- a/packages/dds/tree/src/feature-libraries/optional-field/optionalFieldCodecV2.ts
+++ b/packages/dds/tree/src/feature-libraries/optional-field/optionalFieldCodecV2.ts
@@ -9,6 +9,7 @@ import type { IJsonCodec, JsonCodecPart } from "../../codec/index.js";
 import type {
 	RevisionTagSchema,
 	ChangeAtomId,
+	ChangeDecodingContext,
 	ChangeEncodingContext,
 	RevisionTag,
 } from "../../core/index.js";
@@ -28,9 +29,15 @@ function makeRegisterIdCodec(
 	changeAtomIdCodec: JsonCodecPart<
 		ChangeAtomId,
 		typeof EncodedChangeAtomId,
-		ChangeEncodingContext
+		ChangeEncodingContext,
+		ChangeDecodingContext
 	>,
-): JsonCodecPart<RegisterId, typeof EncodedRegisterId, ChangeEncodingContext> {
+): JsonCodecPart<
+	RegisterId,
+	typeof EncodedRegisterId,
+	ChangeEncodingContext,
+	ChangeDecodingContext
+> {
 	return {
 		encode: (registerId: RegisterId, context: ChangeEncodingContext) => {
 			if (registerId === "self") {
@@ -38,7 +45,7 @@ function makeRegisterIdCodec(
 			}
 			return changeAtomIdCodec.encode(registerId, context);
 		},
-		decode: (registerId: EncodedRegisterId, context: ChangeEncodingContext) => {
+		decode: (registerId: EncodedRegisterId, context: ChangeDecodingContext) => {
 			if (registerId === null) {
 				return "self";
 			}
@@ -52,7 +59,8 @@ export function makeOptionalFieldCodec(
 	revisionTagCodec: JsonCodecPart<
 		RevisionTag,
 		typeof RevisionTagSchema,
-		ChangeEncodingContext
+		ChangeEncodingContext,
+		ChangeDecodingContext
 	>,
 ): IJsonCodec<
 	OptionalChangeset,

--- a/packages/dds/tree/src/feature-libraries/optional-field/optionalFieldCodecs.ts
+++ b/packages/dds/tree/src/feature-libraries/optional-field/optionalFieldCodecs.ts
@@ -5,6 +5,7 @@
 
 import { type ICodecFamily, type JsonCodecPart, makeCodecFamily } from "../../codec/index.js";
 import type {
+	ChangeDecodingContext,
 	ChangeEncodingContext,
 	RevisionTag,
 	RevisionTagSchema,
@@ -21,7 +22,8 @@ export const makeOptionalFieldCodecFamily = (
 	revisionTagCodec: JsonCodecPart<
 		RevisionTag,
 		typeof RevisionTagSchema,
-		ChangeEncodingContext
+		ChangeEncodingContext,
+		ChangeDecodingContext
 	>,
 ): ICodecFamily<OptionalChangeset, FieldChangeEncodingContext, FieldChangeDecodingContext> =>
 	makeCodecFamily([[2, makeV2Codec(revisionTagCodec)]]);

--- a/packages/dds/tree/src/feature-libraries/sequence-field/helperTypes.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/helperTypes.ts
@@ -6,6 +6,7 @@
 import type { DiscriminatedUnionLibrary, IJsonCodec } from "../../codec/index.js";
 import type {
 	ChangeAtomId,
+	ChangeDecodingContext,
 	ChangeEncodingContext,
 	EncodedRevisionTag,
 	RevisionTag,
@@ -40,21 +41,23 @@ export interface SequenceCodecHelpers<TDecodedMarkEffect, TEncodedMarkEffect ext
 		ChangeAtomId,
 		EncodedChangeAtomId,
 		EncodedChangeAtomId,
-		ChangeEncodingContext
+		ChangeEncodingContext,
+		ChangeDecodingContext
 	>;
 	readonly markEffectCodec: IJsonCodec<
 		TDecodedMarkEffect,
 		TEncodedMarkEffect,
 		TEncodedMarkEffect,
-		ChangeEncodingContext
+		ChangeEncodingContext,
+		ChangeDecodingContext
 	>;
 	readonly decoderLibrary: DiscriminatedUnionLibrary<
 		TEncodedMarkEffect,
-		/* args */ [context: ChangeEncodingContext],
+		/* args */ [context: ChangeDecodingContext],
 		TDecodedMarkEffect
 	>;
 	readonly decodeRevision: (
 		encodedRevision: EncodedRevisionTag | undefined,
-		context: ChangeEncodingContext,
+		context: ChangeDecodingContext,
 	) => RevisionTag;
 }

--- a/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldCodecV2.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldCodecV2.ts
@@ -13,6 +13,7 @@ import {
 	type JsonCodecPart,
 } from "../../codec/index.js";
 import type {
+	ChangeDecodingContext,
 	ChangeEncodingContext,
 	ChangesetLocalId,
 	EncodedRevisionTag,
@@ -49,7 +50,8 @@ export function makeV2CodecHelpers(
 	revisionTagCodec: JsonCodecPart<
 		RevisionTag,
 		typeof RevisionTagSchema,
-		ChangeEncodingContext
+		ChangeEncodingContext,
+		ChangeDecodingContext
 	>,
 ): SequenceCodecHelpers<MarkEffect, Encoded.MarkEffect> {
 	const changeAtomIdCodec = makeChangeAtomIdCodec(revisionTagCodec);
@@ -57,7 +59,8 @@ export function makeV2CodecHelpers(
 		MarkEffect,
 		Encoded.MarkEffect,
 		Encoded.MarkEffect,
-		ChangeEncodingContext
+		ChangeEncodingContext,
+		ChangeDecodingContext
 	> = {
 		encode(effect: MarkEffect, context: ChangeEncodingContext): Encoded.MarkEffect {
 			function encodeRevision(
@@ -149,14 +152,14 @@ export function makeV2CodecHelpers(
 				}
 			}
 		},
-		decode(encoded: Encoded.MarkEffect, context: ChangeEncodingContext): MarkEffect {
+		decode(encoded: Encoded.MarkEffect, context: ChangeDecodingContext): MarkEffect {
 			return decoderDispatcher.dispatch(encoded, context);
 		},
 	};
 
 	function decodeRevision(
 		encodedRevision: EncodedRevisionTag | undefined,
-		context: ChangeEncodingContext,
+		context: ChangeDecodingContext,
 	): RevisionTag {
 		if (encodedRevision === undefined) {
 			assert(context.revision !== undefined, 0x996 /* Implicit revision should be provided */);
@@ -168,10 +171,10 @@ export function makeV2CodecHelpers(
 
 	const decoderLibrary: DiscriminatedUnionLibrary<
 		Encoded.MarkEffect,
-		/* args */ [context: ChangeEncodingContext],
+		/* args */ [context: ChangeDecodingContext],
 		MarkEffect
 	> = {
-		moveIn(encoded: Encoded.MoveIn, context: ChangeEncodingContext): MoveIn {
+		moveIn(encoded: Encoded.MoveIn, context: ChangeDecodingContext): MoveIn {
 			const { id, finalEndpoint, revision } = encoded;
 			const mark: MoveIn = {
 				type: "MoveIn",
@@ -184,7 +187,7 @@ export function makeV2CodecHelpers(
 			}
 			return mark;
 		},
-		insert(encoded: Encoded.Insert, context: ChangeEncodingContext): Insert {
+		insert(encoded: Encoded.Insert, context: ChangeDecodingContext): Insert {
 			const { id, revision } = encoded;
 			const mark: Insert = {
 				type: "Insert",
@@ -194,7 +197,7 @@ export function makeV2CodecHelpers(
 			mark.revision = decodeRevision(revision, context);
 			return mark;
 		},
-		remove(encoded: Encoded.Remove, context: ChangeEncodingContext): Remove {
+		remove(encoded: Encoded.Remove, context: ChangeDecodingContext): Remove {
 			const { id, revision, idOverride } = encoded;
 			const mark: Mutable<Remove> = {
 				type: "Remove",
@@ -207,7 +210,7 @@ export function makeV2CodecHelpers(
 			}
 			return mark;
 		},
-		moveOut(encoded: Encoded.MoveOut, context: ChangeEncodingContext): MoveOut {
+		moveOut(encoded: Encoded.MoveOut, context: ChangeDecodingContext): MoveOut {
 			const { id, finalEndpoint, idOverride, revision } = encoded;
 			const mark: Mutable<MoveOut> = {
 				type: "MoveOut",
@@ -226,7 +229,7 @@ export function makeV2CodecHelpers(
 		},
 		attachAndDetach(
 			encoded: Encoded.AttachAndDetach,
-			context: ChangeEncodingContext,
+			context: ChangeDecodingContext,
 		): AttachAndDetach | Rename {
 			const attach = decoderDispatcher.dispatch(encoded.attach, context) as Attach;
 			const detach = decoderDispatcher.dispatch(encoded.detach, context) as Detach;
@@ -250,7 +253,7 @@ export function makeV2CodecHelpers(
 
 	const decoderDispatcher = new DiscriminatedUnionDispatcher<
 		Encoded.MarkEffect,
-		/* args */ [context: ChangeEncodingContext],
+		/* args */ [context: ChangeDecodingContext],
 		MarkEffect
 	>(decoderLibrary);
 
@@ -266,7 +269,8 @@ export function makeV2Codec(
 	revisionTagCodec: JsonCodecPart<
 		RevisionTag,
 		typeof RevisionTagSchema,
-		ChangeEncodingContext
+		ChangeEncodingContext,
+		ChangeDecodingContext
 	>,
 ): IJsonCodec<
 	Changeset,

--- a/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldCodecV3.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldCodecV3.ts
@@ -11,6 +11,7 @@ import {
 	type JsonCodecPart,
 } from "../../codec/index.js";
 import type {
+	ChangeDecodingContext,
 	ChangeEncodingContext,
 	RevisionTag,
 	RevisionTagSchema,
@@ -31,7 +32,8 @@ export function makeV3Codec(
 	revisionTagCodec: JsonCodecPart<
 		RevisionTag,
 		typeof RevisionTagSchema,
-		ChangeEncodingContext
+		ChangeEncodingContext,
+		ChangeDecodingContext
 	>,
 ): IJsonCodec<
 	Changeset,
@@ -50,7 +52,8 @@ export function makeV3Codec(
 		MarkEffect,
 		Encoded.MarkEffect,
 		Encoded.MarkEffect,
-		ChangeEncodingContext
+		ChangeEncodingContext,
+		ChangeDecodingContext
 	> = {
 		encode(effect: MarkEffect, context: ChangeEncodingContext): Encoded.MarkEffect {
 			const type = effect.type;
@@ -67,18 +70,18 @@ export function makeV3Codec(
 				}
 			}
 		},
-		decode(encoded: Encoded.MarkEffect, context: ChangeEncodingContext): MarkEffect {
+		decode(encoded: Encoded.MarkEffect, context: ChangeDecodingContext): MarkEffect {
 			return decoderLibrary.dispatch(encoded, context);
 		},
 	};
 
 	const decoderLibrary = new DiscriminatedUnionDispatcher<
 		Encoded.MarkEffect,
-		/* args */ [context: ChangeEncodingContext],
+		/* args */ [context: ChangeDecodingContext],
 		MarkEffect
 	>({
 		...decoderLibraryV2,
-		rename(encoded: Encoded.Rename, context: ChangeEncodingContext): Rename {
+		rename(encoded: Encoded.Rename, context: ChangeDecodingContext): Rename {
 			return {
 				type: "Rename",
 				idOverride: atomIdCodec.decode(encoded.idOverride, context),

--- a/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldCodecs.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/sequenceFieldCodecs.ts
@@ -5,6 +5,7 @@
 
 import { type JsonCodecPart, makeCodecFamily, type ICodecFamily } from "../../codec/index.js";
 import type {
+	ChangeDecodingContext,
 	ChangeEncodingContext,
 	RevisionTag,
 	RevisionTagSchema,
@@ -22,7 +23,8 @@ export const sequenceFieldChangeCodecFactory = (
 	revisionTagCodec: JsonCodecPart<
 		RevisionTag,
 		typeof RevisionTagSchema,
-		ChangeEncodingContext
+		ChangeEncodingContext,
+		ChangeDecodingContext
 	>,
 ): ICodecFamily<MarkList, FieldChangeEncodingContext, FieldChangeDecodingContext> =>
 	makeCodecFamily<Changeset, FieldChangeEncodingContext, FieldChangeDecodingContext>([

--- a/packages/dds/tree/src/shared-tree-core/editManagerCodecs.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerCodecs.ts
@@ -17,7 +17,12 @@ import {
 	type IJsonCodec,
 	makeDiscontinuedCodecAndSchema,
 } from "../codec/index.js";
-import type { ChangeEncodingContext, EncodedRevisionTag, RevisionTag } from "../core/index.js";
+import type {
+	ChangeDecodingContext,
+	ChangeEncodingContext,
+	EncodedRevisionTag,
+	RevisionTag,
+} from "../core/index.js";
 
 import type { SummaryData } from "./editManager.js";
 import type {
@@ -38,7 +43,7 @@ export const editManagerCodecName = "EditManager";
  */
 interface EditManagerCodecOptions<TChangeset> extends ICodecOptions {
 	/** Codecs for encoding changesets. */
-	changeCodecs: ICodecFamily<TChangeset, ChangeEncodingContext>;
+	changeCodecs: ICodecFamily<TChangeset, ChangeEncodingContext, ChangeDecodingContext>;
 	/** Maps each EditManager format version to the corresponding changeset format version. */
 	dependentChangeFormatVersion: DependentFormatVersion<EditManagerFormatVersion>;
 	/** Codec for encoding revision tags within changesets. */
@@ -46,7 +51,8 @@ interface EditManagerCodecOptions<TChangeset> extends ICodecOptions {
 		RevisionTag,
 		EncodedRevisionTag,
 		EncodedRevisionTag,
-		ChangeEncodingContext
+		ChangeEncodingContext,
+		ChangeDecodingContext
 	>;
 }
 

--- a/packages/dds/tree/src/shared-tree-core/editManagerCodecsCommons.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerCodecsCommons.ts
@@ -16,6 +16,7 @@ import type {
 } from "../core/index.js";
 import {
 	mapIterable,
+	IdDecodingContext,
 	type IdentifierHealingConfig,
 	type JsonCompatibleReadOnly,
 	type Mutable,
@@ -61,13 +62,15 @@ function encodeCommit<TChangeset, T extends Commit<TChangeset>>(
 		TChangeset,
 		JsonCompatibleReadOnly,
 		JsonCompatibleReadOnly,
-		ChangeEncodingContext
+		ChangeEncodingContext,
+		ChangeDecodingContext
 	>,
 	revisionTagCodec: IJsonCodec<
 		RevisionTag,
 		EncodedRevisionTag,
 		EncodedRevisionTag,
-		ChangeEncodingContext
+		ChangeEncodingContext,
+		ChangeDecodingContext
 	>,
 	commit: T,
 	context: ChangeEncodingContext,
@@ -90,23 +93,20 @@ function decodeCommit<TChangeset, T extends EncodedCommit<JsonCompatibleReadOnly
 		TChangeset,
 		JsonCompatibleReadOnly,
 		JsonCompatibleReadOnly,
-		ChangeEncodingContext
+		ChangeEncodingContext,
+		ChangeDecodingContext
 	>,
 	revisionTagCodec: IJsonCodec<
 		RevisionTag,
 		EncodedRevisionTag,
 		EncodedRevisionTag,
-		ChangeEncodingContext
+		ChangeEncodingContext,
+		ChangeDecodingContext
 	>,
 	commit: T,
 	context: ChangeDecodingContext,
 ) {
-	const revision = revisionTagCodec.decode(commit.revision, {
-		originatorId: commit.sessionId,
-		idCompressor: context.idCompressor,
-		revision: undefined,
-		isSummary: context.isSummary,
-	});
+	const revision = revisionTagCodec.decode(commit.revision, context);
 
 	return {
 		...commit,
@@ -120,13 +120,15 @@ export function encodeSharedBranch<TChangeset>(
 		TChangeset,
 		JsonCompatibleReadOnly,
 		JsonCompatibleReadOnly,
-		ChangeEncodingContext
+		ChangeEncodingContext,
+		ChangeDecodingContext
 	>,
 	revisionTagCodec: IJsonCodec<
 		RevisionTag,
 		EncodedRevisionTag,
 		EncodedRevisionTag,
-		ChangeEncodingContext
+		ChangeEncodingContext,
+		ChangeDecodingContext
 	>,
 	data: SharedBranchSummaryData<TChangeset>,
 	context: EditManagerEncodingContext,
@@ -195,55 +197,61 @@ export function decodeSharedBranch<TChangeset>(
 		TChangeset,
 		JsonCompatibleReadOnly,
 		JsonCompatibleReadOnly,
-		ChangeEncodingContext
+		ChangeEncodingContext,
+		ChangeDecodingContext
 	>,
 	revisionTagCodec: IJsonCodec<
 		RevisionTag,
 		EncodedRevisionTag,
 		EncodedRevisionTag,
-		ChangeEncodingContext
+		ChangeEncodingContext,
+		ChangeDecodingContext
 	>,
 	json: EncodedSharedBranch<TChangeset>,
 	context: EditManagerDecodingContext,
 	originatorId: SessionId | undefined,
 ): SharedBranchSummaryData<TChangeset> {
+	// Forest identifiers in a summary can reference multiple sessions, so they are resolved
+	// originatorlessly (heal-aware). Revision tags belong to a single commit, so each is resolved
+	// with that commit's originator session. See the TODO on ChangeDecodingContext.
+	const forestIdDecodingContext = new IdDecodingContext({
+		idCompressor: context.idCompressor,
+		healing: context.healing,
+	});
+	const makeChangeContext = (commitOriginatorId: SessionId): ChangeDecodingContext => ({
+		revision: undefined,
+		idCompressor: context.idCompressor,
+		idDecodingContext: new IdDecodingContext({
+			idCompressor: context.idCompressor,
+			originatorId: commitOriginatorId,
+		}),
+		forestIdDecodingContext,
+	});
 	// TODO: sort out EncodedCommit vs Commit, and make this type check without type assertion.
 	const trunk = json.trunk as readonly (EncodedCommit<JsonCompatibleReadOnly> & SequenceId)[];
 	const data: Mutable<SharedBranchSummaryData<TChangeset>> = {
 		trunk: trunk.map(
 			(commit): SequencedCommit<TChangeset> =>
 				// TODO: sort out EncodedCommit vs Commit, and make this type check without `as`.
-				decodeCommit(changeCodec, revisionTagCodec, commit, {
-					originatorId: commit.sessionId,
-					idCompressor: context.idCompressor,
-					revision: undefined,
-					isSummary: context.isSummary,
-					healing: context.healing,
-				}),
+				decodeCommit(
+					changeCodec,
+					revisionTagCodec,
+					commit,
+					makeChangeContext(commit.sessionId),
+				),
 		),
 		peerLocalBranches: new Map(
 			mapIterable(json.peers, ([sessionId, branch]) => [
 				sessionId,
 				{
-					base: revisionTagCodec.decode(branch.base, {
-						originatorId: sessionId,
-						idCompressor: context.idCompressor,
-						revision: undefined,
-						isSummary: context.isSummary,
-					}),
+					base: revisionTagCodec.decode(branch.base, makeChangeContext(sessionId)),
 					commits: branch.commits.map((commit) =>
 						// TODO: sort out EncodedCommit vs Commit, and make this type check without `as`.
 						decodeCommit(
 							changeCodec,
 							revisionTagCodec,
 							commit as EncodedCommit<JsonCompatibleReadOnly>,
-							{
-								originatorId: commit.sessionId,
-								idCompressor: context.idCompressor,
-								revision: undefined,
-								isSummary: context.isSummary,
-								healing: context.healing,
-							},
+							makeChangeContext(commit.sessionId),
 						),
 					),
 				},
@@ -271,12 +279,7 @@ export function decodeSharedBranch<TChangeset>(
 			originatorId !== undefined,
 			0xc64 /* Cannot decode branch base without originatorId */,
 		);
-		data.base = revisionTagCodec.decode(json.base, {
-			originatorId,
-			idCompressor: context.idCompressor,
-			revision: undefined,
-			isSummary: context.isSummary,
-		});
+		data.base = revisionTagCodec.decode(json.base, makeChangeContext(originatorId));
 	}
 	return data;
 }

--- a/packages/dds/tree/src/shared-tree-core/editManagerCodecsV1toV4.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerCodecsV1toV4.ts
@@ -4,7 +4,12 @@
  */
 
 import type { CodecAndSchema, IJsonCodec, Versioned } from "../codec/index.js";
-import type { ChangeEncodingContext, EncodedRevisionTag, RevisionTag } from "../core/index.js";
+import type {
+	ChangeDecodingContext,
+	ChangeEncodingContext,
+	EncodedRevisionTag,
+	RevisionTag,
+} from "../core/index.js";
 import {
 	type JsonCompatibleReadOnly,
 	type JsonCompatibleReadOnlyObject,
@@ -33,13 +38,15 @@ export function makeV1toV4andV6CodecWithVersion<TChangeset>(
 		TChangeset,
 		JsonCompatibleReadOnly,
 		JsonCompatibleReadOnly,
-		ChangeEncodingContext
+		ChangeEncodingContext,
+		ChangeDecodingContext
 	>,
 	revisionTagCodec: IJsonCodec<
 		RevisionTag,
 		EncodedRevisionTag,
 		EncodedRevisionTag,
-		ChangeEncodingContext
+		ChangeEncodingContext,
+		ChangeDecodingContext
 	>,
 	version: EncodedEditManager<TChangeset>["version"],
 ): CodecAndSchema<

--- a/packages/dds/tree/src/shared-tree-core/editManagerCodecsVSharedBranches.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerCodecsVSharedBranches.ts
@@ -6,7 +6,12 @@
 import { assert } from "@fluidframework/core-utils/internal";
 
 import type { CodecAndSchema, IJsonCodec } from "../codec/index.js";
-import type { ChangeEncodingContext, EncodedRevisionTag, RevisionTag } from "../core/index.js";
+import type {
+	ChangeDecodingContext,
+	ChangeEncodingContext,
+	EncodedRevisionTag,
+	RevisionTag,
+} from "../core/index.js";
 import {
 	type JsonCompatibleReadOnly,
 	type JsonCompatibleReadOnlyObject,
@@ -30,13 +35,15 @@ export function makeSharedBranchesCodecWithVersion<TChangeset>(
 		TChangeset,
 		JsonCompatibleReadOnly,
 		JsonCompatibleReadOnly,
-		ChangeEncodingContext
+		ChangeEncodingContext,
+		ChangeDecodingContext
 	>,
 	revisionTagCodec: IJsonCodec<
 		RevisionTag,
 		EncodedRevisionTag,
 		EncodedRevisionTag,
-		ChangeEncodingContext
+		ChangeEncodingContext,
+		ChangeDecodingContext
 	>,
 	version: EncodedEditManager<TChangeset>["version"],
 ): CodecAndSchema<

--- a/packages/dds/tree/src/shared-tree-core/messageCodecV1ToV4.ts
+++ b/packages/dds/tree/src/shared-tree-core/messageCodecV1ToV4.ts
@@ -7,12 +7,14 @@ import { assert } from "@fluidframework/core-utils/internal";
 
 import type { CodecAndSchema, IJsonCodec, Versioned } from "../codec/index.js";
 import type {
+	ChangeDecodingContext,
 	ChangeEncodingContext,
 	ChangeFamilyCodec,
 	EncodedRevisionTag,
 	RevisionTag,
 } from "../core/index.js";
 import {
+	IdDecodingContext,
 	type JsonCompatibleReadOnlyObject,
 	JsonCompatibleReadOnlySchema,
 } from "../util/index.js";
@@ -28,7 +30,8 @@ export function makeV1ToV4CodecWithVersion<TChangeset>(
 		RevisionTag,
 		EncodedRevisionTag,
 		EncodedRevisionTag,
-		ChangeEncodingContext
+		ChangeEncodingContext,
+		ChangeDecodingContext
 	>,
 	version:
 		| typeof MessageFormatVersion.v1
@@ -74,24 +77,26 @@ export function makeV1ToV4CodecWithVersion<TChangeset>(
 		): DecodedMessage<TChangeset> => {
 			const { revision: encodedRevision, originatorId, changeset } = encoded;
 
-			const revision = revisionTagCodec.decode(encodedRevision, {
+			const idDecodingContext = new IdDecodingContext({
+				idCompressor: context.idCompressor,
 				originatorId,
+			});
+			const changeContext: ChangeDecodingContext = {
 				revision: undefined,
 				idCompressor: context.idCompressor,
-				isSummary: false,
-			});
+				idDecodingContext,
+				// For ops the originator session resolves forest identifiers too.
+				forestIdDecodingContext: idDecodingContext,
+			};
+
+			const revision = revisionTagCodec.decode(encodedRevision, changeContext);
 
 			return {
 				branchId: "main",
 				type: "commit",
 				commit: {
 					revision,
-					change: changeCodec.decode(changeset, {
-						originatorId,
-						revision,
-						idCompressor: context.idCompressor,
-						isSummary: false,
-					}),
+					change: changeCodec.decode(changeset, { ...changeContext, revision }),
 				},
 				sessionId: originatorId,
 			};

--- a/packages/dds/tree/src/shared-tree-core/messageCodecVSharedBranches.ts
+++ b/packages/dds/tree/src/shared-tree-core/messageCodecVSharedBranches.ts
@@ -9,12 +9,13 @@ import type { TAnySchema } from "@sinclair/typebox";
 
 import type { CodecAndSchema, IJsonCodec, Versioned } from "../codec/index.js";
 import type {
+	ChangeDecodingContext,
 	ChangeEncodingContext,
 	ChangeFamilyCodec,
 	EncodedRevisionTag,
 	RevisionTag,
 } from "../core/index.js";
-import type { JsonCompatibleReadOnlyObject } from "../util/index.js";
+import { IdDecodingContext, type JsonCompatibleReadOnlyObject } from "../util/index.js";
 
 import { decodeBranchId, encodeBranchId } from "./branchIdCodec.js";
 import type { MessageDecodingContext, MessageEncodingContext } from "./messageCodecs.js";
@@ -28,7 +29,8 @@ export function makeSharedBranchesCodecWithVersion<TChangeset>(
 		RevisionTag,
 		EncodedRevisionTag,
 		EncodedRevisionTag,
-		ChangeEncodingContext
+		ChangeEncodingContext,
+		ChangeDecodingContext
 	>,
 	version: typeof MessageFormatVersion.vSharedBranches,
 ): CodecAndSchema<DecodedMessage<TChangeset>, MessageEncodingContext> {
@@ -89,14 +91,21 @@ export function makeSharedBranchesCodecWithVersion<TChangeset>(
 				branchName: encodedBranchName,
 			} = encoded;
 
-			const changeContext: ChangeEncodingContext = {
+			const idDecodingContext = new IdDecodingContext({
+				idCompressor: context.idCompressor,
 				originatorId,
+			});
+			const changeContext: ChangeDecodingContext = {
 				revision: undefined,
 				idCompressor: context.idCompressor,
-				isSummary: false,
+				idDecodingContext,
+				// For ops the originator session resolves forest identifiers too.
+				forestIdDecodingContext: idDecodingContext,
 			};
 
-			const branchId = decodeBranchId(context.idCompressor, encodedBranchId, changeContext);
+			const branchId = decodeBranchId(context.idCompressor, encodedBranchId, {
+				originatorId,
+			});
 
 			if (changeset === undefined) {
 				return {
@@ -114,12 +123,7 @@ export function makeSharedBranchesCodecWithVersion<TChangeset>(
 				type: "commit",
 				commit: {
 					revision,
-					change: changeCodec.decode(changeset, {
-						originatorId,
-						revision,
-						idCompressor: context.idCompressor,
-						isSummary: false,
-					}),
+					change: changeCodec.decode(changeset, { ...changeContext, revision }),
 				},
 				branchId,
 				sessionId: originatorId,

--- a/packages/dds/tree/src/shared-tree-core/messageCodecs.ts
+++ b/packages/dds/tree/src/shared-tree-core/messageCodecs.ts
@@ -19,6 +19,7 @@ import {
 	makeDiscontinuedCodecAndSchema,
 } from "../codec/index.js";
 import type {
+	ChangeDecodingContext,
 	ChangeEncodingContext,
 	EncodedRevisionTag,
 	RevisionTag,
@@ -53,7 +54,7 @@ export const messageCodecName = "Message";
  */
 interface MessageCodecBuilderOptions<TChangeset> extends ICodecOptions {
 	/** Codecs for encoding changesets. */
-	changeCodecs: ICodecFamily<TChangeset, ChangeEncodingContext>;
+	changeCodecs: ICodecFamily<TChangeset, ChangeEncodingContext, ChangeDecodingContext>;
 	/** Maps each MessageFormatVersion to the corresponding changeset format version. */
 	dependentChangeFormatVersion: DependentFormatVersion<MessageFormatVersion>;
 	/** Codec for encoding revision tags within changesets. */
@@ -61,7 +62,8 @@ interface MessageCodecBuilderOptions<TChangeset> extends ICodecOptions {
 		RevisionTag,
 		EncodedRevisionTag,
 		EncodedRevisionTag,
-		ChangeEncodingContext
+		ChangeEncodingContext,
+		ChangeDecodingContext
 	>;
 }
 

--- a/packages/dds/tree/src/shared-tree/serializedChange.ts
+++ b/packages/dds/tree/src/shared-tree/serializedChange.ts
@@ -11,10 +11,11 @@ import {
 	type ChangeFamily,
 	type RevisionTag,
 	tagChange,
+	type ChangeDecodingContext,
 	type ChangeEncodingContext,
 	type TaggedChange,
 } from "../core/index.js";
-import type { JsonCompatibleReadOnly } from "../util/index.js";
+import { IdDecodingContext, type JsonCompatibleReadOnly } from "../util/index.js";
 
 import type { SharedTreeChange } from "./sharedTreeChangeTypes.js";
 import type { SharedTreeEditBuilder } from "./sharedTreeEditBuilder.js";
@@ -85,11 +86,15 @@ function decodeSerializedChangeV1(
 			`Cannot apply change. A serialized changed must be applied to the same SharedTree as it was created from.`,
 		);
 	}
-	const context: ChangeEncodingContext = {
+	const idDecodingContext = new IdDecodingContext({
 		idCompressor,
 		originatorId: idCompressor.localSessionId,
+	});
+	const context: ChangeDecodingContext = {
+		idCompressor,
 		revision,
-		isSummary: false,
+		idDecodingContext,
+		forestIdDecodingContext: idDecodingContext,
 	};
 	const treeChange = changeFamily.codecs
 		.resolve(SharedTreeChangeFormatVersion.v4)

--- a/packages/dds/tree/src/shared-tree/sharedTreeChangeCodecs.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTreeChangeCodecs.ts
@@ -56,7 +56,8 @@ export function makeSharedTreeChangeCodecFamily(
 			SharedTreeChange,
 			EncodedSharedTreeChange,
 			EncodedSharedTreeChange,
-			ChangeEncodingContext
+			ChangeEncodingContext,
+			ChangeDecodingContext
 		>,
 	][] = [...dependenciesForChangeFormat.entries()].map(([format, { modularChange }]) => [
 		format,
@@ -149,19 +150,21 @@ function makeSharedTreeChangeCodec(
 		ModularChangeset,
 		JsonCompatibleReadOnly,
 		JsonCompatibleReadOnly,
-		ChangeEncodingContext
+		ChangeEncodingContext,
+		ChangeDecodingContext
 	>,
 	codecOptions: CodecWriteOptions,
 ): IJsonCodec<
 	SharedTreeChange,
 	EncodedSharedTreeChange,
 	EncodedSharedTreeChange,
-	ChangeEncodingContext
+	ChangeEncodingContext,
+	ChangeDecodingContext
 > {
 	const schemaChangeCodec = makeSchemaChangeCodec(codecOptions);
 	const decoderLibrary = new DiscriminatedUnionDispatcher<
 		EncodedSharedTreeInnerChange,
-		[context: ChangeEncodingContext],
+		[context: ChangeDecodingContext],
 		SharedTreeInnerChange
 	>({
 		data(encoded, context): SharedTreeInnerChange {

--- a/packages/dds/tree/src/test/feature-libraries/mitigatedChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/mitigatedChangeFamily.spec.ts
@@ -10,6 +10,7 @@ import type {
 	ChangeFamily,
 	ChangeFamilyEditor,
 	TaggedChange,
+	ChangeDecodingContext,
 	ChangeEncodingContext,
 	RevisionTag,
 	RevisionReplacer,
@@ -60,7 +61,7 @@ const throwingFamily: ChangeFamily<ChangeFamilyEditor, string, unknown> = {
 			throw new Error("changeRevision");
 		},
 	},
-	codecs: {} as unknown as ICodecFamily<string, ChangeEncodingContext>,
+	codecs: {} as unknown as ICodecFamily<string, ChangeEncodingContext, ChangeDecodingContext>,
 	buildProcessor: (context: unknown): ((change: string) => string) => {
 		assert.equal(context, arg1);
 		return (change: string) => {
@@ -103,7 +104,7 @@ const returningFamily: ChangeFamily<ChangeFamilyEditor, string, unknown> = {
 			return "changeRevision";
 		},
 	},
-	codecs: {} as unknown as ICodecFamily<string, ChangeEncodingContext>,
+	codecs: {} as unknown as ICodecFamily<string, ChangeEncodingContext, ChangeDecodingContext>,
 	buildProcessor: (context: unknown): ((change: string) => string) => {
 		assert.equal(context, arg1);
 		return (change: string) => {

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/genericFieldKind.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/genericFieldKind.spec.ts
@@ -19,7 +19,12 @@ import {
 	genericChangeHandler,
 	// eslint-disable-next-line import-x/no-internal-modules
 } from "../../../feature-libraries/modular-schema/index.js";
-import { fakeIdAllocator, brand, idAllocatorFromMaxId } from "../../../util/index.js";
+import {
+	fakeIdAllocator,
+	brand,
+	idAllocatorFromMaxId,
+	IdDecodingContext,
+} from "../../../util/index.js";
 import { TestChange } from "../../testChange.js";
 import { TestNodeId } from "../../testNodeId.js";
 import {
@@ -208,6 +213,14 @@ describe("GenericField", () => {
 			isSummary: false,
 			revision: undefined,
 			idCompressor: testIdCompressor,
+			idDecodingContext: new IdDecodingContext({
+				idCompressor: testIdCompressor,
+				originatorId: "session1" as SessionId,
+			}),
+			forestIdDecodingContext: new IdDecodingContext({
+				idCompressor: testIdCompressor,
+				originatorId: "session1" as SessionId,
+			}),
 		};
 
 		const encodingTestData: EncodingTestData<

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
@@ -28,6 +28,7 @@ import {
 	type DeltaFieldChanges,
 	type DeltaRoot,
 	type DeltaDetachedNodeId,
+	type ChangeDecodingContext,
 	type ChangeEncodingContext,
 	type ChangeAtomIdMap,
 	Multiplicity,
@@ -90,6 +91,7 @@ import {
 	brand,
 	brandConst,
 	idAllocatorFromMaxId,
+	IdDecodingContext,
 	nestedMapFromFlatList,
 	setInNestedMap,
 	tryGetFromNestedMap,
@@ -1420,16 +1422,24 @@ describe("ModularChangeFamily", () => {
 		}
 
 		const sessionId = "session1" as SessionId;
-		const context: ChangeEncodingContext = {
+		const context: ChangeEncodingContext & ChangeDecodingContext = {
 			originatorId: sessionId,
 			isSummary: false,
 			revision: tag1,
 			idCompressor: testIdCompressor,
+			idDecodingContext: new IdDecodingContext({
+				idCompressor: testIdCompressor,
+				originatorId: sessionId,
+			}),
+			forestIdDecodingContext: new IdDecodingContext({
+				idCompressor: testIdCompressor,
+				originatorId: sessionId,
+			}),
 		};
 		const encodingTestDataForAllVersions: EncodingTestData<
 			ModularChangeset,
 			EncodedModularChangesetV1,
-			ChangeEncodingContext
+			ChangeEncodingContext & ChangeDecodingContext
 		> = {
 			successes: [
 				["without constraint", inlineRevision(rootChange1a, tag1), context],
@@ -1479,7 +1489,7 @@ describe("ModularChangeFamily", () => {
 		const encodingTestDataV5Only: EncodingTestData<
 			ModularChangeset,
 			EncodedModularChangesetV2,
-			ChangeEncodingContext
+			ChangeEncodingContext & ChangeDecodingContext
 		> = {
 			successes: [
 				...encodingTestDataForAllVersions.successes,

--- a/packages/dds/tree/src/test/feature-libraries/optional-field/optionalFieldChangeCodecs.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/optional-field/optionalFieldChangeCodecs.test.ts
@@ -21,7 +21,7 @@ import {
 	makeOptionalFieldCodecFamily,
 	// eslint-disable-next-line import-x/no-internal-modules
 } from "../../../feature-libraries/optional-field/optionalFieldCodecs.js";
-import { brand } from "../../../util/index.js";
+import { brand, IdDecodingContext } from "../../../util/index.js";
 import { TestChange } from "../../testChange.js";
 import { TestNodeId } from "../../testNodeId.js";
 import {
@@ -83,6 +83,14 @@ export function testCodecs(): void {
 			isSummary: false,
 			revision: undefined,
 			idCompressor: testIdCompressor,
+			idDecodingContext: new IdDecodingContext({
+				idCompressor: testIdCompressor,
+				originatorId: "session1" as SessionId,
+			}),
+			forestIdDecodingContext: new IdDecodingContext({
+				idCompressor: testIdCompressor,
+				originatorId: "session1" as SessionId,
+			}),
 		};
 		const context: FieldChangeEncodingContext & FieldChangeDecodingContext = {
 			baseContext,

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldCodecs.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceFieldCodecs.test.ts
@@ -15,7 +15,7 @@ import type {
 import { sequenceFieldChangeCodecFactory } from "../../../feature-libraries/sequence-field/sequenceFieldCodecs.js";
 // eslint-disable-next-line import-x/no-internal-modules
 import type { Changeset } from "../../../feature-libraries/sequence-field/types.js";
-import { brand, type JsonCompatibleReadOnly } from "../../../util/index.js";
+import { brand, IdDecodingContext, type JsonCompatibleReadOnly } from "../../../util/index.js";
 import { TestChange } from "../../testChange.js";
 import { TestNodeId } from "../../testNodeId.js";
 import {
@@ -39,6 +39,14 @@ const baseContext = {
 	isSummary: false,
 	revision: tag1,
 	idCompressor: testIdCompressor,
+	idDecodingContext: new IdDecodingContext({
+		idCompressor: testIdCompressor,
+		originatorId: "session1" as SessionId,
+	}),
+	forestIdDecodingContext: new IdDecodingContext({
+		idCompressor: testIdCompressor,
+		originatorId: "session1" as SessionId,
+	}),
 };
 const encodedTag1 = testRevisionTagCodec.encode(tag1);
 const encodedTag2 = testRevisionTagCodec.encode(tag2);

--- a/packages/dds/tree/src/test/rebase/revisionTagCodec.spec.ts
+++ b/packages/dds/tree/src/test/rebase/revisionTagCodec.spec.ts
@@ -5,14 +5,37 @@
 
 import { strict as assert } from "node:assert";
 
+import type { IIdCompressor, SessionId } from "@fluidframework/id-compressor";
 import {
 	createIdCompressor,
 	createSessionId,
 	toIdCompressorWithCore,
 } from "@fluidframework/id-compressor/internal";
 
-import { type RevisionTag, RevisionTagCodec } from "../../core/index.js";
-import { testIdCompressor } from "../utils.js";
+import {
+	type ChangeDecodingContext,
+	type RevisionTag,
+	RevisionTagCodec,
+} from "../../core/index.js";
+import { IdDecodingContext } from "../../util/index.js";
+
+/**
+ * Builds a {@link ChangeDecodingContext} that resolves identifiers using the given compressor and
+ * originator session. `revisionTagCodec.decode` resolves solely through the embedded
+ * {@link IdDecodingContext}, so the compressor provided here is the one used for resolution.
+ */
+function makeDecodeContext(
+	idCompressor: IIdCompressor,
+	originatorId: SessionId,
+): ChangeDecodingContext {
+	const idDecodingContext = new IdDecodingContext({ idCompressor, originatorId });
+	return {
+		revision: undefined,
+		idCompressor,
+		idDecodingContext,
+		forestIdDecodingContext: idDecodingContext,
+	};
+}
 
 describe("RevisionTagCodec", () => {
 	it("handles the root constant revision tag", () => {
@@ -22,20 +45,16 @@ describe("RevisionTagCodec", () => {
 		const codec = new RevisionTagCodec(localCompressor);
 		const encoded = codec.encode(rootRevisionTag);
 		assert.deepEqual(encoded, rootRevisionTag);
-		const decoded = codec.decode(encoded, {
-			originatorId: localCompressor.localSessionId,
-			isSummary: false,
-			revision: undefined,
-			idCompressor: testIdCompressor,
-		});
+		const decoded = codec.decode(
+			encoded,
+			makeDecodeContext(localCompressor, localCompressor.localSessionId),
+		);
 		assert.deepEqual(decoded, rootRevisionTag);
 		const remoteEncoded = new RevisionTagCodec(remoteCompressor).encode(rootRevisionTag);
-		const decodedFromRemote = codec.decode(remoteEncoded, {
-			originatorId: remoteCompressor.localSessionId,
-			isSummary: false,
-			revision: undefined,
-			idCompressor: testIdCompressor,
-		});
+		const decodedFromRemote = codec.decode(
+			remoteEncoded,
+			makeDecodeContext(localCompressor, remoteCompressor.localSessionId),
+		);
 		assert.deepEqual(decodedFromRemote, rootRevisionTag);
 	});
 
@@ -55,22 +74,12 @@ describe("RevisionTagCodec", () => {
 		assert.deepEqual(localId, localEncoded);
 		assert.deepEqual(
 			localId,
-			localCodec.decode(localEncoded, {
-				originatorId: localSession,
-				isSummary: false,
-				revision: undefined,
-				idCompressor: testIdCompressor,
-			}),
+			localCodec.decode(localEncoded, makeDecodeContext(localCompressor, localSession)),
 		);
 		// A remote client should not be able to decode the local ID, as it has not received
 		// the creation range for it
 		assert.throws(() =>
-			remoteCodec.decode(localEncoded, {
-				originatorId: localSession,
-				isSummary: false,
-				revision: undefined,
-				idCompressor: testIdCompressor,
-			}),
+			remoteCodec.decode(localEncoded, makeDecodeContext(remoteCompressor, localSession)),
 		);
 
 		// Simulate the remote client receiving the creation range for the local ID
@@ -79,12 +88,10 @@ describe("RevisionTagCodec", () => {
 		toIdCompressorWithCore(remoteCompressor).finalizeCreationRange(range);
 		// Locally encoding will have the final ID form, as will the remote client
 		localEncoded = localCodec.encode(localId);
-		const remoteDecoded = remoteCodec.decode(localEncoded, {
-			originatorId: localSession,
-			isSummary: false,
-			revision: undefined,
-			idCompressor: testIdCompressor,
-		});
+		const remoteDecoded = remoteCodec.decode(
+			localEncoded,
+			makeDecodeContext(remoteCompressor, localSession),
+		);
 		const remoteEncoded = remoteCodec.encode(remoteDecoded);
 
 		assert.notDeepEqual(localId, localEncoded);
@@ -92,22 +99,12 @@ describe("RevisionTagCodec", () => {
 		assert.deepEqual(remoteEncoded, remoteDecoded);
 		assert.deepEqual(
 			localEncoded,
-			remoteCodec.decode(localEncoded, {
-				originatorId: localSession,
-				isSummary: false,
-				revision: undefined,
-				idCompressor: testIdCompressor,
-			}),
+			remoteCodec.decode(localEncoded, makeDecodeContext(remoteCompressor, localSession)),
 		);
 		// Simulate the remote client referencing the local client's ID
 		assert.deepEqual(
 			localId,
-			localCodec.decode(remoteEncoded, {
-				originatorId: remoteSession,
-				isSummary: false,
-				revision: undefined,
-				idCompressor: testIdCompressor,
-			}),
+			localCodec.decode(remoteEncoded, makeDecodeContext(localCompressor, remoteSession)),
 		);
 	});
 });

--- a/packages/dds/tree/src/test/shared-tree/sharedTreeChangeCodec.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTreeChangeCodec.spec.ts
@@ -9,7 +9,7 @@ import type { SessionId } from "@fluidframework/id-compressor";
 import { validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
 
 import { currentVersion, type CodecWriteOptions } from "../../codec/index.js";
-import { TreeStoredSchemaRepository, type ChangeEncodingContext } from "../../core/index.js";
+import { TreeStoredSchemaRepository, type ChangeDecodingContext } from "../../core/index.js";
 import { FormatValidatorBasic } from "../../external-utilities/index.js";
 // eslint-disable-next-line import-x/no-internal-modules
 import { decode } from "../../feature-libraries/chunked-forest/codec/chunkDecoding.js";
@@ -100,7 +100,7 @@ describe("sharedTreeChangeCodec", () => {
 				codec.decode(
 					// missing 'old' field
 					[{ schema: { new: {} } }],
-					{} as unknown as ChangeEncodingContext,
+					{} as unknown as ChangeDecodingContext,
 				),
 			validateAssertionError(/must have required property 'old'/),
 		);


### PR DESCRIPTION
## Description

Adopts `IdDecodingContext` across the change codecs' **decode** path so that session-id handling is built **once at the decode entry point** rather than reconstructed — and branched on `isSummary` — inside individual codecs.

Previously, `revisionTagCodec`, `changeAtomIdCodec`, and `modularChangeCodec.decodeDetachedNodes` each re-derived how to resolve encoded identifiers from raw `originatorId` / `healing` / `isSummary` fields on the decode context. That was error-prone, especially the `isSummary ? forSummary : forOp` branch inside `decodeDetachedNodes`.

Now `ChangeDecodingContext` carries two ready-made `IdDecodingContext`s, built by the caller that actually knows the decode situation (op vs summary):

- `idDecodingContext` — resolves **revision tags** and other change-atom identifiers using the originating session (per-commit for edit-manager summaries, the message session for ops).
- `forestIdDecodingContext` — resolves identifiers embedded in **forest chunks** (detached-node builds/refreshers), which can reference multiple sessions and therefore use an originatorless, heal-aware resolver for summaries.

For ops the two contexts are identical.

### Why two contexts

A single unified context is not correct for edit-manager summaries: a summary loaded while detached contains **non-final revision tags** that must be resolved with the per-commit originator session, while forest identifiers in the same commit can reference **other** sessions and rely on the originatorless heal path. The `SharedTree > can load a summary while detached` test exercises exactly this. A `TODO` on `ChangeDecodingContext` records that this split should be revisited — specifically whether revision tags are decoded with the correct session id (and whether they should gain healing support), and whether forest decoding could reuse the originator session id we already have (which would let the two contexts collapse back into one).

### Scope

- `revisionTagCodec` / `changeAtomIdCodec` decode now resolve via `idDecodingContext.resolveEncodedId` (unifying revision-tag resolution with the field-batch approach).
- `decodeDetachedNodes` builds its `FieldBatchDecodingContext` from `forestIdDecodingContext` (via `FieldBatchDecodingContext.fromIdDecodingContext`), removing the `isSummary` branch.
- The decode-context type is threaded (`ChangeEncodingContext, ChangeDecodingContext`) through the field codecs, modular change codecs, edit-manager and message codecs, and the detached-field-index / serialized-change entry points.

## Breaking Changes

None. All affected types are `@internal`.

## Reviewer Guidance

No wire-format or public-API change (no `*.api.md` diff). The only behavioral change: a non-final revision tag that lacks its originator session now heals-or-errors through the shared identifier path instead of the previous normalization — which only differs when identifier healing is opted into. Full `@fluidframework/tree` functional suite passes (15014 passing). No changeset (internal-only, type-level reshaping).
