### PR TITLE
fix(client): update TypeScript 6 compatibility

### DIFF
--- a/experimental/dds/tree/src/TransactionInternal.ts
+++ b/experimental/dds/tree/src/TransactionInternal.ts
@@ -474,15 +474,16 @@ export namespace TransactionInternal {
 		 */
 		public validateOnClose(state: ValidState): ChangeResult {
 			// Making the policy choice that storing a detached sequences in an edit but not using it is an error.
-			return this.detached.size !== 0
-				? Result.error({
-						status: EditStatus.Malformed,
-						failure: {
-							kind: FailureKind.UnusedDetachedSequence,
-							sequenceId: this.detached.keys().next().value,
-						},
-					})
-				: Result.ok(state.view);
+			for (const sequenceId of this.detached.keys()) {
+				return Result.error({
+					status: EditStatus.Malformed,
+					failure: {
+						kind: FailureKind.UnusedDetachedSequence,
+						sequenceId,
+					},
+				});
+			}
+			return Result.ok(state.view);
 		}
 
 		/**

--- a/packages/dds/shared-object-base/src/test/attachingBindingAndConnecting.spec.ts
+++ b/packages/dds/shared-object-base/src/test/attachingBindingAndConnecting.spec.ts
@@ -62,6 +62,7 @@ type OverridableType = Overridable<{
 		serializer: IFluidSerializer,
 		telemetryContext?: ITelemetryContext | undefined,
 		incrementalSummaryContext?: IExperimentalIncrementalSummaryContext | undefined,
+		fullTree?: boolean,
 	) => ISummaryTreeWithStats;
 	loadCore: (this: SharedObject, services: IChannelStorageService) => Promise<void>;
 	processMessagesCore: (
@@ -78,11 +79,36 @@ function createTestSharedObject(overrides: OverridableType): {
 	sharedObject: SharedObject;
 } {
 	class TestSharedObject extends SharedObject {
-		protected summarizeCore = overrides?.summarizeCore?.bind(this);
-		protected loadCore = overrides?.loadCore?.bind(this);
-		protected processMessagesCore = overrides?.processMessagesCore?.bind(this);
-		protected onDisconnect = overrides?.onDisconnect?.bind(this);
-		protected applyStashedOp = overrides?.applyStashedOp?.bind(this);
+		protected summarizeCore(
+			serializer: IFluidSerializer,
+			telemetryContext?: ITelemetryContext,
+			incrementalSummaryContext?: IExperimentalIncrementalSummaryContext,
+			fullTree?: boolean,
+		): ISummaryTreeWithStats {
+			assert(overrides.summarizeCore !== undefined, "summarizeCore not set");
+			return overrides.summarizeCore.call(
+				this,
+				serializer,
+				telemetryContext,
+				incrementalSummaryContext,
+				fullTree,
+			);
+		}
+		protected async loadCore(services: IChannelStorageService): Promise<void> {
+			await overrides.loadCore?.call(this, services);
+		}
+		protected processMessagesCore(messagesCollection: IRuntimeMessageCollection): void {
+			assert(overrides.processMessagesCore !== undefined, "processMessagesCore not set");
+			overrides.processMessagesCore.call(this, messagesCollection);
+		}
+		protected onDisconnect(): void {
+			assert(overrides.onDisconnect !== undefined, "onDisconnect not set");
+			overrides.onDisconnect.call(this);
+		}
+		protected applyStashedOp(content: unknown): void {
+			assert(overrides.applyStashedOp !== undefined, "applyStashedOp not set");
+			overrides.applyStashedOp.call(this, content);
+		}
 		protected didAttach =
 			overrides.didAttach?.bind(this) ?? (() => assert.fail("didAttach not set"));
 	}

--- a/packages/dds/shared-object-base/src/test/attachingBindingAndConnecting.spec.ts
+++ b/packages/dds/shared-object-base/src/test/attachingBindingAndConnecting.spec.ts
@@ -85,7 +85,10 @@ function createTestSharedObject(overrides: OverridableType): {
 			incrementalSummaryContext?: IExperimentalIncrementalSummaryContext,
 			fullTree?: boolean,
 		): ISummaryTreeWithStats {
-			assert(overrides.summarizeCore !== undefined, "summarizeCore not set");
+			assert(
+				overrides.summarizeCore !== undefined,
+				"overrides.summarizeCore was not provided",
+			);
 			return overrides.summarizeCore.call(
 				this,
 				serializer,
@@ -95,18 +98,25 @@ function createTestSharedObject(overrides: OverridableType): {
 			);
 		}
 		protected async loadCore(services: IChannelStorageService): Promise<void> {
-			await overrides.loadCore?.call(this, services);
+			assert(overrides.loadCore !== undefined, "overrides.loadCore was not provided");
+			await overrides.loadCore.call(this, services);
 		}
 		protected processMessagesCore(messagesCollection: IRuntimeMessageCollection): void {
-			assert(overrides.processMessagesCore !== undefined, "processMessagesCore not set");
+			assert(
+				overrides.processMessagesCore !== undefined,
+				"overrides.processMessagesCore was not provided",
+			);
 			overrides.processMessagesCore.call(this, messagesCollection);
 		}
 		protected onDisconnect(): void {
-			assert(overrides.onDisconnect !== undefined, "onDisconnect not set");
+			assert(overrides.onDisconnect !== undefined, "overrides.onDisconnect was not provided");
 			overrides.onDisconnect.call(this);
 		}
 		protected applyStashedOp(content: unknown): void {
-			assert(overrides.applyStashedOp !== undefined, "applyStashedOp not set");
+			assert(
+				overrides.applyStashedOp !== undefined,
+				"overrides.applyStashedOp was not provided",
+			);
 			overrides.applyStashedOp.call(this, content);
 		}
 		protected didAttach =

--- a/packages/dds/tree/src/simple-tree/node-kinds/map/mapNode.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/map/mapNode.ts
@@ -322,9 +322,9 @@ abstract class CustomMapNodeBase<const T extends ImplicitAllowedTypes> extends T
 	public has(key: string): boolean {
 		return this.innerNode.tryGetField(brand(key)) !== undefined;
 	}
-	public keys(): IterableIterator<string> {
+	public *keys(): IterableIterator<string> {
 		const node = this.innerNode;
-		return node.keys();
+		yield* node.keys();
 	}
 	public set(key: string, value: InsertableTreeNodeFromImplicitAllowedTypes<T>): this {
 		const kernel = getKernel(this);

--- a/packages/dds/tree/src/test/simple-tree/unhydratedFlexTreeFromInsertable.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/unhydratedFlexTreeFromInsertable.spec.ts
@@ -157,7 +157,7 @@ describe("unhydratedFlexTreeFromInsertable", () => {
 	it("Fails when referenced schema has not yet been instantiated", () => {
 		const schemaFactory = new SchemaFactory("test");
 
-		let Bar: TreeNodeSchema;
+		const Bar = undefined as unknown as TreeNodeSchema;
 		class Foo extends schemaFactory.objectRecursive("Foo", {
 			x: schemaFactory.optionalRecursive([() => Bar]),
 		}) {}

--- a/packages/drivers/odsp-driver/src/test/socketTests/deltaConnectionUpdateTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/socketTests/deltaConnectionUpdateTests.spec.ts
@@ -47,7 +47,7 @@ describe("DeltaConnectionMetadata update tests", () => {
 	const driveId = "driveId";
 	const itemId = "itemId";
 	let epochTracker: EpochTracker;
-	let localCache: LocalPersistentCache;
+	const localCache = undefined as unknown as LocalPersistentCache;
 	let hashedDocumentId: string;
 	let service: OdspDocumentService;
 	let socket: ClientSocketMock | undefined;

--- a/packages/drivers/odsp-driver/src/test/socketTests/socketTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/socketTests/socketTests.spec.ts
@@ -46,7 +46,7 @@ describe("OdspDocumentDeltaConnection tests", () => {
 	const driveId = "driveId";
 	const itemId = "itemId";
 	let epochTracker: EpochTracker;
-	let localCache: LocalPersistentCache;
+	const localCache = undefined as unknown as LocalPersistentCache;
 	let hashedDocumentId: string;
 	const resolvedUrl = {
 		siteUrl,

--- a/packages/loader/driver-utils/src/adapters/compression/summaryblob/documentStorageServiceSummaryBlobCompressionAdapter.ts
+++ b/packages/loader/driver-utils/src/adapters/compression/summaryblob/documentStorageServiceSummaryBlobCompressionAdapter.ts
@@ -144,13 +144,10 @@ export class DocumentStorageServiceCompressionAdapter extends DocumentStorageSer
 	): SummaryObject => {
 		if (input.type === SummaryType.Blob) {
 			const summaryBlob: ISummaryBlob = input;
-			const original: ArrayBufferLike = DocumentStorageServiceCompressionAdapter.toBinaryArray(
+			const original = DocumentStorageServiceCompressionAdapter.toBinaryArray(
 				summaryBlob.content,
 			);
-			const processed: ArrayBufferLike = DocumentStorageServiceCompressionAdapter.encodeBlob(
-				original,
-				config,
-			);
+			const processed = DocumentStorageServiceCompressionAdapter.encodeBlob(original, config);
 			const newSummaryBlob = {
 				type: SummaryType.Blob,
 				content: IsoBuffer.from(processed),
@@ -169,11 +166,10 @@ export class DocumentStorageServiceCompressionAdapter extends DocumentStorageSer
 	private static readonly blobDecoder = (input: SummaryObject): SummaryObject => {
 		if (input.type === SummaryType.Blob) {
 			const summaryBlob: ISummaryBlob = input;
-			const original: Uint8Array = DocumentStorageServiceCompressionAdapter.toBinaryArray(
+			const original = DocumentStorageServiceCompressionAdapter.toBinaryArray(
 				summaryBlob.content,
 			);
-			const processed: ArrayBufferLike =
-				DocumentStorageServiceCompressionAdapter.decodeBlob(original);
+			const processed = DocumentStorageServiceCompressionAdapter.decodeBlob(original);
 			const newSummaryBlob = {
 				type: SummaryType.Blob,
 				content: IsoBuffer.from(processed),

--- a/packages/runtime/container-runtime/src/test/dataStoreCreation.spec.ts
+++ b/packages/runtime/container-runtime/src/test/dataStoreCreation.spec.ts
@@ -44,8 +44,8 @@ describe("Data Store Creation Tests", () => {
 		 * ```
 		 */
 
-		let storage: IRuntimeStorageService;
-		let scope: FluidObject;
+		const storage = undefined as unknown as IRuntimeStorageService;
+		const scope = undefined as unknown as FluidObject;
 		const makeLocallyVisibleFn = () => {};
 		let parentContext: IFluidParentContextPrivate;
 		const defaultName = "default";

--- a/packages/tools/fetch-tool/src/fluidFetchMessages.ts
+++ b/packages/tools/fetch-tool/src/fluidFetchMessages.ts
@@ -315,9 +315,8 @@ export async function fluidFetchMessages(
 	if (messageStats) {
 		return printMessageStats(generator, dumpMessageStats, dumpMessages, messageTypeFilter);
 	} else {
-		let item;
-		// eslint-disable-next-line no-empty -- TODO: Investigate / document what is going on here.
-		for await (item of generator) {
+		for await (const _item of generator) {
+			// Iteration drains the generator so its side effects complete.
 		}
 	}
 }


### PR DESCRIPTION
Update iterator interfaces, test mocks, extraneous casts, and undefined test variables to match the newer standard library and compiler checks.

ArrayBuffer incompatibility and use of built-in types to be addressed separately via #27815 and #27857.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>