### PR TITLE
fix(build-cli): resolve the SDK-provided Copilot CLI

### DIFF
--- a/build-tools/packages/build-cli/src/library/ai/copilotSession.ts
+++ b/build-tools/packages/build-cli/src/library/ai/copilotSession.ts
@@ -150,7 +150,8 @@ export async function runAiSession(
 }
 
 export function resolveCopilotCliPath(): string {
-	// The SDK's default resolver constructs an invalid path for pnpm's scoped package layout.
+	// Resolve from the SDK's dependency context so pnpm selects its nested Copilot CLI.
+	// import.meta.resolve's parentURL overload is experimental, so use createRequire here.
 	const requireFromSdk = createRequire(import.meta.resolve("@github/copilot-sdk"));
 	return requireFromSdk.resolve("@github/copilot/npm-loader.js");
 }

--- a/build-tools/packages/build-cli/src/library/ai/copilotSession.ts
+++ b/build-tools/packages/build-cli/src/library/ai/copilotSession.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { createRequire } from "node:module";
 import { approveAll, CopilotClient, defineTool } from "@github/copilot-sdk";
 
 /**
@@ -86,6 +87,7 @@ export async function runAiSession(
 
 	const client = new CopilotClient({
 		...(githubToken !== undefined ? { githubToken } : {}),
+		cliPath: resolveCopilotCliPath(),
 		// Suppress Node's "ExperimentalWarning: SQLite is an experimental feature"
 		// that the bundled Copilot CLI subprocess emits on stderr.
 		env: {
@@ -145,6 +147,12 @@ export async function runAiSession(
 			ui.verbose?.(`Failed to stop Copilot client cleanly: ${String(error)}`);
 		}
 	}
+}
+
+export function resolveCopilotCliPath(): string {
+	// The SDK's default resolver constructs an invalid path for pnpm's scoped package layout.
+	const requireFromSdk = createRequire(import.meta.resolve("@github/copilot-sdk"));
+	return requireFromSdk.resolve("@github/copilot/npm-loader.js");
 }
 
 const AUTH_REMEDIATION =

--- a/build-tools/packages/build-cli/src/test/commands/ai.test.ts
+++ b/build-tools/packages/build-cli/src/test/commands/ai.test.ts
@@ -4,6 +4,7 @@
  */
 
 import { expect } from "chai";
+import execa from "execa";
 import { describe, it } from "mocha";
 
 import {
@@ -14,6 +15,13 @@ import {
 } from "../../commands/ai.js";
 
 describe("ai command", () => {
+	it("resolves a runnable Copilot CLI from the SDK dependency", async () => {
+		const aiSessionModule = await import("../../library/ai/copilotSession.js");
+		const resolver = Reflect.get(aiSessionModule, "resolveCopilotCliPath");
+		const result = await execa(process.execPath, [resolver(), "--version"]);
+		expect(result.stdout).to.match(/^GitHub Copilot CLI \d+\.\d+\.\d+\./mu);
+	});
+
 	it("supports the configured Copilot launchers", () => {
 		expect(SUPPORTED_ALIASES).to.deep.equal(["dev", "copilot", "oce"]);
 	});


### PR DESCRIPTION
## Description

`flub ai` cannot start its Copilot SDK session when dependencies are installed with pnpm. The SDK's default bundled-CLI resolver constructs an invalid path for pnpm's scoped package layout:

`.../node_modules/@github/index.js`

This change resolves `@github/copilot/npm-loader.js` relative to the installed `@github/copilot-sdk` module and passes that entry point explicitly to `CopilotClient`. This keeps CLI-version ownership with the SDK and avoids adding a separate direct Copilot dependency.

A behavioral test launches the resolved entry point with `--version` and verifies that it is a runnable GitHub Copilot CLI.

This fix unblocks the held Codespace integration in [PR #27869](https://github.com/microsoft/FluidFramework/pull/27869) and must be included in build-tools 0.67.0.

### Why not use Agency's Copilot CLI?

Agency manages its own Copilot CLI version, but it does not expose a supported machine-readable command for obtaining the resolved executable path. Its versioned `~/.copilot-cli/<version>` cache is an internal implementation detail without a stable symlink or public resolver contract.

Using `agency copilot` itself as the SDK subprocess is also incompatible. Agency injects `--session-id`, while `CopilotClient` starts the CLI with `--headless`; Copilot CLI rejects that combination because SDK headless mode manages sessions through JSON-RPC.

Resolving the SDK-owned dependency therefore provides the stable compatibility boundary: the SDK selects its compatible Copilot CLI version, and build-cli launches that executable directly.

### Manual Validation

```
cd /workspaces/FluidFramework/build-tools
pnpm install --frozen-lockfile
pnpm build:fast

node packages/build-cli/bin/dev ai
```

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

The important dependency-resolution detail is that the resolver is rooted at the SDK module using `createRequire`. It therefore selects the Copilot CLI installed for that SDK even when pnpm isolates scoped dependencies.