### PR TITLE
fix(ci): normalize configured npm registry whitespace

### DIFF
--- a/tools/pipelines/templates/include-install-pnpm.yml
+++ b/tools/pipelines/templates/include-install-pnpm.yml
@@ -128,7 +128,9 @@ steps:
     workingDirectory: '$(Pipeline.Workspace)/${{ parameters.buildDirectory }}'
     script: |
       set -eu -o pipefail
-      expected_registry="${NPM_REGISTRY%/}/"
+      # Trim whitespace before normalizing the registry URL to one trailing slash.
+      expected_registry="$(printf '%s' "$NPM_REGISTRY" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+      expected_registry="${expected_registry%/}/"
       npm_registry="$(npm config get registry)"
       if [ "$npm_registry" != "$expected_registry" ]; then
         echo "##vso[task.logissue type=error]npm resolved registry '$npm_registry'; expected '$expected_registry'"


### PR DESCRIPTION
[How contribute to this repo](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).

[Guidelines for Pull Requests](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

## Description

The client packages pipeline failed in its telemetry upload stages after registry validation was added by [PR #27893](https://github.com/microsoft/FluidFramework/pull/27893). The `ado-feeds-ff-download-only` value contained trailing whitespace, so the validation logic normalized it to `…/registry/ /` while npm correctly resolved `…/registry/`, causing an otherwise successful build to fail.

Trim surrounding whitespace before normalizing the configured registry to one trailing slash. This preserves the strict registry safety check while accepting equivalent registry values with incidental whitespace.

Validated the normalization for registry values with trailing whitespace, surrounding whitespace, and an existing trailing slash.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Please verify that trimming whitespace is appropriate before comparing npm and pnpm's resolved registries.
