### PR TITLE
chore(devcontainer): test AI agent Codespace prebuild triggering

### DIFF
--- a/.devcontainer/ai-agent-insiders/devcontainer.json
+++ b/.devcontainer/ai-agent-insiders/devcontainer.json
@@ -2,7 +2,7 @@
 {
 	"name": "AI-enabled (Unstable)",
 	// Bump this version to force a codespace prebuild rebuild. See .devcontainer/README.md.
-	// prebuild-version: 1.0.6
+	// prebuild-version: 1.0.7
 	"build": {
 		"dockerfile": "../Dockerfile",
 		"args": {

--- a/.devcontainer/ai-agent/devcontainer.json
+++ b/.devcontainer/ai-agent/devcontainer.json
@@ -2,7 +2,7 @@
 {
 	"name": "AI-enabled",
 	// Bump this version to force a codespace prebuild rebuild. See .devcontainer/README.md.
-	// prebuild-version: 1.0.8
+	// prebuild-version: 1.0.9
 	"build": {
 		"dockerfile": "../Dockerfile",
 		"args": {


### PR DESCRIPTION
[How contribute to this repo](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).

[Guidelines for Pull Requests](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

## Description

Bump the prebuild versions for the stable and unstable AI agent devcontainers to test Codespace prebuild triggering. This change only invalidates the existing prebuilds; it does not change the devcontainer configuration or runtime behavior.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Confirm that the version bumps trigger fresh Codespace prebuilds for both AI agent devcontainers.