### PR TITLE
fix(merge-tree): advance equivalent-item forward scan

### DIFF
--- a/packages/dds/merge-tree/src/sortedSegmentSet.ts
+++ b/packages/dds/merge-tree/src/sortedSegmentSet.ts
@@ -77,17 +77,21 @@ export class SortedSegmentSet<
 	protected onFindEquivalent(item: T, startIndex: number): { exists: boolean; index: number } {
 		// SortedSegmentSet may contain multiple items with the same key (e.g. a local ref at offset 0 and the segment it is on).
 		// Items should compare as reference-equal, so we do a linear walk to find the actual item in this case.
-		let index = startIndex;
-		if (item === this.sortedItems[index]) {
-			return { exists: true, index };
+		if (item === this.sortedItems[startIndex]) {
+			return { exists: true, index: startIndex };
 		}
-		for (let b = index - 1; b >= 0 && this.compare(item, this.sortedItems[b]) === 0; b--) {
+		for (
+			let b = startIndex - 1;
+			b >= 0 && this.compare(item, this.sortedItems[b]) === 0;
+			b--
+		) {
 			if (this.sortedItems[b] === item) {
 				return { exists: true, index: b };
 			}
 		}
+		let index = startIndex + 1;
 		for (
-			index + 1;
+			;
 			index < this.sortedItems.length && this.compare(item, this.sortedItems[index]) === 0;
 			index++
 		) {


### PR DESCRIPTION
[How contribute to this repo](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).

[Guidelines for Pull Requests](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

## Description

The forward scan in `SortedSegmentSet.onFindEquivalent` used `index + 1` as its `for` initializer — a discarded expression rather than an assignment. The scan therefore restarted at `startIndex`, re-comparing an item the preceding fast path had already rejected. Lookup results were unaffected, so this was a redundant comparison rather than a correctness bug.

This initializer was introduced in [PR #11605](https://github.com/microsoft/FluidFramework/pull/11605), which made the search iterative and added support for multiple items sharing an ordinal.

Declare `let index = startIndex + 1` ahead of the loop so the starting point is stated directly rather than encoded in a side effect, and use `startIndex` for the fast path instead of aliasing it through a mutable `index`. Behavior is unchanged; the existing `SortedSegmentSet` tests cover the affected paths and pass.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

The fast-path `if` could also be folded into the backward loop by starting it at `startIndex`, dropping a branch. I left it alone deliberately: it would add a `compare` call to the single-match case, which is the common one, and #11605 made this code iterative specifically for tracking-group performance during undo. Happy to change it if reviewers disagree.