### PR TITLE
build: update compatibility generation for 2.115.0 release

### DIFF
--- a/packages/common/client-utils/package.json
+++ b/packages/common/client-utils/package.json
@@ -259,9 +259,9 @@
 		}
 	},
 	"fluidCompatMetadata": {
-		"generation": 8,
-		"releaseDate": "2026-07-06",
-		"releasePkgVersion": "2.111.0"
+		"generation": 9,
+		"releaseDate": "2026-08-10",
+		"releasePkgVersion": "2.115.0"
 	},
 	"typeValidation": {
 		"broken": {},

--- a/packages/common/client-utils/src/layerGenerationState.ts
+++ b/packages/common/client-utils/src/layerGenerationState.ts
@@ -9,4 +9,4 @@
  * The generation number for Fluid layer compatibility.
  * @internal
  */
-export const generation = 8;
+export const generation = 9;


### PR DESCRIPTION
## Description

Advances `@fluid-internal/client-utils` compatibility layer generation from 8 to 9 for the client 2.115.0 release.

This PR must merge before the 2.116.0 version-bump PR.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Confirm the generated compatibility metadata and layer generation state.