### PR TITLE
ci(lts): configure the npm registry for npm-based build pipelines

### DIFF
--- a/tools/pipelines/build-benchmark-tool.yml
+++ b/tools/pipelines/build-benchmark-tool.yml
@@ -40,6 +40,8 @@ trigger:
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
+    - tools/pipelines/templates/include-install.yml
+    - tools/pipelines/templates/include-configure-npm-registry.yml
     - tools/pipelines/templates/include-publish-npm-package.yml
     - tools/pipelines/templates/include-publish-npm-package-deployment.yml
     - tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -59,6 +61,8 @@ pr:
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
+    - tools/pipelines/templates/include-install.yml
+    - tools/pipelines/templates/include-configure-npm-registry.yml
 
 variables:
   - template: /tools/pipelines/templates/include-vars.yml@self

--- a/tools/pipelines/build-build-common.yml
+++ b/tools/pipelines/build-build-common.yml
@@ -42,6 +42,8 @@ trigger:
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
+    - tools/pipelines/templates/include-install.yml
+    - tools/pipelines/templates/include-configure-npm-registry.yml
     - tools/pipelines/templates/include-publish-npm-package.yml
     - tools/pipelines/templates/include-publish-npm-package-deployment.yml
     - tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -62,6 +64,8 @@ pr:
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
+    - tools/pipelines/templates/include-install.yml
+    - tools/pipelines/templates/include-configure-npm-registry.yml
 
 variables:
   - template: /tools/pipelines/templates/include-vars.yml@self

--- a/tools/pipelines/build-bundle-size-artifacts.yml
+++ b/tools/pipelines/build-bundle-size-artifacts.yml
@@ -28,6 +28,8 @@ trigger:
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
+    - tools/pipelines/templates/include-install.yml
+    - tools/pipelines/templates/include-configure-npm-registry.yml
     - tools/pipelines/templates/include-publish-npm-package.yml
     - tools/pipelines/templates/include-publish-npm-package-deployment.yml
     - tools/pipelines/templates/include-publish-npm-package-steps.yml

--- a/tools/pipelines/build-bundle-size-tools.yml
+++ b/tools/pipelines/build-bundle-size-tools.yml
@@ -40,6 +40,8 @@ trigger:
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
+    - tools/pipelines/templates/include-install.yml
+    - tools/pipelines/templates/include-configure-npm-registry.yml
     - tools/pipelines/templates/include-publish-npm-package.yml
     - tools/pipelines/templates/include-publish-npm-package-deployment.yml
     - tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -58,6 +60,8 @@ pr:
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
+    - tools/pipelines/templates/include-install.yml
+    - tools/pipelines/templates/include-configure-npm-registry.yml
 
 extends:
   template: templates/build-npm-package.yml

--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -65,6 +65,7 @@ trigger:
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
+    - tools/pipelines/templates/include-configure-npm-registry.yml
     - tools/pipelines/templates/include-publish-npm-package.yml
     - tools/pipelines/templates/include-publish-npm-package-deployment.yml
     - tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -92,6 +93,7 @@ pr:
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
     - tools/pipelines/templates/include-install-pnpm.yml
+    - tools/pipelines/templates/include-configure-npm-registry.yml
 
 schedules:
 - cron: "00 09 * * *" # every day at 9:00 UTC

--- a/tools/pipelines/build-client.yml
+++ b/tools/pipelines/build-client.yml
@@ -64,6 +64,7 @@ trigger:
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
+    - tools/pipelines/templates/include-install.yml
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-configure-npm-registry.yml
     - tools/pipelines/templates/include-publish-npm-package.yml
@@ -92,6 +93,7 @@ pr:
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
+    - tools/pipelines/templates/include-install.yml
     - tools/pipelines/templates/include-install-pnpm.yml
     - tools/pipelines/templates/include-configure-npm-registry.yml
 

--- a/tools/pipelines/build-common-definitions.yml
+++ b/tools/pipelines/build-common-definitions.yml
@@ -42,6 +42,8 @@ trigger:
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
+    - tools/pipelines/templates/include-install.yml
+    - tools/pipelines/templates/include-configure-npm-registry.yml
     - tools/pipelines/templates/include-publish-npm-package.yml
     - tools/pipelines/templates/include-publish-npm-package-deployment.yml
     - tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -62,6 +64,8 @@ pr:
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
+    - tools/pipelines/templates/include-install.yml
+    - tools/pipelines/templates/include-configure-npm-registry.yml
 
 extends:
   template: templates/build-npm-package.yml

--- a/tools/pipelines/build-common-utils.yml
+++ b/tools/pipelines/build-common-utils.yml
@@ -42,6 +42,8 @@ trigger:
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
+    - tools/pipelines/templates/include-install.yml
+    - tools/pipelines/templates/include-configure-npm-registry.yml
     - tools/pipelines/templates/include-publish-npm-package.yml
     - tools/pipelines/templates/include-publish-npm-package-deployment.yml
     - tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -62,6 +64,8 @@ pr:
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
+    - tools/pipelines/templates/include-install.yml
+    - tools/pipelines/templates/include-configure-npm-registry.yml
 
 variables:
   - template: /tools/pipelines/templates/include-vars.yml@self

--- a/tools/pipelines/build-container-definitions.yml
+++ b/tools/pipelines/build-container-definitions.yml
@@ -39,6 +39,8 @@ trigger:
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
+    - tools/pipelines/templates/include-install.yml
+    - tools/pipelines/templates/include-configure-npm-registry.yml
     - tools/pipelines/templates/include-publish-npm-package.yml
     - tools/pipelines/templates/include-publish-npm-package-deployment.yml
     - tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -56,6 +58,8 @@ pr:
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
+    - tools/pipelines/templates/include-install.yml
+    - tools/pipelines/templates/include-configure-npm-registry.yml
 
 extends:
   template: templates/build-npm-package.yml

--- a/tools/pipelines/build-core-interfaces.yml
+++ b/tools/pipelines/build-core-interfaces.yml
@@ -39,6 +39,8 @@ trigger:
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
+    - tools/pipelines/templates/include-install.yml
+    - tools/pipelines/templates/include-configure-npm-registry.yml
     - tools/pipelines/templates/include-publish-npm-package.yml
     - tools/pipelines/templates/include-publish-npm-package-deployment.yml
     - tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -56,6 +58,8 @@ pr:
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
+    - tools/pipelines/templates/include-install.yml
+    - tools/pipelines/templates/include-configure-npm-registry.yml
 
 extends:
   template: templates/build-npm-package.yml

--- a/tools/pipelines/build-driver-definitions.yml
+++ b/tools/pipelines/build-driver-definitions.yml
@@ -39,6 +39,8 @@ trigger:
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
+    - tools/pipelines/templates/include-install.yml
+    - tools/pipelines/templates/include-configure-npm-registry.yml
     - tools/pipelines/templates/include-publish-npm-package.yml
     - tools/pipelines/templates/include-publish-npm-package-deployment.yml
     - tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -56,6 +58,8 @@ pr:
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
+    - tools/pipelines/templates/include-install.yml
+    - tools/pipelines/templates/include-configure-npm-registry.yml
 
 extends:
   template: templates/build-npm-package.yml

--- a/tools/pipelines/build-eslint-config-fluid.yml
+++ b/tools/pipelines/build-eslint-config-fluid.yml
@@ -42,6 +42,8 @@ trigger:
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
+    - tools/pipelines/templates/include-install.yml
+    - tools/pipelines/templates/include-configure-npm-registry.yml
     - tools/pipelines/templates/include-publish-npm-package.yml
     - tools/pipelines/templates/include-publish-npm-package-deployment.yml
     - tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -62,6 +64,8 @@ pr:
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
+    - tools/pipelines/templates/include-install.yml
+    - tools/pipelines/templates/include-configure-npm-registry.yml
 
 variables:
   - template: /tools/pipelines/templates/include-vars.yml@self

--- a/tools/pipelines/build-protocol-definitions.yml
+++ b/tools/pipelines/build-protocol-definitions.yml
@@ -42,6 +42,8 @@ trigger:
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
+    - tools/pipelines/templates/include-install.yml
+    - tools/pipelines/templates/include-configure-npm-registry.yml
     - tools/pipelines/templates/include-publish-npm-package.yml
     - tools/pipelines/templates/include-publish-npm-package-deployment.yml
     - tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -62,6 +64,8 @@ pr:
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
+    - tools/pipelines/templates/include-install.yml
+    - tools/pipelines/templates/include-configure-npm-registry.yml
 
 variables:
   - template: /tools/pipelines/templates/include-vars.yml@self

--- a/tools/pipelines/build-test-tools.yml
+++ b/tools/pipelines/build-test-tools.yml
@@ -40,6 +40,8 @@ trigger:
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
+    - tools/pipelines/templates/include-install.yml
+    - tools/pipelines/templates/include-configure-npm-registry.yml
     - tools/pipelines/templates/include-publish-npm-package.yml
     - tools/pipelines/templates/include-publish-npm-package-deployment.yml
     - tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -58,6 +60,8 @@ pr:
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
+    - tools/pipelines/templates/include-install.yml
+    - tools/pipelines/templates/include-configure-npm-registry.yml
 
 variables:
   - template: /tools/pipelines/templates/include-vars.yml@self

--- a/tools/pipelines/build-tinylicious.yml
+++ b/tools/pipelines/build-tinylicious.yml
@@ -41,6 +41,8 @@ trigger:
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
+    - tools/pipelines/templates/include-install.yml
+    - tools/pipelines/templates/include-configure-npm-registry.yml
     - tools/pipelines/templates/include-publish-npm-package.yml
     - tools/pipelines/templates/include-publish-npm-package-deployment.yml
     - tools/pipelines/templates/include-publish-npm-package-steps.yml
@@ -61,6 +63,8 @@ pr:
     - tools/pipelines/templates/build-npm-package.yml
     - tools/pipelines/templates/include-set-package-version.yml
     - tools/pipelines/templates/include-vars.yml
+    - tools/pipelines/templates/include-install.yml
+    - tools/pipelines/templates/include-configure-npm-registry.yml
 
 extends:
   template: templates/build-npm-package.yml

--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -289,13 +289,6 @@ extends:
           displayName: Use Node 20.15.1
           inputs:
             version: 20.15.1
-        - task: Npm@1
-          displayName: Install npm 10
-          retryCountOnTaskFailure: 4
-          inputs:
-            command: 'custom'
-            customCommand: 'install --global npm@^10'
-            customRegistry: 'useNpmrc'
 
         # Install pnpm
         - template: /tools/pipelines/templates/include-install.yml@self

--- a/tools/pipelines/templates/include-configure-npm-registry.yml
+++ b/tools/pipelines/templates/include-configure-npm-registry.yml
@@ -1,0 +1,57 @@
+# Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+# Licensed under the MIT License.
+
+# include-configure-npm-registry
+#
+# Points npm at the primary Azure Artifacts registry and authenticates against it. The registry is written to a
+# user-level .npmrc whose path is exported as NPM_CONFIG_USERCONFIG, so every later step in the job inherits it.
+# This is required for any pipeline that installs packages, not just the ones that use pnpm, because the repo's
+# .npmrc does not set a registry and npm would otherwise fall back to the public registry.
+
+parameters:
+# The path containing the project(s) to build.
+- name: buildDirectory
+  type: string
+
+# Where to place the user-level .npmrc file. It is referenced for the duration of the job.
+# Rather than rely on the default $HOME/.npmrc, we specify a known-reasonable location here.
+# Users of the template probably don't need to change this.
+- name: userNpmrcPath
+  type: string
+  default: $(Agent.TempDirectory)/.npmrc
+
+steps:
+# Seed the userconfig .npmrc with the primary registry. This propagates to subsequent tasks so
+# that npmAuthenticate (below) and any later pnpm/npm invocation in the job reuse the same file.
+- task: Bash@3
+  displayName: Configure npm registry
+  # A preceding cache restoration task can timeout, which is classified as canceled, but since it's just cache
+  # restoration, we want to continue even if it timed out.
+  condition: or(succeeded(), canceled())
+  inputs:
+    targetType: 'inline'
+    workingDirectory: ${{ parameters.buildDirectory }}
+    script: |
+      set -eu -o pipefail
+      echo "Using node $(node --version)"
+      # This ensures all subsequent tasks in this job will use the npm configuration set here.
+      echo "##vso[task.setvariable variable=NPM_CONFIG_USERCONFIG]$NPM_CONFIG_USERCONFIG"
+      echo "Primary registry: ${NPM_REGISTRY}"
+      echo "registry=${NPM_REGISTRY}" > "$NPM_CONFIG_USERCONFIG"
+      if [ "${NPM_REGISTRY}" == "https://registry.npmjs.org/" ]; then
+        echo "##vso[task.setvariable variable=registryType]public"
+      else
+        echo "##vso[task.setvariable variable=registryType]private"
+      fi
+  env:
+    NPM_REGISTRY: $(ado-feeds-primary-registry)
+    NPM_CONFIG_USERCONFIG: ${{ parameters.userNpmrcPath}}
+
+# Authenticate to the npm feed if required. Runs before any package manager is installed so that
+# `npm install -g <package manager>` can fetch it from the authenticated feed.
+- task: npmAuthenticate@0
+  displayName: 'Npm authenticate'
+  condition: and(succeeded(), eq(variables['registryType'], 'private'))
+  retryCountOnTaskFailure: 1
+  inputs:
+    workingFile: ${{ parameters.userNpmrcPath }}

--- a/tools/pipelines/templates/include-install-pnpm.yml
+++ b/tools/pipelines/templates/include-install-pnpm.yml
@@ -41,40 +41,12 @@ steps:
       restoreKeys: |
         pnpm-store | "$(Agent.OS)"
 
-# Seed the userconfig .npmrc with the primary registry. This propagates to subsequent tasks so
-# that npmAuthenticate (below) and any later pnpm/npm invocation in the job reuse the same file.
-- task: Bash@3
-  displayName: Configure npm registry
-  # The previous task (cache restoration) can timeout, which is classified as canceled, but since it's just cache
-  # restoration, we want to continue even if it timed out.
-  condition: or(succeeded(), canceled())
-  inputs:
-    targetType: 'inline'
-    workingDirectory: ${{ parameters.buildDirectory }}
-    script: |
-      set -eu -o pipefail
-      echo "Using node $(node --version)"
-      # This ensures all subsequent tasks in this job will use the npm configuration set here.
-      echo "##vso[task.setvariable variable=NPM_CONFIG_USERCONFIG]$NPM_CONFIG_USERCONFIG"
-      echo "Primary registry: ${NPM_REGISTRY}"
-      echo "registry=${NPM_REGISTRY}" > "$NPM_CONFIG_USERCONFIG"
-      if [ "${NPM_REGISTRY}" == "https://registry.npmjs.org/" ]; then
-        echo "##vso[task.setvariable variable=registryType]public"
-      else
-        echo "##vso[task.setvariable variable=registryType]private"
-      fi
-  env:
-    NPM_REGISTRY: $(ado-feeds-primary-registry)
-    NPM_CONFIG_USERCONFIG: ${{ parameters.userNpmrcPath}}
-
-# Authenticate to the npm feed if required. Runs before pnpm is installed so that
-# `npm install -g pnpm@<version>` can fetch pnpm itself from the authenticated feed.
-- task: npmAuthenticate@0
-  displayName: 'Npm authenticate'
-  condition: and(succeeded(), eq(variables['registryType'], 'private'))
-  retryCountOnTaskFailure: 1
-  inputs:
-    workingFile: ${{ parameters.userNpmrcPath }}
+# Point npm at the authenticated feed before installing pnpm, so that `npm install -g pnpm@<version>` can
+# fetch pnpm itself from that feed.
+- template: /tools/pipelines/templates/include-configure-npm-registry.yml@self
+  parameters:
+    buildDirectory: ${{ parameters.buildDirectory }}
+    userNpmrcPath: ${{ parameters.userNpmrcPath }}
 
 - task: Bash@3
   displayName: Install pnpm

--- a/tools/pipelines/templates/include-install.yml
+++ b/tools/pipelines/templates/include-install.yml
@@ -14,8 +14,15 @@ parameters:
   type: string
 
 steps:
+  # Both branches configure the npm registry. The pnpm template does it itself, since it needs an authenticated
+  # feed to install pnpm from; npm-based pipelines need it here so that dependency installs and the later global
+  # build-tools installs resolve against the feed rather than the public registry.
   - ${{ if eq(parameters.packageManager, 'pnpm') }}:
     - template: /tools/pipelines/templates/include-install-pnpm.yml@self
+      parameters:
+        buildDirectory: ${{ parameters.buildDirectory }}
+  - ${{ else }}:
+    - template: /tools/pipelines/templates/include-configure-npm-registry.yml@self
       parameters:
         buildDirectory: ${{ parameters.buildDirectory }}
 


### PR DESCRIPTION
## Description

Fixes two pre-existing CI failures on `lts` that prevent the package build pipelines from running, and closes the trigger gap that let them go unnoticed. Follow-up to #27875, which fixed the same class of problem for pnpm installs.

## Changes

**New** `templates/include-configure-npm-registry.yml`, holding the `Configure npm registry` and `Npm authenticate` steps lifted verbatim from `include-install-pnpm.yml`. They write the authenticated `.npmrc` and export `NPM_CONFIG_USERCONFIG` as a job variable.

`include-install.yml` now runs it for npm pipelines too. It previously only reached those steps through `include-install-pnpm.yml`, which is included only when `packageManager` is `pnpm`. `build-client.yml` is the only pipeline that sets that, so the other fourteen consumers of `build-npm-package.yml` ran npm with no registry configured, and the repo `.npmrc` sets none, leaving them pointed at the public registry. The global `@fluid-tools/build-cli` installs in `include-set-package-version.yml` inherit the job variable without changes there.

Drops the `Install npm 10` task from `build-npm-package.yml`. It was a no-op, since the job pins Node 20.15.1 which already bundles npm 10.7.0, and it ran before anything configured npm. `main` has no equivalent step.

Adds both install templates to the trigger and PR path filters of the pipelines consuming `build-npm-package.yml`. They already enumerate their template dependencies, but the install path was missing from all of them, which is why these failures sat undetected.

## Reviewer guidance

Verified on `Build - build-common`, the pipeline that failed on #27874: it now passes and resolves against the `publicPackages` feed instead of `registry.npmjs.org`.

`build-docs-site.yml` is deliberately left out of the path filter change, along with `build-docs.yml` and `templates/build-docker-service.yml`. Those last two still carry their own `Install npm 10` pointed at the public registry — same latent problem, reasonable follow-up.

`main` sidesteps the registry problem differently, by defaulting `buildToolsVersionToInstall` to `repo` so build-tools is built from source with pnpm rather than installed globally from npm. Porting that is a much larger change and deliberately out of scope.

The extracted steps are byte-identical to the originals apart from two comments, and `include-install-pnpm.yml` still runs them in the same position, so the pnpm path is unchanged for its other callers.