### PR TITLE
fix(ci): forward lockfile trust to server Docker builds

### DIFF
--- a/server/gitrest/Dockerfile
+++ b/server/gitrest/Dockerfile
@@ -64,6 +64,7 @@ RUN --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false \
 # This is needed because tools/pipelines/templates/include-install-pnpm.yml uses these options to work around CI package mirror limitations.
 ARG PNPM_CONFIG_TRUST_POLICY
 ARG PNPM_CONFIG_MINIMUM_RELEASE_AGE
+ARG PNPM_CONFIG_TRUST_LOCKFILE
 
 # Using a cache mount for the pnpm store improves the incremental docker build.
 # pnpm's default storeDir is $PNPM_HOME/store when PNPM_HOME is set
@@ -71,7 +72,7 @@ ARG PNPM_CONFIG_MINIMUM_RELEASE_AGE
 # matches and no --store-dir flag is needed.
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false \
-    pnpm install
+    pnpm install --frozen-lockfile
 
 COPY . .
 

--- a/server/historian/Dockerfile
+++ b/server/historian/Dockerfile
@@ -83,6 +83,7 @@ RUN --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false \
 # This is needed because tools/pipelines/templates/include-install-pnpm.yml uses these options to work around CI package mirror limitations.
 ARG PNPM_CONFIG_TRUST_POLICY
 ARG PNPM_CONFIG_MINIMUM_RELEASE_AGE
+ARG PNPM_CONFIG_TRUST_LOCKFILE
 
 # Using a cache mount for the pnpm store improves the incremental docker build.
 # pnpm's default storeDir is $PNPM_HOME/store when PNPM_HOME is set
@@ -90,7 +91,7 @@ ARG PNPM_CONFIG_MINIMUM_RELEASE_AGE
 # matches and no --store-dir flag is needed.
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false \
-    pnpm install
+    pnpm install --frozen-lockfile
 
 COPY . .
 

--- a/server/routerlicious/Dockerfile
+++ b/server/routerlicious/Dockerfile
@@ -112,6 +112,7 @@ RUN --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false \
 # This is needed because tools/pipelines/templates/include-install-pnpm.yml uses these options to work around CI package mirror limitations.
 ARG PNPM_CONFIG_TRUST_POLICY
 ARG PNPM_CONFIG_MINIMUM_RELEASE_AGE
+ARG PNPM_CONFIG_TRUST_LOCKFILE
 
 # Using a cache mount for the pnpm store improves the incremental docker build.
 # pnpm's default storeDir is $PNPM_HOME/store when PNPM_HOME is set
@@ -119,7 +120,7 @@ ARG PNPM_CONFIG_MINIMUM_RELEASE_AGE
 # matches and no --store-dir flag is needed.
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false \
-    pnpm install
+    pnpm install --frozen-lockfile
 
 # And now copy over our actual code and build
 COPY . .

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -452,7 +452,7 @@ extends:
               # which runs precisely when installPackages is true) so the Dockerfile's `pnpm install`
               # skips the checks our npm mirror can't satisfy.
               ${{ if eq(parameters.installPackages, true) }}:
-                buildArguments: --target base $(DockerBuildArgs.output) --build-arg PNPM_CONFIG_TRUST_POLICY=$(PNPM_CONFIG_TRUST_POLICY) --build-arg PNPM_CONFIG_MINIMUM_RELEASE_AGE=$(PNPM_CONFIG_MINIMUM_RELEASE_AGE) --secret id=npmrc,src=$(NPM_CONFIG_USERCONFIG)
+                buildArguments: --target base $(DockerBuildArgs.output) --build-arg PNPM_CONFIG_TRUST_POLICY=$(PNPM_CONFIG_TRUST_POLICY) --build-arg PNPM_CONFIG_MINIMUM_RELEASE_AGE=$(PNPM_CONFIG_MINIMUM_RELEASE_AGE) --build-arg PNPM_CONFIG_TRUST_LOCKFILE=$(PNPM_CONFIG_TRUST_LOCKFILE) --secret id=npmrc,src=$(NPM_CONFIG_USERCONFIG)
               ${{ else }}:
                 buildArguments: --target base $(DockerBuildArgs.output)
               useBuildKit: true
@@ -607,7 +607,7 @@ extends:
             # See the base-image build above for the rationale (including the pnpm supply-chain
             # overrides). Passed here too because a cache miss could re-execute the base stage layers.
             ${{ if eq(parameters.installPackages, true) }}:
-              buildArguments: $(DockerBuildArgs.output) --build-arg PNPM_CONFIG_TRUST_POLICY=$(PNPM_CONFIG_TRUST_POLICY) --build-arg PNPM_CONFIG_MINIMUM_RELEASE_AGE=$(PNPM_CONFIG_MINIMUM_RELEASE_AGE) --secret id=npmrc,src=$(NPM_CONFIG_USERCONFIG)
+              buildArguments: $(DockerBuildArgs.output) --build-arg PNPM_CONFIG_TRUST_POLICY=$(PNPM_CONFIG_TRUST_POLICY) --build-arg PNPM_CONFIG_MINIMUM_RELEASE_AGE=$(PNPM_CONFIG_MINIMUM_RELEASE_AGE) --build-arg PNPM_CONFIG_TRUST_LOCKFILE=$(PNPM_CONFIG_TRUST_LOCKFILE) --secret id=npmrc,src=$(NPM_CONFIG_USERCONFIG)
             ${{ else }}:
               buildArguments: $(DockerBuildArgs.output)
             useBuildKit: true


### PR DESCRIPTION
## Description

Follow-up to #27893, which defines the job-wide `PNPM_CONFIG_TRUST_LOCKFILE=true` setting.

Forward that CI-controlled setting through both `1ES.BuildContainerImage` argument paths and declare it in the Routerlicious, GitRest, and Historian Docker install stages. This prevents pnpm 11 from repeating `minimumReleaseAge` and `trustPolicy` registry-metadata validation for dependencies already represented by each service's trusted committed lockfile.

Each Docker install now explicitly uses `pnpm install --frozen-lockfile`. The three build contexts copy their committed `pnpm-lock.yaml` before install and already configure `frozenLockfile: true`, so the setting cannot authorize lockfile creation or mutation. Tarball integrity verification remains unchanged.

Local Docker development remains unchanged: all forwarded build arguments and authenticated npmrc secret mounts remain optional, no workspace sets `trustLockfile`, and the npmrc is still provided only through a BuildKit secret.

### Validation

- `git diff --check`
- Changed-file policy checks (`dockerfile-copyright-file-header` and `indent-with-spaces-in-yaml`)
- Existing Prettier checks for Routerlicious, GitRest, and Historian
- Prettier check for `tools/pipelines/templates/build-docker-service.yml`
- CI readiness **Check** mode against #27893's head: passed with no auto-fixes
- Revalidated the same checks after rebasing onto `main` following #27893's merge
- Verified exactly two pipeline forwards, three Docker `ARG` declarations, three explicit frozen installs, and no `trustLockfile` workspace setting
- Verified GitSSH has no npm/pnpm install path and is unchanged

The local environment has no Docker CLI, Azure CLI login/PAT, or authenticated Azure DevOps browser session. Routerlicious, GitRest, and Historian pipeline runs and their Stop Network Isolation details (CFSClean compliance, cold-cache evidence, and registry access) remain required CI validation.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Please review the Docker `ARG` scope and confirm the authenticated npmrc remains confined to BuildKit secret mounts.