### PR TITLE
fix: preserve isLatest in publish metadata

### DIFF
--- a/tools/pipelines/templates/include-generate-publish-metadata.yml
+++ b/tools/pipelines/templates/include-generate-publish-metadata.yml
@@ -54,7 +54,7 @@ steps:
       esac
 
       case "${IS_LATEST:-}" in
-        ""|'$(SetVersion.isLatest)'|false|False) isLatest=false ;;
+        ""|false|False) isLatest=false ;;
         true|True) isLatest=true ;;
         *)
           echo "##vso[task.logissue type=error]Invalid isLatest value '$IS_LATEST'"


### PR DESCRIPTION
## Description

Fix publish metadata generation so a resolved `SetVersion.isLatest` value of `true` remains `true`.

Azure Pipelines substituted `$(SetVersion.isLatest)` in both the environment mapping and the shell `case` fallback pattern. This turned the fallback into a `true` pattern that matched before the intended `true` branch, causing `publish-metadata.json` to incorrectly record `"isLatest": false`.

An unresolved output variable now falls through to the existing validation error.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

The change is intentionally limited to removing the self-substituting fallback pattern.