### PR TITLE
fix(container-loader): preserve binary blobs in detached serialization

### DIFF
--- a/.changeset/fix-detached-binary-blob-serialization.md
+++ b/.changeset/fix-detached-binary-blob-serialization.md
@@ -1,0 +1,8 @@
+---
+"@fluidframework/container-loader": minor
+"__section": fix
+---
+
+Detached container serialization now preserves binary attachment blobs
+
+Serializing and rehydrating a detached container now stores attachment blob contents in a versioned base64 format, preventing non-UTF-8 bytes from being replaced. Previously serialized UTF-8 snapshots remain supported.

--- a/examples/apps/blobs/src/app.ts
+++ b/examples/apps/blobs/src/app.ts
@@ -16,6 +16,7 @@ import type {
 import {
 	createDetachedContainer,
 	loadExistingContainer,
+	rehydrateDetachedContainer,
 } from "@fluidframework/container-loader/legacy";
 import { createElement } from "react";
 // eslint-disable-next-line import-x/no-internal-modules
@@ -115,6 +116,33 @@ globalThis.loadAdditionalContainer = async () => {
 	}
 	return loadExistingContainer({
 		request: await createLoadExistingRequest(id),
+		urlResolver,
+		documentServiceFactory,
+		codeLoader,
+	});
+};
+
+globalThis.getContainerForTesting = () => container;
+globalThis.rehydrateDetachedContainerForTesting = (serializedState: string) =>
+	rehydrateDetachedContainer({
+		serializedState,
+		urlResolver,
+		documentServiceFactory,
+		codeLoader,
+	});
+globalThis.attachAndLoadContainerForTesting = async (
+	containerToAttach: IContainer,
+) => {
+	let containerId = `${Date.now()}-detached-blob-test`;
+	await containerToAttach.attach(createCreateNewRequest(containerId));
+	if (service !== "odsp") {
+		if (containerToAttach.resolvedUrl === undefined) {
+			throw new Error("Resolved URL unexpectedly missing after attach");
+		}
+		containerId = containerToAttach.resolvedUrl.id;
+	}
+	return loadExistingContainer({
+		request: await createLoadExistingRequest(containerId),
 		urlResolver,
 		documentServiceFactory,
 		codeLoader,

--- a/examples/apps/blobs/src/app.ts
+++ b/examples/apps/blobs/src/app.ts
@@ -123,16 +123,14 @@ globalThis.loadAdditionalContainer = async () => {
 };
 
 globalThis.getContainerForTesting = () => container;
-globalThis.rehydrateDetachedContainerForTesting = (serializedState: string) =>
+globalThis.rehydrateDetachedContainerForTesting = async (serializedState: string) =>
 	rehydrateDetachedContainer({
 		serializedState,
 		urlResolver,
 		documentServiceFactory,
 		codeLoader,
 	});
-globalThis.attachAndLoadContainerForTesting = async (
-	containerToAttach: IContainer,
-) => {
+globalThis.attachAndLoadContainerForTesting = async (containerToAttach: IContainer) => {
 	let containerId = `${Date.now()}-detached-blob-test`;
 	await containerToAttach.attach(createCreateNewRequest(containerId));
 	if (service !== "odsp") {

--- a/examples/apps/blobs/tests/blobs.test.ts
+++ b/examples/apps/blobs/tests/blobs.test.ts
@@ -36,11 +36,7 @@ describe("blobs", () => {
 	});
 
 	it("preserves binary blobs through detached serialize, rehydrate, and attach", async () => {
-		const blobContents = [
-			[0x00, 0x01, 0x02, 0x03, 0xfe, 0xff],
-			[],
-			[0x80, 0x00, 0x7f],
-		];
+		const blobContents = [[0x00, 0x01, 0x02, 0x03, 0xfe, 0xff], [], [0x80, 0x00, 0x7f]];
 		const roundTrippedBlobContents = await page.evaluate(async (contents) => {
 			const waitForBlobCount = async (
 				collection: IBlobCollection,
@@ -61,14 +57,11 @@ describe("blobs", () => {
 				Promise.all(
 					collection
 						.getBlobs()
-						.map(async ({ blob }) =>
-							Array.from(new Uint8Array(await blob.arrayBuffer())),
-						),
+						.map(async ({ blob }) => Array.from(new Uint8Array(await blob.arrayBuffer()))),
 				);
 
 			const originalContainer = globalThis.getContainerForTesting();
-			const originalCollection =
-				(await originalContainer.getEntryPoint()) as IBlobCollection;
+			const originalCollection = (await originalContainer.getEntryPoint()) as IBlobCollection;
 			const blobsUploaded = waitForBlobCount(originalCollection, contents.length);
 			for (const content of contents) {
 				originalCollection.addBlob(new Blob([new Uint8Array(content)]));
@@ -86,8 +79,7 @@ describe("blobs", () => {
 
 			const attachedContainer =
 				await globalThis.attachAndLoadContainerForTesting(rehydratedContainer);
-			const attachedCollection =
-				(await attachedContainer.getEntryPoint()) as IBlobCollection;
+			const attachedCollection = (await attachedContainer.getEntryPoint()) as IBlobCollection;
 			await waitForBlobCount(attachedCollection, contents.length);
 			const attached = await readBlobContents(attachedCollection);
 

--- a/examples/apps/blobs/tests/blobs.test.ts
+++ b/examples/apps/blobs/tests/blobs.test.ts
@@ -35,6 +35,73 @@ describe("blobs", () => {
 		await expect(page).toClick("button", { text: "Add blob" });
 	});
 
+	it("preserves binary blobs through detached serialize, rehydrate, and attach", async () => {
+		const blobContents = [
+			[0x00, 0x01, 0x02, 0x03, 0xfe, 0xff],
+			[],
+			[0x80, 0x00, 0x7f],
+		];
+		const roundTrippedBlobContents = await page.evaluate(async (contents) => {
+			const waitForBlobCount = async (
+				collection: IBlobCollection,
+				expectedCount: number,
+			): Promise<void> => {
+				if (collection.getBlobs().length === expectedCount) {
+					return;
+				}
+				await new Promise<void>((resolve) => {
+					collection.events.on("blobAdded", () => {
+						if (collection.getBlobs().length === expectedCount) {
+							resolve();
+						}
+					});
+				});
+			};
+			const readBlobContents = async (collection: IBlobCollection): Promise<number[][]> =>
+				Promise.all(
+					collection
+						.getBlobs()
+						.map(async ({ blob }) =>
+							Array.from(new Uint8Array(await blob.arrayBuffer())),
+						),
+				);
+
+			const originalContainer = globalThis.getContainerForTesting();
+			const originalCollection =
+				(await originalContainer.getEntryPoint()) as IBlobCollection;
+			const blobsUploaded = waitForBlobCount(originalCollection, contents.length);
+			for (const content of contents) {
+				originalCollection.addBlob(new Blob([new Uint8Array(content)]));
+			}
+			await blobsUploaded;
+
+			const serializedState = originalContainer.serialize();
+			originalContainer.close();
+			const rehydratedContainer =
+				await globalThis.rehydrateDetachedContainerForTesting(serializedState);
+			const rehydratedCollection =
+				(await rehydratedContainer.getEntryPoint()) as IBlobCollection;
+			await waitForBlobCount(rehydratedCollection, contents.length);
+			const rehydrated = await readBlobContents(rehydratedCollection);
+
+			const attachedContainer =
+				await globalThis.attachAndLoadContainerForTesting(rehydratedContainer);
+			const attachedCollection =
+				(await attachedContainer.getEntryPoint()) as IBlobCollection;
+			await waitForBlobCount(attachedCollection, contents.length);
+			const attached = await readBlobContents(attachedCollection);
+
+			rehydratedContainer.close();
+			attachedContainer.close();
+			return { rehydrated, attached };
+		}, blobContents);
+		const normalize = (contents: number[][]): string[] =>
+			contents.map((content) => content.join(",")).sort();
+
+		expect(normalize(roundTrippedBlobContents.rehydrated)).toEqual(normalize(blobContents));
+		expect(normalize(roundTrippedBlobContents.attached)).toEqual(normalize(blobContents));
+	});
+
 	it("can attach and be loaded in a second container", async () => {
 		// Validate there is a button that can be clicked
 		await expect(page).toClick("button", { text: "Attach container" });

--- a/packages/loader/container-loader/src/memoryBlobStorage.ts
+++ b/packages/loader/container-loader/src/memoryBlobStorage.ts
@@ -30,8 +30,32 @@ export interface MemoryDetachedBlobStorage
 	 * After the container is attached, the detached blob storage is no longer needed and will be disposed.
 	 */
 	dispose?(): void;
-	initialize(attachmentBlobs: string[]): void;
+	initialize(attachmentBlobs: readonly ArrayBufferLike[]): void;
 	serialize(): string | undefined;
+}
+
+const serializedMemoryDetachedBlobStorageVersion = 1;
+
+interface SerializedMemoryDetachedBlobStorage {
+	readonly version: typeof serializedMemoryDetachedBlobStorageVersion;
+	readonly blobs: readonly string[];
+}
+
+function isStringArray(value: unknown): value is string[] {
+	return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+function isSerializedMemoryDetachedBlobStorage(
+	value: unknown,
+): value is SerializedMemoryDetachedBlobStorage {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"version" in value &&
+		value.version === serializedMemoryDetachedBlobStorageVersion &&
+		"blobs" in value &&
+		isStringArray(value.blobs)
+	);
 }
 
 export function tryInitializeMemoryDetachedBlobStorage(
@@ -39,12 +63,23 @@ export function tryInitializeMemoryDetachedBlobStorage(
 	attachmentBlobs: string,
 ): void {
 	assert(detachedStorage.size === 0, 0x99e /* Blob storage already initialized */);
-	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-	const maybeAttachmentBlobs = JSON.parse(attachmentBlobs);
-	assert(Array.isArray(maybeAttachmentBlobs), 0x99f /* Invalid attachmentBlobs */);
+	const maybeAttachmentBlobs: unknown = JSON.parse(attachmentBlobs);
 
-	// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-	detachedStorage.initialize(maybeAttachmentBlobs);
+	// Legacy snapshots stored blob contents as UTF-8 strings.
+	if (isStringArray(maybeAttachmentBlobs)) {
+		detachedStorage.initialize(
+			maybeAttachmentBlobs.map((maybeBlob) => stringToBuffer(maybeBlob, "utf8")),
+		);
+		return;
+	}
+
+	assert(
+		isSerializedMemoryDetachedBlobStorage(maybeAttachmentBlobs),
+		"Invalid attachmentBlobs",
+	);
+	detachedStorage.initialize(
+		maybeAttachmentBlobs.blobs.map((maybeBlob) => stringToBuffer(maybeBlob, "base64")),
+	);
 }
 
 /**
@@ -66,12 +101,18 @@ export function createMemoryDetachedBlobStorage(): MemoryDetachedBlobStorage {
 		},
 		getBlobIds: (): string[] => blobs.map((_, i) => `${i}`),
 		dispose: () => blobs.splice(0),
-		serialize: () =>
-			blobs.length > 0
-				? JSON.stringify(blobs.map((b) => bufferToString(b, "utf8")))
-				: undefined,
-		initialize: (attachmentBlobs: string[]) =>
-			blobs.push(...attachmentBlobs.map((maybeBlob) => stringToBuffer(maybeBlob, "utf8"))),
+		serialize: () => {
+			if (blobs.length === 0) {
+				return undefined;
+			}
+			const serializedStorage: SerializedMemoryDetachedBlobStorage = {
+				version: serializedMemoryDetachedBlobStorageVersion,
+				blobs: blobs.map((blob) => bufferToString(blob, "base64")),
+			};
+			return JSON.stringify(serializedStorage);
+		},
+		initialize: (attachmentBlobs: readonly ArrayBufferLike[]) =>
+			blobs.push(...attachmentBlobs),
 	};
 	return storage;
 }

--- a/packages/loader/container-loader/src/serializedStateManager.ts
+++ b/packages/loader/container-loader/src/serializedStateManager.ts
@@ -130,7 +130,8 @@ export interface IPendingDetachedContainerState extends SnapshotWithBlobs {
 	 */
 	hasAttachmentBlobs: boolean;
 	/**
-	 * Used by the memory blob storage to persisted attachment blobs
+	 * Versioned serialized contents of the memory detached blob storage.
+	 * Current snapshots encode attachment blob bytes as base64.
 	 */
 	attachmentBlobs?: string;
 	/**

--- a/packages/loader/container-loader/src/test/memoryBlobStorage.spec.ts
+++ b/packages/loader/container-loader/src/test/memoryBlobStorage.spec.ts
@@ -129,15 +129,13 @@ describe("MemoryBlobStorage", () => {
 
 		assert.deepStrictEqual(storage.getBlobIds(), ["0", "1"]);
 		const rehydratedBlobContents = await Promise.all(
-			storage
-				.getBlobIds()
-				.map(async (id) => [...new Uint8Array(await storage.readBlob(id))]),
+			storage.getBlobIds().map(async (id) => [...new Uint8Array(await storage.readBlob(id))]),
 		);
 		assert.deepStrictEqual(
 			rehydratedBlobContents,
-			legacyBlobContents.map((blobContent) =>
-				[...new Uint8Array(stringToBuffer(blobContent, "utf8"))],
-			),
+			legacyBlobContents.map((blobContent) => [
+				...new Uint8Array(stringToBuffer(blobContent, "utf8")),
+			]),
 		);
 	});
 

--- a/packages/loader/container-loader/src/test/memoryBlobStorage.spec.ts
+++ b/packages/loader/container-loader/src/test/memoryBlobStorage.spec.ts
@@ -91,7 +91,7 @@ describe("MemoryBlobStorage", () => {
 		];
 		const storage = createMemoryDetachedBlobStorage();
 		const blobResponses = await Promise.all(
-			blobContents.map((blobContent) => storage.createBlob(blobContent.buffer)),
+			blobContents.map(async (blobContent) => storage.createBlob(blobContent.buffer)),
 		);
 
 		assert.deepStrictEqual(
@@ -113,11 +113,11 @@ describe("MemoryBlobStorage", () => {
 		const rehydratedBlobContents = await Promise.all(
 			newStorage
 				.getBlobIds()
-				.map(async (id) => Array.from(new Uint8Array(await newStorage.readBlob(id)))),
+				.map(async (id) => [...new Uint8Array(await newStorage.readBlob(id))]),
 		);
 		assert.deepStrictEqual(
 			rehydratedBlobContents,
-			blobContents.map((blobContent) => Array.from(blobContent)),
+			blobContents.map((blobContent) => [...blobContent]),
 		);
 	});
 
@@ -131,12 +131,12 @@ describe("MemoryBlobStorage", () => {
 		const rehydratedBlobContents = await Promise.all(
 			storage
 				.getBlobIds()
-				.map(async (id) => Array.from(new Uint8Array(await storage.readBlob(id)))),
+				.map(async (id) => [...new Uint8Array(await storage.readBlob(id))]),
 		);
 		assert.deepStrictEqual(
 			rehydratedBlobContents,
 			legacyBlobContents.map((blobContent) =>
-				Array.from(new Uint8Array(stringToBuffer(blobContent, "utf8"))),
+				[...new Uint8Array(stringToBuffer(blobContent, "utf8"))],
 			),
 		);
 	});

--- a/packages/loader/container-loader/src/test/memoryBlobStorage.spec.ts
+++ b/packages/loader/container-loader/src/test/memoryBlobStorage.spec.ts
@@ -83,6 +83,64 @@ describe("MemoryBlobStorage", () => {
 		);
 	});
 
+	it("Serializes binary blobs as versioned base64 and preserves their IDs and order", async () => {
+		const blobContents = [
+			new Uint8Array([0x00, 0x01, 0x02, 0x03, 0xfe, 0xff]),
+			new Uint8Array([]),
+			new Uint8Array([0x80, 0x00, 0x7f]),
+		];
+		const storage = createMemoryDetachedBlobStorage();
+		const blobResponses = await Promise.all(
+			blobContents.map((blobContent) => storage.createBlob(blobContent.buffer)),
+		);
+
+		assert.deepStrictEqual(
+			blobResponses.map(({ id }) => id),
+			["0", "1", "2"],
+		);
+		const serializedStorage = storage.serialize();
+		assert(serializedStorage !== undefined, "Serialized storage is undefined");
+		const parsedSerializedStorage: unknown = JSON.parse(serializedStorage);
+		assert.deepStrictEqual(parsedSerializedStorage, {
+			version: 1,
+			blobs: ["AAECA/7/", "", "gAB/"],
+		});
+
+		const newStorage = createMemoryDetachedBlobStorage();
+		tryInitializeMemoryDetachedBlobStorage(newStorage, serializedStorage);
+
+		assert.deepStrictEqual(newStorage.getBlobIds(), ["0", "1", "2"]);
+		const rehydratedBlobContents = await Promise.all(
+			newStorage
+				.getBlobIds()
+				.map(async (id) => Array.from(new Uint8Array(await newStorage.readBlob(id)))),
+		);
+		assert.deepStrictEqual(
+			rehydratedBlobContents,
+			blobContents.map((blobContent) => Array.from(blobContent)),
+		);
+	});
+
+	it("Can initialize blob storage serialized in the legacy UTF-8 format", async () => {
+		const legacyBlobContents = ["legacy content", "legacy\u0000content"];
+		const storage = createMemoryDetachedBlobStorage();
+
+		tryInitializeMemoryDetachedBlobStorage(storage, JSON.stringify(legacyBlobContents));
+
+		assert.deepStrictEqual(storage.getBlobIds(), ["0", "1"]);
+		const rehydratedBlobContents = await Promise.all(
+			storage
+				.getBlobIds()
+				.map(async (id) => Array.from(new Uint8Array(await storage.readBlob(id)))),
+		);
+		assert.deepStrictEqual(
+			rehydratedBlobContents,
+			legacyBlobContents.map((blobContent) =>
+				Array.from(new Uint8Array(stringToBuffer(blobContent, "utf8"))),
+			),
+		);
+	});
+
 	it("Throws error when initializing from invalid serialized storage", async () => {
 		const newStorage = createMemoryDetachedBlobStorage();
 		const invalidSerializedStorage = "invalid serialized storage";
@@ -90,6 +148,19 @@ describe("MemoryBlobStorage", () => {
 		assert.throws(() => {
 			tryInitializeMemoryDetachedBlobStorage(newStorage, invalidSerializedStorage);
 		}, "Expected an error when initializing from invalid serialized storage");
+	});
+
+	it("Throws error when initializing from an unsupported serialized storage version", () => {
+		const newStorage = createMemoryDetachedBlobStorage();
+
+		assert.throws(
+			() =>
+				tryInitializeMemoryDetachedBlobStorage(
+					newStorage,
+					JSON.stringify({ version: 2, blobs: [] }),
+				),
+			/Invalid attachmentBlobs/,
+		);
 	});
 
 	it("Throws error when tryInitializeMemoryDetachedBlobStorage is called on storage with existing blobs", async () => {

--- a/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
@@ -579,16 +579,14 @@ function serializationTests({
 							configProvider: createTestConfigProvider({}),
 						},
 					});
-					const container = await loader.createDetachedContainer(
-						provider.defaultCodeDetails,
-					);
+					const container = await loader.createDetachedContainer(provider.defaultCodeDetails);
 					const dataStore = (await container.getEntryPoint()) as ITestDataObject;
 					const blobContents = [
 						new Uint8Array([0x00, 0x01, 0x02, 0x03, 0xfe, 0xff]),
 						new Uint8Array([0x80, 0x00, 0x7f]),
 					];
 					const blobHandles = await Promise.all(
-						blobContents.map((blobContent) =>
+						blobContents.map(async (blobContent) =>
 							dataStore._runtime.uploadBlob(blobContent.buffer),
 						),
 					);
@@ -596,9 +594,7 @@ function serializationTests({
 						dataStore._root.set(`binary blob ${index}`, blobHandle);
 					});
 
-					const assertBlobContents = async (
-						dataObject: ITestDataObject,
-					): Promise<void> => {
+					const assertBlobContents = async (dataObject: ITestDataObject): Promise<void> => {
 						const rehydratedBlobContents = await Promise.all(
 							blobContents.map(async (_, index) => {
 								const blobHandle: IFluidHandle<ArrayBufferLike> | undefined =

--- a/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
@@ -565,6 +565,85 @@ function serializationTests({
 				);
 			});
 
+			itExpects(
+				"serialize/rehydrate preserves binary blobs through attach",
+				ContainerStateEventsOrErrors,
+				async function () {
+					if (provider.type === "TestObjectProviderWithVersionedLoad") {
+						this.skip();
+					}
+
+					const loader = provider.makeTestLoader({
+						...testContainerConfig,
+						loaderProps: {
+							configProvider: createTestConfigProvider({}),
+						},
+					});
+					const container = await loader.createDetachedContainer(
+						provider.defaultCodeDetails,
+					);
+					const dataStore = (await container.getEntryPoint()) as ITestDataObject;
+					const blobContents = [
+						new Uint8Array([0x00, 0x01, 0x02, 0x03, 0xfe, 0xff]),
+						new Uint8Array([0x80, 0x00, 0x7f]),
+					];
+					const blobHandles = await Promise.all(
+						blobContents.map((blobContent) =>
+							dataStore._runtime.uploadBlob(blobContent.buffer),
+						),
+					);
+					blobHandles.forEach((blobHandle, index) => {
+						dataStore._root.set(`binary blob ${index}`, blobHandle);
+					});
+
+					const assertBlobContents = async (
+						dataObject: ITestDataObject,
+					): Promise<void> => {
+						const rehydratedBlobContents = await Promise.all(
+							blobContents.map(async (_, index) => {
+								const blobHandle: IFluidHandle<ArrayBufferLike> | undefined =
+									dataObject._root.get(`binary blob ${index}`);
+								assert(blobHandle !== undefined, `binary blob ${index} must exist`);
+								return Array.from(new Uint8Array(await blobHandle.get()));
+							}),
+						);
+						assert.deepStrictEqual(
+							rehydratedBlobContents,
+							blobContents.map((blobContent) => Array.from(blobContent)),
+						);
+					};
+
+					const snapshot = container.serialize();
+					container.close();
+					const rehydratedContainer =
+						await loader.rehydrateDetachedContainerFromSnapshot(snapshot);
+					const rehydratedDataStore =
+						(await rehydratedContainer.getEntryPoint()) as ITestDataObject;
+					await assertBlobContents(rehydratedDataStore);
+
+					const attachP = rehydratedContainer.attach(
+						provider.driver.createCreateNewRequest(provider.documentId),
+					);
+					if (!driverSupportsBlobs(provider.driver)) {
+						return assert.rejects(
+							attachP,
+							(err: IErrorBase) => err.message === usageErrorMessage,
+						);
+					}
+					await attachP;
+					await assertBlobContents(rehydratedDataStore);
+
+					const url = await getUrlFromDetachedBlobStorage(rehydratedContainer, provider);
+					const attachedContainer = await provider
+						.makeTestLoader(testContainerConfig)
+						.resolve({ url });
+					const attachedDataStore =
+						(await attachedContainer.getEntryPoint()) as ITestDataObject;
+					await provider.ensureSynchronized();
+					await assertBlobContents(attachedDataStore);
+				},
+			);
+
 			it("serialize while attaching and rehydrate container with blobs", async function () {
 				// build a fault injected driver to fail attach on the  summary upload
 				// after create that happens in the blob flow


### PR DESCRIPTION
## Description

Detached containers previously serialized attachment blob bytes through UTF-8. Invalid UTF-8 sequences were replaced during `serialize()` and `rehydrateDetachedContainerFromSnapshot()`, corrupting binary payloads.

This change stores detached attachment blobs in a versioned base64 representation while retaining support for legacy UTF-8 snapshots. Regression coverage includes non-UTF-8 and zero bytes, multiple blobs, blob ID/order preservation, rehydration, and attachment in Node and browser paths.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Please focus on the versioned `{ version: 1, blobs: [...] }` wire format and its one-way legacy snapshot compatibility.
