### PR TITLE
build(tree): Update out-of-date auto-generated alpha entrypoint file

### DIFF
--- a/packages/dds/tree/src/entrypoints/alpha.ts
+++ b/packages/dds/tree/src/entrypoints/alpha.ts
@@ -256,9 +256,9 @@ export {
 	SchemaFactoryAlpha, 
 	SchemaStaticsAlpha, 
 	SchemaType, 
-	SharedTreeAlpha,
-	SharedTreeFormatOptions,
-	SharedTreeOptions,
+	SharedTreeAlpha, 
+	SharedTreeFormatOptions, 
+	SharedTreeOptions, 
 	SimpleAllowedTypeAttributes, 
 	SimpleArrayNodeSchema, 
 	SimpleFieldSchema, 
@@ -309,6 +309,7 @@ export {
 	createArrayInsertionAnchor, 
 	createIndependentTreeAlpha, 
 	decodeSchemaCompatibilitySnapshot, 
+	defineTreeDataStore, 
 	encodeSchemaCompatibilitySnapshot, 
 	eraseSchemaDetails, 
 	eraseSchemaDetailsSubclassable, 
@@ -330,7 +331,6 @@ export {
 	replaceConciseTreeHandles, 
 	replaceHandles, 
 	replaceVerboseTreeHandles, 
-	trackDirtyNodes, 
-	defineTreeDataStore
+	trackDirtyNodes
 	// #endregion
 } from "../index.js";


### PR DESCRIPTION
Contents were out of date on main. Regenerated via `npm run generate:entrypoint-sources`.