### PR TITLE
Materialize full-tree summaries from snapshots

### DIFF
--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -321,10 +321,7 @@ import {
 	validateSummaryHeuristicConfiguration,
 	wrapSummaryInChannelsTree,
 } from "./summary/index.js";
-import {
-	fetchSnapshotForSummary,
-	materializeSummary,
-} from "./summary/materializeSummary.js";
+import { fetchSnapshotForSummary, materializeSummary } from "./summary/materializeSummary.js";
 import { Throttler, formExponentialFn } from "./throttler.js";
 
 /**
@@ -625,8 +622,7 @@ export interface IPendingRuntimeState {
 }
 
 const maxConsecutiveReconnectsKey = "Fluid.ContainerRuntime.MaxConsecutiveReconnects";
-const snapshotBasedFullTreeSummaryKey =
-	"Fluid.ContainerRuntime.SnapshotBasedFullTreeSummary";
+const snapshotBasedFullTreeSummaryKey = "Fluid.ContainerRuntime.SnapshotBasedFullTreeSummary";
 
 // The actual limit is 1Mb (socket.io and Kafka limits)
 // We can't estimate it fully, as we
@@ -4455,13 +4451,10 @@ export class ContainerRuntime
 			const minimumSequenceNumber = this.deltaManager.minimumSequenceNumber;
 			const message = `Summary @${summaryRefSeqNum}:${this.deltaManager.minimumSequenceNumber}`;
 			const lastAckedContext = this.lastAckedSummaryContext;
-			const parentSummaryHandle =
-				lastAckedContext?.ackHandle ?? this.loadedFromVersionId;
+			const parentSummaryHandle = lastAckedContext?.ackHandle ?? this.loadedFromVersionId;
 			// Preserve fullTree's handle-free result without forcing unchanged children to regenerate.
 			const shouldMaterializeFullTree =
-				fullTree &&
-				this.snapshotBasedFullTreeSummary &&
-				parentSummaryHandle !== undefined;
+				fullTree && this.snapshotBasedFullTreeSummary && parentSummaryHandle !== undefined;
 
 			const startSummaryResult = this.summarizerNode.startSummary(
 				summaryRefSeqNum,
@@ -4591,10 +4584,8 @@ export class ContainerRuntime
 						this.storage,
 						parentSummaryHandle,
 					);
-					summaryTree = await materializeSummary(
-						summaryTree,
-						parentSnapshot,
-						async (id) => this.storage.readBlob(id),
+					summaryTree = await materializeSummary(summaryTree, parentSnapshot, async (id) =>
+						this.storage.readBlob(id),
 					);
 					partialStats = calculateStats(summaryTree);
 				} catch (error) {

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -321,6 +321,10 @@ import {
 	validateSummaryHeuristicConfiguration,
 	wrapSummaryInChannelsTree,
 } from "./summary/index.js";
+import {
+	fetchSnapshotForSummary,
+	materializeSummary,
+} from "./summary/materializeSummary.js";
 import { Throttler, formExponentialFn } from "./throttler.js";
 
 /**
@@ -621,6 +625,8 @@ export interface IPendingRuntimeState {
 }
 
 const maxConsecutiveReconnectsKey = "Fluid.ContainerRuntime.MaxConsecutiveReconnects";
+const snapshotBasedFullTreeSummaryKey =
+	"Fluid.ContainerRuntime.SnapshotBasedFullTreeSummary";
 
 // The actual limit is 1Mb (socket.io and Kafka limits)
 // We can't estimate it fully, as we
@@ -1573,6 +1579,7 @@ export class ContainerRuntime
 	private readonly loadedFromVersionId: string | undefined;
 
 	private readonly isSnapshotInstanceOfISnapshot: boolean;
+	private readonly snapshotBasedFullTreeSummary: boolean;
 
 	/**
 	 * The summary context of the last acked summary. The properties from this as used when uploading a summary.
@@ -1672,6 +1679,11 @@ export class ContainerRuntime
 				},
 			},
 		});
+		const snapshotBasedFullTreeSummary = this.mc.config.getBoolean(
+			snapshotBasedFullTreeSummaryKey,
+		);
+		this.snapshotBasedFullTreeSummary = snapshotBasedFullTreeSummary === true;
+		featureGatesForTelemetry.snapshotBasedFullTreeSummary = snapshotBasedFullTreeSummary;
 
 		// Validate that the Loader is compatible with this Runtime.
 		const maybeLoaderCompatDetailsForRuntime = context as FluidObject<ILayerCompatDetails>;
@@ -4443,6 +4455,13 @@ export class ContainerRuntime
 			const minimumSequenceNumber = this.deltaManager.minimumSequenceNumber;
 			const message = `Summary @${summaryRefSeqNum}:${this.deltaManager.minimumSequenceNumber}`;
 			const lastAckedContext = this.lastAckedSummaryContext;
+			const parentSummaryHandle =
+				lastAckedContext?.ackHandle ?? this.loadedFromVersionId;
+			// Preserve fullTree's handle-free result without forcing unchanged children to regenerate.
+			const shouldMaterializeFullTree =
+				fullTree &&
+				this.snapshotBasedFullTreeSummary &&
+				parentSummaryHandle !== undefined;
 
 			const startSummaryResult = this.summarizerNode.startSummary(
 				summaryRefSeqNum,
@@ -4533,7 +4552,7 @@ export class ContainerRuntime
 			let summarizeResult: ISummaryTreeWithStats;
 			try {
 				summarizeResult = await this.summarize({
-					fullTree,
+					fullTree: fullTree && !shouldMaterializeFullTree,
 					trackState: true,
 					summaryLogger: summaryNumberLogger,
 					runGC: this.garbageCollector.shouldRunGC,
@@ -4565,6 +4584,29 @@ export class ContainerRuntime
 				};
 			}
 
+			let { summary: summaryTree, stats: partialStats } = summarizeResult;
+			if (shouldMaterializeFullTree) {
+				try {
+					const parentSnapshot = await fetchSnapshotForSummary(
+						this.storage,
+						parentSummaryHandle,
+					);
+					summaryTree = await materializeSummary(
+						summaryTree,
+						parentSnapshot,
+						async (id) => this.storage.readBlob(id),
+					);
+					partialStats = calculateStats(summaryTree);
+				} catch (error) {
+					return {
+						stage: "base",
+						referenceSequenceNumber: summaryRefSeqNum,
+						minimumSequenceNumber,
+						error: wrapError(error, (msg) => new RetriableSummaryError(msg)),
+					};
+				}
+			}
+
 			// If there are pending unacked ops, this summary attempt may fail as the uploaded
 			// summary would be eventually inconsistent.
 			const pendingMessagesFailResult = await this.shouldFailSummaryOnPendingOps(
@@ -4577,8 +4619,6 @@ export class ContainerRuntime
 			if (pendingMessagesFailResult !== undefined) {
 				return pendingMessagesFailResult;
 			}
-
-			const { summary: summaryTree, stats: partialStats } = summarizeResult;
 
 			// Now that we have generated the summary, update the message at last summary to the last message processed.
 			this.messageAtLastSummary = this.deltaManager.lastMessage;

--- a/packages/runtime/container-runtime/src/summary/materializeSummary.ts
+++ b/packages/runtime/container-runtime/src/summary/materializeSummary.ts
@@ -1,0 +1,175 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import type { IContainerStorageService } from "@fluidframework/container-definitions/internal";
+import type {
+	ISnapshotTree,
+	ISummaryBlob,
+	ISummaryTree,
+	SummaryObject,
+} from "@fluidframework/driver-definitions";
+import { SummaryType } from "@fluidframework/driver-definitions";
+
+const materializeSummaryScenarioName = "MaterializeFullTreeSummary";
+
+type SnapshotStorage = Pick<
+	IContainerStorageService,
+	"getSnapshotTree" | "getVersions" | "readBlob"
+>;
+
+/**
+ * Fetches the exact snapshot used as the parent of an incremental summary.
+ */
+export async function fetchSnapshotForSummary(
+	storage: SnapshotStorage,
+	versionId: string,
+): Promise<ISnapshotTree> {
+	const versions = await storage.getVersions(versionId, 1, materializeSummaryScenarioName);
+	const version = versions[0];
+	if (version === undefined) {
+		throw new Error(`Could not resolve parent summary version "${versionId}".`);
+	}
+
+	const snapshot = await storage.getSnapshotTree(version, materializeSummaryScenarioName);
+	if (snapshot === null) {
+		throw new Error(`Could not fetch parent summary snapshot "${versionId}".`);
+	}
+	return snapshot;
+}
+
+/**
+ * Replaces every summary handle with content from the parent snapshot.
+ */
+export async function materializeSummary(
+	summary: ISummaryTree,
+	parentSnapshot: ISnapshotTree,
+	readBlob: (id: string) => Promise<ArrayBufferLike>,
+): Promise<ISummaryTree> {
+	const entries = await Promise.all(
+		Object.entries(summary.tree).map(
+			async ([key, value]) =>
+				[key, await materializeSummaryObject(value, parentSnapshot, readBlob)] as const,
+		),
+	);
+	return {
+		...summary,
+		tree: Object.fromEntries(entries),
+	};
+}
+
+async function materializeSummaryObject(
+	object: SummaryObject,
+	parentSnapshot: ISnapshotTree,
+	readBlob: (id: string) => Promise<ArrayBufferLike>,
+): Promise<SummaryObject> {
+	switch (object.type) {
+		case SummaryType.Tree:
+			return materializeSummary(object, parentSnapshot, readBlob);
+		case SummaryType.Blob:
+		case SummaryType.Attachment:
+			return object;
+		case SummaryType.Handle: {
+			switch (object.handleType) {
+				case SummaryType.Tree:
+					return materializeSnapshotTree(
+						resolveSnapshotTree(parentSnapshot, object.handle),
+						readBlob,
+					);
+				case SummaryType.Blob:
+					return materializeSnapshotBlob(
+						resolveSnapshotBlob(parentSnapshot, object.handle),
+						readBlob,
+					);
+				default:
+					throw new Error("Unsupported summary handle type.");
+			}
+		}
+		default:
+			throw new Error("Unsupported summary object type.");
+	}
+}
+
+async function materializeSnapshotTree(
+	snapshot: ISnapshotTree,
+	readBlob: (id: string) => Promise<ArrayBufferLike>,
+): Promise<ISummaryTree> {
+	const [blobs, trees] = await Promise.all([
+		Promise.all(
+			Object.entries(snapshot.blobs).map(
+				async ([key, id]) => [key, await materializeSnapshotBlob(id, readBlob)] as const,
+			),
+		),
+		Promise.all(
+			Object.entries(snapshot.trees).map(
+				async ([key, tree]) => [key, await materializeSnapshotTree(tree, readBlob)] as const,
+			),
+		),
+	]);
+
+	return {
+		type: SummaryType.Tree,
+		tree: Object.fromEntries([...blobs, ...trees]),
+		unreferenced: snapshot.unreferenced,
+		groupId: snapshot.groupId,
+	};
+}
+
+async function materializeSnapshotBlob(
+	id: string,
+	readBlob: (id: string) => Promise<ArrayBufferLike>,
+): Promise<ISummaryBlob> {
+	return {
+		type: SummaryType.Blob,
+		content: new Uint8Array(await readBlob(id)),
+	};
+}
+
+function resolveSnapshotTree(snapshot: ISnapshotTree, handle: string): ISnapshotTree {
+	const path = getHandlePath(handle);
+	if (path.length === 0) {
+		return snapshot;
+	}
+
+	let current = snapshot;
+	for (const key of path) {
+		const next = current.trees[key];
+		if (next === undefined) {
+			throw new Error(`Parent summary does not contain tree handle "${handle}".`);
+		}
+		current = next;
+	}
+	return current;
+}
+
+function resolveSnapshotBlob(snapshot: ISnapshotTree, handle: string): string {
+	const path = getHandlePath(handle);
+	const blobName = path.pop();
+	if (blobName === undefined) {
+		throw new Error("A blob summary handle cannot reference the snapshot root.");
+	}
+
+	let current = snapshot;
+	for (const key of path) {
+		const next = current.trees[key];
+		if (next === undefined) {
+			throw new Error(`Parent summary does not contain blob handle "${handle}".`);
+		}
+		current = next;
+	}
+
+	const blobId = current.blobs[blobName];
+	if (blobId === undefined) {
+		throw new Error(`Parent summary does not contain blob handle "${handle}".`);
+	}
+	return blobId;
+}
+
+function getHandlePath(handle: string): string[] {
+	const path = handle.split("/");
+	if (path[0] === "") {
+		path.shift();
+	}
+	return path.map((part) => decodeURIComponent(part));
+}

--- a/packages/runtime/container-runtime/src/summary/materializeSummary.ts
+++ b/packages/runtime/container-runtime/src/summary/materializeSummary.ts
@@ -5,12 +5,12 @@
 
 import type { IContainerStorageService } from "@fluidframework/container-definitions/internal";
 import type {
-	ISnapshotTree,
 	ISummaryBlob,
 	ISummaryTree,
 	SummaryObject,
 } from "@fluidframework/driver-definitions";
 import { SummaryType } from "@fluidframework/driver-definitions";
+import type { ISnapshotTree } from "@fluidframework/driver-definitions/internal";
 
 const materializeSummaryScenarioName = "MaterializeFullTreeSummary";
 

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -1918,6 +1918,75 @@ describe("Runtime", () => {
 				assert(summarizeResult.stage === "submit", "Summary did not succeed");
 			});
 
+			it("uses full regeneration for full tree summaries by default", async () => {
+				const summarize = containerRuntime.summarize.bind(containerRuntime);
+				let generatedFullTree: boolean | undefined;
+				containerRuntime.summarize = async (options) => {
+					generatedFullTree = options.fullTree;
+					return summarize(options);
+				};
+
+				const summarizeResult = await containerRuntime.submitSummary({
+					fullTree: true,
+					summaryLogger: createChildLogger(),
+					cancellationToken: neverCancelledSummaryToken,
+					latestSummaryRefSeqNum: 0,
+				});
+
+				assert(summarizeResult.stage === "submit", "Summary did not succeed");
+				assert.equal(generatedFullTree, true);
+			});
+
+			it("materializes full tree summaries from the parent snapshot when configured", async () => {
+				const parentVersion = { id: "parent-version", treeId: "parent-tree" };
+				let fetchedParentSnapshot = false;
+				const mockStorage: Partial<IContainerStorageService> = {
+					uploadSummaryWithContext: async () => "fakeHandle",
+					getVersions: async (versionId) => {
+						assert.equal(versionId, parentVersion.id);
+						return [parentVersion];
+					},
+					getSnapshotTree: async (version) => {
+						assert.deepEqual(version, parentVersion);
+						fetchedParentSnapshot = true;
+						return { blobs: {}, trees: {} };
+					},
+					readBlob: async (id) => {
+						throw new Error(`Unexpected blob read: ${id}`);
+					},
+				};
+				const { runtime } = await ContainerRuntime.loadRuntime2({
+					context: getMockContext({
+						settings: {
+							"Fluid.ContainerRuntime.SnapshotBasedFullTreeSummary": true,
+						},
+						loadedFromVersion: parentVersion,
+						mockStorage,
+					}) as IContainerContext,
+					registry: new FluidDataStoreRegistry([]),
+					existing: false,
+					provideEntryPoint: mockProvideEntryPoint,
+				});
+				const summarize = runtime.summarize.bind(runtime);
+				let generatedFullTree: boolean | undefined;
+				runtime.summarize = async (options) => {
+					generatedFullTree = options.fullTree;
+					return summarize(options);
+				};
+
+				const summarizeResult = await runtime.submitSummary({
+					fullTree: true,
+					summaryLogger: createChildLogger(),
+					cancellationToken: neverCancelledSummaryToken,
+					latestSummaryRefSeqNum: 0,
+				});
+
+				assert(summarizeResult.stage === "submit", "Summary did not succeed");
+				assert.equal(generatedFullTree, false);
+				assert.equal(fetchedParentSnapshot, true);
+				assert.equal(summarizeResult.summaryStats.handleNodeCount, 0);
+			});
+
 			it("summary fails if summary token is canceled", async () => {
 				const cancelledSummaryToken: ISummaryCancellationToken = {
 					cancelled: true,

--- a/packages/runtime/container-runtime/src/test/summary/materializeSummary.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summary/materializeSummary.spec.ts
@@ -1,0 +1,178 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "node:assert";
+
+import { stringToBuffer, Uint8ArrayToString } from "@fluid-internal/client-utils";
+import type { IContainerStorageService } from "@fluidframework/container-definitions/internal";
+import type {
+	ISnapshotTree,
+	ISummaryTree,
+	SummaryObject,
+} from "@fluidframework/driver-definitions";
+import { SummaryType } from "@fluidframework/driver-definitions";
+
+import {
+	fetchSnapshotForSummary,
+	materializeSummary,
+} from "../../summary/materializeSummary.js";
+
+describe("Full tree summary materialization", () => {
+	const parentSnapshot: ISnapshotTree = {
+		blobs: {
+			"root blob": "root-blob-id",
+		},
+		trees: {
+			"tree key": {
+				blobs: {
+					nested: "nested-blob-id",
+				},
+				trees: {},
+				unreferenced: true,
+				groupId: "parent-group",
+			},
+		},
+	};
+	const blobContents = new Map([
+		["root-blob-id", stringToBuffer("root content", "utf8")],
+		["nested-blob-id", stringToBuffer("nested content", "utf8")],
+	]);
+	const readBlob = async (id: string): Promise<ArrayBufferLike> => {
+		const content = blobContents.get(id);
+		assert(content !== undefined, `Unexpected blob ID: ${id}`);
+		return content;
+	};
+
+	it("replaces tree and blob handles while preserving current content", async () => {
+		const incrementalSummary: ISummaryTree = {
+			type: SummaryType.Tree,
+			tree: {
+				tree: {
+					type: SummaryType.Handle,
+					handleType: SummaryType.Tree,
+					handle: "/tree%20key",
+				},
+				blob: {
+					type: SummaryType.Handle,
+					handleType: SummaryType.Blob,
+					handle: "/root%20blob",
+				},
+				currentTree: {
+					type: SummaryType.Tree,
+					tree: {
+						nestedBlob: {
+							type: SummaryType.Handle,
+							handleType: SummaryType.Blob,
+							handle: "/tree%20key/nested",
+						},
+						newBlob: {
+							type: SummaryType.Blob,
+							content: "new content",
+						},
+					},
+					groupId: "current-group",
+				},
+				attachment: {
+					type: SummaryType.Attachment,
+					id: "attachment-id",
+				},
+			},
+		};
+
+		const result = await materializeSummary(
+			incrementalSummary,
+			parentSnapshot,
+			readBlob,
+		);
+
+		assertNoHandles(result);
+		const tree = getSummaryObject(result, "tree", SummaryType.Tree);
+		assert.equal(tree.unreferenced, true);
+		assert.equal(tree.groupId, "parent-group");
+		assert.equal(readSummaryBlob(tree.tree.nested), "nested content");
+		assert.equal(readSummaryBlob(result.tree.blob), "root content");
+
+		const currentTree = getSummaryObject(result, "currentTree", SummaryType.Tree);
+		assert.equal(currentTree.groupId, "current-group");
+		assert.equal(readSummaryBlob(currentTree.tree.nestedBlob), "nested content");
+		assert.deepEqual(currentTree.tree.newBlob, {
+			type: SummaryType.Blob,
+			content: "new content",
+		});
+		assert.deepEqual(result.tree.attachment, {
+			type: SummaryType.Attachment,
+			id: "attachment-id",
+		});
+	});
+
+	it("fails when a handle is absent from the parent snapshot", async () => {
+		await assert.rejects(
+			materializeSummary(
+				{
+					type: SummaryType.Tree,
+					tree: {
+						missing: {
+							type: SummaryType.Handle,
+							handleType: SummaryType.Tree,
+							handle: "/missing",
+						},
+					},
+				},
+				parentSnapshot,
+				readBlob,
+			),
+			/does not contain tree handle/,
+		);
+	});
+
+	it("fetches the requested parent snapshot version", async () => {
+		const version = { id: "parent-version", treeId: "parent-tree" };
+		const storage: Pick<
+			IContainerStorageService,
+			"getSnapshotTree" | "getVersions" | "readBlob"
+		> = {
+			getVersions: async (versionId, count, scenarioName) => {
+				assert.equal(versionId, version.id);
+				assert.equal(count, 1);
+				assert.equal(scenarioName, "MaterializeFullTreeSummary");
+				return [version];
+			},
+			getSnapshotTree: async (requestedVersion, scenarioName) => {
+				assert.deepEqual(requestedVersion, version);
+				assert.equal(scenarioName, "MaterializeFullTreeSummary");
+				return parentSnapshot;
+			},
+			readBlob,
+		};
+
+		assert.equal(await fetchSnapshotForSummary(storage, version.id), parentSnapshot);
+	});
+});
+
+function assertNoHandles(tree: ISummaryTree): void {
+	for (const object of Object.values(tree.tree)) {
+		assert.notEqual(object.type, SummaryType.Handle);
+		if (object.type === SummaryType.Tree) {
+			assertNoHandles(object);
+		}
+	}
+}
+
+function getSummaryObject<TType extends SummaryObject["type"]>(
+	tree: ISummaryTree,
+	key: string,
+	type: TType,
+): Extract<SummaryObject, { type: TType }> {
+	const object = tree.tree[key];
+	assert(object?.type === type, `Expected ${key} to have summary type ${type}`);
+	return object as Extract<SummaryObject, { type: TType }>;
+}
+
+function readSummaryBlob(object: SummaryObject | undefined): string {
+	assert(object?.type === SummaryType.Blob, "Expected a summary blob");
+	return typeof object.content === "string"
+		? object.content
+		: Uint8ArrayToString(object.content, "utf8");
+}

--- a/packages/runtime/container-runtime/src/test/summary/materializeSummary.spec.ts
+++ b/packages/runtime/container-runtime/src/test/summary/materializeSummary.spec.ts
@@ -7,12 +7,9 @@ import { strict as assert } from "node:assert";
 
 import { stringToBuffer, Uint8ArrayToString } from "@fluid-internal/client-utils";
 import type { IContainerStorageService } from "@fluidframework/container-definitions/internal";
-import type {
-	ISnapshotTree,
-	ISummaryTree,
-	SummaryObject,
-} from "@fluidframework/driver-definitions";
+import type { ISummaryTree, SummaryObject } from "@fluidframework/driver-definitions";
 import { SummaryType } from "@fluidframework/driver-definitions";
+import type { ISnapshotTree } from "@fluidframework/driver-definitions/internal";
 
 import {
 	fetchSnapshotForSummary,
@@ -81,11 +78,7 @@ describe("Full tree summary materialization", () => {
 			},
 		};
 
-		const result = await materializeSummary(
-			incrementalSummary,
-			parentSnapshot,
-			readBlob,
-		);
+		const result = await materializeSummary(incrementalSummary, parentSnapshot, readBlob);
 
 		assertNoHandles(result);
 		const tree = getSummaryObject(result, "tree", SummaryType.Tree);

--- a/packages/test/local-server-stress-tests/src/test/localServerStress.spec.ts
+++ b/packages/test/local-server-stress-tests/src/test/localServerStress.spec.ts
@@ -37,6 +37,15 @@ describe("Local Server Stress", () => {
 		configurations: {
 			"Fluid.Container.enableOfflineFull": true,
 			"Fluid.ContainerRuntime.EnableRollback": true,
+			"Fluid.ContainerRuntime.SnapshotBasedFullTreeSummary": true,
+		},
+		clientJoinOptions: {
+			clientAddProbability: 0.01,
+			maxNumberOfClients: 6,
+		},
+		summarizeOnDemandOptions: {
+			probability: 0.01,
+			fullTreeProbability: 0.5,
 		},
 		// Minimization is slow with many seeds; use only to minimize specific failing seeds.
 		skipMinimization: true,

--- a/packages/test/local-server-stress-tests/src/test/localServerStressHarness.ts
+++ b/packages/test/local-server-stress-tests/src/test/localServerStressHarness.ts
@@ -42,6 +42,7 @@ import {
 	createDetachedContainer,
 	loadExistingContainer,
 	loadFrozenContainerFromPendingState,
+	loadSummarizerContainerAndMakeSummary,
 	PendingLocalStateStore,
 } from "@fluidframework/container-loader/internal";
 import type {
@@ -127,6 +128,14 @@ interface AddClient {
 	type: "addClient";
 	clientTag: `client-${number}`;
 	fromClientTag: `client-${number}` | undefined;
+}
+
+/**
+ * @internal
+ */
+interface SummarizeOnDemand {
+	type: "summarizeOnDemand";
+	fullTree: boolean;
 }
 
 /**
@@ -254,6 +263,22 @@ export interface LocalServerStressOptions {
 		 * If the current number of clients has reached the maximum, this probability is ignored.
 		 */
 		clientAddProbability: number;
+
+	};
+
+	/**
+	 * Options for generating on-demand summaries during stress.
+	 */
+	summarizeOnDemandOptions?: {
+		/**
+		 * The probability that any generated operation is replaced with an on-demand summary.
+		 */
+		probability: number;
+
+		/**
+		 * The probability that an on-demand summary requests a full-tree summary.
+		 */
+		fullTreeProbability: number;
 	};
 
 	/**
@@ -386,6 +411,7 @@ const defaultLocalServerStressSuiteOptions: LocalServerStressOptions = {
 		clientAddProbability: 0.01,
 		maxNumberOfClients: 6,
 	},
+	summarizeOnDemandOptions: undefined,
 	only: [],
 	skip: [],
 	parseOperations: (serialized: string) => JSON.parse(serialized) as BaseOperation[],
@@ -532,6 +558,63 @@ function mixinAddRemoveClient<TOperation extends BaseOperation>(
 		minimizationTransforms,
 		generatorFactory,
 		reducer,
+	};
+}
+
+function mixinSummarizeOnDemand<TOperation extends BaseOperation>(
+	model: LocalServerStressModel<TOperation>,
+	options: LocalServerStressOptions,
+): LocalServerStressModel<TOperation | SummarizeOnDemand> {
+	const generatorFactory: () => AsyncGenerator<
+		TOperation | SummarizeOnDemand,
+		LocalServerStressState
+	> = () => {
+		const baseGenerator = model.generatorFactory();
+		return async (
+			state: LocalServerStressState,
+		): Promise<TOperation | SummarizeOnDemand | typeof done> => {
+			const summarizeOptions = options.summarizeOnDemandOptions;
+			if (
+				summarizeOptions !== undefined &&
+				state.validationClient.container.attachState !== AttachState.Detached &&
+				state.random.bool(summarizeOptions.probability)
+			) {
+				return {
+					type: "summarizeOnDemand",
+					fullTree: state.random.bool(summarizeOptions.fullTreeProbability),
+				};
+			}
+			return baseGenerator(state);
+		};
+	};
+
+	const reducer: AsyncReducer<
+		TOperation | SummarizeOnDemand,
+		LocalServerStressState
+	> = async (state, operation) => {
+		if (isOperationType<SummarizeOnDemand>("summarizeOnDemand", operation)) {
+			const url = await state.validationClient.container.getAbsoluteUrl("");
+			assert(url !== undefined, "url of container must be available");
+			await createOnDemandSummary(
+				state.localDeltaConnectionServer,
+				state.codeLoader,
+				url,
+				state.seed,
+				options,
+				operation.fullTree,
+			);
+			return state;
+		}
+		return model.reducer(state, operation);
+	};
+
+	return {
+		...model,
+		generatorFactory,
+		reducer,
+		minimizationTransforms: model.minimizationTransforms as
+			| MinimizationTransform<TOperation | SummarizeOnDemand>[]
+			| undefined,
 	};
 }
 
@@ -914,6 +997,37 @@ async function loadClient(
 		tag,
 		entryPoint: maybe.DefaultStressDataObject,
 	};
+}
+
+async function createOnDemandSummary(
+	localDeltaConnectionServer: ILocalDeltaConnectionServer,
+	codeLoader: ICodeDetailsLoader,
+	url: string,
+	seed: number,
+	options: LocalServerStressOptions,
+	fullTree: boolean,
+): Promise<void> {
+	const result = await loadSummarizerContainerAndMakeSummary({
+		documentServiceFactory: new LocalDocumentServiceFactory(localDeltaConnectionServer),
+		request: { url },
+		urlResolver: new LocalResolver(),
+		codeLoader,
+		logger: createStressLogger(seed),
+		configProvider: {
+			getRawConfig: (name): ConfigTypes | undefined =>
+				name === "Fluid.Summarizer.FullTree.OnDemand"
+					? fullTree
+					: options.configurations?.[name],
+		},
+	});
+	if (!result.success) {
+		throw result.error;
+	}
+
+	assert(
+		result.summaryResults.summaryInfo.handle !== undefined,
+		"On-demand summary must provide a version",
+	);
 }
 
 async function synchronizeClients(connectedClients: Client[]): Promise<void> {
@@ -1409,12 +1523,16 @@ const getFullModel = <TOperation extends BaseOperation>(
 	| RemoveClient
 	| Attach
 	| Synchronize
+	| SummarizeOnDemand
 	| ChangeConnectionState
 > =>
 	mixinAttach(
 		mixinSynchronization(
-			mixinAddRemoveClient(
-				mixinClientSelection(mixinReconnect(ddsModel, options), options),
+			mixinSummarizeOnDemand(
+				mixinAddRemoveClient(
+					mixinClientSelection(mixinReconnect(ddsModel, options), options),
+					options,
+				),
 				options,
 			),
 			options,

--- a/packages/test/local-server-stress-tests/src/test/localServerStressHarness.ts
+++ b/packages/test/local-server-stress-tests/src/test/localServerStressHarness.ts
@@ -263,7 +263,6 @@ export interface LocalServerStressOptions {
 		 * If the current number of clients has reached the maximum, this probability is ignored.
 		 */
 		clientAddProbability: number;
-
 	};
 
 	/**
@@ -588,10 +587,10 @@ function mixinSummarizeOnDemand<TOperation extends BaseOperation>(
 		};
 	};
 
-	const reducer: AsyncReducer<
-		TOperation | SummarizeOnDemand,
-		LocalServerStressState
-	> = async (state, operation) => {
+	const reducer: AsyncReducer<TOperation | SummarizeOnDemand, LocalServerStressState> = async (
+		state,
+		operation,
+	) => {
 		if (isOperationType<SummarizeOnDemand>("summarizeOnDemand", operation)) {
 			const url = await state.validationClient.container.getAbsoluteUrl("");
 			assert(url !== undefined, "url of container must be available");

--- a/packages/test/local-server-tests/src/test/fullTreeSummary.spec.ts
+++ b/packages/test/local-server-tests/src/test/fullTreeSummary.spec.ts
@@ -5,10 +5,7 @@
 
 import { strict as assert } from "assert";
 
-import {
-	stringToBuffer,
-	Uint8ArrayToString,
-} from "@fluid-internal/client-utils";
+import { stringToBuffer, Uint8ArrayToString } from "@fluid-internal/client-utils";
 import { ContainerRuntimeFactoryWithDefaultDataStore } from "@fluidframework/aqueduct/internal";
 import { LoaderHeader } from "@fluidframework/container-definitions/internal";
 import { Loader } from "@fluidframework/container-loader/internal";
@@ -18,16 +15,10 @@ import {
 	type IContainerRuntimeOptions,
 } from "@fluidframework/container-runtime/internal";
 import type { IFluidHandle } from "@fluidframework/core-interfaces";
-import type {
-	ISummaryTree,
-	SummaryObject,
-} from "@fluidframework/driver-definitions";
+import type { ISummaryTree, SummaryObject } from "@fluidframework/driver-definitions";
 import { SummaryType } from "@fluidframework/driver-definitions";
 import { SharedMap } from "@fluidframework/map/internal";
-import {
-	channelsTreeName,
-	gcTreeKey,
-} from "@fluidframework/runtime-definitions/internal";
+import { channelsTreeName, gcTreeKey } from "@fluidframework/runtime-definitions/internal";
 import { LocalDeltaConnectionServer } from "@fluidframework/server-local-server";
 import {
 	createSummarizerCore,
@@ -41,8 +32,7 @@ import {
 
 import { createLoader } from "./utils.js";
 
-const snapshotBasedFullTreeSummaryKey =
-	"Fluid.ContainerRuntime.SnapshotBasedFullTreeSummary";
+const snapshotBasedFullTreeSummaryKey = "Fluid.ContainerRuntime.SnapshotBasedFullTreeSummary";
 
 const runtimeOptions: IContainerRuntimeOptions = {
 	summaryOptions: {
@@ -95,16 +85,15 @@ describe("Snapshot-based full tree summary", () => {
 		const container = await loader.createDetachedContainer(codeDetails);
 		const root = await getContainerEntryPointBackCompat<ITestFluidObject>(container);
 
-		const secondaryDataStore =
-			await root.context.containerRuntime.createDataStore(dataStoreFactory.type);
+		const secondaryDataStore = await root.context.containerRuntime.createDataStore(
+			dataStoreFactory.type,
+		);
 		const secondary = (await secondaryDataStore.entryPoint.get()) as ITestFluidObject;
 		secondary.root.set("stable", "unchanged");
 		root.root.set("secondary", secondary.handle);
 
 		const blobPayload = "materialized attachment content";
-		const blobHandle = await root.runtime.uploadBlob(
-			stringToBuffer(blobPayload, "utf8"),
-		);
+		const blobHandle = await root.runtime.uploadBlob(stringToBuffer(blobPayload, "utf8"));
 		root.root.set("blob", blobHandle);
 		root.root.set("beforeParent", "parent value");
 
@@ -175,8 +164,7 @@ describe("Snapshot-based full tree summary", () => {
 		const loadedSecondary = await loadedSecondaryHandle.get();
 		assert.equal(loadedSecondary.root.get("stable"), "unchanged");
 
-		const loadedBlobHandle =
-			loadedRoot.root.get<IFluidHandle<ArrayBufferLike>>("blob");
+		const loadedBlobHandle = loadedRoot.root.get<IFluidHandle<ArrayBufferLike>>("blob");
 		assert(loadedBlobHandle !== undefined, "Expected the attachment blob handle");
 		assert.equal(
 			Uint8ArrayToString(new Uint8Array(await loadedBlobHandle.get()), "utf8"),

--- a/packages/test/local-server-tests/src/test/fullTreeSummary.spec.ts
+++ b/packages/test/local-server-tests/src/test/fullTreeSummary.spec.ts
@@ -1,0 +1,253 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+
+import {
+	stringToBuffer,
+	Uint8ArrayToString,
+} from "@fluid-internal/client-utils";
+import { ContainerRuntimeFactoryWithDefaultDataStore } from "@fluidframework/aqueduct/internal";
+import { LoaderHeader } from "@fluidframework/container-definitions/internal";
+import { Loader } from "@fluidframework/container-loader/internal";
+import {
+	ContainerRuntime,
+	blobsTreeName,
+	type IContainerRuntimeOptions,
+} from "@fluidframework/container-runtime/internal";
+import type { IFluidHandle } from "@fluidframework/core-interfaces";
+import type {
+	ISummaryTree,
+	SummaryObject,
+} from "@fluidframework/driver-definitions";
+import { SummaryType } from "@fluidframework/driver-definitions";
+import { SharedMap } from "@fluidframework/map/internal";
+import {
+	channelsTreeName,
+	gcTreeKey,
+} from "@fluidframework/runtime-definitions/internal";
+import { LocalDeltaConnectionServer } from "@fluidframework/server-local-server";
+import {
+	createSummarizerCore,
+	createTestConfigProvider,
+	getContainerEntryPointBackCompat,
+	type ITestFluidObject,
+	LoaderContainerTracker,
+	summarizeNow,
+	TestFluidObjectFactory,
+} from "@fluidframework/test-utils/internal";
+
+import { createLoader } from "./utils.js";
+
+const snapshotBasedFullTreeSummaryKey =
+	"Fluid.ContainerRuntime.SnapshotBasedFullTreeSummary";
+
+const runtimeOptions: IContainerRuntimeOptions = {
+	summaryOptions: {
+		summaryConfigOverrides: {
+			state: "summaryOnRequest",
+			initialSummarizerDelayMs: 0,
+			maxAckWaitTime: 20_000,
+			maxOpsSinceLastSummary: 7_000,
+		},
+	},
+};
+
+describe("Snapshot-based full tree summary", () => {
+	let deltaConnectionServer: ReturnType<typeof LocalDeltaConnectionServer.create>;
+	let tracker: LoaderContainerTracker;
+
+	beforeEach(() => {
+		deltaConnectionServer = LocalDeltaConnectionServer.create();
+		tracker = new LoaderContainerTracker(true);
+	});
+
+	afterEach(async () => {
+		tracker.reset();
+		await deltaConnectionServer.webSocketServer.close();
+	});
+
+	it("materializes an incremental summary and loads it as a complete snapshot", async () => {
+		const dataStoreFactory = new TestFluidObjectFactory(
+			[["map", SharedMap.getFactory()]],
+			"default",
+		);
+		const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore({
+			defaultFactory: dataStoreFactory,
+			registryEntries: [[dataStoreFactory.type, Promise.resolve(dataStoreFactory)]],
+			runtimeOptions,
+		});
+		const { loaderProps, codeDetails, urlResolver } = createLoader({
+			deltaConnectionServer,
+			defaultDataStoreFactory: dataStoreFactory,
+			runtimeFactory,
+		});
+		const loader = new Loader({
+			...loaderProps,
+			configProvider: createTestConfigProvider({
+				[snapshotBasedFullTreeSummaryKey]: true,
+			}),
+		});
+		tracker.add(loader);
+
+		const container = await loader.createDetachedContainer(codeDetails);
+		const root = await getContainerEntryPointBackCompat<ITestFluidObject>(container);
+
+		const secondaryDataStore =
+			await root.context.containerRuntime.createDataStore(dataStoreFactory.type);
+		const secondary = (await secondaryDataStore.entryPoint.get()) as ITestFluidObject;
+		secondary.root.set("stable", "unchanged");
+		root.root.set("secondary", secondary.handle);
+
+		const blobPayload = "materialized attachment content";
+		const blobHandle = await root.runtime.uploadBlob(
+			stringToBuffer(blobPayload, "utf8"),
+		);
+		root.root.set("blob", blobHandle);
+		root.root.set("beforeParent", "parent value");
+
+		await container.attach(urlResolver.createCreateNewRequest("full-tree-summary"));
+		await tracker.ensureSynchronized();
+
+		const { container: summarizerContainer, summarizer } = await createSummarizerCore(
+			container,
+			loader,
+		);
+		tracker.addContainer(summarizerContainer);
+		await tracker.ensureSynchronized();
+
+		const parentSummary = await summarizeNow(summarizer, {
+			reason: "create incremental parent",
+		});
+		assert(
+			containsHandle(parentSummary.summaryTree),
+			"Expected the acknowledged parent summary to reuse content from the attach snapshot",
+		);
+
+		root.root.set("afterParent", "changed value");
+		await tracker.ensureSynchronized();
+
+		const legacyFullSummary = await (
+			root.context.containerRuntime as ContainerRuntime
+		).summarize({
+			fullTree: true,
+			trackState: false,
+		});
+		assertNoHandles(legacyFullSummary.summary);
+
+		const materializedSummary = await summarizeNow(summarizer, {
+			reason: "materialize full tree",
+			fullTree: true,
+		});
+		assertNoHandles(materializedSummary.summaryTree);
+
+		for (const key of [channelsTreeName, blobsTreeName, gcTreeKey]) {
+			const expected = legacyFullSummary.summary.tree[key];
+			const actual = materializedSummary.summaryTree.tree[key];
+			assert(expected !== undefined, `Legacy full summary is missing ${key}`);
+			assert(actual !== undefined, `Materialized full summary is missing ${key}`);
+			assert.deepEqual(
+				normalizeSummaryObject(actual),
+				normalizeSummaryObject(expected),
+				`${key} should match the legacy full-generation result`,
+			);
+		}
+
+		const url = await container.getAbsoluteUrl("");
+		assert(url !== undefined, "Expected an absolute container URL");
+		const loadedContainer = await loader.resolve({
+			url,
+			headers: {
+				[LoaderHeader.cache]: false,
+				[LoaderHeader.version]: materializedSummary.summaryVersion,
+			},
+		});
+		const loadedRoot =
+			await getContainerEntryPointBackCompat<ITestFluidObject>(loadedContainer);
+		assert.equal(loadedRoot.root.get("beforeParent"), "parent value");
+		assert.equal(loadedRoot.root.get("afterParent"), "changed value");
+
+		const loadedSecondaryHandle =
+			loadedRoot.root.get<IFluidHandle<ITestFluidObject>>("secondary");
+		assert(loadedSecondaryHandle !== undefined, "Expected the secondary data store handle");
+		const loadedSecondary = await loadedSecondaryHandle.get();
+		assert.equal(loadedSecondary.root.get("stable"), "unchanged");
+
+		const loadedBlobHandle =
+			loadedRoot.root.get<IFluidHandle<ArrayBufferLike>>("blob");
+		assert(loadedBlobHandle !== undefined, "Expected the attachment blob handle");
+		assert.equal(
+			Uint8ArrayToString(new Uint8Array(await loadedBlobHandle.get()), "utf8"),
+			blobPayload,
+		);
+	}).timeout(60_000);
+});
+
+type NormalizedSummaryObject =
+	| {
+			type: "tree";
+			tree: Record<string, NormalizedSummaryObject>;
+			unreferenced: true | undefined;
+			groupId: string | undefined;
+	  }
+	| {
+			type: "blob";
+			content: string;
+	  }
+	| {
+			type: "attachment";
+			id: string;
+	  };
+
+function normalizeSummaryObject(object: SummaryObject): NormalizedSummaryObject {
+	switch (object.type) {
+		case SummaryType.Tree:
+			return {
+				type: "tree",
+				tree: Object.fromEntries(
+					Object.entries(object.tree).map(([key, value]) => [
+						key,
+						normalizeSummaryObject(value),
+					]),
+				),
+				unreferenced: object.unreferenced,
+				groupId: object.groupId,
+			};
+		case SummaryType.Blob: {
+			const content =
+				typeof object.content === "string"
+					? new Uint8Array(stringToBuffer(object.content, "utf8"))
+					: object.content;
+			return {
+				type: "blob",
+				content: Uint8ArrayToString(content, "base64"),
+			};
+		}
+		case SummaryType.Attachment:
+			return {
+				type: "attachment",
+				id: object.id,
+			};
+		case SummaryType.Handle:
+			assert.fail(`Unexpected summary handle: ${object.handle}`);
+	}
+}
+
+function assertNoHandles(tree: ISummaryTree): void {
+	for (const object of Object.values(tree.tree)) {
+		assert.notEqual(object.type, SummaryType.Handle, "Full summary must not contain handles");
+		if (object.type === SummaryType.Tree) {
+			assertNoHandles(object);
+		}
+	}
+}
+
+function containsHandle(tree: ISummaryTree): boolean {
+	return Object.values(tree.tree).some(
+		(object) =>
+			object.type === SummaryType.Handle ||
+			(object.type === SummaryType.Tree && containsHandle(object)),
+	);
+}


### PR DESCRIPTION
[How contribute to this repo](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).

[Guidelines for Pull Requests](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

## Description

Adds a configurable full-tree summary path that generates a normal incremental summary, resolves its handles against the acknowledged parent snapshot, and materializes unchanged blobs and trees instead of regenerating every loaded data store and DDS.

The existing regeneration path remains the default. Enabling `Fluid.ContainerRuntime.SnapshotBasedFullTreeSummary` opts full-tree requests into snapshot materialization; attach summaries and summaries without a parent snapshot continue using full generation.

Adds focused materialization coverage, a local-server end-to-end scenario covering equivalence and reload behavior, and probabilistic local-server stress operations for incremental and full-tree on-demand summaries.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Please focus on the parent-snapshot handle resolution semantics and whether the feature-gate boundary is appropriate for eventually removing runtime-wide `fullTree` regeneration.