### PR TITLE
improvement(website): Make `ApiLink` able to automatically determine API item kind

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -64,6 +64,38 @@ To include repo-local API documentation when building the site locally, you will
 So long as the `LOCAL_API_DOCS` environment variable is set to `true`, local API documentation will be included when building the site.
 To remove the local API docs, simply remove the above variable or set it to `false`, `npm run clean` and rebuild as needed.
 
+## Testing
+
+The website has two complementary test suites:
+
+-   **Unit tests** use [Vitest](https://vitest.dev/) and live under `test/unit`.
+    Use these for isolated components, utilities, data transformations, and error handling that do not require a browser or a complete website build.
+    Unit tests should generally be preferred when either test flavor can cover the behavior because they run quickly and make failures easier to diagnose.
+-   **Site tests** use [Playwright](https://playwright.dev/) and live under `test/site-tests`.
+    Use these for browser-visible behavior, navigation, accessibility, layout, search, and workflows that cross component or page boundaries.
+    Playwright serves the previously built static site, so run `pnpm run build:site` before running site tests when the build output is not current.
+
+Run only the unit tests with:
+
+```shell
+pnpm run test:unit
+```
+
+Run only the site tests with:
+
+```shell
+pnpm run test:site
+```
+
+Run both suites with:
+
+```shell
+pnpm test
+```
+
+The aggregate command installs Playwright's browser dependencies before running the suites.
+`pnpm run build:test` type-checks all test code without executing it.
+
 ## User Telemetry
 
 The Fluid Framework website collects basic user telemetry to help improve the experience for our users.

--- a/website/README.md
+++ b/website/README.md
@@ -326,7 +326,9 @@ The following npm scripts are supported in this directory:
 | `prestart` | Runs pre-site build metadata generation. |
 | `start` | Runs the website in watch mode with Docusaurus. |
 | `pretest` | Install necessary `playwright` dependencies before running tests. |
-| `test` | Run tests using `playwright` |
+| `test` | Run all tests (`playwright` UX tests and `vitest` unit tests) |
+| `test:site` | Run UX tests using `playwright` |
+| `test:unit` | Run unit tests using `vitest` |
 
 <!-- prettier-ignore-end -->
 

--- a/website/docs/build/container-states-events.mdx
+++ b/website/docs/build/container-states-events.mdx
@@ -99,7 +99,7 @@ But the new container has a different ID from the deleted one and subsequent cli
 
 #### Handling publication status
 
-Your code can test for the publication status with the <ApiLink packageName="fluid-framework" apiName="IFluidContainer" apiType="Interface" headingId="attachstate-propertysignature">container.AttachState</ApiLink> property which has an <ApiLink packageName="fluid-framework" apiName="AttachState" apiType="Enum">AttachState</ApiLink> value.
+Your code can test for the publication status with the <ApiLink packageName="fluid-framework" apiName="IFluidContainer" headingId="attachstate-propertysignature">container.AttachState</ApiLink> property which has an <ApiLink packageName="fluid-framework" apiName="AttachState">AttachState</ApiLink> value.
 This can be useful if your application will publish the container in some code paths on the creating client, but not others.
 For example, on the creating computer, you don't want to call `container.attach` if it has already been called. In simple cases, you can know at coding time if that has happened, but when the creating client in complex code flows and calls of `container.attach` appear in more than one branch, you may need to test for this possibility. The following is a simple example.
 
@@ -269,7 +269,7 @@ The container transitions to this state automatically when it is fully caught up
 
 There are scenarios in which you need to control the connection status of the container. To assist, the `container` object has the following APIs:
 
--   A <ApiLink packageName="fluid-framework" apiName="IFluidContainer" apiType="Interface" headingId="connectionstate-propertysignature">container.connectionState</ApiLink> property of type `ConnectionState`. There are four possible values for the property:
+-   A <ApiLink packageName="fluid-framework" apiName="IFluidContainer" headingId="connectionstate-propertysignature">container.connectionState</ApiLink> property of type `ConnectionState`. There are four possible values for the property:
 
     -   `Disconnected`
     -   `EstablishingConnection`: Your code should treat this state the same as it treats the disconnected state. See [Examples](#examples).

--- a/website/docs/build/containers.mdx
+++ b/website/docs/build/containers.mdx
@@ -8,7 +8,7 @@ import { ApiLink, PackageLink } from "@site/src/components/shortLinks";
 The container is the primary unit of encapsulation in the Fluid Framework.
 It enables a group of clients to access the same set of shared objects and co-author changes on those objects.
 It is also a permission boundary ensuring visibility and access only to permitted clients.
-A container is represented by the <ApiLink packageName="fluid-framework" apiName="IFluidContainer" apiType="Interface">FluidContainer</ApiLink> type and consists of a collection of shared objects and APIs to manage the life cycle of those objects.
+A container is represented by the <ApiLink packageName="fluid-framework" apiName="IFluidContainer">FluidContainer</ApiLink> type and consists of a collection of shared objects and APIs to manage the life cycle of those objects.
 
 This article explains:
 

--- a/website/docs/build/experimental-features.mdx
+++ b/website/docs/build/experimental-features.mdx
@@ -30,7 +30,7 @@ When a [container](./containers.mdx) is loaded, there will be several events log
 
 The following is an example of how to enable experimental features with `AzureClient`.
 
-1. First, implement <ApiLink packageName="core-interfaces" apiName="IConfigProviderBase" apiType="Interface" />. For example:
+1. First, implement <ApiLink packageName="core-interfaces" apiName="IConfigProviderBase" />. For example:
 
     ```typescript
     const configProvider = (settings: Record<string, ConfigTypes>): IConfigProviderBase => ({

--- a/website/docs/start/tree-start.mdx
+++ b/website/docs/start/tree-start.mdx
@@ -23,7 +23,7 @@ npm install fluid-framework@latest
 A `SharedTree` can be created by defining a `ContainerSchema` with an initial object of type `SharedTree` and using this schema to create and load your container.
 This example creates a container using an Azure specific client.
 
-**note**: `enableRuntimeIdCompressor` must be enabled in the <ApiLink packageName="container-runtime" apiName="IContainerRuntimeOptions" apiType="TypeAlias">container runtime options</ApiLink> in order to use `SharedTree`
+**note**: `enableRuntimeIdCompressor` must be enabled in the <ApiLink packageName="container-runtime" apiName="IContainerRuntimeOptions">container runtime options</ApiLink> in order to use `SharedTree`
 
 See more info on creating and loading containers [here](../build/containers.mdx#creating-a-container).
 
@@ -93,7 +93,7 @@ This creates a `TodoList` class that is an object schema with two fields, `title
 
 Schemas can also be defined using plain old JavaScript object (POJO) mode.
 Generally, you should prefer customizable mode.
-See <ApiLink packageName="fluid-framework" apiName="SchemaFactory" apiType="Class">the API docs</ApiLink> for more info on the differences between the two modes.
+See <ApiLink packageName="fluid-framework" apiName="SchemaFactory">the API docs</ApiLink> for more info on the differences between the two modes.
 
 ## Initializing the Tree
 
@@ -159,7 +159,7 @@ useEffect(() => {
 
 `nodeChanged` fires whenever one or more properties of the specified node change while `treeChanged` also fires whenever any node in its subtree changes.
 
-See <ApiLink packageName="fluid-framework" apiName="TreeChangeEvents" apiType="Interface">the API</ApiLink> docs for more details.
+See <ApiLink packageName="fluid-framework" apiName="TreeChangeEvents">the API</ApiLink> docs for more details.
 
 ## Editing Tree Data
 

--- a/website/docs/testing/telemetry.mdx
+++ b/website/docs/testing/telemetry.mdx
@@ -32,12 +32,7 @@ The `Loader` constructor is called by both `createContainer()` and `getContainer
 interface as its constructor argument. `ILoaderProps` interface has an optional logger parameter that will take the
 `ITelemetryBaseLogger` defined by the user.
 
-<ApiLink
-	packageName="container-loader"
-	apiName="ILoaderProps"
-	apiType="interface"
-	headingId="logger-propertysignature"
->
+<ApiLink packageName="container-loader" apiName="ILoaderProps" headingId="logger-propertysignature">
 	ILoaderProps.logger
 </ApiLink>
 is used by `Loader` to pipe to container's telemetry system.

--- a/website/package.json
+++ b/website/package.json
@@ -45,7 +45,9 @@
 		"prestart": "npm run generate-versions",
 		"start": "docusaurus start",
 		"pretest": "playwright install --with-deps",
-		"test": "playwright test"
+		"test": "npm run test:unit && npm run test:site",
+		"test:site": "playwright test",
+		"test:unit": "vitest run"
 	},
 	"browserslist": {
 		"production": [
@@ -109,7 +111,8 @@
 		"simple-git": "^3.36.0",
 		"start-server-and-test": "^2.0.8",
 		"typescript": "~5.5.4",
-		"uuid": "^11.0.3"
+		"uuid": "^11.0.3",
+		"vitest": "^4.1.10"
 	},
 	"packageManager": "pnpm@11.15.1+sha512.81350b07e53c9538a02f1f2303b4290fa2d7be04e56e2a970c4cc4b417dc761de196edabd49d55c7dc9580db81007c44143e4e3d7e462b3000d23c255122d065",
 	"engines": {

--- a/website/playwright.config.ts
+++ b/website/playwright.config.ts
@@ -11,6 +11,7 @@ const frontEndUrl = `http://localhost:${frontendPort}`;
 export default defineConfig({
 	// Look for test files in the "test" directory, relative to this configuration file.
 	testDir: "test",
+	testMatch: "site-tests/**/*.spec.ts",
 
 	// Fail the build on CI if you accidentally left test.only in the source code.
 	forbidOnly: !!process.env.CI,

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -54,7 +54,7 @@ importers:
         version: 2.0.1(debug@4.3.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@docusaurus/core':
         specifier: ^3.10.2
-        version: 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
+        version: 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
       '@docusaurus/eslint-plugin':
         specifier: ^3.10.2
         version: 3.10.2(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.5.4)
@@ -63,16 +63,16 @@ importers:
         version: 3.10.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
       '@docusaurus/plugin-content-docs':
         specifier: ^3.10.2
-        version: 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
+        version: 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
       '@docusaurus/preset-classic':
         specifier: ^3.10.2
-        version: 3.10.2(@algolia/client-search@5.56.0)(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(@types/react@18.3.31)(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(supports-color@8.1.1)(typescript@5.5.4)
+        version: 3.10.2(@algolia/client-search@5.56.0)(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(@types/react@18.3.31)(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(supports-color@8.1.1)(typescript@5.5.4)
       '@docusaurus/theme-common':
         specifier: ^3.10.2
-        version: 3.10.2(@docusaurus/plugin-content-docs@3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4))(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
+        version: 3.10.2(@docusaurus/plugin-content-docs@3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4))(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
       '@docusaurus/theme-mermaid':
         specifier: ^3.10.2
-        version: 3.10.2(@docusaurus/plugin-content-docs@3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4))(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
+        version: 3.10.2(@docusaurus/plugin-content-docs@3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4))(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
       '@docusaurus/tsconfig':
         specifier: ^3.10.2
         version: 3.10.2
@@ -132,7 +132,7 @@ importers:
         version: 0.1.3(supports-color@8.1.1)(typescript@5.5.4)
       docusaurus-plugin-sass:
         specifier: ^0.2.5
-        version: 0.2.5(@docusaurus/core@3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4))(sass@1.81.0)(webpack@5.96.1)
+        version: 0.2.5(@docusaurus/core@3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4))(sass@1.81.0)(webpack@5.96.1)
       dompurify:
         specifier: ^3.2.6
         version: 3.2.6
@@ -199,6 +199,9 @@ importers:
       uuid:
         specifier: ^11.1.1
         version: 11.1.1
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@22.19.17)(vite@8.2.1(@types/node@22.19.17)(jiti@1.21.6)(sass@1.81.0)(terser@5.36.0)(yaml@2.6.1))
 
 packages:
 
@@ -1607,6 +1610,9 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.0':
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
 
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
@@ -1873,6 +1879,9 @@ packages:
     resolution: {integrity: sha512-mDYOl8RmldLkOg9i9YKgyBlpcyi/bNySoIVHJ2EJd2qCmZaXRKQKRW2Zkx92bwjik8jfs/A3EFI+p4DsrXi57g==}
     engines: {node: '>=18.0.0'}
 
+  '@oxc-project/types@0.143.0':
+    resolution: {integrity: sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==}
+
   '@pagefind/darwin-arm64@1.5.2':
     resolution: {integrity: sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ==}
     cpu: [arm64]
@@ -2061,6 +2070,99 @@ packages:
   '@polka/url@1.0.0-next.28':
     resolution: {integrity: sha512-8LduaNlMZGwdZ6qWrKlfa+2M4gahzFkprZiAt2TF8uS0qQgBizKXpXURqvTJ4WtmupWxaLqjRb2UCTe72mu+Aw==}
 
+  '@rolldown/binding-android-arm64@1.2.3':
+    resolution: {integrity: sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.2.3':
+    resolution: {integrity: sha512-ieIiibVCp0tX7TLu2cafoNPv8wJyYi01ekXpbf8q2j7F4rGAhhXb/eQh7ge9DRBY78GwmRQtvjZDux7EDbA8kA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.2.3':
+    resolution: {integrity: sha512-Zh9tCon19eDXJoihx0rqKhMUlMYqzwj3aPsSuHmI4RWZh62dWUL+DJN4C5YQya5TcQBJU/Fe8+rY0jhXTQITqA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.2.3':
+    resolution: {integrity: sha512-nGbJWewA1wrXXZiQhjAT5rhibGfns5ZNkDVqxsO6zJ3f3YvpoDNNmGMSbbhLuXKjNScaBJVOAboztAWVespQMg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.3':
+    resolution: {integrity: sha512-QNniJr5Kml0kDEB98jiDOJjXNroxIIi0IXIbdYzY26Xt1pVbeP62+KnoIZLwirOymX/0jDk/2gI/bNUv7A7OIw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.3':
+    resolution: {integrity: sha512-TkqEAcmmvH3I/q4114NB4RVt6241Dao48pF45uLcFGrwAaIn0iITgTAKP/dLjbN0R4buJjGb91+UHSoFmpgIWw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.2.3':
+    resolution: {integrity: sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.3':
+    resolution: {integrity: sha512-6tbrbwfz5GB9DQ4Jwo6hy9v+vR31xZlvzZ6n5Xut6Hhx5PvrA9q/HsK8KMaYQp063iqZGXwNvZtYNLD7EM/x0w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.3':
+    resolution: {integrity: sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.2.3':
+    resolution: {integrity: sha512-TytMwF2KVGqP2tgd0I1OY0PAv78dZRAYcF5ssDzjM34SUXCED3uXvSd5+lHoC0bTD6eEdFz7LdQNCO1y0oVk9w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.2.3':
+    resolution: {integrity: sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.2.3':
+    resolution: {integrity: sha512-Kr0OcsoQI816i6HOl3vFHpd1K0eZyh76zgfj4c1nTyaTsd5r2Mj1lwM4R90y/qaCfmTn9eHy0SKwi98eitRxug==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-win32-arm64-msvc@1.2.3':
+    resolution: {integrity: sha512-hOtMwTqnME+/gJcH/PCZ0wn0zPUjiWOgkHpxbSJpfGKMezHltx1S7/k1SitzVa7Ww2cqrDDaFbZEhcJZO8o+Jw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.2.3':
+    resolution: {integrity: sha512-ekcqMMkI2PlhYnfzQnB/cEdYUVVJViWvoUyLrbzgDoi3Snfc1mVBwdnc306ufA5ejy8JSPjT2RlW1nQSjW7efg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
   '@rushstack/eslint-patch@1.12.0':
     resolution: {integrity: sha512-5EwMtOqvJMMa3HbmxLlF74e+3/HhwBTMcvt3nqVJgGCozO6hzIPOBlwm8mGVNR9SN2IJpxSnlxczyDjcn7qIyw==}
 
@@ -2136,6 +2238,9 @@ packages:
 
   '@slorber/remark-comment@1.0.0':
     resolution: {integrity: sha512-RCE24n7jsOj1M0UPvIQCHTe7fI0sFL4S2nwKVWwHyVr/wI/H8GosgsJGyhnsZoGFnD/P2hLf1mSbrrgSLN93NA==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0':
     resolution: {integrity: sha512-b9MIk7yhdS1pMCZM8VeNfUlSKVRhsHZNMl5O9SfaX0l0t5wjdgu4IDzGB8bpnGBBOjGST3rRFVsaaEtI4W6f7g==}
@@ -2274,6 +2379,9 @@ packages:
   '@types/bonjour@3.5.13':
     resolution: {integrity: sha512-z9fJ5Im06zvUL548KvYNecEVlA7cVDkGUi6kZusb04mpyEFKCIZJvloCcmpmLaIahDpOQGHaHmG6imtPMmPXGQ==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/concat-stream@1.6.1':
     resolution: {integrity: sha512-eHE4cQPoj6ngxBZMvVf6Hw7Mh4jMW4U9lpGmS5GBPB9RYxlFg+CHaVN7ErNY4W9XfLIEn20b4VDYaIrbq0q4uA==}
 
@@ -2387,6 +2495,9 @@ packages:
 
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/eslint-scope@3.7.7':
     resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
@@ -2801,6 +2912,35 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
 
@@ -3043,6 +3183,10 @@ packages:
   asn1js@3.0.10:
     resolution: {integrity: sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==}
     engines: {node: '>=12.0.0'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   astring@1.9.0:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
@@ -3294,6 +3438,10 @@ packages:
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -4293,6 +4441,9 @@ packages:
   es-module-lexer@1.5.4:
     resolution: {integrity: sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==}
 
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -4581,6 +4732,10 @@ packages:
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   express@4.22.1:
     resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
@@ -5796,6 +5951,80 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
+  lightningcss-android-arm64@1.33.0:
+    resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.33.0:
+    resolution: {integrity: sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.33.0:
+    resolution: {integrity: sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.33.0:
+    resolution: {integrity: sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    resolution: {integrity: sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    resolution: {integrity: sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.33.0:
+    resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.33.0:
+    resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.33.0:
+    resolution: {integrity: sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.33.0:
+    resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
+    engines: {node: '>= 12.0.0'}
+
   lilconfig@3.1.2:
     resolution: {integrity: sha512-eop+wDAvpItUys0FWkHIKeC9ybYrTGbU41U5K7+bttZZeohvnY7M9dZ5kB21GNWiFT2q1OoPTvncPCgSOVO5ow==}
     engines: {node: '>=14'}
@@ -5927,6 +6156,9 @@ packages:
 
   lunr@2.3.9:
     resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   make-dir@1.3.0:
     resolution: {integrity: sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==}
@@ -6525,6 +6757,10 @@ packages:
 
   obuf@1.1.2:
     resolution: {integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==}
+
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
 
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
@@ -7652,6 +7888,11 @@ packages:
   robust-predicates@3.0.2:
     resolution: {integrity: sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==}
 
+  rolldown@1.2.3:
+    resolution: {integrity: sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   roughjs@4.6.6:
     resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
 
@@ -7869,6 +8110,9 @@ packages:
     resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -7980,6 +8224,9 @@ packages:
     resolution: {integrity: sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ==}
     engines: {node: '>=12.0.0'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   start-server-and-test@2.0.8:
     resolution: {integrity: sha512-v2fV6NV2F7tL1ocwfI4Wpait+IKjRbT5l3ZZ+ZikXdMLmxYsS8ynGAsCQAUVXkVyGyS+UibsRnvgHkMvJIvCsw==}
     engines: {node: '>=16'}
@@ -7995,6 +8242,9 @@ packages:
 
   std-env@3.8.0:
     resolution: {integrity: sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w==}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -8228,16 +8478,31 @@ packages:
   tiny-warning@1.0.3:
     resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@1.0.1:
     resolution: {integrity: sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==}
+
+  tinyexec@1.3.0:
+    resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
+    engines: {node: '>=18'}
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
   tinypool@1.1.1:
     resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
     engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@3.1.1:
+    resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
+    engines: {node: '>=14.0.0'}
 
   tmp@0.2.7:
     resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
@@ -8619,6 +8884,90 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
+  vite@8.2.1:
+    resolution: {integrity: sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.4.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vscode-jsonrpc@8.2.0:
     resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
     engines: {node: '>=14.0.0'}
@@ -8775,6 +9124,11 @@ packages:
   which@4.0.0:
     resolution: {integrity: sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==}
     engines: {node: ^16.13.0 || >=18.0.0}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   widest-line@3.1.0:
@@ -9291,7 +9645,7 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.29.7
       '@babel/helper-validator-option': 7.29.7
-      browserslist: 4.24.2
+      browserslist: 4.28.7
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -10375,7 +10729,7 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/bundler@3.10.2(acorn@8.15.0)(csso@5.0.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)':
+  '@docusaurus/bundler@3.10.2(acorn@8.15.0)(csso@5.0.5)(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@docusaurus/babel': 3.10.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
@@ -10387,7 +10741,7 @@ snapshots:
       clean-css: 5.3.3
       copy-webpack-plugin: 11.0.0(webpack@5.96.1)
       css-loader: 6.11.0(webpack@5.96.1)
-      css-minimizer-webpack-plugin: 5.0.1(clean-css@5.3.3)(csso@5.0.5)(webpack@5.96.1)
+      css-minimizer-webpack-plugin: 5.0.1(clean-css@5.3.3)(csso@5.0.5)(lightningcss@1.33.0)(webpack@5.96.1)
       cssnano: 6.1.2(postcss@8.5.26)
       file-loader: 6.2.0(webpack@5.96.1)
       html-minifier-terser: 7.2.0
@@ -10417,10 +10771,10 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/core@3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)':
+  '@docusaurus/core@3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)':
     dependencies:
       '@docusaurus/babel': 3.10.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
-      '@docusaurus/bundler': 3.10.2(acorn@8.15.0)(csso@5.0.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
+      '@docusaurus/bundler': 3.10.2(acorn@8.15.0)(csso@5.0.5)(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
       '@docusaurus/logger': 3.10.2
       '@docusaurus/mdx-loader': 3.10.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
       '@docusaurus/utils': 3.10.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
@@ -10557,13 +10911,13 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/plugin-content-blog@3.10.2(@docusaurus/plugin-content-docs@3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4))(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)':
+  '@docusaurus/plugin-content-blog@3.10.2(@docusaurus/plugin-content-docs@3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4))(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)':
     dependencies:
-      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
+      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
       '@docusaurus/logger': 3.10.2
       '@docusaurus/mdx-loader': 3.10.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
-      '@docusaurus/plugin-content-docs': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
-      '@docusaurus/theme-common': 3.10.2(@docusaurus/plugin-content-docs@3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4))(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
+      '@docusaurus/plugin-content-docs': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
+      '@docusaurus/theme-common': 3.10.2(@docusaurus/plugin-content-docs@3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4))(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
       '@docusaurus/types': 3.10.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
       '@docusaurus/utils': 3.10.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
       '@docusaurus/utils-common': 3.10.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
@@ -10600,13 +10954,13 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-content-docs@3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)':
+  '@docusaurus/plugin-content-docs@3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)':
     dependencies:
-      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
+      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
       '@docusaurus/logger': 3.10.2
       '@docusaurus/mdx-loader': 3.10.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
       '@docusaurus/module-type-aliases': 3.10.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
-      '@docusaurus/theme-common': 3.10.2(@docusaurus/plugin-content-docs@3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4))(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
+      '@docusaurus/theme-common': 3.10.2(@docusaurus/plugin-content-docs@3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4))(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
       '@docusaurus/types': 3.10.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
       '@docusaurus/utils': 3.10.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
       '@docusaurus/utils-common': 3.10.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
@@ -10641,9 +10995,9 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-content-pages@3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)':
+  '@docusaurus/plugin-content-pages@3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)':
     dependencies:
-      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
+      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
       '@docusaurus/mdx-loader': 3.10.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
       '@docusaurus/types': 3.10.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
       '@docusaurus/utils': 3.10.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
@@ -10672,9 +11026,9 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-css-cascade-layers@3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)':
+  '@docusaurus/plugin-css-cascade-layers@3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)':
     dependencies:
-      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
+      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
       '@docusaurus/types': 3.10.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
       '@docusaurus/utils': 3.10.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
       '@docusaurus/utils-validation': 3.10.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
@@ -10700,9 +11054,9 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-debug@3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)':
+  '@docusaurus/plugin-debug@3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)':
     dependencies:
-      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
+      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
       '@docusaurus/types': 3.10.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
       '@docusaurus/utils': 3.10.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
       fs-extra: 11.3.2
@@ -10729,9 +11083,9 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-google-analytics@3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)':
+  '@docusaurus/plugin-google-analytics@3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)':
     dependencies:
-      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
+      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
       '@docusaurus/types': 3.10.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
       '@docusaurus/utils-validation': 3.10.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
       react: 18.3.1
@@ -10756,9 +11110,9 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-google-gtag@3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)':
+  '@docusaurus/plugin-google-gtag@3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)':
     dependencies:
-      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
+      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
       '@docusaurus/types': 3.10.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
       '@docusaurus/utils-validation': 3.10.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
       react: 18.3.1
@@ -10783,9 +11137,9 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-google-tag-manager@3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)':
+  '@docusaurus/plugin-google-tag-manager@3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)':
     dependencies:
-      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
+      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
       '@docusaurus/types': 3.10.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
       '@docusaurus/utils-validation': 3.10.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
       react: 18.3.1
@@ -10810,9 +11164,9 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-sitemap@3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)':
+  '@docusaurus/plugin-sitemap@3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)':
     dependencies:
-      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
+      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
       '@docusaurus/logger': 3.10.2
       '@docusaurus/types': 3.10.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
       '@docusaurus/utils': 3.10.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
@@ -10842,9 +11196,9 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-svgr@3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)':
+  '@docusaurus/plugin-svgr@3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)':
     dependencies:
-      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
+      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
       '@docusaurus/types': 3.10.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
       '@docusaurus/utils': 3.10.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
       '@docusaurus/utils-validation': 3.10.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
@@ -10873,22 +11227,22 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/preset-classic@3.10.2(@algolia/client-search@5.56.0)(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(@types/react@18.3.31)(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(supports-color@8.1.1)(typescript@5.5.4)':
+  '@docusaurus/preset-classic@3.10.2(@algolia/client-search@5.56.0)(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(@types/react@18.3.31)(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(supports-color@8.1.1)(typescript@5.5.4)':
     dependencies:
-      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
-      '@docusaurus/plugin-content-blog': 3.10.2(@docusaurus/plugin-content-docs@3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4))(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
-      '@docusaurus/plugin-content-docs': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
-      '@docusaurus/plugin-content-pages': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
-      '@docusaurus/plugin-css-cascade-layers': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
-      '@docusaurus/plugin-debug': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
-      '@docusaurus/plugin-google-analytics': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
-      '@docusaurus/plugin-google-gtag': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
-      '@docusaurus/plugin-google-tag-manager': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
-      '@docusaurus/plugin-sitemap': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
-      '@docusaurus/plugin-svgr': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
-      '@docusaurus/theme-classic': 3.10.2(@types/react@18.3.31)(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
-      '@docusaurus/theme-common': 3.10.2(@docusaurus/plugin-content-docs@3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4))(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
-      '@docusaurus/theme-search-algolia': 3.10.2(@algolia/client-search@5.56.0)(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(@types/react@18.3.31)(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(supports-color@8.1.1)(typescript@5.5.4)
+      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
+      '@docusaurus/plugin-content-blog': 3.10.2(@docusaurus/plugin-content-docs@3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4))(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
+      '@docusaurus/plugin-content-docs': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
+      '@docusaurus/plugin-content-pages': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
+      '@docusaurus/plugin-css-cascade-layers': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
+      '@docusaurus/plugin-debug': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
+      '@docusaurus/plugin-google-analytics': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
+      '@docusaurus/plugin-google-gtag': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
+      '@docusaurus/plugin-google-tag-manager': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
+      '@docusaurus/plugin-sitemap': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
+      '@docusaurus/plugin-svgr': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
+      '@docusaurus/theme-classic': 3.10.2(@types/react@18.3.31)(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
+      '@docusaurus/theme-common': 3.10.2(@docusaurus/plugin-content-docs@3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4))(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
+      '@docusaurus/theme-search-algolia': 3.10.2(@algolia/client-search@5.56.0)(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(@types/react@18.3.31)(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(supports-color@8.1.1)(typescript@5.5.4)
       '@docusaurus/types': 3.10.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -10919,16 +11273,16 @@ snapshots:
       '@types/react': 18.3.31
       react: 18.3.1
 
-  '@docusaurus/theme-classic@3.10.2(@types/react@18.3.31)(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)':
+  '@docusaurus/theme-classic@3.10.2(@types/react@18.3.31)(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)':
     dependencies:
-      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
+      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
       '@docusaurus/logger': 3.10.2
       '@docusaurus/mdx-loader': 3.10.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
       '@docusaurus/module-type-aliases': 3.10.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
-      '@docusaurus/plugin-content-blog': 3.10.2(@docusaurus/plugin-content-docs@3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4))(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
-      '@docusaurus/plugin-content-docs': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
-      '@docusaurus/plugin-content-pages': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
-      '@docusaurus/theme-common': 3.10.2(@docusaurus/plugin-content-docs@3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4))(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
+      '@docusaurus/plugin-content-blog': 3.10.2(@docusaurus/plugin-content-docs@3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4))(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
+      '@docusaurus/plugin-content-docs': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
+      '@docusaurus/plugin-content-pages': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
+      '@docusaurus/theme-common': 3.10.2(@docusaurus/plugin-content-docs@3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4))(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
       '@docusaurus/theme-translations': 3.10.2
       '@docusaurus/types': 3.10.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
       '@docusaurus/utils': 3.10.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
@@ -10968,11 +11322,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/theme-common@3.10.2(@docusaurus/plugin-content-docs@3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4))(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)':
+  '@docusaurus/theme-common@3.10.2(@docusaurus/plugin-content-docs@3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4))(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)':
     dependencies:
       '@docusaurus/mdx-loader': 3.10.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
       '@docusaurus/module-type-aliases': 3.10.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
-      '@docusaurus/plugin-content-docs': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
+      '@docusaurus/plugin-content-docs': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
       '@docusaurus/utils': 3.10.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
       '@docusaurus/utils-common': 3.10.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
       '@types/history': 4.7.11
@@ -10993,11 +11347,11 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/theme-mermaid@3.10.2(@docusaurus/plugin-content-docs@3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4))(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)':
+  '@docusaurus/theme-mermaid@3.10.2(@docusaurus/plugin-content-docs@3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4))(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)':
     dependencies:
-      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
+      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
       '@docusaurus/module-type-aliases': 3.10.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
-      '@docusaurus/theme-common': 3.10.2(@docusaurus/plugin-content-docs@3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4))(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
+      '@docusaurus/theme-common': 3.10.2(@docusaurus/plugin-content-docs@3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4))(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
       '@docusaurus/types': 3.10.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
       '@docusaurus/utils-validation': 3.10.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
       mermaid: 11.12.0(supports-color@8.1.1)
@@ -11024,14 +11378,14 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/theme-search-algolia@3.10.2(@algolia/client-search@5.56.0)(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(@types/react@18.3.31)(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(supports-color@8.1.1)(typescript@5.5.4)':
+  '@docusaurus/theme-search-algolia@3.10.2(@algolia/client-search@5.56.0)(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(@types/react@18.3.31)(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(supports-color@8.1.1)(typescript@5.5.4)':
     dependencies:
       '@algolia/autocomplete-core': 1.19.9(@algolia/client-search@5.56.0)(algoliasearch@5.56.0)(search-insights@2.17.3)
       '@docsearch/react': 4.7.0(@algolia/client-search@5.56.0)(@types/react@18.3.31)(algoliasearch@5.56.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)
-      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
+      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
       '@docusaurus/logger': 3.10.2
-      '@docusaurus/plugin-content-docs': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
-      '@docusaurus/theme-common': 3.10.2(@docusaurus/plugin-content-docs@3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4))(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
+      '@docusaurus/plugin-content-docs': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
+      '@docusaurus/theme-common': 3.10.2(@docusaurus/plugin-content-docs@3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4))(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
       '@docusaurus/theme-translations': 3.10.2
       '@docusaurus/utils': 3.10.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
       '@docusaurus/utils-validation': 3.10.2(acorn@8.15.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
@@ -11355,6 +11709,8 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/sourcemap-codec@1.5.0': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@jridgewell/trace-mapping@0.3.31':
     dependencies:
@@ -11760,6 +12116,8 @@ snapshots:
     dependencies:
       '@oclif/core': 4.0.33
 
+  '@oxc-project/types@0.143.0': {}
+
   '@pagefind/darwin-arm64@1.5.2':
     optional: true
 
@@ -11959,6 +12317,50 @@ snapshots:
 
   '@polka/url@1.0.0-next.28': {}
 
+  '@rolldown/binding-android-arm64@1.2.3':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.2.3':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.2.3':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.2.3':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.2.3':
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.2.3':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.2.3':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
+
   '@rushstack/eslint-patch@1.12.0': {}
 
   '@rushstack/eslint-plugin-security@0.11.0(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.5.4)':
@@ -12050,6 +12452,8 @@ snapshots:
       micromark-factory-space: 1.1.0
       micromark-util-character: 1.2.0
       micromark-util-symbol: 1.1.0
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.29.7(supports-color@8.1.1))':
     dependencies:
@@ -12260,6 +12664,11 @@ snapshots:
     dependencies:
       '@types/node': 22.19.17
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/concat-stream@1.6.1':
     dependencies:
       '@types/node': 22.19.17
@@ -12401,6 +12810,8 @@ snapshots:
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 0.7.34
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/eslint-scope@3.7.7':
     dependencies:
@@ -12846,6 +13257,47 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.1
+
+  '@vitest/mocker@4.1.10(vite@8.2.1(@types/node@22.19.17)(jiti@1.21.6)(sass@1.81.0)(terser@5.36.0)(yaml@2.6.1))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.2.1(@types/node@22.19.17)(jiti@1.21.6)(sass@1.81.0)(terser@5.36.0)(yaml@2.6.1)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.1
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.1
+
   '@webassemblyjs/ast@1.14.1':
     dependencies:
       '@webassemblyjs/helper-numbers': 1.13.2
@@ -13134,6 +13586,8 @@ snapshots:
       pvtsutils: 1.3.6
       pvutils: 1.2.0
       tslib: 2.8.1
+
+  assertion-error@2.0.1: {}
 
   astring@1.9.0: {}
 
@@ -13440,6 +13894,8 @@ snapshots:
   ccount@1.1.0: {}
 
   ccount@2.0.1: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -13817,7 +14273,7 @@ snapshots:
     optionalDependencies:
       webpack: 5.96.1
 
-  css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(csso@5.0.5)(webpack@5.96.1):
+  css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(csso@5.0.5)(lightningcss@1.33.0)(webpack@5.96.1):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       cssnano: 6.1.2(postcss@8.4.49)
@@ -13829,6 +14285,7 @@ snapshots:
     optionalDependencies:
       clean-css: 5.3.3
       csso: 5.0.5
+      lightningcss: 1.33.0
 
   css-prefers-color-scheme@10.0.0(postcss@8.5.26):
     dependencies:
@@ -14308,8 +14765,7 @@ snapshots:
 
   detect-libc@2.0.3: {}
 
-  detect-libc@2.1.2:
-    optional: true
+  detect-libc@2.1.2: {}
 
   detect-node@2.1.0: {}
 
@@ -14385,9 +14841,9 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
-  docusaurus-plugin-sass@0.2.5(@docusaurus/core@3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4))(sass@1.81.0)(webpack@5.96.1):
+  docusaurus-plugin-sass@0.2.5(@docusaurus/core@3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4))(sass@1.81.0)(webpack@5.96.1):
     dependencies:
-      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
+      '@docusaurus/core': 3.10.2(@mdx-js/react@3.1.0(@types/react@18.3.31)(react@18.3.1))(acorn@8.15.0)(csso@5.0.5)(debug@4.3.7(supports-color@8.1.1))(lightningcss@1.33.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)(typescript@5.5.4)
       sass: 1.81.0
       sass-loader: 10.5.2(sass@1.81.0)(webpack@5.96.1)
     transitivePeerDependencies:
@@ -14671,6 +15127,8 @@ snapshots:
       safe-array-concat: 1.1.3
 
   es-module-lexer@1.5.4: {}
+
+  es-module-lexer@2.3.1: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -15080,6 +15538,8 @@ snapshots:
       strip-final-newline: 2.0.0
 
   expand-template@2.0.3: {}
+
+  expect-type@1.4.0: {}
 
   express@4.22.1(supports-color@8.1.1):
     dependencies:
@@ -16415,6 +16875,55 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  lightningcss-android-arm64@1.33.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.33.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.33.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.33.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.33.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.33.0:
+    optional: true
+
+  lightningcss@1.33.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.33.0
+      lightningcss-darwin-arm64: 1.33.0
+      lightningcss-darwin-x64: 1.33.0
+      lightningcss-freebsd-x64: 1.33.0
+      lightningcss-linux-arm-gnueabihf: 1.33.0
+      lightningcss-linux-arm64-gnu: 1.33.0
+      lightningcss-linux-arm64-musl: 1.33.0
+      lightningcss-linux-x64-gnu: 1.33.0
+      lightningcss-linux-x64-musl: 1.33.0
+      lightningcss-win32-arm64-msvc: 1.33.0
+      lightningcss-win32-x64-msvc: 1.33.0
+
   lilconfig@3.1.2: {}
 
   lines-and-columns@1.2.4: {}
@@ -16529,6 +17038,10 @@ snapshots:
       yallist: 4.0.0
 
   lunr@2.3.9: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   make-dir@1.3.0:
     dependencies:
@@ -17494,6 +18007,8 @@ snapshots:
       es-object-atoms: 1.1.1
 
   obuf@1.1.2: {}
+
+  obug@2.1.4: {}
 
   on-finished@2.4.1:
     dependencies:
@@ -18959,6 +19474,26 @@ snapshots:
 
   robust-predicates@3.0.2: {}
 
+  rolldown@1.2.3:
+    dependencies:
+      '@oxc-project/types': 0.143.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.2.3
+      '@rolldown/binding-darwin-arm64': 1.2.3
+      '@rolldown/binding-darwin-x64': 1.2.3
+      '@rolldown/binding-freebsd-x64': 1.2.3
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.3
+      '@rolldown/binding-linux-arm64-gnu': 1.2.3
+      '@rolldown/binding-linux-arm64-musl': 1.2.3
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.3
+      '@rolldown/binding-linux-s390x-gnu': 1.2.3
+      '@rolldown/binding-linux-x64-gnu': 1.2.3
+      '@rolldown/binding-linux-x64-musl': 1.2.3
+      '@rolldown/binding-openharmony-arm64': 1.2.3
+      '@rolldown/binding-win32-arm64-msvc': 1.2.3
+      '@rolldown/binding-win32-x64-msvc': 1.2.3
+
   roughjs@4.6.6:
     dependencies:
       hachure-fill: 0.5.2
@@ -19233,6 +19768,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -19360,6 +19897,8 @@ snapshots:
 
   stable-hash-x@0.2.0: {}
 
+  stackback@0.0.2: {}
+
   start-server-and-test@2.0.8(supports-color@8.1.1):
     dependencies:
       arg: 5.0.2
@@ -19378,6 +19917,8 @@ snapshots:
   statuses@2.0.1: {}
 
   std-env@3.8.0: {}
+
+  std-env@4.2.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -19673,14 +20214,25 @@ snapshots:
 
   tiny-warning@1.0.3: {}
 
+  tinybench@2.9.0: {}
+
   tinyexec@1.0.1: {}
+
+  tinyexec@1.3.0: {}
 
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
   tinypool@1.1.1: {}
+
+  tinyrainbow@3.1.1: {}
 
   tmp@0.2.7: {}
 
@@ -20152,6 +20704,48 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
+  vite@8.2.1(@types/node@22.19.17)(jiti@1.21.6)(sass@1.81.0)(terser@5.36.0)(yaml@2.6.1):
+    dependencies:
+      lightningcss: 1.33.0
+      picomatch: 4.0.4
+      postcss: 8.5.26
+      rolldown: 1.2.3
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 22.19.17
+      fsevents: 2.3.3
+      jiti: 1.21.6
+      sass: 1.81.0
+      terser: 5.36.0
+      yaml: 2.6.1
+
+  vitest@4.1.10(@types/node@22.19.17)(vite@8.2.1(@types/node@22.19.17)(jiti@1.21.6)(sass@1.81.0)(terser@5.36.0)(yaml@2.6.1)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@22.19.17)(jiti@1.21.6)(sass@1.81.0)(terser@5.36.0)(yaml@2.6.1))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.1
+      vite: 8.2.1(@types/node@22.19.17)(jiti@1.21.6)(sass@1.81.0)(terser@5.36.0)(yaml@2.6.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.17
+    transitivePeerDependencies:
+      - msw
+
   vscode-jsonrpc@8.2.0: {}
 
   vscode-languageserver-protocol@3.17.5:
@@ -20297,7 +20891,7 @@ snapshots:
       '@webassemblyjs/wasm-edit': 1.14.1
       '@webassemblyjs/wasm-parser': 1.14.1
       acorn: 8.15.0
-      browserslist: 4.24.2
+      browserslist: 4.28.7
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.17.1
       es-module-lexer: 1.5.4
@@ -20403,6 +20997,11 @@ snapshots:
   which@4.0.0:
     dependencies:
       isexe: 3.1.1
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   widest-line@3.1.0:
     dependencies:

--- a/website/src/components/shortLinks.tsx
+++ b/website/src/components/shortLinks.tsx
@@ -128,7 +128,7 @@ function resolveApiDocument(
 	apiName: string,
 	apiType: ApiItemKind | undefined,
 ): GlobalDoc {
-	const documentIdPrefix = `api/${packageName}/${apiName.toLocaleLowerCase()}-`;
+	const documentIdPrefix = `api/${packageName}/${apiName.toLowerCase()}-`;
 	const candidates = documents.filter(
 		(document) =>
 			document.id.startsWith(documentIdPrefix) &&

--- a/website/src/components/shortLinks.tsx
+++ b/website/src/components/shortLinks.tsx
@@ -49,7 +49,10 @@ export interface ApiLinkProps {
 	/**
 	 * The kind of API item to link to.
 	 *
-	 * @remarks May be omitted when the package exports only one API item with the specified name.
+	 * @remarks
+	 * May be omitted when the package exports only one API item with the specified name.
+	 *
+	 * {@link ApiLink} will throw an error if this is omitted and multiple API item kinds with the specified name are exported by the package.
 	 */
 	apiType?: ApiItemKind;
 
@@ -70,6 +73,9 @@ export interface ApiLinkProps {
 
 /**
  * A convenient mechanism for linking to the API documentation for a specified API item.
+ *
+ * @throws
+ * If {@link ApiLinkProps.apiType} is omitted and multiple API item kinds with the specified name are exported by the package.
  *
  * @privateRemarks
  * TODOs:

--- a/website/src/components/shortLinks.tsx
+++ b/website/src/components/shortLinks.tsx
@@ -3,7 +3,11 @@
  * Licensed under the MIT License.
  */
 
-import { useDoc } from "@docusaurus/plugin-content-docs/client";
+import {
+	type GlobalDoc,
+	useActivePluginAndVersion,
+	useDoc,
+} from "@docusaurus/plugin-content-docs/client";
 import type { ApiItemKind } from "@fluid-tools/api-markdown-documenter";
 import type { ReactNode } from "react";
 
@@ -42,8 +46,12 @@ export interface ApiLinkProps {
 	children?: ReactNode;
 	packageName: string;
 	apiName: string;
-	// TODO: do we have enough context to determine this automatically when unambiguous?
-	apiType: ApiItemKind;
+	/**
+	 * The kind of API item to link to.
+	 *
+	 * @remarks May be omitted when the package exports only one API item with the specified name.
+	 */
+	apiType?: ApiItemKind;
 
 	/**
 	 * (Optional) heading ID on the target page to link to.
@@ -62,6 +70,16 @@ export interface ApiLinkProps {
 
 /**
  * A convenient mechanism for linking to the API documentation for a specified API item.
+ *
+ * @privateRemarks
+ * TODOs:
+ * - Allow version overrides for cases where a user wants to link to a different version than the current one.
+ * - Allow linking to API items that are rendered to their parent item's page.
+ * - Allow linking to child members of namespaces, classes, interfaces, etc. (Currently this is done via page headings,
+ * but it would be better to consume aspects of the API docs config and automatically derive the right path to link to
+ * any kind of API item, regardless of whether or not it is configured to render to its own page or its parents.
+ * Additionally, there is currently no way to link items are rendered in sub-directories of their parent item, e.g.
+ * children of namespaces.)
  */
 export function ApiLink({
 	apiName,
@@ -70,12 +88,74 @@ export function ApiLink({
 	headingId,
 	children,
 }: ApiLinkProps): JSX.Element {
-	const root = useLinkPathBase();
+	const activePluginAndVersion = useActivePluginAndVersion();
+	const activeVersion = activePluginAndVersion?.activeVersion;
+	if (activeVersion === undefined) {
+		throw new Error("ApiLink must be rendered within a versioned Docusaurus document.");
+	}
+
+	const apiDocument = resolveApiDocument(activeVersion.docs, packageName, apiName, apiType);
 	const headingPostfix = headingId === undefined ? "" : `#${headingId}`;
-	// `api-documenter` generates all lowercase entries for API item names and types.
-	// Convert input names and types to lowercase to match.
-	const path = `${root}${packageName}/${apiName.toLocaleLowerCase()}-${apiType.toLocaleLowerCase()}${headingPostfix}`;
-	return <a href={path}>{children ?? apiName}</a>;
+	return <a href={`${apiDocument.path}${headingPostfix}`}>{children ?? apiName}</a>;
+}
+
+/**
+ * Resolves the Docusaurus document for an API item in a particular documentation version.
+ *
+ * @param documents - All documents registered for the active Docusaurus documentation version.
+ * @param packageName - The unscoped package name used as the package directory in the generated API docs.
+ * @param apiName - The exported API item name.
+ * @param apiType - The API item kind. When omitted, the name must identify exactly one document in the package.
+ * @returns The matching Docusaurus document, whose path includes the active documentation version.
+ *
+ * @throws If no document matches the package, name, and optional API item kind.
+ * @throws If {@link apiType} is omitted and the package contains multiple API item kinds with the same name.
+ *
+ * @remarks
+ * API Markdown document IDs follow the pattern `api/<package>/<lowercase-name>-<lowercase-kind>`.
+ * Resolution uses document IDs rather than paths because IDs are stable across documentation versions, while
+ * Docusaurus supplies the correctly versioned path on the returned document.
+ */
+function resolveApiDocument(
+	documents: GlobalDoc[],
+	packageName: string,
+	apiName: string,
+	apiType: ApiItemKind | undefined,
+): GlobalDoc {
+	const documentIdPrefix = `api/${packageName}/${apiName.toLocaleLowerCase()}-`;
+	const candidates = documents.filter(
+		(document) =>
+			document.id.startsWith(documentIdPrefix) &&
+			// Exclude descendants of folders (e.g. for namespaces) whose qualified name shares this prefix.
+			!document.id.slice(documentIdPrefix.length).includes("/"),
+	);
+
+	if (apiType !== undefined) {
+		const documentId = `${documentIdPrefix}${apiType.toLocaleLowerCase()}`;
+		const match = candidates.find((document) => document.id === documentId);
+		if (match !== undefined) {
+			return match;
+		}
+		throw new Error(
+			`No API documentation found for "${packageName}/${apiName}" with type "${apiType}".`,
+		);
+	}
+
+	const firstCandidate = candidates[0];
+	if (firstCandidate === undefined) {
+		throw new Error(`No API documentation found for "${packageName}/${apiName}".`);
+	}
+	if (candidates.length === 1) {
+		return firstCandidate;
+	}
+
+	const candidateTypes = candidates
+		// The portion after the qualified-name prefix is the lowercase API item kind.
+		.map((document) => document.id.slice(documentIdPrefix.length))
+		.join(", ");
+	throw new Error(
+		`Multiple API documents found for "${packageName}/${apiName}" (${candidateTypes}). Specify \`apiType\` to disambiguate the link.`,
+	);
 }
 
 /**

--- a/website/src/components/shortLinks.tsx
+++ b/website/src/components/shortLinks.tsx
@@ -74,7 +74,7 @@ export interface ApiLinkProps {
  * @privateRemarks
  * TODOs:
  * - Allow version overrides for cases where a user wants to link to a different version than the current one.
- * - Allow linking to API items that are rendered to their parent item's page.
+ * - Allow linking to API items that are rendered to their parent item's page. (Currently this is done via page headings.)
  * - Allow linking to child members of namespaces, classes, interfaces, etc. (Currently this is done via page headings,
  * but it would be better to consume aspects of the API docs config and automatically derive the right path to link to
  * any kind of API item, regardless of whether or not it is configured to render to its own page or its parents.

--- a/website/test/tsconfig.json
+++ b/website/test/tsconfig.json
@@ -1,6 +1,8 @@
 {
 	"extends": "../../common/build/build-common/tsconfig.test.node16.json",
 	"compilerOptions": {
+		"module": "ESNext",
+		"moduleResolution": "Bundler",
 		"types": ["node"],
 	},
 }

--- a/website/test/unit/shortLinks.test.ts
+++ b/website/test/unit/shortLinks.test.ts
@@ -1,0 +1,154 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import type { GlobalDoc, GlobalVersion } from "@docusaurus/plugin-content-docs/client";
+import type { ApiItemKind } from "@fluid-tools/api-markdown-documenter";
+import type { ReactElement, ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { useActivePluginAndVersion } = vi.hoisted(() => ({
+	useActivePluginAndVersion: vi.fn(),
+}));
+
+vi.mock("@docusaurus/plugin-content-docs/client", () => ({
+	useActivePluginAndVersion,
+	useDoc: vi.fn(),
+}));
+
+// Tests intentionally reach into the website's component implementation.
+// eslint-disable-next-line import/no-internal-modules
+import { ApiLink, type ApiLinkProps } from "../../src/components/shortLinks.js";
+
+function createDocument(id: string, path: string): GlobalDoc {
+	return { id, path };
+}
+
+function useDocuments(documents: GlobalDoc[]): void {
+	const activeVersion: GlobalVersion = {
+		name: "current",
+		label: "Current",
+		isLast: true,
+		path: "/docs",
+		mainDocId: "introduction",
+		docs: documents,
+		draftIds: [],
+	};
+	useActivePluginAndVersion.mockReturnValue({ activeVersion });
+}
+
+function renderApiLink(props: ApiLinkProps): { href: string; children: ReactNode } {
+	const link = ApiLink(props) as ReactElement<{ href: string; children: ReactNode }>;
+	return { href: link.props.href, children: link.props.children };
+}
+
+describe("ApiLink", () => {
+	afterEach(() => {
+		useActivePluginAndVersion.mockReset();
+	});
+
+	it("infers the API type when exactly one document matches", () => {
+		useDocuments([
+			createDocument(
+				"api/fluid-framework/ifluidcontainer-interface",
+				"/docs/api/fluid-framework/ifluidcontainer-interface",
+			),
+		]);
+
+		expect(
+			renderApiLink({
+				packageName: "fluid-framework",
+				apiName: "IFluidContainer",
+			}),
+		).toEqual({
+			href: "/docs/api/fluid-framework/ifluidcontainer-interface",
+			children: "IFluidContainer",
+		});
+	});
+
+	it("uses the versioned document path and appends a heading", () => {
+		useDocuments([
+			createDocument(
+				"api/container-loader/iloaderprops-interface",
+				"/docs/v1/api/container-loader/iloaderprops-interface",
+			),
+		]);
+
+		expect(
+			renderApiLink({
+				packageName: "container-loader",
+				apiName: "ILoaderProps",
+				headingId: "logger-propertysignature",
+				children: "logger",
+			}),
+		).toEqual({
+			href: "/docs/v1/api/container-loader/iloaderprops-interface#logger-propertysignature",
+			children: "logger",
+		});
+	});
+
+	it("uses apiType to disambiguate documents with the same API name", () => {
+		useDocuments([
+			createDocument("api/example/widget-class", "/docs/api/example/widget-class"),
+			createDocument("api/example/widget-interface", "/docs/api/example/widget-interface"),
+		]);
+
+		expect(
+			renderApiLink({
+				packageName: "example",
+				apiName: "Widget",
+				apiType: "Class" as ApiItemKind,
+			}),
+		).toEqual({
+			href: "/docs/api/example/widget-class",
+			children: "Widget",
+		});
+	});
+
+	it("throws when rendered outside a versioned Docusaurus document", () => {
+		useActivePluginAndVersion.mockReturnValue(undefined);
+
+		expect(() => renderApiLink({ packageName: "example", apiName: "Widget" })).toThrowError(
+			"ApiLink must be rendered within a versioned Docusaurus document.",
+		);
+	});
+
+	it("throws when no API document matches", () => {
+		useDocuments([
+			createDocument(
+				"api/example/widget-namespace/member-class",
+				"/docs/api/example/widget-namespace/member-class",
+			),
+		]);
+
+		expect(() => renderApiLink({ packageName: "example", apiName: "Widget" })).toThrowError(
+			'No API documentation found for "example/Widget".',
+		);
+	});
+
+	it("throws when the specified API type does not match", () => {
+		useDocuments([
+			createDocument("api/example/widget-interface", "/docs/api/example/widget-interface"),
+		]);
+
+		expect(() =>
+			renderApiLink({
+				packageName: "example",
+				apiName: "Widget",
+				apiType: "Class" as ApiItemKind,
+			}),
+		).toThrowError('No API documentation found for "example/Widget" with type "Class".');
+	});
+
+	it("throws with candidate types when API name inference is ambiguous", () => {
+		useDocuments([
+			createDocument("api/example/widget-class", "/docs/api/example/widget-class"),
+			createDocument("api/example/widget-interface", "/docs/api/example/widget-interface"),
+		]);
+
+		expect(() => renderApiLink({ packageName: "example", apiName: "Widget" })).toThrowError(
+			'Multiple API documents found for "example/Widget" (class, interface). Specify `apiType` to disambiguate the link.',
+		);
+	});
+});

--- a/website/versioned_docs/version-1/build/container-states-events.mdx
+++ b/website/versioned_docs/version-1/build/container-states-events.mdx
@@ -97,7 +97,7 @@ But the new container has a different ID from the deleted one and subsequent cli
 
 #### Handling publication status
 
-Your code can test for the publication status with the <ApiLink packageName="fluid-static" apiName="IFluidContainer" apiType="Interface" headingId="attachstate-propertysignature">container.AttachState</ApiLink> property which has an <ApiLink packageName="container-definitions" apiName="AttachState" apiType="Enum">AttachState</ApiLink> value.
+Your code can test for the publication status with the <ApiLink packageName="fluid-static" apiName="IFluidContainer" headingId="attachstate-propertysignature">container.AttachState</ApiLink> property which has an <ApiLink packageName="container-definitions" apiName="AttachState">AttachState</ApiLink> value.
 This can be useful if your application will publish the container in some code paths on the creating client, but not others.
 For example, on the creating computer, you don't want to call `container.attach` if it has already been called. In simple cases, you can know at coding time if that has happened, but when the creating client in complex code flows and calls of `container.attach` appear in more than one branch, you may need to test for this possibility. The following is a simple example.
 
@@ -257,7 +257,7 @@ The container transitions to this state automatically when it is fully caught up
 
 There are scenarios in which you need to control the connection status of the container. To assist, the `container` object has the following APIs:
 
--   A <ApiLink packageName="fluid-static" apiName="IFluidContainer" apiType="Interface" headingId="connectionstate-propertysignature">container.connectionState</ApiLink> property of type `ConnectionState`. There are four possible values for the property:
+-   A <ApiLink packageName="fluid-static" apiName="IFluidContainer" headingId="connectionstate-propertysignature">container.connectionState</ApiLink> property of type `ConnectionState`. There are four possible values for the property:
 
     -   `Disconnected`
     -   `EstablishingConnection`: Your code should treat this state the same as it treats the disconnected state. See [Examples](#examples).

--- a/website/versioned_docs/version-1/build/containers.mdx
+++ b/website/versioned_docs/version-1/build/containers.mdx
@@ -8,7 +8,7 @@ import { ApiLink, PackageLink } from "@site/src/components/shortLinks";
 The container is the primary unit of encapsulation in the Fluid Framework.
 It enables a group of clients to access the same set of shared objects and co-author changes on those objects.
 It is also a permission boundary ensuring visibility and access only to permitted clients.
-A container is represented by the <ApiLink packageName="fluid-static" apiName="IFluidContainer" apiType="Interface">FluidContainer</ApiLink> type and consists of a collection of shared objects and APIs to manage the life cycle of those objects.
+A container is represented by the <ApiLink packageName="fluid-static" apiName="IFluidContainer">FluidContainer</ApiLink> type and consists of a collection of shared objects and APIs to manage the life cycle of those objects.
 
 This article explains:
 

--- a/website/versioned_docs/version-1/release-notes.mdx
+++ b/website/versioned_docs/version-1/release-notes.mdx
@@ -23,11 +23,11 @@ We are now surfacing errors on FluidContainer "disposed" event, so the applicati
 
 ## fluid-framework
 
--   Add the missing <ApiLink packageName="container-loader" apiName="ConnectionState" apiType="Enum" /> export to `fluid-framework`
+-   Add the missing <ApiLink packageName="container-loader" apiName="ConnectionState" /> export to `fluid-framework`
 
 ## @fluidframework/azure-client
 
--   Fix <ApiLink packageName="azure-client" apiName="AzureClient" apiType="Class" /> issue where the second user could not connect in `local` mode
+-   Fix <ApiLink packageName="azure-client" apiName="AzureClient" /> issue where the second user could not connect in `local` mode
 
 # 1.0.0
 
@@ -40,17 +40,11 @@ We've added two new methods to AzureClient that will enable developers to recove
 -   <ApiLink
     	packageName="azure-client"
     	apiName="AzureClient"
-    	apiType="Class"
     	headingId="getcontainerversions-method"
     >
     	`getContainerVersions(id, options)`
     </ApiLink>
--   <ApiLink
-    	packageName="azure-client"
-    	apiName="AzureClient"
-    	apiType="Class"
-    	headingId="copycontainer-method"
-    >
+-   <ApiLink packageName="azure-client" apiName="AzureClient" headingId="copycontainer-method">
     	`copyContainer(id, containerSchema)`
     </ApiLink>
 

--- a/website/versioned_docs/version-1/testing/telemetry.mdx
+++ b/website/versioned_docs/version-1/testing/telemetry.mdx
@@ -32,12 +32,7 @@ The `Loader` constructor is called by both `createContainer()` and `getContainer
 interface as its constructor argument. `ILoaderProps` interface has an optional logger parameter that will take the
 `ITelemetryBaseLogger` defined by the user.
 
-<ApiLink
-	packageName="container-loader"
-	apiName="ILoaderProps"
-	apiType="Interface"
-	headingId="logger-propertysignature"
->
+<ApiLink packageName="container-loader" apiName="ILoaderProps" headingId="logger-propertysignature">
 	ILoaderProps.logger
 </ApiLink>
 is used by `Loader` to pipe to container's telemetry system.

--- a/website/vitest.config.mts
+++ b/website/vitest.config.mts
@@ -1,0 +1,17 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	oxc: {
+		jsx: {
+			runtime: "automatic",
+		},
+	},
+	test: {
+		include: ["test/unit/**/*.test.{ts,tsx}"],
+	},
+});


### PR DESCRIPTION
Makes API links shorter / easier to write in the standard case.

Also adds unit tests, including vitest infra for unit testing the site's React components.