### PR TITLE
fix(build-cli): always emit isLatest output

### DIFF
--- a/build-tools/packages/build-cli/src/commands/generate/buildVersion.ts
+++ b/build-tools/packages/build-cli/src/commands/generate/buildVersion.ts
@@ -160,9 +160,11 @@ export default class GenerateBuildVersionCommand extends BaseCommand<
 		if (flags.tag !== undefined) {
 			const isLatest = getIsLatest(flags.tag, version, tags, shouldIncludeInternalVersions);
 			this.log(`isLatest=${isLatest}`);
-			if (isRelease && isLatest === true) {
-				this.log(generateSetVariableString("isLatest", String(isLatest), { isOutput: true }));
-			}
+			this.log(
+				generateSetVariableString("isLatest", String(isRelease && isLatest), {
+					isOutput: true,
+				}),
+			);
 		}
 	}
 

--- a/build-tools/packages/build-cli/src/test/commands/generate/buildVersion.test.ts
+++ b/build-tools/packages/build-cli/src/test/commands/generate/buildVersion.test.ts
@@ -158,6 +158,12 @@ describe("generate:buildVersion", () => {
 			},
 		);
 		stdoutLineEquals(stdout, 0, "version=0.4.12345");
+		stdoutLineEquals(stdout, 2, "isLatest=false");
+		stdoutLineEquals(
+			stdout,
+			3,
+			"##vso[task.setvariable variable=isLatest;isOutput=true]false",
+		);
 	});
 
 	it("outputs isLatest=true when release is release", async () => {
@@ -181,6 +187,7 @@ describe("generate:buildVersion", () => {
 		);
 		stdoutLineEquals(stdout, 0, "version=0.5.2002");
 		stdoutLineEquals(stdout, 2, "isLatest=true");
+		stdoutLineEquals(stdout, 3, "##vso[task.setvariable variable=isLatest;isOutput=true]true");
 	});
 
 	it("outputs isLatest=false when release is prerelease", async () => {
@@ -204,6 +211,11 @@ describe("generate:buildVersion", () => {
 		);
 		stdoutLineEquals(stdout, 0, "version=0.5.2002-12345");
 		stdoutLineEquals(stdout, 2, "isLatest=false");
+		stdoutLineEquals(
+			stdout,
+			3,
+			"##vso[task.setvariable variable=isLatest;isOutput=true]false",
+		);
 	});
 
 	it("reads release setting from env variable", async () => {
@@ -658,6 +670,11 @@ describe("generate:buildVersion", () => {
 		);
 		stdoutLineEquals(stdout, 0, "version=2.0.2");
 		stdoutLineEquals(stdout, 2, "isLatest=false");
+		stdoutLineEquals(
+			stdout,
+			3,
+			"##vso[task.setvariable variable=isLatest;isOutput=true]false",
+		);
 	});
 
 	it("next unpublished minor version (2.2.0) returns isLatest true", async () => {


### PR DESCRIPTION
## Description

We want all build pipelines to publish manifests containing the computed value of `isLatest`. It is more convenient for that to always be emitted as an output variable than its current semantics of true-or-undefined.

See #27838 and #27832 for context.
