### PR TITLE
docs: Fix stale links to github wiki

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -70,7 +70,7 @@ The sections are configured in [fluidBuild.config.cjs](https://github.com/micros
 > Client releases with breaking _legacy_ changes should use the `legacy` section, not `breaking`. The `breaking` section is reserved for major releases, which practically means server.
 
 > [!NOTE]
-> For deprecations, follow the [deprecation process](https://github.com/microsoft/FluidFramework/wiki/API-Deprecation).
+> For deprecations, follow the [deprecation process](../docs/content/Contributing/API-Deprecation.md).
 > Ensure that both the deprecation changeset and the removal changeset include a link to the GitHub tracking issue, when one exists.
 
 
@@ -221,7 +221,7 @@ Any change that should be communicated to customers or partners should have a ch
 ## More information
 
 - [Official changesets documentation](https://github.com/changesets/changesets)
-- [Changesets FAQ](https://github.com/microsoft/FluidFramework/wiki/Changesets-FAQ)
+- [Changesets FAQ](../docs/content/Contributing/Breaking-vs-Non-Breaking-Changes/Changesets-FAQ.md)
 - For questions, contact @tylerbutler
 
 ## Updating changelogs from changesets

--- a/.claude/skills/api-changes/SKILL.md
+++ b/.claude/skills/api-changes/SKILL.md
@@ -76,7 +76,7 @@ A breaking change removes or modifies an existing API in a way that causes compi
 If this is a breaking change to `@public` or `@legacy @public`, tell the user this is likely a mistake — major releases happen very rarely. Breaking `@public` APIs must be coordinated with a major release; the old API must be deprecated at least 3 months prior in a minor release with a clear replacement.
 
 Share these links with the user for the required process:
-- API Deprecation wiki: https://github.com/microsoft/FluidFramework/wiki/API-Deprecation
+- API deprecation documentation: ../../../docs/content/Contributing/API-Deprecation.md
 - Client 3.0 Breaking Changes tracking issue: https://github.com/microsoft/FluidFramework/issues/23271
 
 ### @beta / @legacy+@alpha
@@ -88,7 +88,7 @@ If this is a breaking change to `@beta` or `@legacy @alpha`, tell the user:
 
 Share these links with the user:
 - Beta | Legacy Breaking Changes tracking issue: https://github.com/microsoft/FluidFramework/issues/25322
-- Full process: https://github.com/microsoft/FluidFramework/wiki/Beta-Break-Process
+- Full process: ../../../docs/content/Contributing/Breaking-vs-Non-Breaking-Changes/Beta-Break-Process.md
 
 ### @alpha only
 
@@ -118,7 +118,7 @@ If any API is being deprecated, check that the following are in place and flag a
 - [ ] In-codebase uses removed (test-only uses may remain with an explanatory comment)
 - [ ] Changeset present (see Step 6)
 
-Share this link with the user for full deprecation guidance: https://github.com/microsoft/FluidFramework/wiki/API-Deprecation
+Share this link with the user for full deprecation guidance: ../../../docs/content/Contributing/API-Deprecation.md
 
 ---
 

--- a/.claude/skills/api-changes/SKILL.md
+++ b/.claude/skills/api-changes/SKILL.md
@@ -76,7 +76,7 @@ A breaking change removes or modifies an existing API in a way that causes compi
 If this is a breaking change to `@public` or `@legacy @public`, tell the user this is likely a mistake — major releases happen very rarely. Breaking `@public` APIs must be coordinated with a major release; the old API must be deprecated at least 3 months prior in a minor release with a clear replacement.
 
 Share these links with the user for the required process:
-- API deprecation documentation: ../../../docs/content/Contributing/API-Deprecation.md
+- [API deprecation documentation](../../../docs/content/Contributing/API-Deprecation.md)
 - Client 3.0 Breaking Changes tracking issue: https://github.com/microsoft/FluidFramework/issues/23271
 
 ### @beta / @legacy+@alpha

--- a/.claude/skills/review/api-conventions.md
+++ b/.claude/skills/review/api-conventions.md
@@ -2,7 +2,7 @@
 
 > Source: [Coding Guidelines](../../../docs/content/Guidelines/Coding-Guidelines.md)
 >
-> This is a distilled, review-focused version of the wiki page. If this file feels outdated, re-check the source.
+> This is a distilled, review-focused version of the source document. If this file feels outdated, re-check the source.
 
 ## Design Philosophy
 

--- a/.claude/skills/review/api-conventions.md
+++ b/.claude/skills/review/api-conventions.md
@@ -1,6 +1,6 @@
 # Fluid Framework API Conventions — Review Criteria
 
-> Source: https://github.com/microsoft/FluidFramework/wiki/Coding-Guidelines
+> Source: [Coding Guidelines](../../../docs/content/Guidelines/Coding-Guidelines.md)
 >
 > This is a distilled, review-focused version of the wiki page. If this file feels outdated, re-check the source.
 

--- a/.devcontainer/ai-agent/GETTING_STARTED.md
+++ b/.devcontainer/ai-agent/GETTING_STARTED.md
@@ -2,7 +2,7 @@
 
 This codespace is pre-configured for AI-agent-assisted development of the Fluid Framework. It includes [agency](https://aka.ms/agency), GitHub Copilot CLI, GitHub CLI, and SSH access.
 
-> For full documentation, see the [AI-enabled Codespace wiki page](../../docs/content/Development-Environment/AI-enabled-Codespace.md).
+> For full documentation, see [AI-enabled Codespace](../../docs/content/Development-Environment/AI-enabled-Codespace.md).
 
 ## First-time Setup
 

--- a/.devcontainer/ai-agent/GETTING_STARTED.md
+++ b/.devcontainer/ai-agent/GETTING_STARTED.md
@@ -2,7 +2,7 @@
 
 This codespace is pre-configured for AI-agent-assisted development of the Fluid Framework. It includes [agency](https://aka.ms/agency), GitHub Copilot CLI, GitHub CLI, and SSH access.
 
-> For full documentation, see the [AI-enabled Codespace wiki page](https://github.com/microsoft/FluidFramework/wiki/AI%E2%80%90enabled-Codespace).
+> For full documentation, see the [AI-enabled Codespace wiki page](../../docs/content/Development-Environment/AI-enabled-Codespace.md).
 
 ## First-time Setup
 

--- a/.devcontainer/ai-agent/GETTING_STARTED.md
+++ b/.devcontainer/ai-agent/GETTING_STARTED.md
@@ -70,7 +70,7 @@ dev --mcp 'sharepoint'
 
 ## More Information
 
-- [AI-enabled Codespace wiki](https://github.com/microsoft/FluidFramework/wiki/AI%E2%80%90enabled-Codespace) — Full documentation for this codespace profile
+- [AI-enabled Codespace documentation](../../docs/content/Development-Environment/AI-enabled-Codespace.md) — Full documentation for this codespace profile
 - [DEV.md](../../DEV.md) — Development setup, build commands, and workflow guide
 - [CONTRIBUTING.md](../../CONTRIBUTING.md) — Contribution guidelines
 - [FluidFramework.com](https://fluidframework.com) — Documentation and API reference

--- a/.devcontainer/ai-agent/first-run-notice.txt
+++ b/.devcontainer/ai-agent/first-run-notice.txt
@@ -21,4 +21,4 @@ Other commands:
   pnpm test              Run tests
   pnpm fluid-build .     Build only the current package and its dependencies
 
-More information on this codespace: https://github.com/microsoft/FluidFramework/wiki/AI%E2%80%90enabled-Codespace
+More information on this codespace: https://github.com/microsoft/FluidFramework/blob/main/docs/content/Development-Environment/AI-enabled-Codespace.md

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 [How contribute to this repo](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).
 
-[Guidelines for Pull Requests](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
+[Guidelines for Pull Requests](../docs/content/Contributing/PR-Guidelines.md#guidelines).
 
 The sections included below are suggestions for what you may want to include.
 Feel free to remove or alter parts of this template that do not offer value for your specific change.
@@ -17,12 +17,12 @@ Feel free to remove or alter parts of this template that do not offer value for 
 ## Breaking Changes
 
 > If this introduces a breaking change, please describe the impact and migration path for existing applications below.
-> See [Breaking-vs-Non-breaking-Changes](https://github.com/microsoft/FluidFramework/wiki/Breaking-vs-Non-breaking-Changes) for details.
+> See [Breaking-vs-Non-breaking-Changes](../docs/content/Contributing/Breaking-vs-Non-Breaking-Changes.md) for details.
 > If there are no breaking changes, delete this section.
 
 ## Reviewer Guidance
 
-The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
+The review process is outlined in [the pull request guidelines](../docs/content/Contributing/PR-Guidelines.md#guidelines).
 
 > List any specific things you want to get reviewer opinions on, and anything a reviewer would need to know to review this PR effectively.
 > Things you might want to include:

--- a/.github/workflows/data/changeset-missing.md
+++ b/.github/workflows/data/changeset-missing.md
@@ -1,1 +1,1 @@
-This PR requires a changeset, but none is present. You should add one before you merge. See the documentation [in the wiki](https://github.com/microsoft/FluidFramework/wiki/Changesets#adding-a-changeset-to-a-pr) for more information about changesets and how to create them.
+This PR requires a changeset, but none is present. You should add one before you merge. See the [changeset documentation](../../../docs/content/Contributing/Breaking-vs-Non-Breaking-Changes/Changesets.md) for more information about changesets and how to create them.

--- a/.github/workflows/data/linkcheck-failure.md
+++ b/.github/workflows/data/linkcheck-failure.md
@@ -1,4 +1,3 @@
 🔗 Found some broken links! 💔
 
-Run a link check locally to find them. See
-<https://github.com/microsoft/FluidFramework/wiki/Checking-for-broken-links-in-the-documentation> for more information.
+Run a link check locally to find them. See [Checking for Broken Links](../../../docs/content/Contributing/Working-with-the-Website/Checking-for-Broken-Links.md) for more information.

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -45,4 +45,4 @@ jobs:
           wrong_pr_description_message: |
             Your PR description contains placeholder content from the PR template. Remove or replace the placeholder
             content. More information at:
-            https://github.com/microsoft/FluidFramework/wiki/Commit-message-style#pr-template-content
+            https://github.com/microsoft/FluidFramework/blob/main/docs/content/Contributing/Commit-Message-Style.md

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -45,4 +45,4 @@ jobs:
           wrong_pr_description_message: |
             Your PR description contains placeholder content from the PR template. Remove or replace the placeholder
             content. More information at:
-            https://github.com/microsoft/FluidFramework/blob/main/docs/content/Contributing/Commit-Message-Style.md
+            https://github.com/microsoft/FluidFramework/blob/main/docs/content/Contributing/Commit-Message-Style.md#pr-template-content

--- a/.tours/welcome.tour
+++ b/.tours/welcome.tour
@@ -8,7 +8,7 @@
       "file": ".devcontainer/ai-agent/GETTING_STARTED.md",
       "line": 1,
       "title": "Welcome",
-      "description": "This is your AI-enabled codespace. It comes pre-configured with AI CLI tooling on top of the standard Fluid Framework development environment.\n\nThis tour will walk you through the AI-specific features. For full documentation, see the [AI-enabled Codespace wiki](https://github.com/microsoft/FluidFramework/wiki/AI%E2%80%90enabled-Codespace)."
+      "description": "This is your AI-enabled codespace. It comes pre-configured with AI CLI tooling on top of the standard Fluid Framework development environment.\n\nThis tour will walk you through the AI-specific features. For full documentation, see the [AI-enabled Codespace documentation](../docs/content/Development-Environment/AI-enabled-Codespace.md)."
     },
     {
       "file": ".devcontainer/ai-agent/GETTING_STARTED.md",
@@ -44,7 +44,7 @@
       "file": ".devcontainer/ai-agent/GETTING_STARTED.md",
       "line": 1,
       "title": "Next Steps",
-      "description": "You're all set! Here's what to do:\n\n1. Run `pnpm install:agency` and open a new terminal\n2. Try `dev`, `claude`, or `copilot` to start an AI-assisted session\n3. Check [DEV.md](./DEV.md) for the full development workflow\n\nFor more info, see the [AI-enabled Codespace wiki](https://github.com/microsoft/FluidFramework/wiki/AI%E2%80%90enabled-Codespace)."
+      "description": "You're all set! Here's what to do:\n\n1. Run `pnpm install:agency` and open a new terminal\n2. Try `dev`, `claude`, or `copilot` to start an AI-assisted session\n3. Check [DEV.md](./DEV.md) for the full development workflow\n\nFor more info, see the [AI-enabled Codespace documentation](../docs/content/Development-Environment/AI-enabled-Codespace.md)."
     }
   ]
 }

--- a/azure/README.md
+++ b/azure/README.md
@@ -55,5 +55,5 @@ install it as a dependency when using azure-client, but we don't install it alon
 Not finding what you're looking for in this README?
 Check out our [developer documentation](../docs/content/Home.md) or [fluidframework.com](https://fluidframework.com/docs/).
 
-Still not finding what you're looking for? Please [file an issue](https://github.com/microsoft/FluidFramework/wiki/Submitting-Bugs-and-Feature-Requests).
+Still not finding what you're looking for? Please [file an issue](../docs/content/Contributing/Submitting-Bugs-and-Feature-Requests.md).
 Thank you!

--- a/azure/README.md
+++ b/azure/README.md
@@ -31,7 +31,7 @@ See the [package README](./packages/external-controller/README.md) for more info
 ### Adding/updating dependencies
 
 For information on adding and removing dependencies, see [Managing
-dependencies](https://github.com/microsoft/FluidFramework/wiki/Managing-dependencies) in our wiki.
+dependencies](../docs/content/Contributing/Managing-Dependencies.md) in our documentation.
 
 ### Dependency overrides
 
@@ -53,7 +53,7 @@ install it as a dependency when using azure-client, but we don't install it alon
 # Help
 
 Not finding what you're looking for in this README?
-Check out our [Github Wiki](https://github.com/microsoft/FluidFramework/wiki) or [fluidframework.com](https://fluidframework.com/docs/).
+Check out our [developer documentation](../docs/content/Home.md) or [fluidframework.com](https://fluidframework.com/docs/).
 
 Still not finding what you're looking for? Please [file an issue](https://github.com/microsoft/FluidFramework/wiki/Submitting-Bugs-and-Feature-Requests).
 Thank you!

--- a/build-tools/packages/build-cli/docs/typetestDetails.md
+++ b/build-tools/packages/build-cli/docs/typetestDetails.md
@@ -43,8 +43,6 @@ Generating type tests has two parts: the prepare phase and the generate phase. T
 See the [`flub typetests`](./typetests.md) and [`flub generate:typetests`](./generate.md#flub-generate-typetests)
 reference documentation for details about the flags and options they provide.
 
-[api type validation]: https://github.com/microsoft/FluidFramework/wiki/API-Type-Validation
-
 ## The prepare phase: resetting tests and updating the previous version
 
 The prepare phase determines the baseline previous version to use, updates the previous version devDependency in
@@ -92,3 +90,6 @@ details about the flags and options available.
 > The `generate:typetests` command is designed to produce a single output file - the type tests - per invocation, and to
 > generate tests for a single entrypoint. If you want to generate tests for both the alpha entrypoint and the legacy
 > entrypoint, for example, you will need to use `generate:typetests` twice, once for each entrypoint.
+
+<!-- Links -->
+[api type validation]: ../../../../docs/content/Contributing/API-Type-Validation.md

--- a/build-tools/packages/build-cli/src/commands/ai.ts
+++ b/build-tools/packages/build-cli/src/commands/ai.ts
@@ -252,7 +252,7 @@ export default class AiCommand extends BaseCommand<typeof AiCommand> {
 
 		this.error(
 			"Could not find agent-aliases.sh. This command is designed for the AI-enabled Codespace.\n" +
-				"See: https://github.com/microsoft/FluidFramework/wiki/AI%E2%80%90enabled-Codespace",
+				"See: https://github.com/microsoft/FluidFramework/blob/main/docs/content/Development-Environment/AI-enabled-Codespace.md",
 			{ exit: 1 },
 		);
 	}

--- a/build-tools/packages/build-cli/src/library/changesets.ts
+++ b/build-tools/packages/build-cli/src/library/changesets.ts
@@ -188,7 +188,7 @@ export type ChangesetEntry = Omit<Changeset, "metadata" | "mainPackage" | "chang
  * then the custom metadata is interpreted as change metadata and the changeset tools fail.
  *
  * For more information about the custom metadata we use in our changesets, see
- * https://github.com/microsoft/FluidFramework/wiki/Changesets#custom-metadata
+ * {@link https://github.com/microsoft/FluidFramework/blob/main/docs/content/Contributing/Breaking-vs-Non-Breaking-Changes.md | Breaking vs Non-Breaking Changes}.
  *
  * **Note that this is a lossy action!** The metadata is completely removed. Changesets are typically in source
  * control so changes can usually be reverted.

--- a/build-tools/packages/build-cli/src/library/changesets.ts
+++ b/build-tools/packages/build-cli/src/library/changesets.ts
@@ -188,7 +188,7 @@ export type ChangesetEntry = Omit<Changeset, "metadata" | "mainPackage" | "chang
  * then the custom metadata is interpreted as change metadata and the changeset tools fail.
  *
  * For more information about the custom metadata we use in our changesets, see
- * {@link https://github.com/microsoft/FluidFramework/blob/main/docs/content/Contributing/Breaking-vs-Non-Breaking-Changes.md | Breaking vs Non-Breaking Changes}.
+ * {@link https://github.com/microsoft/FluidFramework/blob/main/.changeset/README.md#custom-metadata | Changeset custom metadata}.
  *
  * **Note that this is a lossy action!** The metadata is completely removed. Changesets are typically in source
  * control so changes can usually be reverted.

--- a/build-tools/packages/build-cli/src/library/releaseLevel.ts
+++ b/build-tools/packages/build-cli/src/library/releaseLevel.ts
@@ -5,7 +5,7 @@
 
 /**
  * The release level of an API.
- * @remarks Derived from {@link https://github.com/microsoft/FluidFramework/wiki/Release-Tags | TSDoc release tags}.
+ * @remarks Derived from {@link https://github.com/microsoft/FluidFramework/blob/main/docs/content/Guidelines/Documentation-Guidelines/Documenting-TypeScript/Release-Tags.md | TSDoc release tags}.
  */
 export const ReleaseLevel = {
 	/**

--- a/build-tools/packages/build-infrastructure/src/test/data/testRepo/.changeset/README.md
+++ b/build-tools/packages/build-infrastructure/src/test/data/testRepo/.changeset/README.md
@@ -7,4 +7,4 @@ This folder contains changesets, which are markdown files that hold two key bits
    [in the changeset documentation](../../../../../../../../docs/content/Contributing/Breaking-vs-Non-Breaking-Changes/Changesets.md) or in [the official changesets documentation.](https://github.com/changesets/changesets)
 
 There is also a list of [frequently asked questions](../../../../../../../../docs/content/Contributing/Breaking-vs-Non-Breaking-Changes/Changesets-FAQ.md) in
-the wiki.
+the documentation.

--- a/build-tools/packages/build-infrastructure/src/test/data/testRepo/.changeset/README.md
+++ b/build-tools/packages/build-infrastructure/src/test/data/testRepo/.changeset/README.md
@@ -4,8 +4,7 @@ This folder contains changesets, which are markdown files that hold two key bits
 
 1. a version type (following semver), and
 2. change information to be added to a changelog. You can find the full documentation for it
-   [in the changesets section of our wiki](https://github.com/microsoft/FluidFramework/wiki/Changesets) or in [the official changesets documentation.](https://github.com/changesets/changesets)
+   [in the changeset documentation](../../../../../../../../docs/content/Contributing/Breaking-vs-Non-Breaking-Changes/Changesets.md) or in [the official changesets documentation.](https://github.com/changesets/changesets)
 
-There is also a list of [frequently asked questions](https://github.com/microsoft/FluidFramework/wiki/Changesets-FAQ) in
+There is also a list of [frequently asked questions](../../../../../../../../docs/content/Contributing/Breaking-vs-Non-Breaking-Changes/Changesets-FAQ.md) in
 the wiki.
-

--- a/build-tools/packages/build-infrastructure/src/test/data/testRepo/.changeset/README.md
+++ b/build-tools/packages/build-infrastructure/src/test/data/testRepo/.changeset/README.md
@@ -4,7 +4,7 @@ This folder contains changesets, which are markdown files that hold two key bits
 
 1. a version type (following semver), and
 2. change information to be added to a changelog. You can find the full documentation for it
-   [in the changeset documentation](../../../../../../../../docs/content/Contributing/Breaking-vs-Non-Breaking-Changes/Changesets.md) or in [the official changesets documentation.](https://github.com/changesets/changesets)
+   [in the repo changeset documentation](../../../../../../../../docs/content/Contributing/Breaking-vs-Non-Breaking-Changes/Changesets.md) or in [the official changesets documentation.](https://github.com/changesets/changesets)
 
 There is also a list of [frequently asked questions](../../../../../../../../docs/content/Contributing/Breaking-vs-Non-Breaking-Changes/Changesets-FAQ.md) in
 the documentation.

--- a/server/routerlicious/.changeset/README.md
+++ b/server/routerlicious/.changeset/README.md
@@ -7,7 +7,7 @@ This folder contains changesets, which are markdown files that hold two key bits
    [in the changeset documentation](../../../docs/content/Contributing/Breaking-vs-Non-Breaking-Changes/Changesets.md) or in [the official changesets documentation.](https://github.com/changesets/changesets)
 
 There is also a list of [frequently asked questions](../../../docs/content/Contributing/Breaking-vs-Non-Breaking-Changes/Changesets-FAQ.md) in
-the wiki.
+the documentation.
 
 ## Updating changelogs from changesets
 

--- a/server/routerlicious/.changeset/README.md
+++ b/server/routerlicious/.changeset/README.md
@@ -4,7 +4,7 @@ This folder contains changesets, which are markdown files that hold two key bits
 
 1. a version type (following semver), and
 2. change information to be added to a changelog. You can find the full documentation for it
-   [in the changeset documentation](../../../docs/content/Contributing/Breaking-vs-Non-Breaking-Changes/Changesets.md) or in [the official changesets documentation.](https://github.com/changesets/changesets)
+   [in the repo changeset documentation](../../../docs/content/Contributing/Breaking-vs-Non-Breaking-Changes/Changesets.md) or in [the official changesets documentation.](https://github.com/changesets/changesets)
 
 There is also a list of [frequently asked questions](../../../docs/content/Contributing/Breaking-vs-Non-Breaking-Changes/Changesets-FAQ.md) in
 the documentation.

--- a/server/routerlicious/.changeset/README.md
+++ b/server/routerlicious/.changeset/README.md
@@ -4,9 +4,9 @@ This folder contains changesets, which are markdown files that hold two key bits
 
 1. a version type (following semver), and
 2. change information to be added to a changelog. You can find the full documentation for it
-   [in the changesets section of our wiki](https://github.com/microsoft/FluidFramework/wiki/Changesets) or in [the official changesets documentation.](https://github.com/changesets/changesets)
+   [in the changeset documentation](../../../docs/content/Contributing/Breaking-vs-Non-Breaking-Changes/Changesets.md) or in [the official changesets documentation.](https://github.com/changesets/changesets)
 
-There is also a list of [frequently asked questions](https://github.com/microsoft/FluidFramework/wiki/Changesets-FAQ) in
+There is also a list of [frequently asked questions](../../../docs/content/Contributing/Breaking-vs-Non-Breaking-Changes/Changesets-FAQ.md) in
 the wiki.
 
 ## Updating changelogs from changesets

--- a/server/routerlicious/README.md
+++ b/server/routerlicious/README.md
@@ -120,7 +120,7 @@ attach to the running tests with VS Code or any other node debugger.
 ### Documentation
 
 If you want to build API documentation locally, see
-[Building Documentation](https://github.com/microsoft/FluidFramework/wiki/Building-documentation-locally).
+[Building Documentation](../../docs/content/Contributing/Working-with-the-Website/Building-Documentation-Locally.md).
 
 ## Design principals
 

--- a/tools/markdown-magic/src/utilities.cjs
+++ b/tools/markdown-magic/src/utilities.cjs
@@ -112,7 +112,7 @@ function getPackageMetadata(packageJsonFilePath) {
 /**
  * Gets the appropriate special scope kind for the provided package name, if applicable.
  *
- * @remarks for an overview of the Fluid Framework's package scopes, see {@link https://github.com/microsoft/FluidFramework/wiki/npm-package-scopes}.
+ * @remarks for an overview of the Fluid Framework's package scopes, see {@link https://github.com/microsoft/FluidFramework/blob/main/docs/content/Contributing/npm-Package-Scopes.md | npm Package Scopes}.
  *
  * @param {string} packageName
  * @returns {"" | "FRAMEWORK" | "EXAMPLE" | "EXPERIMENTAL" | "INTERNAL" | "PRIVATE" | "TOOLS" | undefined}

--- a/website/README.md
+++ b/website/README.md
@@ -288,7 +288,7 @@ As a general rule, links between documents on the site should:
 
 ##### Images
 
-When adding image assets for use in the website, please follow the instructions outlined [here](https://github.com/microsoft/FluidFramework/wiki/Uploading-images-for-the-website-to-Azure-blob-storage).
+When adding image assets for use in the website, please follow the [image upload instructions](../docs/content/Contributing/Working-with-the-Website/Uploading-Images-for-the-Website.md).
 Namely, avoid adding binary files like images to the GitHub repo.
 Instead, upload them to our Azure blob storage, and reference by URL.
 E.g., <https://storage.fluidframework.com/static/images/website/brainstorm-example.png>

--- a/website/docs/build/packages.mdx
+++ b/website/docs/build/packages.mdx
@@ -59,4 +59,4 @@ You can [read more about the scopes and their intent][scopes] in the Fluid Frame
 {/* Links */}
 [FluidContainer]: ./containers.mdx
 [fluid-framework]: ../api/fluid-framework/index.md
-[scopes]: https://github.com/microsoft/FluidFramework/wiki/npm-package-scopes
+[scopes]: https://github.com/microsoft/FluidFramework/blob/main/docs/content/Contributing/npm-Package-Scopes.md

--- a/website/docs/build/releases-and-apitags.mdx
+++ b/website/docs/build/releases-and-apitags.mdx
@@ -76,4 +76,4 @@ There are no API stability guarantees for packages in the `@fluid-experimental` 
 `@fluid-experimental` APIs are for developers to try experimental features and provide feedback. It's possible that these APIs can get completely scrapped or drastically changed in a minor release based on developer feedback.
 `@fluid-internal` APIs are only meant for internal consumption by the framework and should not be used.
 
-For additional information on Release tags, visit the [github documentation](https://github.com/microsoft/FluidFramework/wiki/Release-Tags).
+For additional information on release tags, visit the [release tag documentation](https://github.com/microsoft/FluidFramework/blob/main/docs/content/Guidelines/Documentation-Guidelines/Documenting-TypeScript/Release-Tags.md).

--- a/website/versioned_docs/version-1/build/packages.mdx
+++ b/website/versioned_docs/version-1/build/packages.mdx
@@ -41,4 +41,4 @@ In addition to the scoped packages, two unscoped packages are published: the [fl
 Unless you are contributing to the Fluid Framework, you should only need the unscoped packages and packages from the **@fluidframework** scope.
 You can [read more about the scopes and their intent][scopes] in the Fluid Framework wiki.
 
-[scopes]: https://github.com/microsoft/FluidFramework/wiki/npm-package-scopes
+[scopes]: https://github.com/microsoft/FluidFramework/blob/main/docs/content/Contributing/npm-Package-Scopes.md


### PR DESCRIPTION
The wiki was migrated into the repo, but this template was not correctly updated to match.