### PR TITLE
fix(ci): keep pnpm installs on authenticated registries (2.114 backport)

### DIFF
--- a/tools/pipelines/templates/include-build-lint.yml
+++ b/tools/pipelines/templates/include-build-lint.yml
@@ -21,7 +21,7 @@ parameters:
 
 steps:
 - ${{ if ne(parameters.taskBuild, 'false') }}:
-  - task: Npm@1
+  - task: Bash@3
     displayName: npm run ${{ parameters.taskBuild }}
     env:
       # Set FLUB_TYPETEST_SKIP_VERSION_OUTPUT to 1 when building from test/* branches
@@ -32,17 +32,21 @@ steps:
       # per package during builds, producing 100+ identical warnings in build logs.
       BASELINE_BROWSER_MAPPING_IGNORE_OLD_DATA: 1
     inputs:
-      command: 'custom'
-      workingDir: $(Pipeline.Workspace)/${{ parameters.buildDirectory }}
-      customCommand: 'run ${{ parameters.taskBuild }}'
+      targetType: inline
+      workingDirectory: $(Pipeline.Workspace)/${{ parameters.buildDirectory }}
+      script: |
+        set -eu -o pipefail
+        npm run ${{ parameters.taskBuild }}
 
 - ${{ if ne(parameters.taskLint, false) }}:
-  - task: Npm@1
+  - task: Bash@3
     displayName: npm run ${{ parameters.taskLintName }}
     env:
       # Suppress baseline-browser-mapping staleness warnings during lint as well.
       BASELINE_BROWSER_MAPPING_IGNORE_OLD_DATA: 1
     inputs:
-      command: 'custom'
-      workingDir: $(Pipeline.Workspace)/${{ parameters.buildDirectory }}
-      customCommand: 'run ${{ parameters.taskLintName }}'
+      targetType: inline
+      workingDirectory: $(Pipeline.Workspace)/${{ parameters.buildDirectory }}
+      script: |
+        set -eu -o pipefail
+        npm run ${{ parameters.taskLintName }}

--- a/tools/pipelines/templates/include-install-pnpm.yml
+++ b/tools/pipelines/templates/include-install-pnpm.yml
@@ -128,7 +128,9 @@ steps:
     workingDirectory: '$(Pipeline.Workspace)/${{ parameters.buildDirectory }}'
     script: |
       set -eu -o pipefail
-      expected_registry="${NPM_REGISTRY%/}/"
+      # Trim whitespace before normalizing the registry URL to one trailing slash.
+      expected_registry="$(printf '%s' "$NPM_REGISTRY" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+      expected_registry="${expected_registry%/}/"
       npm_registry="$(npm config get registry)"
       if [ "$npm_registry" != "$expected_registry" ]; then
         echo "##vso[task.logissue type=error]npm resolved registry '$npm_registry'; expected '$expected_registry'"

--- a/tools/pipelines/templates/include-install-pnpm.yml
+++ b/tools/pipelines/templates/include-install-pnpm.yml
@@ -120,19 +120,36 @@ steps:
 # Install and configure pnpm
 - task: Bash@3
   displayName: Install pnpm
+  env:
+    NPM_CONFIG_USERCONFIG: ${{ parameters.userNpmrcPath }}
+    NPM_REGISTRY: ${{ parameters.primaryRegistry }}
   inputs:
     targetType: 'inline'
     workingDirectory: '$(Pipeline.Workspace)/${{ parameters.buildDirectory }}'
     script: |
       set -eu -o pipefail
+      expected_registry="${NPM_REGISTRY%/}/"
+      npm_registry="$(npm config get registry)"
+      if [ "$npm_registry" != "$expected_registry" ]; then
+        echo "##vso[task.logissue type=error]npm resolved registry '$npm_registry'; expected '$expected_registry'"
+        exit 1
+      fi
+      echo "npm registry: $npm_registry"
+
       # Parse the pnpm version pinned in package.json's "packageManager" field
       # (e.g. "pnpm@10.33.0+sha512..." -> "pnpm@10.33.0").
       # This discards the integrity hash suffix, which npm does not provide a practical way to use,
       # and trusts the package repository to serve the correct version.
       PNPM_VERSION=$(node -e "const p=require('./package.json');console.log(p.packageManager.split('+')[0])")
-      npm install -g "$PNPM_VERSION" --userconfig "${{ parameters.userNpmrcPath }}"
+      npm install -g "$PNPM_VERSION"
       echo "Using pnpm $(pnpm -v)"
-      echo "Pnpm user config location: $(pnpm config get userconfig)"
+      pnpm_registry="$(pnpm config get registry)"
+      if [ "$pnpm_registry" != "$expected_registry" ]; then
+        echo "##vso[task.logissue type=error]pnpm resolved registry '$pnpm_registry'; expected '$expected_registry'"
+        exit 1
+      fi
+      echo "pnpm registry: $pnpm_registry"
+      echo "Pnpm user config location: $NPM_CONFIG_USERCONFIG"
       pnpm config set store-dir ${{ parameters.pnpmStorePath }}
       echo "Pnpm store: ${{ parameters.pnpmStorePath }}"
       # CI uses mirrored registries that may not preserve trust metadata consistently.
@@ -143,3 +160,7 @@ steps:
       # Disable minimum release age checks in CI to avoid false positives.
       echo "Disabling pnpm minimumReleaseAge check as workaround for npm mirror publish time issues"
       echo "##vso[task.setvariable variable=PNPM_CONFIG_MINIMUM_RELEASE_AGE]0"
+      # CI installs use reviewed, committed lockfiles. Trust them so pnpm does not query
+      # registry metadata to reapply supply-chain policies to every locked dependency.
+      echo "Trusting committed lockfiles for CI installs"
+      echo "##vso[task.setvariable variable=PNPM_CONFIG_TRUST_LOCKFILE]true"

--- a/tools/pipelines/templates/include-setup-npmrc-for-download.yml
+++ b/tools/pipelines/templates/include-setup-npmrc-for-download.yml
@@ -7,8 +7,8 @@
 # The file is created in a "global" location that should not interfere with anything else.
 #
 # Npm@ tasks always override the user-level .npmrc file with one of their own, so they do not work with this
-# configuration. For that reason, using them to install dependencies should be avoided. Using them for other kinds
-# of npm invocations should be fine.
+# configuration. Avoid them for dependency installs and for scripts that might directly or indirectly perform npm
+# or pnpm registry operations. Use Bash instead so nested package-manager commands inherit the authenticated userconfig.
 
 parameters:
 # Location for the .npmrc file.

--- a/tools/pipelines/templates/include-test-task.yml
+++ b/tools/pipelines/templates/include-test-task.yml
@@ -17,12 +17,14 @@ parameters:
 steps:
 # Test - With coverage
 - ${{ if and(parameters.testCoverage, startsWith(parameters.taskTestStep, 'ci:test')) }}:
-  - task: Npm@1
+  - task: Bash@3
     displayName: npm run ${{ parameters.taskTestStep }}:coverage
     inputs:
-      command: 'custom'
-      workingDir: $(Pipeline.Workspace)/${{ parameters.buildDirectory }}
-      customCommand: 'run ${{ parameters.taskTestStep }}:coverage'
+      targetType: inline
+      workingDirectory: $(Pipeline.Workspace)/${{ parameters.buildDirectory }}
+      script: |
+        set -eu -o pipefail
+        npm run ${{ parameters.taskTestStep }}:coverage
     condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
     env:
       # Tests can use this environment variable to behave differently when running from a test branch
@@ -33,12 +35,14 @@ steps:
 
 # Test - No coverage
 - ${{ else }}:
-  - task: Npm@1
+  - task: Bash@3
     displayName: npm run ${{ parameters.taskTestStep }}
     inputs:
-      command: 'custom'
-      workingDir: $(Pipeline.Workspace)/${{ parameters.buildDirectory }}
-      customCommand: 'run ${{ parameters.taskTestStep }}'
+      targetType: inline
+      workingDirectory: $(Pipeline.Workspace)/${{ parameters.buildDirectory }}
+      script: |
+        set -eu -o pipefail
+        npm run ${{ parameters.taskTestStep }}
     condition: and(succeededOrFailed(), eq(variables['startTest'], 'true'))
     env:
       # Tests can use this environment variable to behave differently when running from a test branch


### PR DESCRIPTION
## Description

Backport #27893 to `release/client/2.114`.

Prevent network-isolated build-tools and client pipelines from contacting `registry.npmjs.org`. The shared pnpm setup explicitly uses the authenticated Azure Artifacts configuration, verifies npm and pnpm registry resolution, and preserves that configuration in shared build, lint, and test scripts.

Validation: ran the repository CI readiness quick check against `release/client/2.114`.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Please compare this backport with #27893 and focus on any release-branch conflict resolutions.