### PR TITLE
build: tag untagged asserts for 2.115.0 release

### DIFF
--- a/packages/common/core-utils/src/math.ts
+++ b/packages/common/core-utils/src/math.ts
@@ -10,6 +10,6 @@ import { assert } from "./assert.js";
  * @internal
  */
 export function clamp(value: number, min: number, max: number): number {
-	assert(min <= max, "clamp requires min <= max");
+	assert(min <= max, 0xd18 /* clamp requires min <= max */);
 	return Math.min(Math.max(value, min), max);
 }

--- a/packages/dds/tree/src/simple-tree/api/treeNodeApi.ts
+++ b/packages/dds/tree/src/simple-tree/api/treeNodeApi.ts
@@ -416,7 +416,10 @@ export function deltaMarksToArrayOpsWithRetain<TRetain extends ArrayNodeRetainOp
 		}
 	}
 	// DeltaMark arrays are allowed to omit the trailing retain, while our user facing array equivalents are not, so add it if necessary.
-	assert(processedLength <= postEditLength, "Array delta exceeds post-edit array length");
+	assert(
+		processedLength <= postEditLength,
+		0xd19 /* Array delta exceeds post-edit array length */,
+	);
 	if (processedLength < postEditLength) {
 		ops.push(buildRetainOp(postEditLength - processedLength, false));
 	}

--- a/packages/dds/tree/src/test/simple-tree/api/treeNodeApi.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/treeNodeApi.spec.ts
@@ -2844,7 +2844,7 @@ describe("treeNodeApi", () => {
 			it("rejects operations beyond the post-edit length", () => {
 				assert.throws(
 					() => deltaMarksToArrayOpsWithRetain([{ count: 2 }], 1, buildRetain),
-					/Array delta exceeds post-edit array length/,
+					validateAssertionError(/Array delta exceeds post-edit array length/),
 				);
 			});
 		});

--- a/packages/framework/quill-react/src/formatted/quillFormattedView.tsx
+++ b/packages/framework/quill-react/src/formatted/quillFormattedView.tsx
@@ -248,7 +248,7 @@ function contentOpsToQuillDelta(
 	if (remainingQuillContent.length > 0) {
 		assert(
 			remainingQuillContent === "\n",
-			"Expected only Quill's mandatory terminal newline to remain",
+			0xd1a /* Expected only Quill's mandatory terminal newline to remain */,
 		);
 		// Delete the extra new line which is required by quill.
 		quillOps.push({ delete: 1 });

--- a/packages/runtime/container-runtime/src/pendingStateManager.ts
+++ b/packages/runtime/container-runtime/src/pendingStateManager.ts
@@ -380,7 +380,7 @@ export class PendingStateManager implements IDisposable {
 		const batchStart = this.pendingMessages.get(
 			this.pendingMessages.length - lastPendingMessage.batchInfo.length,
 		);
-		assert(batchStart !== undefined, "pending batch start message is missing");
+		assert(batchStart !== undefined, 0xd1b /* pending batch start message is missing */);
 		return getEffectiveBatchId(batchStart);
 	}
 

--- a/packages/runtime/container-runtime/src/test/versionMarks/versionMarkResolver.spec.ts
+++ b/packages/runtime/container-runtime/src/test/versionMarks/versionMarkResolver.spec.ts
@@ -10,6 +10,7 @@ import type {
 	IStream,
 	IStreamResult,
 } from "@fluidframework/driver-definitions/internal";
+import { validateAssertionError } from "@fluidframework/test-runtime-utils/internal";
 
 import { generateBatchId, type InboundMessageResult } from "../../opLifecycle/index.js";
 import type { InboundSequencedContainerRuntimeMessage } from "../../messageTypes.js";
@@ -570,7 +571,7 @@ describe("VersionMarkResolver", () => {
 			const resolver = makeResolver({ reader, currentSequenceNumber: 20 });
 			await assert.rejects(
 				async () => resolver.resolve(generateBatchId("missing", 9), 10),
-				/before the requested range start/,
+				validateAssertionError(/before the requested range start/),
 			);
 		});
 	});

--- a/packages/runtime/container-runtime/src/versionMarks/versionMarkResolver.ts
+++ b/packages/runtime/container-runtime/src/versionMarks/versionMarkResolver.ts
@@ -265,7 +265,7 @@ export class VersionMarkResolver implements IVersionMarkResolver {
 		// trim inference below is meaningless, so fail loudly rather than misclassify.
 		assert(
 			firstScannedSequenceNumber === undefined || firstScannedSequenceNumber >= from,
-			"historical op reader returned an op before the requested range start",
+			0xd1c /* historical op reader returned an op before the requested range start */,
 		);
 		const tip = this.hooks.getCurrentSequenceNumber();
 		if (from > tip) {

--- a/packages/runtime/test-runtime-utils/src/assertionShortCodesMap.ts
+++ b/packages/runtime/test-runtime-utils/src/assertionShortCodesMap.ts
@@ -1957,5 +1957,10 @@ export const shortCodeMap = {
 	"0xd14": "id should be defined when loading a container",
 	"0xd15": "Container not detached",
 	"0xd16": "Container failed to attach",
-	"0xd17": "Registry must be a function"
+	"0xd17": "Registry must be a function",
+	"0xd18": "clamp requires min <= max",
+	"0xd19": "Array delta exceeds post-edit array length",
+	"0xd1a": "Expected only Quill's mandatory terminal newline to remain",
+	"0xd1b": "pending batch start message is missing",
+	"0xd1c": "historical op reader returned an op before the requested range start"
 };


### PR DESCRIPTION
## Description

Tags currently untagged asserts so the client 2.115.0 release passes release readiness checks.

This PR must merge before the 2.116.0 version-bump PR.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Confirm the generated assert tags and assertion short-code map updates.