### PR TITLE
Revert "fix: preserve isLatest in publish metadata"

### DIFF
--- a/tools/pipelines/templates/include-generate-publish-metadata.yml
+++ b/tools/pipelines/templates/include-generate-publish-metadata.yml
@@ -54,7 +54,7 @@ steps:
       esac
 
       case "${IS_LATEST:-}" in
-        ""|false|False) isLatest=false ;;
+        ""|'$(SetVersion.isLatest)'|false|False) isLatest=false ;;
         true|True) isLatest=true ;;
         *)
           echo "##vso[task.logissue type=error]Invalid isLatest value '$IS_LATEST'"


### PR DESCRIPTION
Reverts microsoft/FluidFramework#27832. Build failures show this variable isn't getting injected. Previous behavior of never "isLatest" is acceptable while I investigate.
