### PR TITLE
Clarify tree schema type branding

### DIFF
--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -407,7 +407,7 @@ import * as InternalTypes from "./internalTypes.js";
 export { InternalTypes };
 
 // Internal/System types:
-// These would be put in `internalTypes` except doing so tents to cause errors like:
+// These would be put in `internalTypes` except doing so tends to cause errors like:
 // The inferred type of 'NodeMap' cannot be named without a reference to '../../node_modules/@fluidframework/tree/lib/internalTypes.js'. This is likely not portable. A type annotation is necessary.
 export type { MapNodeInsertableData } from "./simple-tree/index.js";
 

--- a/packages/dds/tree/src/simple-tree/core/treeNode.ts
+++ b/packages/dds/tree/src/simple-tree/core/treeNode.ts
@@ -9,8 +9,8 @@ import { UsageError } from "@fluidframework/telemetry-utils/internal";
 import { markEager } from "./flexList.js";
 import { tryGetTreeNodeSchema } from "./treeNodeKernel.js";
 import { NodeKind, type TreeNodeSchemaClass } from "./treeNodeSchema.js";
-// eslint-disable-next-line import-x/no-deprecated
-import { type WithType, typeNameSymbol, type typeSchemaSymbol } from "./withType.js";
+// eslint-disable-next-line import-x/no-deprecated -- Required to implement the deprecated compatibility member.
+import type { WithType, typeNameSymbol, typeSchemaSymbol } from "./withType.js";
 
 /**
  * A non-{@link NodeKind.Leaf|leaf} SharedTree node. Includes objects, arrays, and maps.
@@ -76,18 +76,17 @@ export abstract class TreeNode implements WithType {
 	readonly #brand!: unknown;
 
 	/**
-	 * Adds a type symbol for stronger typing.
-	 * @privateRemarks
-	 * Subclasses provide more specific strings for this to get strong typing of otherwise type compatible nodes.
+	 * Adds a schema identifier brand for stronger and more efficient type checking.
+	 * @privateRemarks Subclasses provide more specific values to distinguish otherwise type-compatible nodes.
 	 * @deprecated Use {@link typeSchemaSymbol} instead.
 	 */
-	// eslint-disable-next-line import-x/no-deprecated
+	// eslint-disable-next-line import-x/no-deprecated -- Required to implement the deprecated compatibility member.
 	public abstract get [typeNameSymbol](): string;
 
 	/**
-	 * Adds a type symbol for stronger typing.
+	 * {@inheritDoc typeSchemaSymbol}
 	 * @privateRemarks
-	 * Subclasses provide more specific strings for this to get strong typing of otherwise type compatible nodes.
+	 * Subclasses provide more specific values for this to get strong typing of otherwise type compatible nodes.
 	 */
 	public abstract get [typeSchemaSymbol](): TreeNodeSchemaClass;
 

--- a/packages/dds/tree/src/simple-tree/core/treeNode.ts
+++ b/packages/dds/tree/src/simple-tree/core/treeNode.ts
@@ -9,7 +9,7 @@ import { UsageError } from "@fluidframework/telemetry-utils/internal";
 import { markEager } from "./flexList.js";
 import { tryGetTreeNodeSchema } from "./treeNodeKernel.js";
 import { NodeKind, type TreeNodeSchemaClass } from "./treeNodeSchema.js";
-// eslint-disable-next-line import-x/no-deprecated -- Required to implement the deprecated compatibility member.
+// eslint-disable-next-line import-x/no-deprecated -- Required to implement the deprecated typeNameSymbol API.
 import type { WithType, typeNameSymbol, typeSchemaSymbol } from "./withType.js";
 
 /**
@@ -80,7 +80,7 @@ export abstract class TreeNode implements WithType {
 	 * @privateRemarks Subclasses provide more specific values to distinguish otherwise type-compatible nodes.
 	 * @deprecated Use {@link typeSchemaSymbol} instead.
 	 */
-	// eslint-disable-next-line import-x/no-deprecated -- Required to implement the deprecated compatibility member.
+	// eslint-disable-next-line import-x/no-deprecated -- Required to implement the deprecated typeNameSymbol API.
 	public abstract get [typeNameSymbol](): string;
 
 	/**

--- a/packages/dds/tree/src/simple-tree/core/treeNode.ts
+++ b/packages/dds/tree/src/simple-tree/core/treeNode.ts
@@ -9,8 +9,12 @@ import { UsageError } from "@fluidframework/telemetry-utils/internal";
 import { markEager } from "./flexList.js";
 import { tryGetTreeNodeSchema } from "./treeNodeKernel.js";
 import { NodeKind, type TreeNodeSchemaClass } from "./treeNodeSchema.js";
-// eslint-disable-next-line import-x/no-deprecated -- Required to implement the deprecated typeNameSymbol API.
-import type { WithType, typeNameSymbol, typeSchemaSymbol } from "./withType.js";
+import type {
+	WithType,
+	// eslint-disable-next-line import-x/no-deprecated -- Required to implement the deprecated typeNameSymbol API.
+	typeNameSymbol,
+	typeSchemaSymbol,
+} from "./withType.js";
 
 /**
  * A non-{@link NodeKind.Leaf|leaf} SharedTree node. Includes objects, arrays, and maps.

--- a/packages/dds/tree/src/simple-tree/core/withType.ts
+++ b/packages/dds/tree/src/simple-tree/core/withType.ts
@@ -97,8 +97,10 @@ export const contentSchemaSymbol: unique symbol = Symbol("SharedTree Schema");
  * @privateRemarks
  * The properties of this are implemented as getters rather than instance properties as that is the easiest way to make them non-enumerable,
  * and also saves memory and time as they only have to be setup on the prototype.
- * We want these to be non-enumerable as they should not be shown to users as they are internal typing brands.
- * How we declare them here actually doesn't impact that, but is a good way to communicate to users and internal devs that these should be implemented as getters to accomplish the above.
+ * These being non-enumerable inherited properties minimizes impact on users,
+ * hiding them from things like `Reflect.ownKeys`, Object spread, `Object.getOwnPropertyDescriptors`, and `for...in` loops.
+ * How we declare them here actually doesn't impact that,
+ * but is a good way to communicate to users and internal devs that these should be implemented as inherited getters to accomplish the above.
  * @sealed @public
  */
 export interface WithType<

--- a/packages/dds/tree/src/simple-tree/core/withType.ts
+++ b/packages/dds/tree/src/simple-tree/core/withType.ts
@@ -3,24 +3,22 @@
  * Licensed under the MIT License.
  */
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars, unused-imports/no-unused-imports -- Used by doc links
+// Used by doc links:
+// eslint-disable-next-line @typescript-eslint/no-unused-vars, unused-imports/no-unused-imports
 import type { TreeAlpha } from "../../shared-tree/index.js";
 
 import type { TreeNode } from "./treeNode.js";
 import type { NodeKind, TreeNodeSchemaClass } from "./treeNodeSchema.js";
 
 /**
- * The type of a {@link TreeNode}.
+ * An internal brand to improve compiler performance.
  * For more information about the type, use `Tree.schema(theNode)` instead.
  * @remarks
- * This symbol mainly exists on nodes to allow TypeScript to provide more accurate type checking.
  * `Tree.is` and `Tree.schema` provide a superset of this information in more friendly ways.
- *
- * This symbol should not manually be added to objects as doing so allows the object to be invalidly used where nodes are expected.
- * Instead construct a real node of the desired type using its constructor.
  * @privateRemarks
- * This prevents non-nodes from being accidentally used as nodes, as well as allows the type checker to distinguish different node types.
- * @deprecated External code should use `Tree.schema(theNode)` for schema related runtime data access. For type narrowing, use `WithType` instead of the symbols directly.
+ * The identifier of a {@link TreeNode}'s schema.
+ * This allows the type checker to distinguish different node types more efficiently than via {@link typeSchemaSymbol}.
+ * @deprecated External code should use `Tree.schema(theNode)` for schema related runtime data access. For type narrowing, use {@link WithType} instead of the symbols directly.
  * @system @public
  */
 export const typeNameSymbol: unique symbol = Symbol("TreeNode Type");
@@ -96,6 +94,11 @@ export const contentSchemaSymbol: unique symbol = Symbol("SharedTree Schema");
  * 	}
  * }
  * ```
+ * @privateRemarks
+ * The properties of this are implemented as getters rather than instance properties as that is the easiest way to make them non-enumerable,
+ * and also saves memory and time as they only have to be setup on the prototype.
+ * We want these to be non-enumerable as they should not be shown to users as they are internal typing brands.
+ * How we declare them here actually doesn't impact that, but is a good way to communicate to users and internal devs that these should be implemented as getters to accomplish the above.
  * @sealed @public
  */
 export interface WithType<
@@ -105,6 +108,15 @@ export interface WithType<
 > {
 	/**
 	 * Type symbol, marking a type in a way to increase type safety via strong type checking.
+	 *
+	 * Use `Tree.schema(theNode)` for schema related runtime data access. For type narrowing, use `WithType` instead of the symbols directly.
+	 * @remarks
+	 * This should be redundant with {@link typeSchemaSymbol}, but is kept for improved compiler performance.
+	 * If we just rely on {@link typeSchemaSymbol}, the compiler has to work much harder to distinguish schema in unions,
+	 * which can cause large schema unions to hit "error TS2859: Excessive complexity comparing types".
+	 *
+	 * This property is not intended for any use other than helping the compiler distinguish schema types,
+	 * and should not be referenced in any code other than internal to the tree package.
 	 * @deprecated Use {@link typeSchemaSymbol} instead.
 	 */
 	get [typeNameSymbol](): TName;

--- a/packages/dds/tree/src/simple-tree/node-kinds/array/arrayNode.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/array/arrayNode.ts
@@ -23,7 +23,7 @@ import type { NodeSchemaOptionsAlpha, System_Unsafe } from "../../api/index.js";
 import {
 	CompatibilityLevel,
 	type WithType,
-	// eslint-disable-next-line import-x/no-deprecated -- Required to implement the deprecated compatibility member.
+	// eslint-disable-next-line import-x/no-deprecated -- Required to implement the deprecated typeNameSymbol API.
 	typeNameSymbol,
 	NodeKind,
 	type TreeNode,
@@ -1534,7 +1534,7 @@ export function arraySchema<
 		public static readonly persistedMetadata: JsonCompatibleReadOnlyObject | undefined =
 			persistedMetadata;
 
-		// eslint-disable-next-line import-x/no-deprecated -- Required to implement the deprecated compatibility member.
+		// eslint-disable-next-line import-x/no-deprecated -- Required to implement the deprecated typeNameSymbol API.
 		public get [typeNameSymbol](): TName {
 			return identifier;
 		}

--- a/packages/dds/tree/src/simple-tree/node-kinds/array/arrayNode.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/array/arrayNode.ts
@@ -23,7 +23,7 @@ import type { NodeSchemaOptionsAlpha, System_Unsafe } from "../../api/index.js";
 import {
 	CompatibilityLevel,
 	type WithType,
-	// eslint-disable-next-line import-x/no-deprecated
+	// eslint-disable-next-line import-x/no-deprecated -- Required to implement the deprecated compatibility member.
 	typeNameSymbol,
 	NodeKind,
 	type TreeNode,
@@ -1534,7 +1534,7 @@ export function arraySchema<
 		public static readonly persistedMetadata: JsonCompatibleReadOnlyObject | undefined =
 			persistedMetadata;
 
-		// eslint-disable-next-line import-x/no-deprecated
+		// eslint-disable-next-line import-x/no-deprecated -- Required to implement the deprecated compatibility member.
 		public get [typeNameSymbol](): TName {
 			return identifier;
 		}

--- a/packages/dds/tree/src/simple-tree/node-kinds/map/mapNode.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/map/mapNode.ts
@@ -33,7 +33,7 @@ import {
 	type InnerNode,
 	NodeKind,
 	type TreeNodeSchema,
-	// eslint-disable-next-line import-x/no-deprecated -- Required to implement the deprecated compatibility member.
+	// eslint-disable-next-line import-x/no-deprecated -- Required to implement the deprecated typeNameSymbol API.
 	typeNameSymbol,
 	type TreeNode,
 	typeSchemaSymbol,
@@ -485,7 +485,7 @@ export function mapSchema<
 		public static readonly persistedMetadata: JsonCompatibleReadOnlyObject | undefined =
 			persistedMetadata;
 
-		// eslint-disable-next-line import-x/no-deprecated -- Required to implement the deprecated compatibility member.
+		// eslint-disable-next-line import-x/no-deprecated -- Required to implement the deprecated typeNameSymbol API.
 		public get [typeNameSymbol](): TName {
 			return identifier;
 		}

--- a/packages/dds/tree/src/simple-tree/node-kinds/map/mapNode.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/map/mapNode.ts
@@ -33,7 +33,7 @@ import {
 	type InnerNode,
 	NodeKind,
 	type TreeNodeSchema,
-	// eslint-disable-next-line import-x/no-deprecated
+	// eslint-disable-next-line import-x/no-deprecated -- Required to implement the deprecated compatibility member.
 	typeNameSymbol,
 	type TreeNode,
 	typeSchemaSymbol,
@@ -485,7 +485,7 @@ export function mapSchema<
 		public static readonly persistedMetadata: JsonCompatibleReadOnlyObject | undefined =
 			persistedMetadata;
 
-		// eslint-disable-next-line import-x/no-deprecated
+		// eslint-disable-next-line import-x/no-deprecated -- Required to implement the deprecated compatibility member.
 		public get [typeNameSymbol](): TName {
 			return identifier;
 		}

--- a/packages/dds/tree/src/simple-tree/node-kinds/object/objectNode.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/object/objectNode.ts
@@ -32,7 +32,7 @@ import {
 	type TreeNodeSchema,
 	NodeKind,
 	type WithType,
-	// eslint-disable-next-line import-x/no-deprecated -- Required for deprecated compatibility handling.
+	// eslint-disable-next-line import-x/no-deprecated -- Required to handle the deprecated typeNameSymbol API.
 	typeNameSymbol,
 	typeSchemaSymbol,
 	type InternalTreeNode,
@@ -335,7 +335,7 @@ function createProxyHandler(
 			if (propertyKey === typeSchemaSymbol) {
 				return schema;
 			}
-			// eslint-disable-next-line import-x/no-deprecated -- Required for deprecated compatibility handling.
+			// eslint-disable-next-line import-x/no-deprecated -- Required to handle the deprecated typeNameSymbol API.
 			if (propertyKey === typeNameSymbol) {
 				return schema.identifier;
 			}
@@ -633,7 +633,7 @@ export function objectSchema<
 		public static readonly persistedMetadata: JsonCompatibleReadOnlyObject | undefined =
 			nodeOptions.persistedMetadata;
 
-		// eslint-disable-next-line import-x/no-deprecated -- Required to implement the deprecated compatibility member.
+		// eslint-disable-next-line import-x/no-deprecated -- Required to implement the deprecated typeNameSymbol API.
 		public get [typeNameSymbol](): TName {
 			return identifier;
 		}

--- a/packages/dds/tree/src/simple-tree/node-kinds/object/objectNode.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/object/objectNode.ts
@@ -32,7 +32,7 @@ import {
 	type TreeNodeSchema,
 	NodeKind,
 	type WithType,
-	// eslint-disable-next-line import-x/no-deprecated
+	// eslint-disable-next-line import-x/no-deprecated -- Required for deprecated compatibility handling.
 	typeNameSymbol,
 	typeSchemaSymbol,
 	type InternalTreeNode,
@@ -335,7 +335,7 @@ function createProxyHandler(
 			if (propertyKey === typeSchemaSymbol) {
 				return schema;
 			}
-			// eslint-disable-next-line import-x/no-deprecated
+			// eslint-disable-next-line import-x/no-deprecated -- Required for deprecated compatibility handling.
 			if (propertyKey === typeNameSymbol) {
 				return schema.identifier;
 			}
@@ -633,7 +633,7 @@ export function objectSchema<
 		public static readonly persistedMetadata: JsonCompatibleReadOnlyObject | undefined =
 			nodeOptions.persistedMetadata;
 
-		// eslint-disable-next-line import-x/no-deprecated
+		// eslint-disable-next-line import-x/no-deprecated -- Required to implement the deprecated compatibility member.
 		public get [typeNameSymbol](): TName {
 			return identifier;
 		}

--- a/packages/dds/tree/src/simple-tree/node-kinds/record/recordNode.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/record/recordNode.ts
@@ -17,7 +17,7 @@ import type { NodeSchemaOptionsAlpha } from "../../api/index.js";
 import {
 	type TreeNodeSchema,
 	NodeKind,
-	// eslint-disable-next-line import-x/no-deprecated -- Required for deprecated compatibility handling.
+	// eslint-disable-next-line import-x/no-deprecated -- Required to handle the deprecated typeNameSymbol API.
 	typeNameSymbol,
 	typeSchemaSymbol,
 	type UnhydratedFlexTreeNode,
@@ -78,7 +78,7 @@ function createRecordNodeProxy(
 					case typeSchemaSymbol: {
 						return schema;
 					}
-					// eslint-disable-next-line import-x/no-deprecated -- Required for deprecated compatibility handling.
+					// eslint-disable-next-line import-x/no-deprecated -- Required to handle the deprecated typeNameSymbol API.
 					case typeNameSymbol: {
 						return schema.identifier;
 					}
@@ -370,7 +370,7 @@ export function recordSchema<
 		public static readonly persistedMetadata: JsonCompatibleReadOnlyObject | undefined =
 			persistedMetadata;
 
-		// eslint-disable-next-line import-x/no-deprecated -- Required to implement the deprecated compatibility member.
+		// eslint-disable-next-line import-x/no-deprecated -- Required to implement the deprecated typeNameSymbol API.
 		public get [typeNameSymbol](): TName {
 			return identifier;
 		}

--- a/packages/dds/tree/src/simple-tree/node-kinds/record/recordNode.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/record/recordNode.ts
@@ -17,7 +17,7 @@ import type { NodeSchemaOptionsAlpha } from "../../api/index.js";
 import {
 	type TreeNodeSchema,
 	NodeKind,
-	// eslint-disable-next-line import-x/no-deprecated
+	// eslint-disable-next-line import-x/no-deprecated -- Required for deprecated compatibility handling.
 	typeNameSymbol,
 	typeSchemaSymbol,
 	type UnhydratedFlexTreeNode,
@@ -78,7 +78,7 @@ function createRecordNodeProxy(
 					case typeSchemaSymbol: {
 						return schema;
 					}
-					// eslint-disable-next-line import-x/no-deprecated
+					// eslint-disable-next-line import-x/no-deprecated -- Required for deprecated compatibility handling.
 					case typeNameSymbol: {
 						return schema.identifier;
 					}
@@ -370,7 +370,7 @@ export function recordSchema<
 		public static readonly persistedMetadata: JsonCompatibleReadOnlyObject | undefined =
 			persistedMetadata;
 
-		// eslint-disable-next-line import-x/no-deprecated
+		// eslint-disable-next-line import-x/no-deprecated -- Required to implement the deprecated compatibility member.
 		public get [typeNameSymbol](): TName {
 			return identifier;
 		}

--- a/packages/dds/tree/src/test/simple-tree/core/treeNode.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/core/treeNode.spec.ts
@@ -23,17 +23,21 @@ import {
 describe("simple-tree core types", () => {
 	describe("TreeNode", () => {
 		it("Assignability", () => {
+			class TestClass extends new SchemaFactory("Test").object("test", {}) {}
+
 			// @ts-expect-error TreeNode should not allow non-node objects.
 			const n: TreeNode = {};
-			// @ts-expect-error TreeNode should not allow non-node objects.
+			// @ts-expect-error TreeNode should not allow non-node objects, even with schema.
 			const n2: TreeNode = {
-				[typeNameSymbol]: "",
+				[typeNameSymbol]: "Test.test",
+				[typeSchemaSymbol]: TestClass,
 			};
 
 			// Declared as a separate implicitly typed variable to avoid "Object literal may only specify known properties" error
 			// (which is good, but not what we are testing for here).
 			const n3 = {
 				[typeNameSymbol]: "",
+				[typeSchemaSymbol]: TestClass,
 				"#brand": undefined,
 			};
 			// @ts-expect-error TreeNode should not allow non-node objects, even if you use "add missing properties" refactor.

--- a/packages/dds/tree/src/test/simple-tree/objectFactory.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/objectFactory.spec.ts
@@ -86,8 +86,8 @@ describe("SharedTreeObject factories", () => {
 
 	it("can re-use content objects", () => {
 		const root = hydrate(Schema, initialTree());
-		// The `create` functions stamp the content with a `[typeNameSymbol]`.
-		// This test ensures that they shallow copy the content before doing the stamp.
+		// Constructing a node must not stamp schema-disambiguating metadata onto the input object.
+		// The same object can be updated and reused to construct a node with a different schema.
 		const content = { content: 43 };
 		root.poly = new ChildA(content);
 		content.content = 44;


### PR DESCRIPTION
## Description

Clarifications around `typeNameSymbol` brand. Turns out we can't just remove it, so this clarifies why.

A future change (for 3.0) will make breaking API changes to further clean this up (stop non-type exporting the symbol, rename it, remove the deprecations)

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
