### PR TITLE
feat(container-runtime): Default document schema to declare createBlobPayloadPending support at 2.40.0+

### DIFF
--- a/.changeset/fruity-cats-rest.md
+++ b/.changeset/fruity-cats-rest.md
@@ -1,0 +1,16 @@
+---
+"@fluidframework/container-runtime": minor
+"__section": feature
+---
+
+Document schema now declares `createBlobPayloadPending` support by default when `minVersionForCollab` is 2.40.0+
+
+When `minVersionForCollab` is set to `"2.40.0"` or later, the document schema now declares support for the
+`createBlobPayloadPending` capability by default. This only affects what gets negotiated into the document
+schema (which requires all collaborating clients to understand the format) - it does **not** change any
+observable behavior. `BlobManager`'s pending-payload upload behavior remains off unless a caller explicitly
+sets `createBlobPayloadPending: true` in their `ContainerRuntimeOptions`.
+
+Pre-enabling the schema declaration now means documents will already be schema-compatible by the time we're
+ready to turn on the corresponding client behavior by default in a future release, at which point that change
+will not require a slow, fleet-wide document schema migration.

--- a/CrossClientCompatibilityDevGuide.md
+++ b/CrossClientCompatibilityDevGuide.md
@@ -50,7 +50,7 @@ If a change affects the data format (see above), it should be gated by a **conta
 
 The runtime uses `minVersionForCollab` to automatically set certain container runtime options. This is handled by the `runtimeOptionsAffectingDocSchemaConfigMap` in [containerCompatibility.ts](./packages/runtime/container-runtime/src/containerCompatibility.ts).
 
-**Example:** If `minVersionForCollab` is set to `"2.0.0"`, then features such as grouped batching are safely enabled, since the lowest version we need to support collaboration with understands the associated data format changes. On the other hand, features such as `createBlobPayloadPending` remain disabled, as clients need to be running runtime version 2.40.0 or later to understand the associated data format changes.
+**Example:** If `minVersionForCollab` is set to `"2.0.0"`, then features such as grouped batching are safely enabled, since the lowest version we need to support collaboration with understands the associated data format changes. `createBlobPayloadPending` remains disabled at `"2.0.0"` and only defaults on once `minVersionForCollab` reaches `"2.40.0"`, since clients need to be running runtime version 2.40.0 or later to understand the associated data format changes.
 
 ```typescript
 // Simplified view of the config map (see containerCompatibility.ts for full details)
@@ -61,11 +61,13 @@ const runtimeOptionsAffectingDocSchemaConfigMap: ConfigMap<RuntimeOptionsAffecti
 	},
 	createBlobPayloadPending: {
 		"1.0.0": undefined,
-		// Could be enabled by default in a future version
+		"2.40.0": true,
 	},
 	// ... other options
 };
 ```
+
+> **Note on decoupling the schema declaration from client behavior:** For `createBlobPayloadPending`, the default above only controls what gets negotiated into the *document schema* - it does not, by itself, turn on the corresponding client behavior (in this case, `BlobManager`'s pending-payload upload path). `containerRuntime.ts` separately tracks whether the option was *explicitly* set by the caller (the same "explicit vs defaulted" idiom used for `enableRuntimeIdCompressor`), and only that explicit request drives the actual behavior change. This split exists because a document schema declaration is effectively permanent once other clients observe it in a document (undoing it would require excluding old documents or a slow compatibility window), whereas client-side behavior can be safely rolled forward or back with a simple package update.
 
 > **Note on `"2.0.0-defaults"`:** This is a special version string (considered less than `"2.0.0"` by `semver`) used as the default when a customer does not explicitly set `minVersionForCollab`. It exists to distinguish the unspecified case from an explicit `"2.0.0"` setting. Some options (e.g., `explicitSchemaControl`) use a threshold of `"2.0.0"` rather than `"2.0.0-defaults"`, meaning they only activate when the customer _explicitly_ sets `minVersionForCollab` to `"2.0.0"` or higher. See `defaultMinVersionForCollab` in [compatibilityBase.ts](./packages/runtime/runtime-utils/src/compatibilityBase.ts) for more information.
 

--- a/packages/runtime/container-runtime/src/containerCompatibility.ts
+++ b/packages/runtime/container-runtime/src/containerCompatibility.ts
@@ -157,10 +157,15 @@ const runtimeOptionsAffectingDocSchemaConfigMap: ConfigMap<RuntimeOptionsAffecti
 			// "3.0.0": { enableGCSweep: true },
 		},
 		createBlobPayloadPending: {
-			// This feature is new and disabled by default. In the future we will enable it by default, but we have not
-			// closed on the version where that will happen yet.  Probably a .10 release since blob functionality is not
-			// exposed on the `@public` API surface.
+			// NOTE: This default only controls what gets declared/negotiated in the document schema (i.e. whether
+			// documents record that clients here understand the pending-blob-payload format). It does NOT turn on
+			// the actual pending-payload behavior in BlobManager - that remains opt-in (see the "explicit vs
+			// defaulted" handling in containerRuntime.ts) until we have higher confidence in the client-side
+			// behavior. Pre-enabling the schema declaration now means documents will already be schema-compatible
+			// by the time we're ready to flip the behavior default too, which then becomes a simple code change
+			// rather than requiring a slow, fleet-wide document schema migration.
 			"1.0.0": undefined,
+			"2.40.0": true,
 		},
 	};
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -481,8 +481,18 @@ export interface ContainerRuntimeOptions {
 	readonly explicitSchemaControl: boolean;
 
 	/**
-	 * Create blob handles with pending payloads when calling createBlob (default is `undefined` (disabled)).
+	 * Create blob handles with pending payloads when calling createBlob (default is `undefined` (disabled), except
+	 * for the document schema declaration described below).
 	 * When enabled (`true`), createBlob will return a handle before the blob upload completes.
+	 *
+	 * @remarks
+	 * This option affects the document schema (i.e. it is negotiated across all clients collaborating on a
+	 * document), so once `minVersionForCollab` is 2.40.0 or later, the document schema will declare support for
+	 * this capability by default. However, actually exercising the new pending-payload behavior in `createBlob`
+	 * still requires this option to be explicitly set to `true` by the caller - the default value is never used
+	 * to turn on the behavior itself, only the document schema declaration. This split exists because a document
+	 * schema declaration is effectively permanent for a document once other clients observe it, whereas the
+	 * client-side behavior can be safely changed (including reverted) via a package update.
 	 */
 	readonly createBlobPayloadPending: true | undefined;
 
@@ -1063,6 +1073,18 @@ export class ContainerRuntime
 				? runtimeOptions.enableRuntimeIdCompressor
 				: defaultConfigs.enableRuntimeIdCompressor;
 
+		// `createBlobPayloadPending`'s default (from `defaultConfigs`, based on `minVersionForCollab`) only controls
+		// whether we declare/negotiate the pending-blob-payload capability in the document schema. It intentionally
+		// does NOT turn on the actual pending-payload behavior in BlobManager, since we want to stage the schema
+		// change and the client-side behavior change independently: schema changes are slow/sticky (once documents
+		// declare a capability, that can't be walked back), whereas behavior changes are cheap to roll out or roll
+		// back via a new package version. So we track whether the caller *explicitly* requested the behavior,
+		// and only that explicit request (not the defaulted value) is used to drive BlobManager's actual behavior
+		// below. See `createBlobPayloadPendingExplicitlyRequested` usage further down.
+		const createBlobPayloadPendingExplicitlyRequested =
+			"createBlobPayloadPending" in runtimeOptions &&
+			runtimeOptions.createBlobPayloadPending === true;
+
 		const tryFetchBlob = async <T>(blobName: string): Promise<T | undefined> => {
 			const blobId = context.baseSnapshot?.blobs[blobName];
 			if (context.baseSnapshot !== undefined && blobId !== undefined) {
@@ -1297,6 +1319,7 @@ export class ContainerRuntime
 			featureGatesForTelemetry,
 			provideEntryPoint,
 			updatedMinVersionForCollab,
+			createBlobPayloadPendingExplicitlyRequested,
 			requestHandler,
 			undefined, // summaryConfiguration
 			recentBatchInfo,
@@ -1656,6 +1679,10 @@ export class ContainerRuntime
 		featureGatesForTelemetry: Record<string, boolean | number | undefined>,
 		provideEntryPoint: (containerRuntime: IContainerRuntime) => Promise<FluidObject>,
 		public readonly minVersionForCollab: MinimumVersionForCollab,
+		// Whether the caller explicitly requested `createBlobPayloadPending` behavior (as opposed to it merely
+		// being the defaulted value for the document schema declaration). See the comment where this is computed
+		// in `loadRuntime2` for why this is tracked separately from `runtimeOptions.createBlobPayloadPending`.
+		private readonly createBlobPayloadPendingExplicitlyRequested: boolean,
 		private readonly requestHandler?: (
 			request: IRequest,
 			runtime: IContainerRuntime,
@@ -2162,7 +2189,13 @@ export class ContainerRuntime
 			isBlobDeleted: (blobPath: string) => this.garbageCollector.isNodeDeleted(blobPath),
 			runtime: this,
 			pendingBlobs: pendingRuntimeState?.pendingAttachmentBlobs,
-			createBlobPayloadPending: this.sessionSchema.createBlobPayloadPending === true,
+			// The document schema must permit the pending-payload format (negotiated across clients), AND the
+			// caller of this session must have explicitly opted into the behavior. See the comment on
+			// `createBlobPayloadPendingExplicitlyRequested` for why the defaulted schema value alone is not
+			// sufficient to turn on this behavior.
+			createBlobPayloadPending:
+				this.sessionSchema.createBlobPayloadPending === true &&
+				this.createBlobPayloadPendingExplicitlyRequested,
 		});
 
 		this.deltaScheduler = new DeltaScheduler(

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -4647,6 +4647,7 @@ describe("Runtime", () => {
 					enableRuntimeIdCompressor: undefined,
 					enableGroupedBatching: true,
 					explicitSchemaControl: true,
+					createBlobPayloadPending: true,
 					stagingModeAutoFlushThreshold: 1000,
 					disableSchemaUpgrade: false,
 				};
@@ -4659,6 +4660,50 @@ describe("Runtime", () => {
 						minVersionForCollab,
 					},
 				]);
+			});
+
+			it("createBlobPayloadPending: schema defaults on at 2.40.0+ but BlobManager behavior stays off unless explicitly requested", async () => {
+				const { runtime } = await ContainerRuntime.loadRuntime2({
+					context: getMockContext() as IContainerContext,
+					registry: new FluidDataStoreRegistry([]),
+					existing: false,
+					runtimeOptions: {},
+					provideEntryPoint: mockProvideEntryPoint,
+					minVersionForCollab: pkgVersion,
+				});
+
+				// The document schema declaration defaults on (negotiable across the fleet)...
+				assert.strictEqual(
+					(runtime as unknown as { sessionSchema: { createBlobPayloadPending?: boolean } })
+						.sessionSchema.createBlobPayloadPending,
+					true,
+					"document schema should declare createBlobPayloadPending support by default at 2.40.0+",
+				);
+				// ...but BlobManager itself must not exercise the new behavior unless the caller explicitly asked for it.
+				assert.strictEqual(
+					(runtime as unknown as { blobManager: { createBlobPayloadPending: boolean } })
+						.blobManager.createBlobPayloadPending,
+					false,
+					"BlobManager should not use pending-payload behavior unless explicitly requested by the caller",
+				);
+			});
+
+			it("createBlobPayloadPending: BlobManager behavior turns on when explicitly requested", async () => {
+				const { runtime } = await ContainerRuntime.loadRuntime2({
+					context: getMockContext() as IContainerContext,
+					registry: new FluidDataStoreRegistry([]),
+					existing: false,
+					runtimeOptions: { createBlobPayloadPending: true, explicitSchemaControl: true },
+					provideEntryPoint: mockProvideEntryPoint,
+					minVersionForCollab: pkgVersion,
+				});
+
+				assert.strictEqual(
+					(runtime as unknown as { blobManager: { createBlobPayloadPending: boolean } })
+						.blobManager.createBlobPayloadPending,
+					true,
+					"BlobManager should use pending-payload behavior when explicitly requested",
+				);
 			});
 
 			for (const runtimeOption of [


### PR DESCRIPTION
## Description

When `minVersionForCollab` is set to `"2.40.0"` or later, the document schema now declares support for the
`createBlobPayloadPending` capability by default, instead of requiring callers to opt in explicitly.

Importantly, this only affects what gets negotiated into the document schema (which all collaborating clients
must understand) — it does **not** change any observable behavior. `BlobManager`'s pending-payload upload
behavior remains off unless a caller explicitly sets `createBlobPayloadPending: true` in their
`ContainerRuntimeOptions`. This split is deliberate: a document schema declaration is effectively permanent
once other clients observe it in a document, whereas client-side behavior can be safely rolled forward or back
via a package update. Pre-enabling the schema declaration now means documents will already be schema-compatible
by the time we're ready to turn on the corresponding client behavior by default in a future release, at which
point that change becomes a simple code change rather than a slow, fleet-wide document schema migration.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

- Please double check the reasoning for decoupling the schema default from the client-side behavior default —
  documented in `CrossClientCompatibilityDevGuide.md` as a pattern to reuse for future schema-affecting options.
- `containerRuntime.ts` tracks whether `createBlobPayloadPending` was explicitly requested (mirroring the
  existing `enableRuntimeIdCompressor` explicit-vs-defaulted handling) and only that explicit value gates
  `BlobManager`'s actual behavior.