### PR TITLE
fix: preserve BubbleBench container compatibility

### DIFF
--- a/.changeset/preserve-bubblebench-container-compatibility.md
+++ b/.changeset/preserve-bubblebench-container-compatibility.md
@@ -1,6 +1,0 @@
----
-"__section": fix
----
-BubbleBench remains compatible with Fluid and native array containers
-
-BubbleBench now uses a minimal shared collection contract so its implementations can provide either Tree arrays or native arrays without requiring the full built-in array interface.

--- a/.changeset/preserve-bubblebench-container-compatibility.md
+++ b/.changeset/preserve-bubblebench-container-compatibility.md
@@ -1,0 +1,6 @@
+---
+"__section": fix
+---
+BubbleBench remains compatible with Fluid and native array containers
+
+BubbleBench now uses a minimal shared collection contract so its implementations can provide either Tree arrays or native arrays without requiring the full built-in array interface.

--- a/examples/benchmarks/bubblebench/common/src/types.ts
+++ b/examples/benchmarks/bubblebench/common/src/types.ts
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+import type { FluidIterable } from "@fluidframework/core-interfaces";
+
 import { normal, randomColor, rnd } from "./rnd.js";
 
 /**
@@ -16,14 +18,20 @@ export interface IBubble {
 	vy: number;
 }
 
+interface ReadonlyBubbleCollection extends FluidIterable<IBubble> {
+	readonly length: number;
+	readonly [index: number]: IBubble;
+	map<U>(callbackfn: (value: IBubble, index: number) => U): U[];
+}
+
 /**
  * @internal
  */
 export interface IClient {
 	readonly clientId: string;
 	readonly color: string;
-	// Mark `IBubble[]` as read-only, as SharedTree ArrayNodes are not compatible with JavaScript arrays for writing purposes.
-	readonly bubbles: readonly IBubble[];
+	// SharedTree ArrayNodes are not compatible with JavaScript arrays for writing purposes.
+	readonly bubbles: ReadonlyBubbleCollection;
 }
 
 /**
@@ -31,7 +39,7 @@ export interface IClient {
  */
 export interface IAppState {
 	readonly localClient: IClient;
-	readonly clients: Iterable<IClient>;
+	readonly clients: FluidIterable<IClient>;
 	readonly width: number;
 	readonly height: number;
 	setSize(width?: number, height?: number);

--- a/examples/benchmarks/bubblebench/experimental-tree/src/state.ts
+++ b/examples/benchmarks/bubblebench/experimental-tree/src/state.ts
@@ -11,6 +11,7 @@ import {
 	type SimpleClient,
 	type IBubble,
 } from "@fluid-example/bubblebench-common";
+import type { FluidIterable } from "@fluidframework/core-interfaces";
 import type { Change, SharedTree } from "@fluid-experimental/tree";
 
 import { type TreeArrayProxy, TreeObjectProxy, fromJson } from "./proxy/index.js";
@@ -68,7 +69,7 @@ export class AppState implements IAppState {
 		return this._height;
 	}
 
-	public get clients(): Iterable<IClient> {
+	public get clients(): FluidIterable<IClient> {
 		return this.root.clients;
 	}
 

--- a/examples/benchmarks/bubblebench/ot/src/state.ts
+++ b/examples/benchmarks/bubblebench/ot/src/state.ts
@@ -12,6 +12,7 @@ import {
 	type SimpleClient,
 } from "@fluid-example/bubblebench-common";
 import type { SharedJson1 } from "@fluid-experimental/sharejs-json1";
+import type { FluidIterable } from "@fluidframework/core-interfaces";
 
 import { observe } from "./proxy/index.js";
 
@@ -19,7 +20,7 @@ interface IApp {
 	clients: IArrayish<SimpleClient>;
 }
 
-interface IArrayish<T> extends ArrayLike<T>, Pick<T[], "push">, Iterable<T> {}
+interface IArrayish<T> extends ArrayLike<T>, Pick<T[], "push">, FluidIterable<T> {}
 
 export class AppState implements IAppState {
 	private readonly root: IApp;

--- a/examples/benchmarks/bubblebench/shared-tree/src/appState.ts
+++ b/examples/benchmarks/bubblebench/shared-tree/src/appState.ts
@@ -10,6 +10,7 @@ import {
 	makeBubble,
 	randomColor,
 } from "@fluid-example/bubblebench-common";
+import type { FluidIterable } from "@fluidframework/core-interfaces";
 import { type TreeView, Tree } from "@fluidframework/tree";
 
 import { type App, Client } from "./schema.js";
@@ -50,7 +51,7 @@ export class AppState implements IAppState {
 		return client;
 	}
 
-	public get clients(): Iterable<IClient> {
+	public get clients(): FluidIterable<IClient> {
 		return this.tree.root.clients;
 	}
 


### PR DESCRIPTION
## Description

BubbleBench needs to support both Fluid Tree arrays and native arrays. This PR introduces a minimal shared collection contract so the benchmark remains compatible with both container implementations without requiring the full built-in array interface.

This is an internal-only change to private BubbleBench packages, so it does not include a changeset.

Validation performed:

- `git diff --check upstream/main...HEAD`
- `build:compile` for all five BubbleBench packages: `common`, `baseline`, `ot`, `experimental-tree`, and `shared-tree`
- Jest suites run sequentially for `ot`, `experimental-tree`, and `shared-tree` (all passed)

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

The diff is limited to the shared BubbleBench collection type and its three Tree/OT adapters.