### PR TITLE
build(eslint-config-fluid): remove eslint-plugin-fluid feed ingestion workaround

### DIFF
--- a/common/build/eslint-config-fluid/pnpm-lock.yaml
+++ b/common/build/eslint-config-fluid/pnpm-lock.yaml
@@ -7,9 +7,6 @@ settings:
 overrides:
   '@rushstack/eslint-plugin>@typescript-eslint/utils@<8.58.0': ~8.58.0
   eslint-plugin-tsdoc>@typescript-eslint/utils@<8.58.0: ~8.58.0
-  '@fluid-internal/eslint-plugin-fluid@^0.5.0': ^0.4.1
-  '@fluid-internal/eslint-plugin-fluid@^0.4.1>@typescript-eslint/parser@<8.58.0': ~8.58.0
-  '@fluid-internal/eslint-plugin-fluid@^0.4.1>@typescript-eslint/utils@<8.58.0': ~8.58.0
   '@babel/core@>=7 <8': ^7.29.6
   brace-expansion@>=1 <2: ^1.1.17
   brace-expansion@>=2 <3: ^2.1.3
@@ -45,8 +42,8 @@ importers:
         specifier: ~9.39.2
         version: 9.39.2
       '@fluid-internal/eslint-plugin-fluid':
-        specifier: ^0.4.1
-        version: 0.4.1(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
+        specifier: ^0.5.0
+        version: 0.5.0(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
       '@rushstack/eslint-plugin':
         specifier: ~0.23.2
         version: 0.23.2(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
@@ -502,8 +499,8 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@fluid-internal/eslint-plugin-fluid@0.4.1':
-    resolution: {integrity: sha512-JTFmMtNDJ+pR0Z0jvreXgq2GymqcCSD0InclRQfimEJ4KzIwdHCPHCmODlll1FG/Qp852baMYgdKHHD4qqRP/w==}
+  '@fluid-internal/eslint-plugin-fluid@0.5.0':
+    resolution: {integrity: sha512-Fs+Ksl/BXXl/++YJBZYxlNdN/9UuEPs9ooDfF8XkeRW+BRqwE42zeYanM4cm3fl2OM8201Jykiybcn+Pq1CTiQ==}
     peerDependencies:
       eslint: ^8.57.0 || ^9.37.0
 
@@ -2340,7 +2337,7 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
-  '@fluid-internal/eslint-plugin-fluid@0.4.1(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)':
+  '@fluid-internal/eslint-plugin-fluid@0.5.0(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
       '@microsoft/tsdoc': 0.15.1
       '@typescript-eslint/parser': 8.58.2(eslint@9.39.2(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
@@ -2497,7 +2494,7 @@ snapshots:
   '@typescript-eslint/project-service@8.58.2(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.58.2(typescript@6.0.3)
-      '@typescript-eslint/types': 8.58.2
+      '@typescript-eslint/types': 8.65.0
       debug: 4.4.3(supports-color@8.1.1)
       typescript: 6.0.3
     transitivePeerDependencies:

--- a/common/build/eslint-config-fluid/pnpm-workspace.yaml
+++ b/common/build/eslint-config-fluid/pnpm-workspace.yaml
@@ -47,18 +47,6 @@ overrides:
   #   As of 2026-08-05 eslint-plugin-tsdoc (v0.5.2), does not have a version using v8.58 or later.
   "eslint-plugin-tsdoc>@typescript-eslint/utils@<8.58.0": ~8.58.0
 
-  # Feed ingestion workaround for own package consumption
-  # @fluid-internal/eslint-plugin-fluid@^0.5.0 is the package intended to be consumed but
-  # it is not consumable by ADO pipelines until 2026-08-10. For example see:
-  # https://dev.azure.com/fluidframework/public/_artifacts/feed/publicPackages/Npm/@fluid-internal%2Feslint-plugin-fluid/upstreams/0.4.1
-  # Until then keep 0.5.0 in the package.json but override here. The only required element
-  # of 0.5.0 versus 0.4.1 for TypeScript 6 compatibility are the updates to
-  # @typescript-eslint/parser and @typescript-eslint/utils. So override those (to 8.58.0
-  # as in 0.5.0) as well.
-  "@fluid-internal/eslint-plugin-fluid@^0.5.0": ^0.4.1
-  "@fluid-internal/eslint-plugin-fluid@^0.4.1>@typescript-eslint/parser@<8.58.0": ~8.58.0
-  "@fluid-internal/eslint-plugin-fluid@^0.4.1>@typescript-eslint/utils@<8.58.0": ~8.58.0
-
   # Security overrides.
   # Resolve known security vulnerabilities in transitive dependencies.
   "@babel/core@>=7 <8": ^7.29.6


### PR DESCRIPTION
## Description

`eslint-config-fluid` declares `@fluid-internal/eslint-plugin-fluid@^0.5.0`, but pnpm `overrides` added in #27861 silently downgraded installs back to `0.4.1` while `0.5.0` was still waiting to be ingested into the ADO `publicPackages` upstream feed. That block was documented as only being needed until 2026-08-10, which has now passed, so it and its two companion `@typescript-eslint` transitive pins are removed.

The lockfile was regenerated with the `install-no-frozen` script and now resolves `0.5.0` directly, matching the declared specifier.

The `@rushstack/eslint-plugin` and `eslint-plugin-tsdoc` overrides are intentionally left in place — those cover third-party packages lagging on TypeScript 6, not feed ingestion.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

-   The lockfile also picks up `@typescript-eslint/types@8.65.0` (was `8.58.2`) under `project-service` — incidental churn from re-resolving with `resolutionMode: highest`, not related to the plugin bump.
-   Worth confirming the eslint-config-fluid pipeline installs cleanly against the feed, since that is the scenario the workaround existed to paper over.

Fixes: [AB#79930](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/79930)
