### PR TITLE
fix(historian): validate Git object SHAs

### DIFF
--- a/server/historian/packages/historian-base/src/services/restGitService.ts
+++ b/server/historian/packages/historian-base/src/services/restGitService.ts
@@ -15,6 +15,7 @@ import {
 	type IWholeFlatSummary,
 	type IWholeSummaryPayloadType,
 	LatestSummaryId,
+	NetworkError,
 } from "@fluidframework/server-services-client";
 import { type ITenantStorage, runWithRetry } from "@fluidframework/server-services-core";
 import {
@@ -37,6 +38,8 @@ const packageDetails = require("../../package.json");
 const userAgent = `Historian/${packageDetails.version}`;
 
 const LatestSummaryShaKey = `${LatestSummaryId}-sha`;
+// eslint-disable-next-line unicorn/better-regex
+const canonicalGitShaRegex = /^[0-9a-f]{40}$/i;
 
 export interface IDocument {
 	existing: boolean;
@@ -52,6 +55,12 @@ function endsWith(value: string, endings: string[]): boolean {
 	}
 
 	return false;
+}
+
+function validateGitSha(sha: string): void {
+	if (!canonicalGitShaRegex.test(sha)) {
+		throw new NetworkError(400, "Invalid Git object SHA.");
+	}
 }
 
 export class RestGitService {
@@ -132,6 +141,7 @@ export class RestGitService {
 	}
 
 	public async getBlob(tenantId: string, sha: string, useCache: boolean): Promise<git.IBlob> {
+		validateGitSha(sha);
 		const cacheKey = `${tenantId}:${sha}`;
 		return this.resolve(
 			cacheKey,
@@ -184,6 +194,7 @@ export class RestGitService {
 	}
 
 	public async getCommit(sha: string, useCache: boolean): Promise<git.ICommit> {
+		validateGitSha(sha);
 		return this.resolve(
 			sha,
 			async () =>
@@ -370,6 +381,7 @@ export class RestGitService {
 	}
 
 	public async getTree(sha: string, recursive: boolean, useCache: boolean): Promise<git.ITree> {
+		validateGitSha(sha);
 		const key = recursive ? `${sha}:recursive` : sha;
 		return this.resolve(
 			key,

--- a/server/historian/packages/historian-base/src/services/restGitService.ts
+++ b/server/historian/packages/historian-base/src/services/restGitService.ts
@@ -39,7 +39,7 @@ const userAgent = `Historian/${packageDetails.version}`;
 
 const LatestSummaryShaKey = `${LatestSummaryId}-sha`;
 // eslint-disable-next-line unicorn/better-regex
-const canonicalGitShaRegex = /^[0-9a-f]{40}$/i;
+const canonicalGitShaRegex = /^[0-9a-f]{40}$/;
 
 export interface IDocument {
 	existing: boolean;

--- a/server/historian/packages/historian-base/src/test/restGitService.spec.ts
+++ b/server/historian/packages/historian-base/src/test/restGitService.spec.ts
@@ -1,0 +1,113 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+
+import { NetworkError } from "@fluidframework/server-services-client";
+import type { ITenantStorage } from "@fluidframework/server-services-core";
+import * as sinon from "sinon";
+
+import { RestGitService } from "../services";
+import { TestCache } from "./utils";
+
+const tenantId = "tenant";
+const documentId = "document";
+const canonicalSha = "0123456789abcdef0123456789abcdef01234567";
+const storage: ITenantStorage = {
+	historianUrl: "http://historian",
+	internalHistorianUrl: "http://historian",
+	url: "http://storage",
+	owner: "owner",
+	repository: "repository",
+	credentials: {
+		user: "user",
+		password: "password",
+	},
+};
+
+describe("RestGitService Git object SHA validation", () => {
+	const sandbox = sinon.createSandbox();
+	let cache: TestCache;
+	let service: RestGitService;
+
+	beforeEach(() => {
+		cache = new TestCache();
+		service = new RestGitService(storage, false, tenantId, documentId, cache);
+	});
+
+	afterEach(() => sandbox.restore());
+
+	for (const testCase of [
+		{
+			name: "blob",
+			read: (sha: string) => service.getBlob(tenantId, sha, true),
+		},
+		{
+			name: "commit",
+			read: (sha: string) => service.getCommit(sha, true),
+		},
+		{
+			name: "tree",
+			read: (sha: string) => service.getTree(sha, false, true),
+		},
+	]) {
+		it(`rejects a cache-key injection through ${testCase.name} before cache access`, async () => {
+			const cacheGet = sandbox.spy(cache, "get");
+
+			await assert.rejects(
+				testCase.read(`${tenantId}:${documentId}:summary:container`),
+				(error: unknown) =>
+					error instanceof NetworkError &&
+					error.code === 400 &&
+					error.message === "Invalid Git object SHA.",
+			);
+
+			sinon.assert.notCalled(cacheGet);
+		});
+	}
+
+	for (const invalidSha of [
+		"0123456789abcdef0123456789abcdef0123456",
+		"0123456789abcdef0123456789abcdef012345678",
+		"g123456789abcdef0123456789abcdef01234567",
+	]) {
+		it(`rejects noncanonical SHA ${invalidSha}`, async () => {
+			const cacheGet = sandbox.spy(cache, "get");
+
+			await assert.rejects(service.getCommit(invalidSha, true), NetworkError);
+
+			sinon.assert.notCalled(cacheGet);
+		});
+	}
+
+	it("allows a canonical SHA to reach the cache", async () => {
+		const commit = {
+			sha: canonicalSha,
+			url: "http://storage/commit",
+			author: {
+				name: "author",
+				email: "author@example.com",
+				date: "2026-08-07T00:00:00.000Z",
+			},
+			committer: {
+				name: "committer",
+				email: "committer@example.com",
+				date: "2026-08-07T00:00:00.000Z",
+			},
+			message: "message",
+			tree: {
+				sha: canonicalSha,
+				url: "http://storage/tree",
+			},
+			parents: [],
+		};
+		await cache.set(canonicalSha, commit);
+		const cacheGet = sandbox.spy(cache, "get");
+
+		assert.strictEqual(await service.getCommit(canonicalSha, true), commit);
+
+		sinon.assert.calledOnceWithExactly(cacheGet, canonicalSha);
+	});
+});

--- a/server/historian/packages/historian-base/src/test/restGitService.spec.ts
+++ b/server/historian/packages/historian-base/src/test/restGitService.spec.ts
@@ -15,6 +15,10 @@ import { TestCache } from "./utils";
 const tenantId = "tenant";
 const documentId = "document";
 const canonicalSha = "0123456789abcdef0123456789abcdef01234567";
+const invalidGitShaError = (error: unknown): boolean =>
+	error instanceof NetworkError &&
+	error.code === 400 &&
+	error.message === "Invalid Git object SHA.";
 const storage: ITenantStorage = {
 	historianUrl: "http://historian",
 	internalHistorianUrl: "http://historian",
@@ -58,10 +62,7 @@ describe("RestGitService Git object SHA validation", () => {
 
 			await assert.rejects(
 				testCase.read(`${tenantId}:${documentId}:summary:container`),
-				(error: unknown) =>
-					error instanceof NetworkError &&
-					error.code === 400 &&
-					error.message === "Invalid Git object SHA.",
+				invalidGitShaError,
 			);
 
 			sinon.assert.notCalled(cacheGet);
@@ -72,11 +73,12 @@ describe("RestGitService Git object SHA validation", () => {
 		"0123456789abcdef0123456789abcdef0123456",
 		"0123456789abcdef0123456789abcdef012345678",
 		"g123456789abcdef0123456789abcdef01234567",
+		"0123456789ABCDEF0123456789ABCDEF01234567",
 	]) {
 		it(`rejects noncanonical SHA ${invalidSha}`, async () => {
 			const cacheGet = sandbox.spy(cache, "get");
 
-			await assert.rejects(service.getCommit(invalidSha, true), NetworkError);
+			await assert.rejects(service.getCommit(invalidSha, true), invalidGitShaError);
 
 			sinon.assert.notCalled(cacheGet);
 		});


### PR DESCRIPTION
## Description

Historian used the unvalidated Git object `sha` parameter as a Redis cache key. A specially constructed value could collide with another cache entry type, allowing data to be returned before the request reached storage routing and authorization checks.

Validate blob, commit, and tree identifiers as canonical 40-character hexadecimal Git SHAs before any cache access. Invalid identifiers now return HTTP 400.

Regression tests verify that cache-key injection values, incorrectly sized SHAs, and non-hexadecimal SHAs are rejected without reading Redis, while canonical SHAs continue to use the cache normally.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Please focus on whether validation in `RestGitService` covers every Git-object cache entry point while preserving valid internal calls from header and full-tree retrieval.