### PR TITLE
Preserve SharedTree no-change constraints during refresher updates

### DIFF
--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -1673,34 +1673,9 @@ export function updateRefreshers(
 		}
 	}
 
-	const {
-		fieldChanges,
-		nodeChanges,
-		nodeToParent,
-		nodeAliases,
-		crossFieldKeys,
-		maxId,
-		revisions,
-		constraintViolationCount,
-		noChangeConstraint,
-		noChangeConstraintOnRevert,
-		builds,
-		destroys,
-	} = change;
-
 	return makeModularChangeset({
-		fieldChanges,
-		nodeChanges,
-		nodeToParent,
-		nodeAliases,
-		crossFieldKeys,
-		maxId: maxId as number,
-		revisions,
-		constraintViolationCount,
-		noChangeConstraint,
-		noChangeConstraintOnRevert,
-		builds,
-		destroys,
+		...change,
+		maxId: change.maxId,
 		refreshers,
 	});
 }

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeFamily.ts
@@ -1682,6 +1682,8 @@ export function updateRefreshers(
 		maxId,
 		revisions,
 		constraintViolationCount,
+		noChangeConstraint,
+		noChangeConstraintOnRevert,
 		builds,
 		destroys,
 	} = change;
@@ -1695,6 +1697,8 @@ export function updateRefreshers(
 		maxId: maxId as number,
 		revisions,
 		constraintViolationCount,
+		noChangeConstraint,
+		noChangeConstraintOnRevert,
 		builds,
 		destroys,
 		refreshers,

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeUtils.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeUtils.ts
@@ -12,7 +12,6 @@ import {
 	type RevisionInfo,
 	type RevisionTag,
 	type TaggedChange,
-	type TreeChunk,
 } from "../../core/index.js";
 import { brand, type Mutable, type RangeQueryResult } from "../../util/index.js";
 import {
@@ -33,12 +32,9 @@ import type { FlexFieldKind } from "./fieldKind.js";
 import { genericFieldKind } from "./genericFieldKind.js";
 import {
 	newCrossFieldKeyTable,
-	type CrossFieldKeyTable,
 	type FieldChange,
 	type FieldChangeMap,
-	type FieldId,
 	type ModularChangeset,
-	type NoChangeConstraint,
 	type NodeChangeset,
 	type NodeId,
 } from "./modularChangeTypes.js";
@@ -47,22 +43,17 @@ export function hasConflicts(change: ModularChangeset): boolean {
 	return (change.constraintViolationCount ?? 0) > 0;
 }
 
-export function makeModularChangeset(props?: {
-	fieldChanges?: FieldChangeMap;
-	nodeChanges?: ChangeAtomIdBTree<NodeChangeset>;
-	nodeToParent?: ChangeAtomIdBTree<FieldId>;
-	nodeAliases?: ChangeAtomIdBTree<NodeId>;
-	crossFieldKeys?: CrossFieldKeyTable;
-	maxId: number | undefined;
-	revisions?: readonly RevisionInfo[];
-	constraintViolationCount?: number;
-	noChangeConstraint?: NoChangeConstraint;
-	noChangeConstraintOnRevert?: NoChangeConstraint;
-	builds?: ChangeAtomIdBTree<TreeChunk>;
-	destroys?: ChangeAtomIdBTree<number>;
-	refreshers?: ChangeAtomIdBTree<TreeChunk>;
-}): ModularChangeset {
-	const p = props ?? { maxId: -1 };
+/**
+ * Creates a normalized changeset from the provided properties.
+ *
+ * Required changeset maps are initialized when omitted, and empty optional properties are not
+ * included in the returned changeset. `maxId` accepts an unbranded allocator ID; `undefined`
+ * indicates that the changeset contains no IDs.
+ */
+export function makeModularChangeset(
+	props: Partial<Omit<ModularChangeset, "maxId">> & { maxId?: number } = {},
+): ModularChangeset {
+	const p = props;
 	const changeset: Mutable<ModularChangeset> = {
 		fieldChanges: p.fieldChanges ?? new Map<FieldKey, FieldChange>(),
 		nodeChanges: p.nodeChanges ?? newChangeAtomIdBTree(),

--- a/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeUtils.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/modularChangeUtils.ts
@@ -53,7 +53,7 @@ export function makeModularChangeset(props?: {
 	nodeToParent?: ChangeAtomIdBTree<FieldId>;
 	nodeAliases?: ChangeAtomIdBTree<NodeId>;
 	crossFieldKeys?: CrossFieldKeyTable;
-	maxId: number;
+	maxId: number | undefined;
 	revisions?: readonly RevisionInfo[];
 	constraintViolationCount?: number;
 	noChangeConstraint?: NoChangeConstraint;
@@ -74,7 +74,7 @@ export function makeModularChangeset(props?: {
 	if (p.revisions !== undefined && p.revisions.length > 0) {
 		changeset.revisions = p.revisions;
 	}
-	if (p.maxId >= 0) {
+	if (p.maxId !== undefined && p.maxId >= 0) {
 		changeset.maxId = brand(p.maxId);
 	}
 	if (p.constraintViolationCount !== undefined && p.constraintViolationCount > 0) {

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/modularChangeFamily.spec.ts
@@ -1288,6 +1288,17 @@ describe("ModularChangeFamily", () => {
 			return tryGetFromNestedMap(nodeMap, major, minor);
 		};
 
+		it("preserves no-change constraints", () => {
+			const input: ModularChangeset = {
+				...Change.empty(),
+				noChangeConstraint: { violated: false },
+				noChangeConstraintOnRevert: { violated: false },
+			};
+
+			const updated = updateRefreshers(input, getDetachedNode, []);
+			assert.deepEqual(updated, input);
+		});
+
 		it("preserves relevant refreshers that are present in the input", () => {
 			const input: ModularChangeset = {
 				...Change.empty(),

--- a/packages/test/local-server-tests/src/test/sharedTreeConstraints.spec.ts
+++ b/packages/test/local-server-tests/src/test/sharedTreeConstraints.spec.ts
@@ -1,0 +1,133 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+
+import { ContainerRuntimeFactoryWithDefaultDataStore } from "@fluidframework/aqueduct/internal";
+import { loadExistingContainer } from "@fluidframework/container-loader/internal";
+import { LocalDeltaConnectionServer } from "@fluidframework/server-local-server";
+import {
+	createAndAttachContainerUsingProps,
+	type ITestFluidObject,
+	LoaderContainerTracker,
+	TestFluidObjectFactory,
+	toIDeltaManagerFull,
+	waitForContainerConnection,
+} from "@fluidframework/test-utils/internal";
+import { type ITree, SchemaFactory, TreeViewConfiguration } from "@fluidframework/tree";
+import { asAlpha, CommitOutcome, FluidClientVersion } from "@fluidframework/tree/alpha";
+import { configuredSharedTree } from "@fluidframework/tree/internal";
+
+import { createLoader } from "./utils.js";
+
+describe("SharedTree transaction constraints", () => {
+	it("does not apply a noChange-constrained transaction resubmitted after a sequenced edit", async () => {
+		const treeId = "tree";
+		const schemaFactory = new SchemaFactory("sharedTreeConstraintTest");
+		class StringArray extends schemaFactory.array("StringArray", schemaFactory.string) {}
+		const viewConfiguration = new TreeViewConfiguration({ schema: StringArray });
+		const sharedTree = configuredSharedTree({
+			minVersionForCollab: FluidClientVersion.v2_80,
+		});
+
+		const deltaConnectionServer = LocalDeltaConnectionServer.create();
+		const dataStoreFactory = new TestFluidObjectFactory(
+			[[treeId, sharedTree.getFactory()]],
+			"default",
+		);
+		const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore({
+			defaultFactory: dataStoreFactory,
+			registryEntries: [[dataStoreFactory.type, Promise.resolve(dataStoreFactory)]],
+			runtimeOptions: { enableRuntimeIdCompressor: "on" },
+		});
+		const { codeDetails, loaderProps, urlResolver } = createLoader({
+			deltaConnectionServer,
+			defaultDataStoreFactory: dataStoreFactory,
+			runtimeFactory,
+		});
+		const tracker = new LoaderContainerTracker();
+
+		try {
+			const containerA = await createAndAttachContainerUsingProps(
+				{ ...loaderProps, codeDetails },
+				urlResolver.createCreateNewRequest("shared-tree-constraint-resubmit"),
+			);
+			tracker.addContainer(containerA);
+			const dataObjectA = (await containerA.getEntryPoint()) as ITestFluidObject;
+			const treeA = await dataObjectA.getSharedObject<ITree>(treeId);
+			const viewA = asAlpha(treeA.viewWith(viewConfiguration));
+			viewA.initialize(["initial"]);
+			await tracker.ensureSynchronized();
+
+			const url = await containerA.getAbsoluteUrl("");
+			assert(url !== undefined, "container should have a URL after attach");
+			const containerB = await loadExistingContainer({
+				...loaderProps,
+				request: { url },
+			});
+			tracker.addContainer(containerB);
+			const dataObjectB = (await containerB.getEntryPoint()) as ITestFluidObject;
+			const treeB = await dataObjectB.getSharedObject<ITree>(treeId);
+			const viewB = asAlpha(treeB.viewWith(viewConfiguration));
+
+			const settledOutcome = new Promise<CommitOutcome>((resolve) => {
+				const unsubscribe = viewA.events.on("changed", (metadata) => {
+					if (metadata.isLocal) {
+						unsubscribe();
+						metadata.events.on("settled", resolve);
+					}
+				});
+			});
+
+			const disconnected = new Promise<void>((resolve) => {
+				containerA.once("disconnected", () => resolve());
+			});
+
+			const deltaManagerA = toIDeltaManagerFull(containerA.deltaManager);
+			// Enrich and submit the transaction locally, but keep its op pending for resubmission.
+			await deltaManagerA.outbound.pause();
+			viewA.runTransaction(
+				() => {
+					viewA.root.insertAtEnd("constrained");
+				},
+				{ preconditions: [{ type: "noChange" }] },
+			);
+			assert.deepEqual([...viewA.root], ["initial", "constrained"]);
+
+			containerA.disconnect();
+			await disconnected;
+
+			containerA.connect();
+			await waitForContainerConnection(containerA);
+			await deltaManagerA.inbound.pause();
+
+			// Sequence B's edit first while A is unable to rebase its pending transaction.
+			viewB.root.insertAtEnd("sequenced");
+			await tracker.ensureSynchronized(containerB);
+			assert.deepEqual([...viewB.root], ["initial", "sequenced"]);
+
+			deltaManagerA.outbound.resume();
+			await deltaManagerA.outbound.waitTillProcessingDone();
+			deltaManagerA.inbound.resume();
+			await tracker.ensureSynchronized();
+
+			assert.deepEqual(
+				{
+					outcome: await settledOutcome,
+					clientA: [...viewA.root],
+					clientB: [...viewB.root],
+				},
+				{
+					outcome: CommitOutcome.NewContentOnly,
+					clientA: ["initial", "sequenced"],
+					clientB: ["initial", "sequenced"],
+				},
+			);
+		} finally {
+			tracker.reset();
+			await deltaConnectionServer.webSocketServer.close();
+		}
+	});
+});

--- a/packages/test/local-server-tests/src/test/sharedTreeConstraints.spec.ts
+++ b/packages/test/local-server-tests/src/test/sharedTreeConstraints.spec.ts
@@ -7,6 +7,7 @@ import { strict as assert } from "assert";
 
 import { ContainerRuntimeFactoryWithDefaultDataStore } from "@fluidframework/aqueduct/internal";
 import { loadExistingContainer } from "@fluidframework/container-loader/internal";
+import type { IContainer } from "@fluidframework/container-definitions/internal";
 import { LocalDeltaConnectionServer } from "@fluidframework/server-local-server";
 import {
 	createAndAttachContainerUsingProps,
@@ -17,13 +18,21 @@ import {
 	waitForContainerConnection,
 } from "@fluidframework/test-utils/internal";
 import { type ITree, SchemaFactory, TreeViewConfiguration } from "@fluidframework/tree";
-import { asAlpha, CommitOutcome, FluidClientVersion } from "@fluidframework/tree/alpha";
+// This import should be updated to beta/public once the relevant transaction & constraint APIs are stabilized.
+import {
+	asAlpha,
+	CommitOutcome,
+	FluidClientVersion,
+	type TreeViewAlpha,
+} from "@fluidframework/tree/alpha";
 import { configuredSharedTree } from "@fluidframework/tree/internal";
 
 import { createLoader } from "./utils.js";
 
 describe("SharedTree transaction constraints", () => {
-	it("does not apply a noChange-constrained transaction resubmitted after a sequenced edit", async () => {
+	// This is a regression test for an issue where commit enrichment did not appropriately propagate constraint metadata.
+	// It is intentionally a bit particular about delta manager queue choreography to ensure that it exercises that enrichment code path.
+	it("respects noChange constraints across op resubmission", async () => {
 		const treeId = "tree";
 		const schemaFactory = new SchemaFactory("sharedTreeConstraintTest");
 		class StringArray extends schemaFactory.array("StringArray", schemaFactory.string) {}
@@ -39,7 +48,7 @@ describe("SharedTree transaction constraints", () => {
 		);
 		const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore({
 			defaultFactory: dataStoreFactory,
-			registryEntries: [[dataStoreFactory.type, Promise.resolve(dataStoreFactory)]],
+			registryEntries: [[dataStoreFactory.type, dataStoreFactory]],
 			runtimeOptions: { enableRuntimeIdCompressor: "on" },
 		});
 		const { codeDetails, loaderProps, urlResolver } = createLoader({
@@ -49,15 +58,21 @@ describe("SharedTree transaction constraints", () => {
 		});
 		const tracker = new LoaderContainerTracker();
 
+		const getTreeView = async (
+			container: IContainer,
+		): Promise<TreeViewAlpha<typeof StringArray>> => {
+			const dataObject = (await container.getEntryPoint()) as ITestFluidObject;
+			const tree = await dataObject.getSharedObject<ITree>(treeId);
+			return asAlpha(tree.viewWith(viewConfiguration));
+		};
+
 		try {
 			const containerA = await createAndAttachContainerUsingProps(
 				{ ...loaderProps, codeDetails },
 				urlResolver.createCreateNewRequest("shared-tree-constraint-resubmit"),
 			);
 			tracker.addContainer(containerA);
-			const dataObjectA = (await containerA.getEntryPoint()) as ITestFluidObject;
-			const treeA = await dataObjectA.getSharedObject<ITree>(treeId);
-			const viewA = asAlpha(treeA.viewWith(viewConfiguration));
+			const viewA = await getTreeView(containerA);
 			viewA.initialize(["initial"]);
 			await tracker.ensureSynchronized();
 
@@ -68,9 +83,7 @@ describe("SharedTree transaction constraints", () => {
 				request: { url },
 			});
 			tracker.addContainer(containerB);
-			const dataObjectB = (await containerB.getEntryPoint()) as ITestFluidObject;
-			const treeB = await dataObjectB.getSharedObject<ITree>(treeId);
-			const viewB = asAlpha(treeB.viewWith(viewConfiguration));
+			const viewB = await getTreeView(containerB);
 
 			const settledOutcome = new Promise<CommitOutcome>((resolve) => {
 				const unsubscribe = viewA.events.on("changed", (metadata) => {
@@ -86,7 +99,6 @@ describe("SharedTree transaction constraints", () => {
 			});
 
 			const deltaManagerA = toIDeltaManagerFull(containerA.deltaManager);
-			// Enrich and submit the transaction locally, but keep its op pending for resubmission.
 			await deltaManagerA.outbound.pause();
 			viewA.runTransaction(
 				() => {


### PR DESCRIPTION
## Description

SharedTree recomputes refresher data when pending edits are resubmitted after reconnecting. `updateRefreshers` reconstructed the modular changeset without preserving its no-change constraints, which allowed a constrained transaction to be applied after a concurrent sequenced edit.

This change preserves `noChangeConstraint` and `noChangeConstraintOnRevert` while updating refreshers. It adds a focused unit test for the reconstructed changeset and a local-server end-to-end test covering the disconnected edit and resubmit flow.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Please verify that preserving the global no-change constraint fields is the appropriate behavior whenever refresher data is recomputed.