### PR TITLE
ci(lts): install pnpm from the authenticated feed instead of corepack

### DIFF
--- a/tools/pipelines/templates/include-install-pnpm.yml
+++ b/tools/pipelines/templates/include-install-pnpm.yml
@@ -41,29 +41,24 @@ steps:
       restoreKeys: |
         pnpm-store | "$(Agent.OS)"
 
+# Seed the userconfig .npmrc with the primary registry. This propagates to subsequent tasks so
+# that npmAuthenticate (below) and any later pnpm/npm invocation in the job reuse the same file.
 - task: Bash@3
-  displayName: Install and configure pnpm
+  displayName: Configure npm registry
   # The previous task (cache restoration) can timeout, which is classified as canceled, but since it's just cache
   # restoration, we want to continue even if it timed out.
   condition: or(succeeded(), canceled())
   inputs:
     targetType: 'inline'
     workingDirectory: ${{ parameters.buildDirectory }}
-    # workspace-concurrency 0 means use use the CPU core count. This is better than the default (4) for larger agents.
     script: |
       set -eu -o pipefail
       echo "Using node $(node --version)"
-      sudo corepack enable
-      echo "Using pnpm $(pnpm -v)"
-      # This ensures all subsequent tasks in this job will use the pnpm configuration set here.
+      # This ensures all subsequent tasks in this job will use the npm configuration set here.
       echo "##vso[task.setvariable variable=NPM_CONFIG_USERCONFIG]$NPM_CONFIG_USERCONFIG"
-      echo "Pnpm user config location: $(pnpm config get userconfig)"
-      pnpm config set store-dir ${{ parameters.pnpmStorePath }}
-      echo "Pnpm store: ${{ parameters.pnpmStorePath }}"
       echo "Primary registry: ${NPM_REGISTRY}"
-      pnpm config set -g workspace-concurrency 0
-      pnpm config set registry "${NPM_REGISTRY}"
-      if [ ${NPM_REGISTRY} == "https://registry.npmjs.org/" ]; then
+      echo "registry=${NPM_REGISTRY}" > "$NPM_CONFIG_USERCONFIG"
+      if [ "${NPM_REGISTRY}" == "https://registry.npmjs.org/" ]; then
         echo "##vso[task.setvariable variable=registryType]public"
       else
         echo "##vso[task.setvariable variable=registryType]private"
@@ -71,16 +66,49 @@ steps:
   env:
     NPM_REGISTRY: $(ado-feeds-primary-registry)
     NPM_CONFIG_USERCONFIG: ${{ parameters.userNpmrcPath}}
-    # We should leverage the primary npm registry to install pnpm as well. However, ADO artifacts feeds do not implement
-    # the full npm registry API including a route that corepack uses to get package metadata--the version route here:
-    # https://github.com/nodejs/corepack/blob/bc13d40037d0b1bfd386e260ae741f55505b5c7c/sources/npmRegistryUtils.ts#L32
-    # Thus installing pnpm from an ADO feed using corepack is not possible at time of writing.
-    # COREPACK_NPM_REGISTRY: $(ado-feeds-primary-registry)
 
-# Authenticate to npm feed if required
+# Authenticate to the npm feed if required. Runs before pnpm is installed so that
+# `npm install -g pnpm@<version>` can fetch pnpm itself from the authenticated feed.
 - task: npmAuthenticate@0
   displayName: 'Npm authenticate'
   condition: and(succeeded(), eq(variables['registryType'], 'private'))
   retryCountOnTaskFailure: 1
   inputs:
     workingFile: ${{ parameters.userNpmrcPath }}
+
+- task: Bash@3
+  displayName: Install pnpm
+  inputs:
+    targetType: 'inline'
+    workingDirectory: ${{ parameters.buildDirectory }}
+    # workspace-concurrency 0 means use use the CPU core count. This is better than the default (4) for larger agents.
+    script: |
+      set -eu -o pipefail
+      # Resolve the pnpm version from the "packageManager" field (e.g. "pnpm@9.15.7+sha512..." -> "pnpm@9.15.7").
+      # The integrity hash suffix is discarded, since npm provides no practical way to use it; we trust the
+      # feed to serve the correct version. Not every caller passes a buildDirectory that contains a
+      # package.json (some point at an artifact directory), so fall back to the repo root.
+      PNPM_VERSION=$(node -e '
+        const fs = require("fs");
+        const path = require("path");
+        for (const dir of [process.cwd(), process.env.SOURCES_DIR]) {
+          const file = path.join(dir, "package.json");
+          if (!fs.existsSync(file)) continue;
+          const packageManager = JSON.parse(fs.readFileSync(file, "utf8")).packageManager;
+          if (packageManager) {
+            console.log(packageManager.split("+")[0]);
+            process.exit(0);
+          }
+        }
+        console.error("Could not resolve a packageManager field to install pnpm from.");
+        process.exit(1);
+      ')
+      echo "Installing ${PNPM_VERSION}"
+      npm install -g "$PNPM_VERSION" --userconfig "${{ parameters.userNpmrcPath }}"
+      echo "Using pnpm $(pnpm -v)"
+      echo "Pnpm user config location: $(pnpm config get userconfig)"
+      pnpm config set store-dir ${{ parameters.pnpmStorePath }}
+      echo "Pnpm store: ${{ parameters.pnpmStorePath }}"
+      pnpm config set -g workspace-concurrency 0
+  env:
+    SOURCES_DIR: $(Build.SourcesDirectory)


### PR DESCRIPTION
## Description

CI on `lts` fails during pnpm setup, before any build or policy rule gets a chance to run. `templates/include-install-pnpm.yml` on this branch still uses `sudo corepack enable`, which makes corepack fetch pnpm from the public npm registry — no longer reachable from the build agents.

`main` hit the same problem and fixed it in [#27333](https://github.com/microsoft/FluidFramework/pull/27333) by dropping corepack and installing pnpm with plain `npm` against the authenticated ADO feed. That change landed on 2026-05-22 and was never ported here. This PR ports it.

The template's own comment explained why it hadn't been pointed at the ADO feed before: corepack needs a package-metadata route that ADO artifacts feeds don't implement. Installing with `npm` sidesteps that entirely.

### Changes

`templates/include-install-pnpm.yml` — the single `Install and configure pnpm` task is split into three, mirroring `main`:

1. **Configure npm registry** — seeds `registry=` into the userconfig `.npmrc` and sets the `registryType` variable.
2. **Npm authenticate** — moved to run *before* pnpm is installed, so the install itself can authenticate against the feed. Previously it ran after.
3. **Install pnpm** — resolves the version pinned in the `packageManager` field (currently `pnpm@9.15.7`, hash suffix stripped) and runs `npm install -g "$PNPM_VERSION" --userconfig <npmrc>`.

`store-dir`, `workspace-concurrency 0`, the `NPM_CONFIG_USERCONFIG` propagation, the cache task, and all template parameters are unchanged. The now-redundant `pnpm config set registry` is dropped since the registry is written directly into the userconfig.

### One deviation from `main`

`main` reads `packageManager` from `./package.json` relative to the build directory. That assumption doesn't hold on this branch: `include-test-real-service.yml` passes `buildDirectory: $(Pipeline.Workspace)` (an artifact directory) and `include-install-build-tools.yml` passes `build-tools`, which has no `package.json` here. A bare `require('./package.json')` would abort under `set -eu` in both jobs.

The version lookup therefore tries the build directory first and falls back to `$(Build.SourcesDirectory)`, failing with an explicit message if neither yields a `packageManager` field. All three caller scenarios were exercised against the resolver locally and each returns `pnpm@9.15.7`.

### Deliberately not ported from `main`

`main`'s current version has drifted further since #27333 — it also sets `PNPM_CONFIG_TRUST_POLICY=off` and `PNPM_CONFIG_MINIMUM_RELEASE_AGE=0`, and carries extra cache-key parameters from later PRs. Those target pnpm 10/11 behavior and `main`'s cache layout; `lts` is on pnpm 9.15.7, so they're omitted to keep this to the minimum needed to unblock CI.

### Validation

The template parses and the version resolver was tested against each caller's build directory. Real verification is CI on this PR — if the `Install pnpm` step succeeds where `Install and configure pnpm` was failing, the fix is confirmed.
