### PR TITLE
fix(historian): accept null storage name in ownership validation

### DIFF
--- a/server/historian/packages/historian-base/src/routes/utils.ts
+++ b/server/historian/packages/historian-base/src/routes/utils.ts
@@ -345,7 +345,7 @@ function validateAlfredDocumentResponse(
 			typeof document.scheduledDeletionTime !== "string") ||
 		(document.isEphemeralContainer !== undefined &&
 			typeof document.isEphemeralContainer !== "boolean") ||
-		(document.storageName !== undefined && typeof document.storageName !== "string")
+		(document.storageName != null && typeof document.storageName !== "string")
 	) {
 		const error = new NetworkError(502, "Invalid document response from Alfred.");
 		logOwnershipOutcome(tenantId, documentId, operation, routeType, "dependencyError", error);

--- a/server/historian/packages/historian-base/src/test/routes.spec.ts
+++ b/server/historian/packages/historian-base/src/test/routes.spec.ts
@@ -9,6 +9,7 @@ import * as sinon from "sinon";
 import request from "supertest";
 import * as nconf from "nconf";
 import { TestThrottler } from "@fluidframework/server-test-utils";
+import type { IDocument } from "@fluidframework/server-services-core";
 import { Lumberjack, TestEngine1 } from "@fluidframework/server-services-telemetry";
 import { configureGlobalTelemetryContext } from "@fluidframework/server-services-utils";
 import * as historianApp from "../app";
@@ -1556,6 +1557,42 @@ describe("summary ownership routes", () => {
 				outcome: "exempted",
 			}),
 		);
+	});
+
+	it("allows a normal summary after initial creation while denying a cross-tenant document", async () => {
+		let document: IDocument | null = null;
+		const readDocument = sandbox
+			.stub(documentManager, "readDocument")
+			.callsFake(async () => document);
+		const createSummary = sandbox
+			.stub(RestGitService.prototype, "createSummary")
+			.resolves({ id: sha });
+
+		await superTest
+			.post(`/repos/${tenantId}/git/summaries`)
+			.query({ initial: "true" })
+			.set("Authorization", authorization)
+			.send({ type: "container", trees: [], blobs: [] })
+			.expect(201);
+
+		document = { ...activeDocument };
+		// MongoDB persists an explicitly undefined optional field as null.
+		Object.assign(document, { storageName: null });
+		await superTest
+			.post(`/repos/${tenantId}/git/summaries`)
+			.set("Authorization", authorization)
+			.send({ type: "container", trees: [], blobs: [] })
+			.expect(201);
+
+		document = { ...document, tenantId: "victim-tenant" };
+		await superTest
+			.post(`/repos/${tenantId}/git/summaries`)
+			.set("Authorization", authorization)
+			.send({ type: "container", trees: [], blobs: [] })
+			.expect(404);
+
+		sinon.assert.callCount(readDocument, 3);
+		sinon.assert.calledTwice(createSummary);
 	});
 
 	for (const testCase of [

--- a/server/historian/packages/historian-base/src/test/routes.spec.ts
+++ b/server/historian/packages/historian-base/src/test/routes.spec.ts
@@ -1595,6 +1595,28 @@ describe("summary ownership routes", () => {
 		sinon.assert.calledTwice(createSummary);
 	});
 
+	it("rejects a non-string storage name from Alfred", async () => {
+		const document = { ...activeDocument };
+		Object.assign(document, { storageName: 123 });
+		sandbox.stub(documentManager, "readDocument").resolves(document);
+		const createSummary = sandbox.stub(RestGitService.prototype, "createSummary");
+		const logError = sandbox.spy(Lumberjack, "error");
+
+		const response = await superTest
+			.post(`/repos/${tenantId}/git/summaries`)
+			.set("Authorization", authorization)
+			.send({ type: "container", trees: [], blobs: [] })
+			.expect(502);
+
+		assert.strictEqual(response.body, "Invalid document response from Alfred.");
+		sinon.assert.notCalled(createSummary);
+		sinon.assert.calledWithMatch(
+			logError,
+			"HistorianSummaryDocumentOwnershipValidation",
+			sinon.match({ operation: "post", outcome: "dependencyError" }),
+		);
+	});
+
 	for (const testCase of [
 		{ name: "active", document: activeDocument },
 		{


### PR DESCRIPTION
[How contribute to this repo](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).

[Guidelines for Pull Requests](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

## Description

MongoDB persists an explicitly present `storageName: undefined` field as `null`, and Alfred returns that stored document unchanged. Historian's ownership validator treated `null` as a malformed Alfred response, causing ordinary non-initial summary uploads to return HTTP 502 before reaching GitRest. Because Scribe received neither a SummaryAck nor SummaryNack, clients waited for the approximately 20-second summary timeout.

Treat `storageName: null` as an absent optional field. Fresh authoritative Alfred ownership validation remains required, and cross-tenant requests continue to receive the non-disclosing HTTP 404 response.

Validation:

- Added a route integration regression covering initial creation, a successful ordinary non-initial summary with Mongo-shaped `storageName: null`, and continued cross-tenant denial.
- Targeted regression test passes.
- Full `historian-base` suite passes: 91/91.
- CI's Docker non-compat leg is the final end-to-end confirmation.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Please verify that accepting `null` is limited to the optional storage name field and does not weaken tenant/document identity or lifecycle validation.
