### PR TITLE
fix: normalize missing isLatest output in publish metadata

### DIFF
--- a/tools/pipelines/templates/include-generate-publish-metadata.yml
+++ b/tools/pipelines/templates/include-generate-publish-metadata.yml
@@ -53,14 +53,13 @@ steps:
           ;;
       esac
 
-      case "${IS_LATEST:-}" in
-        ""|false|False) isLatest=false ;;
-        true|True) isLatest=true ;;
-        *)
-          echo "##vso[task.logissue type=error]Invalid isLatest value '$IS_LATEST'"
-          exit 1
-          ;;
-      esac
+      # SetVersion.isLatest is currently only emitted for latest release builds, so an
+      # unresolved macro means false. Remove this normalization after
+      # https://github.com/microsoft/FluidFramework/pull/27840 is available in build-tools.
+      isLatest=false
+      if [ "${IS_LATEST:-}" = "true" ]; then
+        isLatest=true
+      fi
 
       # Unlike the other fields there is no safe fallback here: guessing wrong either
       # double-publishes or drops the release entirely, so require an explicit boolean.


### PR DESCRIPTION
## Description

Work around the current undefined-or-true behavior of `SetVersion.isLatest` when generating publish metadata.

`flub generate buildVersion` currently only emits the Azure output variable for latest release builds. For ordinary builds, Azure leaves `$(SetVersion.isLatest)` unresolved, which caused the publish metadata step to fail in [client build 413948](https://dev.azure.com/fluidframework/internal/_build/results?buildId=413948).

The YAML now uses true-only normalization: only an explicit `true` produces `"isLatest": true`; false, empty, and unresolved values produce `false`. A comment links to https://github.com/microsoft/FluidFramework/pull/27840 so the workaround can be removed once the build-tools fix is available.

## Reviewer Guidance

Test run [here](https://dev.azure.com/fluidframework/internal/_build/results?buildId=414079&view=results)