### PR TITLE
fix(test): remove skip from idCompressor test

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/idCompressor.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/idCompressor.spec.ts
@@ -937,11 +937,7 @@ describeCompat("IdCompressor Summaries", "NoCompat", (getTestObjectProvider, com
 		);
 	});
 
-	it("Newly connected container synchronizes from summary", async function () {
-		// TODO: This test is consistently failing when ran against AFR. See ADO:7931
-		if (provider.driver.type === "routerlicious" && provider.driver.endpointName === "frs") {
-			this.skip();
-		}
+	it("Newly connected container synchronizes from summary", async () => {
 		const container = await createContainer(enabledConfig);
 		const defaultDataStore = (await container.getEntryPoint()) as ITestDataObject;
 		const idCompressor: IIdCompressor = (defaultDataStore._root as any).runtime.idCompressor;


### PR DESCRIPTION
## Description

After updating the summarization tests to conform the the [WritingTestsThatTakeSummaries.md](https://github.com/microsoft/FluidFramework/blob/main/packages/test/test-end-to-end-tests/WritingTestsThatTakeSummaries.md#the-rules-that-keep-these-tests-deterministic) that talks about flaky tests this test should no longer fail on AFR. This PR has more details on the test changes themselves: https://github.com/microsoft/FluidFramework/pull/27858. 

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
