### PR TITLE
Add fluidFrameworkAllAlpha bundle for size testing

### DIFF
--- a/examples/utils/bundle-size-tests/src/fluidFrameworkAllAlpha.ts
+++ b/examples/utils/bundle-size-tests/src/fluidFrameworkAllAlpha.ts
@@ -1,0 +1,13 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+// Here we intentionally leak everything reachable from the alpha entry point.
+// This captures a worst case (except for internal and legacy) non-tree shaken bundle.
+// eslint-disable-next-line import-x/no-internal-modules -- We need to import alpha to measure it.
+import * as Framework from "fluid-framework/alpha";
+
+export function apisToBundle(): typeof Framework {
+	return Framework;
+}

--- a/examples/utils/bundle-size-tests/webpack.config.cjs
+++ b/examples/utils/bundle-size-tests/webpack.config.cjs
@@ -74,6 +74,7 @@ module.exports = {
 		directory: "./src/sharedDirectory",
 		experimentalSharedTree: "./src/experimentalSharedTree",
 		fluidFramework: "./src/fluidFramework",
+		fluidFrameworkAllAlpha: "./src/fluidFrameworkAllAlpha",
 		loader: "./src/loader",
 		map: "./src/sharedMap",
 		matrix: "./src/sharedMatrix",


### PR DESCRIPTION
## Description

Add a test bundle which includes all fluidframework/alpha APIs.

This should help track the size of new features as they land, even when they are not pulled into the more specific bundles.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
