### PR TITLE
fix(devcontainer): document scheduled nested prebuilds

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -41,13 +41,17 @@ Heavy setup work runs in `onCreateCommand` so it is captured by Codespace prebui
 
 ## Prebuild configuration
 
-Prebuilds use the **"on configuration change"** trigger, which only fires when `devcontainer.json` or the referenced `Dockerfile` changes. It does **not** detect changes to files those configs depend on, such as scripts in `scripts/codespace-setup/`.
+The Standard profile uses the **"on configuration change"** trigger. GitHub detects changes to the root `.devcontainer/devcontainer.json` and its referenced `Dockerfile`, but not to files those configs depend on, such as scripts in `scripts/codespace-setup/`.
 
-### The `prebuild-version` comment
+The Lightweight and AI-enabled profiles run prebuilds **once a week**. [GitHub does not support configuration-change triggers for `devcontainer.json` files in subdirectories of `.devcontainer`](https://docs.github.com/en/codespaces/prebuilding-your-codespaces/configuring-prebuilds#configuring-prebuilds), so changes to these profiles are picked up by their next scheduled run.
 
-Each `devcontainer.json` contains a `// prebuild-version: N` comment. **Bump this value whenever you change files in `scripts/codespace-setup/`** and your PR doesn't already modify a `devcontainer.json` or the `Dockerfile` — this ensures a prebuild-triggering file is modified, which forces a rebuild.
+To investigate the triggers or update a nested profile immediately, use JIT elevation to obtain repository administrator access, then open [Settings > Codespaces](https://github.com/microsoft/FluidFramework/settings/codespaces). A prebuild can be manually triggered from its configuration menu.
 
-A CI check (`devcontainer-prebuild-check.yml`) enforces this: PRs that modify `scripts/codespace-setup/**` without also modifying a `devcontainer.json` or the `Dockerfile` will fail.
+### The Standard profile's `prebuild-version` comment
+
+The root `.devcontainer/devcontainer.json` contains a `// prebuild-version: N` comment. **Bump this value whenever you change files in `scripts/codespace-setup/`** and your PR doesn't already modify the root `devcontainer.json` or its `Dockerfile`. This forces the Standard prebuild to regenerate.
+
+A CI check (`devcontainer-prebuild-check.yml`) enforces this requirement for the Standard profile. The scheduled nested profiles do not use version-bump comments.
 
 ## AI-enabled vs. AI-enabled (Insiders)
 

--- a/.devcontainer/ai-agent-insiders/devcontainer.json
+++ b/.devcontainer/ai-agent-insiders/devcontainer.json
@@ -1,8 +1,8 @@
 // AI-enabled (Unstable) — everything in AI-enabled, plus the flub AI launcher command.
 {
 	"name": "AI-enabled (Unstable)",
-	// Bump this version to force a codespace prebuild rebuild. See .devcontainer/README.md.
-	// prebuild-version: 1.0.8
+	// Prebuilds run weekly. After JIT elevation, investigate or manually trigger them at
+	// https://github.com/microsoft/FluidFramework/settings/codespaces.
 	"build": {
 		"dockerfile": "../Dockerfile",
 		"args": {

--- a/.devcontainer/ai-agent/devcontainer.json
+++ b/.devcontainer/ai-agent/devcontainer.json
@@ -1,8 +1,8 @@
 // Codespaces profile optimized for AI-agent workflows with extra CLI tooling.
 {
 	"name": "AI-enabled",
-	// Bump this version to force a codespace prebuild rebuild. See .devcontainer/README.md.
-	// prebuild-version: 1.0.10
+	// Prebuilds run weekly. After JIT elevation, investigate or manually trigger them at
+	// https://github.com/microsoft/FluidFramework/settings/codespaces.
 	"build": {
 		"dockerfile": "../Dockerfile",
 		"args": {

--- a/.devcontainer/lightweight/devcontainer.json
+++ b/.devcontainer/lightweight/devcontainer.json
@@ -1,8 +1,8 @@
 // Lightweight Codespaces profile for docs, API review, and focused package edits.
 {
 	"name": "Lightweight (Review/Docs)",
-	// Bump this version to force a codespace prebuild rebuild. See .devcontainer/README.md.
-	// prebuild-version: 1
+	// Prebuilds run weekly. After JIT elevation, investigate or manually trigger them at
+	// https://github.com/microsoft/FluidFramework/settings/codespaces.
 	"build": {
 		"dockerfile": "../Dockerfile",
 		"args": {

--- a/.github/workflows/devcontainer-prebuild-check.yml
+++ b/.github/workflows/devcontainer-prebuild-check.yml
@@ -1,9 +1,9 @@
 name: "Devcontainer prebuild check"
 
-# Codespace prebuilds in "on configuration change" mode only trigger when
-# devcontainer.json or the Dockerfile change. This job catches PRs that modify
-# the setup scripts the devcontainer depends on WITHOUT also bumping a
-# devcontainer.json file, which would leave prebuilds stale.
+# The Standard Codespace prebuild uses "on configuration change" mode, which
+# only watches the root devcontainer.json and its Dockerfile. Nested profiles
+# run on schedules and do not require version bumps. This job prevents setup
+# script changes from leaving the Standard prebuild stale.
 
 on:
   pull_request:
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   check-prebuild-version:
-    name: Check prebuild version bump
+    name: Check Standard prebuild version bump
     runs-on: ubuntu-latest
     steps:
       # release notes: https://github.com/actions/checkout/releases/tag/v6.0.0
@@ -25,26 +25,20 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      - name: Check if a prebuild-triggering file was also modified
+      - name: Check if a Standard prebuild trigger was also modified
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           CHANGED_FILES=$(git diff --name-only "$BASE_SHA"..."$HEAD_SHA")
 
-          if echo "$CHANGED_FILES" | grep -qE '(devcontainer\.json|Dockerfile)'; then
-            echo "A devcontainer.json or Dockerfile was modified — prebuild will be triggered."
+          if echo "$CHANGED_FILES" | grep -qE '^\.devcontainer/(devcontainer\.json|Dockerfile)$'; then
+            echo "The root devcontainer.json or Dockerfile was modified — the Standard prebuild will be triggered."
           else
-            echo "::error::Setup scripts in scripts/codespace-setup/ were modified but no devcontainer.json or Dockerfile was updated."
+            echo "::error::Setup scripts in scripts/codespace-setup/ were modified but the root devcontainer.json or Dockerfile was not updated."
             echo ""
-            echo "Codespace prebuilds only trigger on devcontainer.json or Dockerfile changes."
-            echo "Bump the // prebuild-version: N comment in the relevant devcontainer.json"
-            echo "file(s) to ensure the prebuild is regenerated."
-            echo ""
-            echo "Files to consider:"
-            echo "  .devcontainer/devcontainer.json"
-            echo "  .devcontainer/lightweight/devcontainer.json"
-            echo "  .devcontainer/ai-agent/devcontainer.json"
-            echo "  .devcontainer/ai-agent-insiders/devcontainer.json"
+            echo "Bump the // prebuild-version: N comment in .devcontainer/devcontainer.json"
+            echo "to ensure the Standard prebuild is regenerated."
+            echo "Nested Codespace profiles run on schedules and do not use version-bump comments."
             exit 1
           fi


### PR DESCRIPTION
## Description

GitHub does not support the "on configuration change" prebuild trigger for `devcontainer.json` files in subdirectories of `.devcontainer`. As a result, the Lightweight and AI-enabled profiles could not be automatically rebuilt through their existing `prebuild-version` comments.

Document that these nested profiles run weekly and can be investigated or manually triggered from the Codespaces repository settings after JIT elevation. Remove their ineffective version-bump comments and link to GitHub's documented nested-configuration limitation.

Keep the Standard root profile on "on configuration change" and narrow its CI guard so only the root `.devcontainer/devcontainer.json` or `.devcontainer/Dockerfile` satisfy the required trigger update.

The weekly schedules themselves are configured in GitHub repository settings and are not stored in this repository.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Please verify that the documented weekly schedules match the configurations under [Settings > Codespaces](https://github.com/microsoft/FluidFramework/settings/codespaces).
