### PR TITLE
Add adaptLegacyDataStoreFactory, use in TableDocument

### DIFF
--- a/.changeset/adapt-legacy-data-store-factories.md
+++ b/.changeset/adapt-legacy-data-store-factories.md
@@ -1,0 +1,17 @@
+---
+"@fluidframework/runtime-utils": minor
+"__section": feature
+---
+Legacy data store factories can now be used with ServiceClient
+
+The new `adaptLegacyDataStoreFactory` alpha API converts a `ServiceClientLegacyDataStoreFactory` into a `DataStoreKind` for use with `ServiceClient` APIs.
+`ServiceClientLegacyDataStoreFactory` extends `IFluidDataStoreFactory` with an optional, documented nested data store registry, which the adapter preserves.
+
+```typescript
+import { adaptLegacyDataStoreFactory } from "@fluidframework/runtime-utils/legacy/alpha";
+
+const dataStoreKind = adaptLegacyDataStoreFactory<MyDataObject>(
+	MyDataObject.getFactory(),
+);
+const container = await client.createAttachedContainer(dataStoreKind);
+```

--- a/examples/data-objects/table-document/src/test/localServerTestUtils.ts
+++ b/examples/data-objects/table-document/src/test/localServerTestUtils.ts
@@ -3,16 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { strict as assert } from "assert";
-
-import { ContainerRuntimeFactoryWithDefaultDataStore } from "@fluidframework/aqueduct/legacy";
-import { Loader } from "@fluidframework/container-loader/legacy";
-import {
-	LocalDocumentServiceFactory,
-	LocalResolver,
-	createLocalResolverCreateNewRequest,
-} from "@fluidframework/local-driver/legacy";
-import { LocalDeltaConnectionServer } from "@fluidframework/server-local-server";
+import { startEphemeralService } from "@fluidframework/local-driver/alpha";
+import { adaptLegacyDataStoreFactory } from "@fluidframework/runtime-utils/legacy/alpha";
 
 import { TableDocument } from "../document.js";
 
@@ -21,50 +13,26 @@ interface LocalTableDocumentTestContext {
 	readonly tableDocument: TableDocument;
 	/** Waits for locally submitted changes to be acknowledged by the local service. */
 	readonly ensureSynchronized: () => Promise<void>;
-	/** Closes the container and its in-memory local service. */
+	/** Closes the container and its ephemeral service. */
 	readonly disposeContainerAndLocalService: () => Promise<void>;
 }
 
+const tableDocumentKind = adaptLegacyDataStoreFactory<TableDocument>(
+	TableDocument.getFactory(),
+);
+
 /**
- * Creates a `TableDocument` connected to an in-memory local service using the current Fluid version.
+ * Creates a `TableDocument` connected to an ephemeral service using the current Fluid version.
  *
- * @returns The table document and functions for synchronizing and disposing its local test context.
+ * @returns The table document and functions for synchronizing and disposing its local container.
  */
 export async function createLocalTableDocument(): Promise<LocalTableDocumentTestContext> {
-	const deltaConnectionServer = LocalDeltaConnectionServer.create();
-	const codeDetails = { package: "table-document-test" };
-	const tableDocumentFactory = TableDocument.getFactory();
-	const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore({
-		defaultFactory: tableDocumentFactory,
-		registryEntries: [tableDocumentFactory.registryEntry],
-	});
-	const loader = new Loader({
-		urlResolver: new LocalResolver(),
-		documentServiceFactory: new LocalDocumentServiceFactory(deltaConnectionServer),
-		codeLoader: {
-			load: async () => ({
-				module: { fluidExport: runtimeFactory },
-				details: codeDetails,
-			}),
-		},
-	});
-	const container = await loader.createDetachedContainer(codeDetails);
-	await container.attach(createLocalResolverCreateNewRequest("table-document-test"));
-	const tableDocument = await container.getEntryPoint();
-	assert(tableDocument instanceof TableDocument, "Expected a TableDocument entry point");
+	const service = startEphemeralService();
+	const container = await service.defaultClient.createAttachedContainer(tableDocumentKind);
 
 	return {
-		tableDocument,
-		ensureSynchronized: async () => {
-			// Yield so locally submitted changes can mark the container dirty before checking it.
-			await new Promise<void>((resolve) => setTimeout(resolve, 0));
-			if (container.isDirty) {
-				await new Promise<void>((resolve) => container.once("saved", () => resolve()));
-			}
-		},
-		disposeContainerAndLocalService: async () => {
-			container.close();
-			await deltaConnectionServer.close();
-		},
+		tableDocument: container.data,
+		ensureSynchronized: async () => service.synchronize(),
+		disposeContainerAndLocalService: async () => service.close(),
 	};
 }

--- a/packages/runtime/runtime-utils/api-report/runtime-utils.legacy.alpha.api.md
+++ b/packages/runtime/runtime-utils/api-report/runtime-utils.legacy.alpha.api.md
@@ -5,6 +5,9 @@
 ```ts
 
 // @alpha @legacy
+export function adaptLegacyDataStoreFactory<T>(factory: ServiceClientLegacyDataStoreFactory): DataStoreKind<T>;
+
+// @alpha @legacy
 export function asLegacyAlpha(runtime: IContainerRuntimeBase): ContainerRuntimeBaseAlpha;
 
 // @alpha @legacy
@@ -79,6 +82,11 @@ export abstract class RuntimeFactoryHelper<T = IContainerRuntime> implements IRu
     // (undocumented)
     get IRuntimeFactory(): this;
     abstract preInitialize(context: IContainerContext, existing: boolean): Promise<IRuntime & T>;
+}
+
+// @alpha @legacy
+export interface ServiceClientLegacyDataStoreFactory extends IFluidDataStoreFactory {
+    readonly IFluidDataStoreRegistry?: IFluidDataStoreRegistry;
 }
 
 // @beta @legacy

--- a/packages/runtime/runtime-utils/src/index.ts
+++ b/packages/runtime/runtime-utils/src/index.ts
@@ -82,8 +82,9 @@ export type {
 	MinimumMinorSemanticVersion,
 	SemanticVersion,
 } from "./compatibilityBase.js";
-export type { Audience } from "./serviceClientBase.js";
+export type { Audience, ServiceClientLegacyDataStoreFactory } from "./serviceClientBase.js";
 export {
+	adaptLegacyDataStoreFactory,
 	DataStoreKindImplementation,
 	ServiceContainerBase,
 	getContainerAudience,

--- a/packages/runtime/runtime-utils/src/serviceClientBase.ts
+++ b/packages/runtime/runtime-utils/src/serviceClientBase.ts
@@ -21,6 +21,7 @@ import type {
 	IFluidDataStoreChannel,
 	IFluidDataStoreContext,
 	IFluidDataStoreFactory,
+	IFluidDataStoreRegistry,
 } from "@fluidframework/runtime-definitions/internal";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
@@ -29,12 +30,45 @@ import { UsageError } from "@fluidframework/telemetry-utils/internal";
  */
 
 /**
+ * A legacy data store factory that can be adapted for use with the `ServiceClient` APIs.
+ *
+ * @remarks
+ * A factory may provide an `IFluidDataStoreRegistry` when data stores created by it can
+ * create or load nested data stores. The adapter preserves this registry so the container
+ * runtime can resolve each segment of a nested data store's package path.
+ *
+ * @legacy @alpha
+ */
+export interface ServiceClientLegacyDataStoreFactory extends IFluidDataStoreFactory {
+	/**
+	 * The registry used to resolve nested data stores created or loaded by this factory's data stores.
+	 *
+	 * @remarks
+	 * This is optional for factories whose data stores do not contain nested data stores.
+	 *
+	 * @privateRemarks
+	 * `FluidDataStoreContext.factoryFromPackagePath` in `@fluidframework/container-runtime`
+	 * reads this property from each `FluidDataStoreRegistryEntry` while traversing a data store's
+	 * package path. Registry entries independently provide `IFluidDataStoreFactory` and
+	 * `IFluidDataStoreRegistry` capabilities, which is why the registry is not part of
+	 * `IFluidDataStoreFactory`. Legacy factory objects commonly serve as both providers, so
+	 * preserving this optional capability affects whether their nested data stores can be loaded.
+	 */
+	readonly IFluidDataStoreRegistry?: IFluidDataStoreRegistry;
+}
+
+type DataStoreKindFactory = Pick<
+	ServiceClientLegacyDataStoreFactory,
+	"type" | "instantiateDataStore" | "createDataStore" | "IFluidDataStoreRegistry"
+>;
+
+/**
  * Implementation of `DataStoreKind`.
  * @internal
  */
 export class DataStoreKindImplementation<T>
 	extends ErasedTypeImplementation<DataStoreKind<T>>
-	implements DataStoreKind<T>, IFluidDataStoreFactory
+	implements DataStoreKind<T>, ServiceClientLegacyDataStoreFactory
 {
 	/**
 	 * Type guard for narrowing unions which contain DataStoreKind<T> to DataStoreKind<T>.
@@ -64,12 +98,7 @@ export class DataStoreKindImplementation<T>
 		readonly runtime: IFluidDataStoreChannel;
 	};
 
-	public constructor(
-		private readonly factory: Pick<
-			DataStoreKindImplementation<T>,
-			"type" | "instantiateDataStore" | "createDataStore"
-		>,
-	) {
+	public constructor(private readonly factory: DataStoreKindFactory) {
 		super();
 		this.type = factory.type;
 		if (factory.createDataStore !== undefined) {
@@ -88,6 +117,10 @@ export class DataStoreKindImplementation<T>
 		return this;
 	}
 
+	public get IFluidDataStoreRegistry(): IFluidDataStoreRegistry | undefined {
+		return this.factory.IFluidDataStoreRegistry;
+	}
+
 	public async adapt(value: Promise<DataStoreKind>): Promise<DataStoreKind<T>> {
 		const input = await value;
 		if (input === this) {
@@ -100,6 +133,25 @@ export class DataStoreKindImplementation<T>
 			`Mismatched DataStoreKind type. Expected: ${this.type}, got: ${input.type}`,
 		);
 	}
+}
+
+/**
+ * Adapts a legacy data store factory for use with the `ServiceClient` APIs.
+ *
+ * @remarks
+ * The returned data store kind delegates creation and loading to `factory` and preserves any
+ * nested data store registry it provides.
+ *
+ * @typeParam T - The API exposed by data stores created by `factory`.
+ * @param factory - The legacy data store factory to adapt.
+ * @returns A data store kind backed by `factory`.
+ *
+ * @legacy @alpha
+ */
+export function adaptLegacyDataStoreFactory<T>(
+	factory: ServiceClientLegacyDataStoreFactory,
+): DataStoreKind<T> {
+	return new DataStoreKindImplementation<T>(factory);
 }
 
 /**

--- a/packages/runtime/runtime-utils/src/test/serviceClientBase.spec.ts
+++ b/packages/runtime/runtime-utils/src/test/serviceClientBase.spec.ts
@@ -1,0 +1,55 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "node:assert";
+
+import type {
+	IFluidDataStoreChannel,
+	IFluidDataStoreContext,
+	IFluidDataStoreRegistry,
+} from "@fluidframework/runtime-definitions/internal";
+
+import {
+	adaptLegacyDataStoreFactory,
+	DataStoreKindImplementation,
+	type ServiceClientLegacyDataStoreFactory,
+} from "../serviceClientBase.js";
+
+describe("adaptLegacyDataStoreFactory", () => {
+	it("delegates factory behavior and preserves its nested registry", async () => {
+		const channel = Object.create(null) as IFluidDataStoreChannel;
+		const context = Object.create(null) as IFluidDataStoreContext;
+		const registry = {
+			IFluidDataStoreRegistry: undefined as unknown as IFluidDataStoreRegistry,
+			get: async () => undefined,
+		} satisfies IFluidDataStoreRegistry;
+		registry.IFluidDataStoreRegistry = registry;
+
+		let instantiateExisting: boolean | undefined;
+		const factory: ServiceClientLegacyDataStoreFactory & {
+			readonly IFluidDataStoreRegistry: IFluidDataStoreRegistry;
+		} = {
+			type: "legacy-factory",
+			IFluidDataStoreRegistry: registry,
+			get IFluidDataStoreFactory() {
+				return this;
+			},
+			instantiateDataStore: async (_context, existing) => {
+				instantiateExisting = existing;
+				return channel;
+			},
+			createDataStore: () => ({ runtime: channel }),
+		};
+
+		const kind = adaptLegacyDataStoreFactory<unknown>(factory);
+		DataStoreKindImplementation.narrowGeneric(kind);
+
+		assert.equal(kind.type, factory.type);
+		assert.equal(kind.IFluidDataStoreRegistry, registry);
+		assert.equal(await kind.instantiateDataStore(context, true), channel);
+		assert.equal(instantiateExisting, true);
+		assert.equal(kind.createDataStore?.(context).runtime, channel);
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3553,18 +3553,15 @@ importers:
       '@fluidframework/build-tools':
         specifier: catalog:buildTools
         version: 0.65.0(@types/node@22.19.17)(supports-color@10.2.2)
-      '@fluidframework/container-loader':
-        specifier: workspace:~
-        version: link:../../../packages/loader/container-loader
       '@fluidframework/eslint-config-fluid':
         specifier: catalog:eslint
         version: 13.0.0(@typescript-eslint/utils@8.61.0)(eslint@9.39.1)(supports-color@10.2.2)(typescript@5.4.5)
       '@fluidframework/local-driver':
         specifier: workspace:~
         version: link:../../../packages/drivers/local-driver
-      '@fluidframework/server-local-server':
-        specifier: ^7.0.1
-        version: 7.0.1(supports-color@10.2.2)
+      '@fluidframework/runtime-utils':
+        specifier: workspace:~
+        version: link:../../../packages/runtime/runtime-utils
       '@microsoft/api-extractor':
         specifier: 7.58.1
         version: 7.58.1(patch_hash=949a26f6cec9ac4e37522f178b8e4982136ccfeb8c6d0835130ef2aa6788f4fa)(@types/node@22.19.17)


### PR DESCRIPTION
## Description

Add new legacy alpha adaptLegacyDataStoreFactory API, and use it to clean up TableDocument test setup.

## Breaking Changes

This adops some alpha APIs in TableDocument tests. As this package is likley to be moved out of this repo, that may be a problem.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
