### PR TITLE
fix(devcontainer): prevent build CLI install prompt

### DIFF
--- a/.devcontainer/ai-agent-insiders/devcontainer.json
+++ b/.devcontainer/ai-agent-insiders/devcontainer.json
@@ -2,7 +2,7 @@
 {
 	"name": "AI-enabled (Unstable)",
 	// Bump this version to force a codespace prebuild rebuild. See .devcontainer/README.md.
-	// prebuild-version: 1.0.7
+	// prebuild-version: 1.0.8
 	"build": {
 		"dockerfile": "../Dockerfile",
 		"args": {

--- a/.devcontainer/ai-agent/devcontainer.json
+++ b/.devcontainer/ai-agent/devcontainer.json
@@ -2,7 +2,7 @@
 {
 	"name": "AI-enabled",
 	// Bump this version to force a codespace prebuild rebuild. See .devcontainer/README.md.
-	// prebuild-version: 1.0.9
+	// prebuild-version: 1.0.10
 	"build": {
 		"dockerfile": "../Dockerfile",
 		"args": {

--- a/scripts/codespace-setup/install-build-cli.sh
+++ b/scripts/codespace-setup/install-build-cli.sh
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 echo "Installing @fluid-tools/build-cli globally..."
-pnpm add -g @fluid-tools/build-cli
+CI=true pnpm add -g --allow-build=core-js @fluid-tools/build-cli
 
 echo "flub installed: $(which flub)"
 flub --version


### PR DESCRIPTION
## Description

The stable AI-enabled Codespaces prebuild hangs while installing `@fluid-tools/build-cli` because pnpm 11 prompts for approval to run the transitive `core-js` build script. Since prebuilds are unattended, the prompt remains open until the workflow is cancelled.

Run the global installation in CI mode and explicitly allow the `core-js` build script. Bump both AI-enabled devcontainer prebuild versions so GitHub regenerates the Stable prebuild to exercise the fix and the Insiders prebuild to verify configuration-change triggering.

This can be confirmed by checking that both Codespaces Prebuild workflows trigger after merge and that the Stable run completes the build CLI installation without displaying the package-build approval prompt.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Please verify that explicitly allowing `core-js` is the preferred pnpm 11 approach for this global installation.