### PR TITLE
build(server): delegate package and image publishing

### DIFF
--- a/tools/pipelines/server-gitrest.yml
+++ b/tools/pipelines/server-gitrest.yml
@@ -94,7 +94,7 @@ extends:
     shouldPublishNpmPackages: ${{ variables.publish }}
     releaseKind: both
     publishOverride: ${{ parameters.publishOverride }}
-    publishAsPartOfBuild: true
+    publishAsPartOfBuild: false
     buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     dockerBuildBumpsVersion: true
     emitDockerImageDigest: true

--- a/tools/pipelines/server-gitssh.yml
+++ b/tools/pipelines/server-gitssh.yml
@@ -93,4 +93,4 @@ extends:
     installPackages: false
     enableDockerImagePull: false
     tagName: gitssh
-    publishAsPartOfBuild: true
+    publishAsPartOfBuild: false

--- a/tools/pipelines/server-historian.yml
+++ b/tools/pipelines/server-historian.yml
@@ -93,7 +93,7 @@ extends:
     shouldPublishNpmPackages: ${{ variables.publish }}
     releaseKind: both
     publishOverride: ${{ parameters.publishOverride }}
-    publishAsPartOfBuild: true
+    publishAsPartOfBuild: false
     buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     buildDirectory: ${{ variables.FluidFrameworkDirectory }}/server/historian
     containerName: fluidframework/routerlicious/historian

--- a/tools/pipelines/server-routerlicious.yml
+++ b/tools/pipelines/server-routerlicious.yml
@@ -112,7 +112,7 @@ extends:
     shouldPublishNpmPackages: ${{ variables.publish }}
     releaseKind: both
     publishOverride: ${{ parameters.publishOverride }}
-    publishAsPartOfBuild: true
+    publishAsPartOfBuild: false
     buildToolsVersionToInstall: ${{ parameters.buildToolsVersionToInstall }}
     interdependencyRange: ${{ parameters.interdependencyRange }}
     buildDirectory: ${{ variables.FluidFrameworkDirectory }}/server/routerlicious


### PR DESCRIPTION
## Summary
- delegate npm and Docker publication for GitRest, Historian, and Routerlicious
- delegate Docker-only publication for GitSSH
- preserve fixed `releaseKind: both` policy for all npm-producing server pipelines

The four build pipelines continue to produce immutable candidates and `pack/publish-metadata.json`, but publisher ownership moves to the dedicated ff_publishing pipelines.
