### PR TITLE
Remove non-test use of internal createEndpointIndex API in table-document

### DIFF
--- a/examples/data-objects/table-document/src/document.ts
+++ b/examples/data-objects/table-document/src/document.ts
@@ -12,13 +12,10 @@ import {
 import { DataObject, DataObjectFactory } from "@fluidframework/aqueduct/legacy";
 import { IEvent, IFluidHandle } from "@fluidframework/core-interfaces";
 import { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/legacy";
-// eslint-disable-next-line import-x/no-internal-modules -- #26904: `sequence` internals used in examples
-import { createEndpointIndex } from "@fluidframework/sequence/internal";
 import {
 	PropertySet,
 	ReferencePosition,
 	SequenceDeltaEvent,
-	SharedString,
 } from "@fluidframework/sequence/legacy";
 
 import { CellRange } from "./cellrange.js";
@@ -96,11 +93,8 @@ export class TableDocument
 	}
 
 	public async getRange(label: string): Promise<CellRange> {
-		const endpointIndex = createEndpointIndex(this.matrix as unknown as SharedString);
 		const intervals = this.matrix.getIntervalCollection(label);
-		intervals.attachIndex(endpointIndex);
-		const interval = endpointIndex.nextInterval(0);
-		intervals.detachIndex(endpointIndex);
+		const interval = intervals.nextInterval(0);
 		return new CellRange(interval, this.localRefToRowCol);
 	}
 


### PR DESCRIPTION
## Description

Remove non-test use of internal createEndpointIndex API in table-document.

This makes this example pratical to copy/replicate outside of this repo.

This does not address its tests: changing them and the implementation indepndently is being done to better show that this did not require test changes to still pass, and because the test changes are larger and less important.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
