### PR TITLE
ci(lts): emit publish-metadata.json and delegate client publishing

### DIFF
--- a/tools/pipelines/build-benchmark-tool.yml
+++ b/tools/pipelines/build-benchmark-tool.yml
@@ -75,6 +75,7 @@ extends:
   template: templates/build-npm-package.yml
   parameters:
     publish: ${{ variables.publish }}
+    publishAsPartOfBuild: true
     shouldPublish: ${{ variables.shouldPublish }}
     canRelease: ${{ variables.canRelease }}
     componentDetection: ${{ variables.componentDetection }}

--- a/tools/pipelines/build-build-common.yml
+++ b/tools/pipelines/build-build-common.yml
@@ -77,6 +77,7 @@ extends:
   template: templates/build-npm-package.yml
   parameters:
     publish: ${{ variables.publish }}
+    publishAsPartOfBuild: true
     shouldPublish: ${{ variables.shouldPublish }}
     canRelease: ${{ variables.canRelease }}
     componentDetection: ${{ variables.componentDetection }}

--- a/tools/pipelines/build-bundle-size-artifacts.yml
+++ b/tools/pipelines/build-bundle-size-artifacts.yml
@@ -50,3 +50,4 @@ extends:
     checkoutSubmodules: true
     releaseBuildOverride: none
     publishOverride: default
+    publishAsPartOfBuild: true

--- a/tools/pipelines/build-bundle-size-tools.yml
+++ b/tools/pipelines/build-bundle-size-tools.yml
@@ -67,6 +67,7 @@ extends:
   template: templates/build-npm-package.yml
   parameters:
     publishOverride: ${{ parameters.publishOverride }}
+    publishAsPartOfBuild: true
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     buildDirectory: tools/bundle-size-tools

--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -62,6 +62,7 @@ trigger:
     - tools/pipelines/build-client.yml
     - tools/pipelines/scripts/build-version.js
     - tools/pipelines/templates/build-npm-package.yml
+    - tools/pipelines/templates/include-generate-publish-metadata.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install.yml
@@ -91,6 +92,7 @@ pr:
     - tools/pipelines/build-client.yml
     - tools/pipelines/scripts/build-version.js
     - tools/pipelines/templates/build-npm-package.yml
+    - tools/pipelines/templates/include-generate-publish-metadata.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install.yml
@@ -115,6 +117,7 @@ extends:
   template: templates/build-npm-package.yml@self
   parameters:
     publish: ${{ variables.publish }}
+    publishAsPartOfBuild: false
     shouldPublish: ${{ variables.shouldPublish }}
     canRelease: ${{ variables.canRelease }}
     componentDetection: ${{ variables.componentDetection }}

--- a/tools/pipelines/build-common-definitions.yml
+++ b/tools/pipelines/build-common-definitions.yml
@@ -71,6 +71,7 @@ extends:
   template: templates/build-npm-package.yml
   parameters:
     publishOverride: ${{ parameters.publishOverride }}
+    publishAsPartOfBuild: true
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     buildDirectory: common/lib/common-definitions

--- a/tools/pipelines/build-common-utils.yml
+++ b/tools/pipelines/build-common-utils.yml
@@ -77,6 +77,7 @@ extends:
   template: templates/build-npm-package.yml
   parameters:
     publish: ${{ variables.publish }}
+    publishAsPartOfBuild: true
     shouldPublish: ${{ variables.shouldPublish }}
     canRelease: ${{ variables.canRelease }}
     componentDetection: ${{ variables.componentDetection }}

--- a/tools/pipelines/build-container-definitions.yml
+++ b/tools/pipelines/build-container-definitions.yml
@@ -65,6 +65,7 @@ extends:
   template: templates/build-npm-package.yml
   parameters:
     publishOverride: ${{ parameters.publishOverride }}
+    publishAsPartOfBuild: true
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     buildDirectory: common/lib/container-definitions

--- a/tools/pipelines/build-core-interfaces.yml
+++ b/tools/pipelines/build-core-interfaces.yml
@@ -65,6 +65,7 @@ extends:
   template: templates/build-npm-package.yml
   parameters:
     publishOverride: ${{ parameters.publishOverride }}
+    publishAsPartOfBuild: true
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     buildDirectory: common/lib/core-interfaces

--- a/tools/pipelines/build-docs-site.yml
+++ b/tools/pipelines/build-docs-site.yml
@@ -28,6 +28,7 @@ extends:
   template: templates/build-npm-package.yml
   parameters:
     publishOverride: skip
+    publishAsPartOfBuild: true
     releaseBuildOverride: none
     buildDirectory: docs
     taskBuild: build

--- a/tools/pipelines/build-driver-definitions.yml
+++ b/tools/pipelines/build-driver-definitions.yml
@@ -65,6 +65,7 @@ extends:
   template: templates/build-npm-package.yml
   parameters:
     publishOverride: ${{ parameters.publishOverride }}
+    publishAsPartOfBuild: true
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     buildDirectory: common/lib/driver-definitions

--- a/tools/pipelines/build-eslint-config-fluid.yml
+++ b/tools/pipelines/build-eslint-config-fluid.yml
@@ -77,6 +77,7 @@ extends:
   template: templates/build-npm-package.yml
   parameters:
     publish: ${{ variables.publish }}
+    publishAsPartOfBuild: true
     shouldPublish: ${{ variables.shouldPublish }}
     canRelease: ${{ variables.canRelease }}
     componentDetection: ${{ variables.componentDetection }}

--- a/tools/pipelines/build-protocol-definitions.yml
+++ b/tools/pipelines/build-protocol-definitions.yml
@@ -77,6 +77,7 @@ extends:
   template: templates/build-npm-package.yml
   parameters:
     publish: ${{ variables.publish }}
+    publishAsPartOfBuild: true
     shouldPublish: ${{ variables.shouldPublish }}
     canRelease: ${{ variables.canRelease }}
     componentDetection: ${{ variables.componentDetection }}

--- a/tools/pipelines/build-test-tools.yml
+++ b/tools/pipelines/build-test-tools.yml
@@ -74,6 +74,7 @@ extends:
   template: templates/build-npm-package.yml
   parameters:
     publish: ${{ variables.publish }}
+    publishAsPartOfBuild: true
     shouldPublish: ${{ variables.shouldPublish }}
     canRelease: ${{ variables.canRelease }}
     componentDetection: ${{ variables.componentDetection }}

--- a/tools/pipelines/build-tinylicious.yml
+++ b/tools/pipelines/build-tinylicious.yml
@@ -70,6 +70,7 @@ extends:
   template: templates/build-npm-package.yml
   parameters:
     publishOverride: ${{ parameters.publishOverride }}
+    publishAsPartOfBuild: true
     releaseBuildOverride: ${{ parameters.releaseBuildOverride }}
     buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     buildDirectory: server/tinylicious

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -108,6 +108,16 @@ parameters:
 - name: publish
   type: boolean
 
+# Indicates who owns the publish step for this build:
+#   true  - publishing happens as part of this build pipeline's own publish stages.
+#   false - publishing is delegated to the dedicated publish pipeline, which consumes the packed tarballs
+#           and publish-metadata.json produced here.
+# This is recorded in publish-metadata.json so the publish pipeline can tell which runs it owns.
+# Deliberately has no default: every pipeline must state which side owns its publishing, so that a search
+# for `publishAsPartOfBuild: true` is an accurate list of what has not been migrated yet.
+- name: publishAsPartOfBuild
+  type: boolean
+
 # Indicates if we should or should not skip all publish stages
 - name: shouldPublish
   type: boolean
@@ -398,6 +408,11 @@ extends:
               workingDirectory: '${{ parameters.buildDirectory }}'
               filePath: $(Build.SourcesDirectory)/scripts/pack-packages.sh
 
+          - template: /tools/pipelines/templates/include-generate-publish-metadata.yml@self
+            parameters:
+              publishOverride: ${{ parameters.publishOverride }}
+              publishAsPartOfBuild: ${{ parameters.publishAsPartOfBuild }}
+
         # Collect/publish/run bundle analysis
         - ${{ if eq(parameters.taskBundleAnalysis, true) }}:
           - task: Npm@1
@@ -440,7 +455,7 @@ extends:
               fi
 
     # Publish stage
-    - ${{ if eq(parameters.publish, true) }}:
+    - ${{ if and(eq(parameters.publish, true), eq(parameters.publishAsPartOfBuild, true)) }}:
       - template: /tools/pipelines/templates/include-publish-npm-package.yml@self
         parameters:
           tagName: ${{ parameters.tagName }}

--- a/tools/pipelines/templates/include-generate-publish-metadata.yml
+++ b/tools/pipelines/templates/include-generate-publish-metadata.yml
@@ -53,14 +53,13 @@ steps:
           ;;
       esac
 
-      case "${IS_LATEST:-}" in
-        ""|'$(SetVersion.isLatest)'|false|False) isLatest=false ;;
-        true|True) isLatest=true ;;
-        *)
-          echo "##vso[task.logissue type=error]Invalid isLatest value '$IS_LATEST'"
-          exit 1
-          ;;
-      esac
+      # SetVersion.isLatest is currently only emitted for latest release builds, so an
+      # unresolved macro means false. Remove this normalization after
+      # https://github.com/microsoft/FluidFramework/pull/27840 is available in build-tools.
+      isLatest=false
+      if [ "${IS_LATEST:-}" = "true" ]; then
+        isLatest=true
+      fi
 
       # Unlike the other fields there is no safe fallback here: guessing wrong either
       # double-publishes or drops the release entirely, so require an explicit boolean.

--- a/tools/pipelines/templates/include-generate-publish-metadata.yml
+++ b/tools/pipelines/templates/include-generate-publish-metadata.yml
@@ -1,0 +1,94 @@
+# Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+# Licensed under the MIT License.
+
+parameters:
+- name: publishOverride
+  type: string
+
+# Indicates who owns the publish step for this build:
+#   true  - publishing happens as part of this build pipeline's own publish stages.
+#   false - publishing is delegated to the dedicated publish pipeline, which consumes the packed tarballs
+#           and publish-metadata.json produced here.
+# This is recorded in publish-metadata.json so the publish pipeline can tell which runs it owns.
+# Deliberately has no default: every pipeline must state which side owns its publishing, so that a search
+# for `publishAsPartOfBuild: true` is an accurate list of what has not been migrated yet.
+- name: publishAsPartOfBuild
+  type: boolean
+
+steps:
+- task: Bash@3
+  displayName: Generate publish metadata
+  condition: and(succeeded(), eq(variables['System.TeamProject'], 'internal'))
+  env:
+    VERSION: $(SetVersion.version)
+    RELEASE: $(release)
+    PUBLISH_OVERRIDE: ${{ parameters.publishOverride }}
+    IS_LATEST: $(SetVersion.isLatest)
+    PUBLISH_AS_PART_OF_BUILD: ${{ parameters.publishAsPartOfBuild }}
+  inputs:
+    targetType: inline
+    workingDirectory: $(Build.ArtifactStagingDirectory)/pack
+    script: |
+      set -eu -o pipefail
+
+      if [ -z "${VERSION:-}" ]; then
+        echo "##vso[task.logissue type=error]Missing version: SetVersion.version output was empty"
+        exit 1
+      fi
+
+      case "${RELEASE:-}" in
+        "") release=none ;;
+        none|prerelease|release) release="$RELEASE" ;;
+        *)
+          echo "##vso[task.logissue type=error]Invalid release value '$RELEASE'"
+          exit 1
+          ;;
+      esac
+
+      case "$PUBLISH_OVERRIDE" in
+        default|force|skip) ;;
+        *)
+          echo "##vso[task.logissue type=error]Invalid publishOverride value '$PUBLISH_OVERRIDE'"
+          exit 1
+          ;;
+      esac
+
+      case "${IS_LATEST:-}" in
+        ""|'$(SetVersion.isLatest)'|false|False) isLatest=false ;;
+        true|True) isLatest=true ;;
+        *)
+          echo "##vso[task.logissue type=error]Invalid isLatest value '$IS_LATEST'"
+          exit 1
+          ;;
+      esac
+
+      # Unlike the other fields there is no safe fallback here: guessing wrong either
+      # double-publishes or drops the release entirely, so require an explicit boolean.
+      case "${PUBLISH_AS_PART_OF_BUILD:-}" in
+        false|False) publishAsPartOfBuild=false ;;
+        true|True) publishAsPartOfBuild=true ;;
+        *)
+          echo "##vso[task.logissue type=error]Invalid publishAsPartOfBuild value '${PUBLISH_AS_PART_OF_BUILD:-}'"
+          exit 1
+          ;;
+      esac
+
+      jq -n \
+        --argjson schemaVersion 1 \
+        --arg version "$VERSION" \
+        --arg release "$release" \
+        --arg publishOverride "$PUBLISH_OVERRIDE" \
+        --argjson isLatest "$isLatest" \
+        --argjson publishAsPartOfBuild "$publishAsPartOfBuild" \
+        '{
+          schemaVersion: $schemaVersion,
+          version: $version,
+          release: $release,
+          publishOverride: $publishOverride,
+          isLatest: $isLatest,
+          publishAsPartOfBuild: $publishAsPartOfBuild,
+          supportsDevFeed: false
+        }' > publish-metadata.json
+
+      echo "Generated publish-metadata.json:"
+      cat publish-metadata.json

--- a/tools/pipelines/templates/include-generate-publish-metadata.yml
+++ b/tools/pipelines/templates/include-generate-publish-metadata.yml
@@ -85,8 +85,7 @@ steps:
           release: $release,
           publishOverride: $publishOverride,
           isLatest: $isLatest,
-          publishAsPartOfBuild: $publishAsPartOfBuild,
-          supportsDevFeed: false
+          publishAsPartOfBuild: $publishAsPartOfBuild
         }' > publish-metadata.json
 
       echo "Generated publish-metadata.json:"


### PR DESCRIPTION
## Description

Onboards the LTS `Build - client packages` build to the same publishing process `main` already uses, where the build produces artifacts and a separate pipeline publishes them.

On `main`, the client build is artifact-only for publishing: it builds, packs, and writes `pack/publish-metadata.json`, and the publish pipeline consumes that artifact and owns all publish, promotion, and tag decisions. The `lts` branch had not been onboarded, so it still published in-build and emitted no metadata.

## Changes

* **New** `templates/include-generate-publish-metadata.yml`, which writes `pack/publish-metadata.json` next to the packed tarballs. Byte-identical to the copy on `main`.
* `templates/build-npm-package.yml` gains a `publishAsPartOfBuild` parameter, generates the metadata right after `npm pack`, and gates its in-build publish stage on `publish && publishAsPartOfBuild`.
* `build-client.yml` sets `publishAsPartOfBuild: false`. The other 14 consumers set `true`, keeping their current behavior.

## Behavioral parity

The publish pipeline recomputes eligibility from the candidate's branch and the `publishOverride` in the metadata, applying the same rule `include-vars.yml` applies here: only `main`, `release/*`, and `test/*` publish by default, and `force` still overrides. Manifest upload stays off for LTS.

| Case | Result |
| --- | --- |
| `lts`, override `default` | no publication |
| `lts`, override `force` | internal feeds, no manifest |
| `release/*`, `test/*` | unchanged |

LTS candidates may now reach the internal-dev feed, which the in-build LTS publish template had no stage for. Per review this is acceptable.

## Reviewer guidance

`publishAsPartOfBuild` deliberately has **no default**, so every pipeline must declare which side owns its publishing and a search for `publishAsPartOfBuild: true` is an accurate list of what has not been migrated yet.

Fixes [AB#79900](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/79900)
