### PR TITLE
feat(build-cli): bump build tools to 0.66.1

### DIFF
--- a/build-tools/package.json
+++ b/build-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "build-tools-release-group-root",
-	"version": "0.66.0",
+	"version": "0.66.1",
 	"private": true,
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/build-tools/packages/build-cli/package.json
+++ b/build-tools/packages/build-cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-tools/build-cli",
-	"version": "0.66.0",
+	"version": "0.66.1",
 	"description": "Build tools for the Fluid Framework",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/build-tools/packages/build-infrastructure/package.json
+++ b/build-tools/packages/build-infrastructure/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-tools/build-infrastructure",
-	"version": "0.66.0",
+	"version": "0.66.1",
 	"description": "Fluid build infrastructure",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/build-tools/packages/build-tools/package.json
+++ b/build-tools/packages/build-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluidframework/build-tools",
-	"version": "0.66.0",
+	"version": "0.66.1",
 	"description": "Fluid Build tools",
 	"homepage": "https://fluidframework.com",
 	"repository": {

--- a/build-tools/packages/version-tools/package.json
+++ b/build-tools/packages/version-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluid-tools/version-tools",
-	"version": "0.66.0",
+	"version": "0.66.1",
 	"description": "Versioning tools for Fluid Framework",
 	"homepage": "https://fluidframework.com",
 	"repository": {


### PR DESCRIPTION
## Description

Bump build-tools to the patched version (0.66.1) for internal only release

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Let me know if there's a PR that should be in this release