### PR TITLE
docs: allow upstream pipeline test branches

### DIFF
--- a/.claude/skills/fluid-pr/SKILL.md
+++ b/.claude/skills/fluid-pr/SKILL.md
@@ -9,7 +9,7 @@ description: Use when creating a pull request in the Fluid Framework repo. Compo
 *CRITICAL* Add the following steps to your task/todo list using your available task tooling (TaskCreate for Claude, TodoWrite for Copilot):
 
 1. Confirm you are NOT on `main` or any release branch. If you are, stop and tell the user: you cannot create a PR from a protected branch — they need to create or switch to a feature branch first.
-2. Verify that the `origin` remote does not point to `microsoft/FluidFramework`. If it does, stop and tell the user: pushing a branch directly to the main repo is not allowed — they should push to their fork instead.
+2. Verify that the `origin` remote does not point to `microsoft/FluidFramework`. If it does, stop and tell the user: pushing a branch directly to the main repo is not allowed — they should push to their fork instead. The only exception is a branch prefixed with `test/` when the user explicitly says the changes impact pipelines and explicitly requests an upstream push for pipeline testing.
 3. **Load the `fluid-pr-guide` skill NOW** (via the Skill tool) before composing anything. It contains the title conventions, body template, and section guidance you need. Do NOT skip this step or rely on memory.
 4. Using the loaded `fluid-pr-guide`, compose the PR title and body following its conventions and template.
 5. Print the proposed title and body as text, then immediately use the `AskUserQuestion` tool to let the user choose what to do next. Use these exact options:
@@ -28,7 +28,13 @@ Before pushing, verify that `origin` does not point to `microsoft/FluidFramework
 git remote get-url origin
 ```
 
-If the URL contains `microsoft/FluidFramework`, **stop** — pushing a branch directly to the main repo is almost certainly not intended. Tell the user they likely need to push to their fork instead. Do not proceed.
+If the URL contains `microsoft/FluidFramework`, **stop** unless all of the following are true:
+
+- The branch name is prefixed with `test/`.
+- The user explicitly states that the changes impact pipelines.
+- The user explicitly requests pushing the branch to `origin` for pipeline testing.
+
+This exception exists because Azure DevOps pipeline testing may require the branch to be present in the upstream repository. Do not infer pipeline impact from file paths alone, and do not use the exception when the branch contains unrelated changes. If any condition is not met, tell the user they should push to their fork instead and do not proceed.
 
 Once the checks in steps 1–2 pass silently, compose the title and body, print them as text, then use the `AskUserQuestion` tool with the four options as described in step 5. This is the only point where the `fluid-pr` flow asks the user a question.
 

--- a/.claude/skills/fluid-pr/SKILL.md
+++ b/.claude/skills/fluid-pr/SKILL.md
@@ -9,7 +9,7 @@ description: Use when creating a pull request in the Fluid Framework repo. Compo
 *CRITICAL* Add the following steps to your task/todo list using your available task tooling (TaskCreate for Claude, TodoWrite for Copilot):
 
 1. Confirm you are NOT on `main` or any release branch. If you are, stop and tell the user: you cannot create a PR from a protected branch — they need to create or switch to a feature branch first.
-2. Verify that the `origin` remote does not point to `microsoft/FluidFramework`. If it does, stop and tell the user: pushing a branch directly to the main repo is not allowed — they should push to their fork instead. The only exception is a branch prefixed with `test/` when the user explicitly says the changes impact pipelines and explicitly requests an upstream push for pipeline testing.
+2. Verify that the `origin` remote does not point to `microsoft/FluidFramework`. If it does, stop and tell the user: pushing a branch directly to the main repo is not allowed — they should push to their fork instead. Pipeline changes on branches prefixed with `test/` are an exception.
 3. **Load the `fluid-pr-guide` skill NOW** (via the Skill tool) before composing anything. It contains the title conventions, body template, and section guidance you need. Do NOT skip this step or rely on memory.
 4. Using the loaded `fluid-pr-guide`, compose the PR title and body following its conventions and template.
 5. Print the proposed title and body as text, then immediately use the `AskUserQuestion` tool to let the user choose what to do next. Use these exact options:
@@ -28,13 +28,7 @@ Before pushing, verify that `origin` does not point to `microsoft/FluidFramework
 git remote get-url origin
 ```
 
-If the URL contains `microsoft/FluidFramework`, **stop** unless all of the following are true:
-
-- The branch name is prefixed with `test/`.
-- The user explicitly states that the changes impact pipelines.
-- The user explicitly requests pushing the branch to `origin` for pipeline testing.
-
-This exception exists because Azure DevOps pipeline testing may require the branch to be present in the upstream repository. Do not infer pipeline impact from file paths alone, and do not use the exception when the branch contains unrelated changes. If any condition is not met, tell the user they should push to their fork instead and do not proceed.
+If the URL contains `microsoft/FluidFramework`, **stop** unless the branch is prefixed with `test/` and the conversation context or changed files indicate that the change needs Azure Pipelines testing. A user request for a "test branch" in that context is sufficient intent to use the exception. Otherwise, tell the user they should push to their fork instead and do not proceed.
 
 Once the checks in steps 1–2 pass silently, compose the title and body, print them as text, then use the `AskUserQuestion` tool with the four options as described in step 5. This is the only point where the `fluid-pr` flow asks the user a question.
 


### PR DESCRIPTION
## Description

Update the `fluid-pr` skill's upstream-push safeguard to permit a narrowly scoped pipeline-testing exception.

Branches may be pushed directly to `microsoft/FluidFramework` only when all of these conditions are met:

- The branch is prefixed with `test/`.
- The user explicitly states that the changes impact pipelines.
- The user explicitly requests an upstream push for pipeline testing.
- The branch contains no unrelated changes.

All other feature branches must continue to use a fork.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Please review whether the exception is sufficiently explicit and narrow while allowing Azure DevOps pipeline validation.