### PR TITLE
build(server): remove releaseKind queue-time parameter

### DIFF
--- a/tools/pipelines/server-gitrest.yml
+++ b/tools/pipelines/server-gitrest.yml
@@ -14,15 +14,6 @@ parameters:
     - none
     - release
 
-- name: releaseKind
-  displayName: Release Kind
-  type: string
-  default: both
-  values:
-    - both
-    - npm
-    - docker
-
 - name: publishOverride
   displayName: Publish Override (default = based on branch)
   type: string
@@ -101,7 +92,7 @@ extends:
     shouldPushDockerImage: ${{ variables.pushImage }}
     shouldReleaseDockerImage: ${{ variables.releaseImage }}
     shouldPublishNpmPackages: ${{ variables.publish }}
-    releaseKind: ${{ parameters.releaseKind }}
+    releaseKind: both
     publishOverride: ${{ parameters.publishOverride }}
     publishAsPartOfBuild: true
     buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}

--- a/tools/pipelines/server-historian.yml
+++ b/tools/pipelines/server-historian.yml
@@ -14,15 +14,6 @@ parameters:
     - none
     - release
 
-- name: releaseKind
-  displayName: Release Kind
-  type: string
-  default: both
-  values:
-    - both
-    - npm
-    - docker
-
 - name: publishOverride
   displayName: Publish Override (default = based on branch)
   type: string
@@ -100,7 +91,7 @@ extends:
     shouldPushDockerImage: ${{ variables.pushImage }}
     shouldReleaseDockerImage: ${{ variables.releaseImage }}
     shouldPublishNpmPackages: ${{ variables.publish }}
-    releaseKind: ${{ parameters.releaseKind }}
+    releaseKind: both
     publishOverride: ${{ parameters.publishOverride }}
     publishAsPartOfBuild: true
     buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}

--- a/tools/pipelines/server-routerlicious.yml
+++ b/tools/pipelines/server-routerlicious.yml
@@ -14,14 +14,6 @@ parameters:
     - none
     - prerelease
     - release
-- name: releaseKind
-  displayName: Release Kind
-  type: string
-  default: both
-  values:
-    - both
-    - npm
-    - docker
 - name: publishOverride
   displayName: Publish Override (default = based on branch)
   type: string
@@ -118,7 +110,7 @@ extends:
     shouldPushDockerImage: ${{ variables.pushImage }}
     shouldReleaseDockerImage: ${{ variables.releaseImage }}
     shouldPublishNpmPackages: ${{ variables.publish }}
-    releaseKind: ${{ parameters.releaseKind }}
+    releaseKind: both
     publishOverride: ${{ parameters.publishOverride }}
     publishAsPartOfBuild: true
     buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}


### PR DESCRIPTION
## Summary

There's no strong reason we need to support publishing server packages to only one of npm/docker. This simplifies the general setup ahead of moving them to be published via the newly stood up publishing pipelines.

- remove the queue-time `releaseKind` selector from GitRest, Historian, and Routerlicious
- pass `releaseKind: both` internally while the shared build template still requires it

