### PR TITLE
ci(lts): preserve auth for nested package installs

### DIFF
--- a/tools/pipelines/templates/build-npm-package.yml
+++ b/tools/pipelines/templates/build-npm-package.yml
@@ -318,21 +318,29 @@ extends:
 
         # Build
         - ${{ if ne(parameters.taskBuild, 'false') }}:
-          - task: Npm@1
+          - task: Bash@3
             displayName: npm run ${{ parameters.taskBuild }}
+            env:
+              NPM_CONFIG_USERCONFIG: $(NPM_CONFIG_USERCONFIG)
             inputs:
-              command: 'custom'
-              workingDir: ${{ parameters.buildDirectory }}
-              customCommand: 'run ${{ parameters.taskBuild }}'
+              targetType: 'inline'
+              workingDirectory: ${{ parameters.buildDirectory }}
+              script: |
+                set -eu -o pipefail
+                npm run ${{ parameters.taskBuild }}
 
         # Lint
         - ${{ if ne(parameters.taskLint, false) }}:
-          - task: Npm@1
+          - task: Bash@3
             displayName: npm run lint
+            env:
+              NPM_CONFIG_USERCONFIG: $(NPM_CONFIG_USERCONFIG)
             inputs:
-              command: 'custom'
-              workingDir: ${{ parameters.buildDirectory }}
-              customCommand: 'run lint'
+              targetType: 'inline'
+              workingDirectory: ${{ parameters.buildDirectory }}
+              script: |
+                set -eu -o pipefail
+                npm run lint
         # Test
         - ${{ if ne(parameters.taskTest, 'false') }}:
           # Run any additional tests first so their results can be copied to the ~/nyc dir and published below
@@ -340,21 +348,29 @@ extends:
 
           # Test - No coverage
           - ${{ if ne(variables['testCoverage'], true) }}:
-            - task: Npm@1
+            - task: Bash@3
               displayName: npm run ${{ parameters.taskTest }}
+              env:
+                NPM_CONFIG_USERCONFIG: $(NPM_CONFIG_USERCONFIG)
               inputs:
-                command: 'custom'
-                workingDir: ${{ parameters.buildDirectory }}
-                customCommand: 'run ${{ parameters.taskTest }}'
+                targetType: 'inline'
+                workingDirectory: ${{ parameters.buildDirectory }}
+                script: |
+                  set -eu -o pipefail
+                  npm run ${{ parameters.taskTest }}
 
           # Test - With coverage
           - ${{ if eq(variables['testCoverage'], true) }}:
-            - task: Npm@1
+            - task: Bash@3
               displayName: npm run ci:test:coverage
+              env:
+                NPM_CONFIG_USERCONFIG: $(NPM_CONFIG_USERCONFIG)
               inputs:
-                command: 'custom'
-                workingDir: ${{ parameters.buildDirectory }}
-                customCommand: 'run ci:test:coverage'
+                targetType: 'inline'
+                workingDirectory: ${{ parameters.buildDirectory }}
+                script: |
+                  set -eu -o pipefail
+                  npm run ci:test:coverage
             # Some webpacked file using externals introduce file name with quotes in them
             # and Istanbul's cobertura reporter doesn't escape them causing parse error when we publish
             # A quick fix to patch the file with sed. (See https://github.com/bcoe/c8/issues/302)

--- a/tools/pipelines/templates/include-install-pnpm.yml
+++ b/tools/pipelines/templates/include-install-pnpm.yml
@@ -50,12 +50,32 @@ steps:
 
 - task: Bash@3
   displayName: Install pnpm
+  env:
+    NPM_CONFIG_USERCONFIG: $(NPM_CONFIG_USERCONFIG)
+    NPM_REGISTRY: $(ado-feeds-primary-registry)
+    SOURCES_DIR: $(Build.SourcesDirectory)
   inputs:
     targetType: 'inline'
     workingDirectory: ${{ parameters.buildDirectory }}
     # workspace-concurrency 0 means use use the CPU core count. This is better than the default (4) for larger agents.
     script: |
       set -eu -o pipefail
+      normalize_registry() {
+        local registry="$1"
+        while [ "${registry%/}" != "$registry" ]; do
+          registry="${registry%/}"
+        done
+        printf '%s/' "$registry"
+      }
+
+      expected_registry="$(normalize_registry "$NPM_REGISTRY")"
+      npm_registry="$(normalize_registry "$(npm config get registry)")"
+      if [ "$npm_registry" != "$expected_registry" ]; then
+        echo "##vso[task.logissue type=error]npm resolved registry '$npm_registry'; expected '$expected_registry'"
+        exit 1
+      fi
+      echo "npm registry: $npm_registry"
+
       # Resolve the pnpm version from the "packageManager" field (e.g. "pnpm@9.15.7+sha512..." -> "pnpm@9.15.7").
       # The integrity hash suffix is discarded, since npm provides no practical way to use it; we trust the
       # feed to serve the correct version. Not every caller passes a buildDirectory that contains a
@@ -78,9 +98,13 @@ steps:
       echo "Installing ${PNPM_VERSION}"
       npm install -g "$PNPM_VERSION" --userconfig "${{ parameters.userNpmrcPath }}"
       echo "Using pnpm $(pnpm -v)"
+      pnpm_registry="$(normalize_registry "$(pnpm config get registry)")"
+      if [ "$pnpm_registry" != "$expected_registry" ]; then
+        echo "##vso[task.logissue type=error]pnpm resolved registry '$pnpm_registry'; expected '$expected_registry'"
+        exit 1
+      fi
+      echo "pnpm registry: $pnpm_registry"
       echo "Pnpm user config location: $(pnpm config get userconfig)"
       pnpm config set store-dir ${{ parameters.pnpmStorePath }}
       echo "Pnpm store: ${{ parameters.pnpmStorePath }}"
       pnpm config set -g workspace-concurrency 0
-  env:
-    SOURCES_DIR: $(Build.SourcesDirectory)

--- a/tools/pipelines/templates/include-install.yml
+++ b/tools/pipelines/templates/include-install.yml
@@ -29,6 +29,8 @@ steps:
   - task: Bash@3
     displayName: Install dependencies
     retryCountOnTaskFailure: 4
+    env:
+      NPM_CONFIG_USERCONFIG: $(NPM_CONFIG_USERCONFIG)
     inputs:
       targetType: 'inline'
       workingDirectory: ${{ parameters.buildDirectory }}

--- a/tools/pipelines/templates/include-setup-npmrc-for-download.yml
+++ b/tools/pipelines/templates/include-setup-npmrc-for-download.yml
@@ -3,12 +3,12 @@
 
 # Creates an .npmrc file which uses the appropriate feeds from our ADO
 # org to download packages from the right locations, adds the necessary authentication to it, and sets configuration so
-# for the rest of the job execution all invocations of npm (EXCEPT installs through Npm@ tasks) use it.
+# for the rest of the job execution all invocations of npm (EXCEPT invocations through Npm@ tasks) use it.
 # The file is created in a "global" location that should not interfere with anything else.
 #
-# Npm@ tasks always override the user-level .npmrc file with one of their own, so they do not work with this
-# configuration. For that reason, using them to install dependencies should be avoided. Using them for other kinds
-# of npm invocations should be fine.
+# Npm@ tasks always override the user-level .npmrc file with one of their own, so avoid them for dependency installs
+# and for scripts that might directly or indirectly perform npm or pnpm registry operations. Use Bash instead so
+# nested package-manager commands inherit the authenticated userconfig.
 
 parameters:
 # Location for the .npmrc file.


### PR DESCRIPTION
## Description

This PR replaces the temporary LTS compatibility-test suppression in #27892 with authenticated full compatibility testing.

Build 416226 showed that `Npm@1` replaced the authenticated `NPM_CONFIG_USERCONFIG` with `/mnt/vss/_work/1/npm/416226.npmrc`. Compatibility tests then ran nested `npm view` and `npm install` commands against `registry.npmjs.org` instead of the primary Azure Artifacts feed.

The LTS monolithic build template now runs build, lint, regular-test, and coverage-test scripts through `Bash@3`, explicitly preserving `NPM_CONFIG_USERCONFIG`. The pnpm install path also fails fast unless both npm and pnpm resolve the configured primary Azure registry, with trailing slashes normalized before comparison.

The branch preserves the original compatibility matrix: the local and Tinylicious real-service scripts retain `--baseVersion=1.4.0`, and no `fluid__test__compatVersion: '[\"0\"]'` filter is present. This keeps coverage for versions `1.4.0`, `0.59.4003`, `0.58.2002`, and `0.45.4`.

This ports the focused approach from #27893 to LTS's older monolithic pipeline without importing the newer pipeline architecture.

Validation:
- Ran the CI readiness checker against `upstream/lts`; only root pipeline files changed, so there were no package-scoped checks to run.
- Verified npm and pnpm registry lookup and trailing-slash normalization with an authenticated-userconfig-shaped `.npmrc`.
- Ran `git diff --check`.
- Confirmed no compatibility-test filter remains and the compatibility harness is unchanged.
- Confirmed the remaining `Npm@1` tasks only run bundle analysis and API documentation scripts, not compatibility or nested registry operations.

## Reviewer Guidance

See the [Fluid Framework PR guidelines](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Please focus on the LTS-specific port of the Bash task conversion and on the fail-fast registry checks in the pnpm install path.

## Other information or known dependencies

PR #27892 is expected to land first as a temporary mitigation. Before this PR merges, this branch must be synchronized with the updated `lts` branch and #27892's suppression resolved in favor of the original compatibility settings described above.