### PR TITLE
fix(bundle-size): baseline PR comparisons on the commit the PR build merged

### DIFF
--- a/.github/workflows/pr-bundle-size-comments.yml
+++ b/.github/workflows/pr-bundle-size-comments.yml
@@ -65,6 +65,8 @@ jobs:
       contains(github.event.check_run.details_url, '10f9b53e-c7fd-4538-9fff-13cd088a436c')
     runs-on: ubuntu-latest
     permissions:
+      # `contents: read` for the getCommit call that resolves the base commit.
+      contents: read
       pull-requests: write
     steps:
       - name: Resolve PR for check SHA
@@ -76,12 +78,11 @@ jobs:
             const { owner, repo } = context.repo;
             const sha = context.payload.check_run.head_sha;
 
-            // Find the open PR whose head SHA matches this check. A single GraphQL query returns the
-            // PR number, head SHA, and base ref in one round-trip (we use all three: number to address
-            // the sticky, head + base to compute merge-base for the pending body). At most one PR is
-            // expected in practice. Two open PRs *can* share a head SHA (same branch PR'd against two
-            // base refs), in which case only the first one matched here gets a sticky — accepted
-            // limitation.
+            // Find the open PR whose head SHA matches this check. A single GraphQL query returns
+            // the PR number and head SHA in one round-trip (we use both: number to address the
+            // sticky, head to report in the body). At most one PR is expected in practice. Two open
+            // PRs *can* share a head SHA (same branch PR'd against two base refs), in which case
+            // only the first one matched here gets a sticky — accepted limitation.
             const { search } = await github.graphql(
               `query($q: String!) {
                  search(query: $q, type: ISSUE, first: 1) {
@@ -89,7 +90,6 @@ jobs:
                      ... on PullRequest {
                        number
                        headRefOid
-                       baseRefName
                      }
                    }
                  }
@@ -102,28 +102,72 @@ jobs:
               return;
             }
 
-            // Server-side merge-base lookup. compareCommits resolves to the SHA on shared history (or
-            // null on disjoint history) for any successful HTTP response, and throws for HTTP/network/
-            // rate-limit failure. API failure here is fatal.
-            let mb;
-            try {
-              const { data } = await github.rest.repos.compareCommits({
-                owner, repo, base: pr.baseRefName, head: pr.headRefOid,
-              });
-              mb = data.merge_base_commit?.sha ?? undefined;
-            } catch (err) {
-              core.error(`Merge-base lookup failed for PR #${pr.number} (base=${pr.baseRefName}, head=${pr.headRefOid}): ${err.message}`);
-              throw err;
-            }
-            if (!mb) {
-              core.info(`PR #${pr.number} has no shared history with ${pr.baseRefName}; nothing to do.`);
+            core.info(`Matched PR #${pr.number} head=${pr.headRefOid}`);
+            core.setOutput("pr_num", pr.number);
+            core.setOutput("head_sha", pr.headRefOid);
+
+      - name: Resolve base commit from the ADO build
+        id: find_base
+        if: steps.find_pr.outputs.pr_num != ''
+        # release notes: https://github.com/actions/github-script/releases/tag/v9.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            // The check run's details_url points at the exact ADO build behind it, so its
+            // sourceVersion — the `refs/pull/<n>/merge` commit ADO resolved at queue time — can be
+            // read without searching for a matching build. Its first parent is the target-branch
+            // commit that build merged the PR into, i.e. the comparison's baseline.
+            //
+            // Best-effort: the sticky just shows a nicer pending body, and the real comparison
+            // derives the base itself. Any failure here leaves the base unresolved in the body.
+            const detailsUrl = new URL(context.payload.check_run.details_url);
+            const buildId = detailsUrl.searchParams.get("buildId");
+            if (!buildId) {
+              core.info(`No buildId in details_url ${detailsUrl}; leaving the base unresolved.`);
               return;
             }
 
-            core.info(`Matched PR #${pr.number} head=${pr.headRefOid} base=${pr.baseRefName} mergeBase=${mb}`);
-            core.setOutput("pr_num", pr.number);
-            core.setOutput("head_sha", pr.headRefOid);
-            core.setOutput("merge_base", mb);
+            // `details_url` is <origin>/<org>/<projectId>/_build/results, so the project-scoped API
+            // root is the first two path segments.
+            const [, org, projectId] = detailsUrl.pathname.split("/");
+            const buildUrl = `${detailsUrl.origin}/${org}/${projectId}/_apis/build/builds/${buildId}?api-version=7.1`;
+
+            let sourceVersion;
+            try {
+              const response = await fetch(buildUrl);
+              if (!response.ok) {
+                core.info(`ADO build ${buildId} lookup failed (${response.status}); leaving the base unresolved.`);
+                return;
+              }
+              ({ sourceVersion } = await response.json());
+            } catch (error) {
+              core.info(`ADO build ${buildId} lookup failed (${error}); leaving the base unresolved.`);
+              return;
+            }
+
+            // Not yet populated if ADO hasn't resolved the merge ref for a just-queued build.
+            if (!sourceVersion) {
+              core.info(`ADO build ${buildId} has no sourceVersion yet; leaving the base unresolved.`);
+              return;
+            }
+
+            const { owner, repo } = context.repo;
+            let parents;
+            try {
+              ({ data: { parents } } = await github.rest.repos.getCommit({ owner, repo, ref: sourceVersion }));
+            } catch (error) {
+              core.info(`Could not read ${sourceVersion} (${error}); leaving the base unresolved.`);
+              return;
+            }
+
+            // A test-merge commit always has two parents: [target branch tip, PR HEAD].
+            if (parents.length < 2) {
+              core.info(`${sourceVersion} is not a merge commit; leaving the base unresolved.`);
+              return;
+            }
+
+            core.info(`ADO build ${buildId} merged PR into ${parents[0].sha}`);
+            core.setOutput("base_sha", parents[0].sha);
 
       - name: Render initial comment body
         id: render
@@ -133,14 +177,18 @@ jobs:
         env:
           PR_NUM: ${{ steps.find_pr.outputs.pr_num }}
           HEAD_SHA: ${{ steps.find_pr.outputs.head_sha }}
-          MERGE_BASE: ${{ steps.find_pr.outputs.merge_base }}
+          BASE_SHA: ${{ steps.find_base.outputs.base_sha }}
         with:
           script: |
             const fs = require("fs");
+            const baseSha = process.env.BASE_SHA;
             const body = [
               "## Bundle size comparison",
               "",
-              `Base commit: \`${process.env.MERGE_BASE}\``,
+              // An empty baseSha means the lookup failed — normally the base is readable off the
+              // ADO build. Harmless for correctness: the comparison derives the base independently,
+              // so it will be filled in when this comment is replaced with the results.
+              `Base commit: ${baseSha ? `\`${baseSha}\`` : "_could not be determined; will be reported when the comparison runs_"}`,
               `Head commit: \`${process.env.HEAD_SHA}\``,
               "",
               "Pending — `Build - client packages` is running. Results will appear here when the build completes.",
@@ -240,11 +288,12 @@ jobs:
             const { owner, repo } = context.repo;
             const sha = context.payload.check_run.head_sha;
 
-            // Find the open PR whose head SHA matches this check. A single GraphQL query returns the
-            // PR number, head SHA, and base ref in one round-trip; the REST search API would return
-            // only the number, requiring a follow-up pulls.get() call. At most one PR is expected in
-            // practice. Two open PRs *can* share a head SHA (same branch PR'd against two base refs),
-            // in which case only the first one matched here gets a comparison — accepted limitation.
+            // Find the open PR whose head SHA matches this check. A single GraphQL query returns
+            // the PR number, head SHA, and base ref in one round-trip; the REST search API would
+            // return only the number, requiring a follow-up pulls.get() call. At most one PR is
+            // expected in practice. Two open PRs *can* share a head SHA (same branch PR'd against
+            // two base refs), in which case only the first one matched here gets a comparison —
+            // accepted limitation.
             //
             // Also acts as the cross-SHA staleness guard: an event for a stale SHA (e.g. push A then
             // B, A's build completes anyway) finds no open PR with head A and emits no matrix entry.
@@ -269,41 +318,19 @@ jobs:
               return;
             }
 
-            // Server-side merge-base lookup. compareCommits resolves to the SHA on shared history (or null
-            // on disjoint history) for any successful HTTP response, and throws for HTTP/network/rate-limit
-            // failure — distinguishing "no shared history" (legitimate, emit no entry and stay green) from
-            // "API call failed" (often actionable, e.g. a rate limit). API failure here is fatal.
-            let mb;
-            try {
-              const { data } = await github.rest.repos.compareCommits({
-                owner, repo, base: pr.baseRefName, head: pr.headRefOid,
-              });
-              mb = data.merge_base_commit?.sha ?? undefined;
-            } catch (err) {
-              core.error(`Merge-base lookup failed for PR #${pr.number} (base=${pr.baseRefName}, head=${pr.headRefOid}): ${err.message}`);
-              throw err;
-            }
-            if (!mb) {
-              core.info(`Affected PRs (0): PR #${pr.number} has no shared history with ${pr.baseRefName}`);
-              core.setOutput("prs", "[]");
-              return;
-            }
-
             const affected = [{
               number: pr.number,
               head: pr.headRefOid,
-              baseRef: pr.baseRefName,
-              mergeBase: mb,
             }];
-            core.info(`Affected PRs (1): #${pr.number} head=${pr.headRefOid} base=${pr.baseRefName} mergeBase=${mb}`);
+            core.info(`Affected PRs (1): #${pr.number} head=${pr.headRefOid} base=${pr.baseRefName}`);
             core.setOutput("prs", JSON.stringify(affected));
 
   # Reacts to the baseline pipeline (`Build - Client bundle size artifacts`) completing on a main/release
-  # commit. The check SHA is on the base branch, so we produce a matrix entry per open PR whose merge-base
-  # equals this SHA — typically 0–few PRs. Fires on `success` or `failure` so a baseline failure also
-  # re-triggers affected PRs (the compare job's flub call returns the appropriate failure kind and the
-  # sticky updates from "Pending — …" to a per-kind body), but skips `neutral` / `cancelled` / `skipped`
-  # so path-filtered or otherwise no-op baseline completions don't generate noise.
+  # commit. The check SHA is on the base branch, so we produce a matrix entry per open PR that is likely
+  # to be waiting on this baseline — typically 0–few PRs. Fires on `success` or `failure` so a baseline
+  # failure also re-triggers affected PRs (the compare job's flub call returns the appropriate failure
+  # kind and the sticky updates from "Pending — …" to a per-kind body), but skips `neutral` / `cancelled`
+  # / `skipped` so path-filtered or otherwise no-op baseline completions don't generate noise.
   identify-from-baseline-build:
     if: >-
       github.event.action == 'completed' &&
@@ -323,44 +350,54 @@ jobs:
             const { owner, repo } = context.repo;
             const sha = context.payload.check_run.head_sha;
 
-            const prs = await github.paginate(github.rest.pulls.list, {
-              owner, repo, state: "open", per_page: 100,
-            });
+            // Selects PRs waiting on this baseline: those whose current test-merge commit has the
+            // commit this baseline build ran on as its first parent, matching how the comparison
+            // derives its base. Candidates only — flub re-derives each PR's true base, so a false
+            // positive costs one redundant (idempotent) comparison.
+            //
+            // One paginated GraphQL query returns every open PR with the fields we need, versus two
+            // REST calls per PR (~250 for this repo) — that matters against the hourly rate limit.
+            const query = `
+              query($owner: String!, $repo: String!, $cursor: String) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequests(states: OPEN, first: 100, after: $cursor) {
+                    pageInfo { hasNextPage endCursor }
+                    nodes {
+                      number
+                      headRefOid
+                      baseRefName
+                      potentialMergeCommit { parents(first: 1) { nodes { oid } } }
+                    }
+                  }
+                }
+              }`;
 
             const affected = [];
-            for (const pr of prs) {
-              // Server-side merge-base lookup. Resolves to the SHA on shared history (or null on disjoint
-              // history) for any successful HTTP response, and throws for HTTP/network/rate-limit failure.
-              // Per-PR API failure is logged and skipped so a transient hit doesn't abort the whole scan;
-              // disjoint history naturally falls through the match check below.
-              let mb;
-              try {
-                const { data } = await github.rest.repos.compareCommits({
-                  owner, repo, base: pr.base.ref, head: pr.head.sha,
-                });
-                mb = data.merge_base_commit?.sha ?? undefined;
-              } catch (err) {
-                core.warning(`Skipping PR #${pr.number}: merge-base lookup failed (base=${pr.base.ref}, head=${pr.head.sha}): ${err.message}`);
-                continue;
+            let cursor = undefined;
+            let scanned = 0;
+            do {
+              const { repository } = await github.graphql(query, { owner, repo, cursor });
+              const page = repository.pullRequests;
+              for (const pr of page.nodes) {
+                scanned++;
+                // A PR is missed here if `potentialMergeCommit` is null (GitHub hasn't computed
+                // mergeability, or the PR conflicts) or if it has since been recomputed against a
+                // newer target tip than the one its ADO build used. Either way the miss is
+                // self-correcting: the baseline build for that newer tip completes shortly after and
+                // matches the PR, and flub then re-derives its true (already built) base.
+                const mergeParent = pr.potentialMergeCommit?.parents?.nodes?.[0]?.oid;
+                if (mergeParent === sha) {
+                  core.info(`  matched #${pr.number} head=${pr.headRefOid} base=${pr.baseRefName}`);
+                  affected.push({
+                    number: pr.number,
+                    head: pr.headRefOid,
+                  });
+                }
               }
+              cursor = page.pageInfo.hasNextPage ? page.pageInfo.endCursor : undefined;
+            } while (cursor);
 
-              if (mb === sha) {
-                affected.push({
-                  number: pr.number,
-                  head: pr.head.sha,
-                  baseRef: pr.base.ref,
-                  mergeBase: mb,
-                });
-              }
-            }
-            if (affected.length === 0) {
-              core.info("Affected PRs (0): none");
-            } else {
-              core.info(`Affected PRs (${affected.length}):`);
-              for (const a of affected) {
-                core.info(`  - #${a.number} head=${a.head} base=${a.baseRef} mergeBase=${a.mergeBase}`);
-              }
-            }
+            core.info(`Scanned ${scanned} open PRs; affected PRs (${affected.length})`);
             core.setOutput("prs", JSON.stringify(affected));
 
   compare:
@@ -380,15 +417,20 @@ jobs:
       fail-fast: false
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
     steps:
-      # Check out the PR's base branch (never PR HEAD — PR-authored code isn't trusted) just to get build-tools
+      # Check out the default branch (never PR HEAD — PR-authored code isn't trusted) just to get build-tools
       # source so we can build flub. The comparison itself reads only ADO artifacts identified by SHA — no local
       # git state is required.
+      #
+      # The default branch — not the PR's base ref — because `check_run` workflows always run the default
+      # branch's copy of this file, so that's the only branch guaranteed to have a flub whose CLI contract
+      # matches the invocation below. Release branches lag main and don't carry this command at all.
       # release notes: https://github.com/actions/checkout/releases/tag/v6.0.2
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ matrix.pr.baseRef }}
+          ref: ${{ github.event.repository.default_branch }}
           fetch-depth: "1"
           persist-credentials: false
 
@@ -412,18 +454,22 @@ jobs:
           npm link
 
       - name: Compare bundle sizes
-        # Expected failure modes (missing/in-progress/failed baseline, no
-        # analyzer.json) come back as a structured `{ kind, side }` payload
+        # The baseline commit isn't passed in: flub derives it from the PR's ADO build (the first
+        # parent of the `refs/pull/<n>/merge` commit that build checked out), which is the only
+        # baseline that isolates this PR's delta. Expected failure modes (missing/in-progress/failed
+        # baseline, no analyzer.json) come back as a structured `{ kind, side }` payload
         # under `--json` and a zero exit — the render step dispatches on
         # `kind` to produce a friendly sticky body. Non-zero exit is reserved
         # for *unexpected* errors (network, malformed zip, …); upstream oclif
         # bug oclif/core#1608 swallows their message in `--json` mode, so we
         # re-run without `--json` to surface it in the action log.
+        env:
+          # Used only to raise the rate limit on the read-only commit lookup flub does.
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -uo pipefail
           set +e
           flub report comparePipelineBundleArtifacts \
-            --base ${{ matrix.pr.mergeBase }} \
             --head ${{ matrix.pr.head }} \
             --json > bundle-comparison.json
           EC=$?
@@ -434,7 +480,6 @@ jobs:
             echo
             echo "flub --json exited $EC; re-running without --json so the error message is visible:"
             flub report comparePipelineBundleArtifacts \
-              --base ${{ matrix.pr.mergeBase }} \
               --head ${{ matrix.pr.head }} 2>&1
             exit "$EC"
           fi
@@ -449,7 +494,6 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           PR_NUM: ${{ matrix.pr.number }}
-          BASE_SHA: ${{ matrix.pr.mergeBase }}
           HEAD_SHA: ${{ matrix.pr.head }}
         with:
           script: |
@@ -541,11 +585,12 @@ jobs:
               // Friendly per-(side, kind) sticky body for expected failure modes.
               const failureMessages = {
                 base: {
-                  "no-build": "No baseline CI build was found for the merge-base commit. It may be older than the workflow's search horizon, or the baseline pipeline may not have run on it. Try merging a recent main commit into this PR.",
-                  "in-progress": "Pending — the baseline CI build for the merge-base commit hasn't completed yet. Results will appear here when the build finishes.",
-                  "all-failed": "The baseline CI build for the merge-base commit failed — likely a flaky producer build. Try merging a recent main commit into this PR, or re-queue the baseline pipeline manually.",
+                  "no-build": "No baseline CI build was found for the target-branch commit this PR was built against. It may be older than the workflow's search horizon, or the baseline pipeline may not have run on it. Pushing to the PR re-runs the comparison against a newer baseline.",
+                  "in-progress": "Pending — the baseline CI build for the target-branch commit this PR was built against hasn't completed yet. Results will appear here when the build finishes.",
+                  "all-failed": "The baseline CI build for the target-branch commit this PR was built against failed — likely a flaky producer build. Pushing to the PR re-runs the comparison against a newer baseline, or the baseline pipeline can be re-queued manually.",
                   "no-id": "An ADO state anomaly prevented looking up the baseline build (no usable build id). This shouldn't happen in practice — please report.",
-                  "no-analyzer-jsons": "The baseline build completed but didn't publish a bundle-size artifact for the merge-base commit. Try merging a recent main commit into this PR.",
+                  "no-analyzer-jsons": "The baseline build completed but didn't publish a bundle-size artifact for the target-branch commit this PR was built against. Pushing to the PR re-runs the comparison against a newer baseline.",
+                  "no-base-commit": "Couldn't determine which target-branch commit the PR build was based on. Pushing to the PR re-runs the comparison; if it persists, please report.",
                 },
                 head: {
                   "no-build": "No CI build was found for the PR HEAD commit. This shouldn't happen — the workflow only runs after the PR's `Build - client packages` check completes. Please report.",
@@ -563,7 +608,10 @@ jobs:
             const body = [
               "## Bundle size comparison",
               "",
-              `Base commit: \`${process.env.BASE_SHA}\``,
+              // The base is the target-branch commit the PR's ADO build merged into — reported by
+              // flub, since only that build knows it. Absent when the failure happened before it
+              // could be resolved.
+              `Base commit: ${data.baseCommit ? `\`${data.baseCommit}\`` : "_unresolved_"}`,
               `Head commit: \`${process.env.HEAD_SHA}\``,
               "",
               data.kind === "completed"

--- a/build-tools/packages/build-cli/docs/report.md
+++ b/build-tools/packages/build-cli/docs/report.md
@@ -43,15 +43,16 @@ _See code: [src/commands/report/codeCoverage.ts](https://github.com/microsoft/Fl
 
 ## `flub report comparePipelineBundleArtifacts`
 
-Download ADO bundle-size artifacts for two commits and emit their per-package, per-bundle differences as JSON. Base-side artifacts come from the `Build - Client bundle size artifacts` pipeline (runs on main/release pushes); head-side artifacts come from the `Build - client packages` pipeline (runs on PR commits). Intended for the PR-comment CI workflow; for local inner-dev-loop comparisons use `check bundleSize` instead.
+Download ADO bundle-size artifacts for a PR's CI build and its baseline and emit their per-package, per-bundle differences as JSON. Head-side artifacts come from the `Build - client packages` pipeline (runs on PR commits); base-side artifacts come from the `Build - Client bundle size artifacts` pipeline (runs on main/release pushes). The base commit is the target-branch commit the PR build actually built against — a PR build builds `refs/pull/<n>/merge`, i.e. the PR HEAD merged into the target branch tip at queue time, so that tip (not the merge-base) is the only baseline that isolates the PR's own delta. Intended for the PR-comment CI workflow; for local inner-dev-loop comparisons use `check bundleSize` instead.
 
 ```
 USAGE
-  $ flub report comparePipelineBundleArtifacts --base <value> --head <value> [--json] [-v | --quiet]
+  $ flub report comparePipelineBundleArtifacts --githubToken <value> --head <value> [--json] [-v | --quiet]
 
 FLAGS
-  --base=<value>  (required) Base commit SHA — the merge-base on the target branch. The baseline of the comparison.
-  --head=<value>  (required) Head commit SHA — the PR's latest commit. The compare side of the comparison.
+  --githubToken=<value>  (required) [env: GITHUB_TOKEN] GitHub access token used to resolve the PR build's test-merge
+                         commit.
+  --head=<value>         (required) Head commit SHA — the PR's latest commit. The compare side of the comparison.
 
 LOGGING FLAGS
   -v, --verbose  Enable verbose logging.
@@ -61,10 +62,13 @@ GLOBAL FLAGS
   --json  Format output as json.
 
 DESCRIPTION
-  Download ADO bundle-size artifacts for two commits and emit their per-package, per-bundle differences as JSON.
-  Base-side artifacts come from the `Build - Client bundle size artifacts` pipeline (runs on main/release pushes);
-  head-side artifacts come from the `Build - client packages` pipeline (runs on PR commits). Intended for the PR-comment
-  CI workflow; for local inner-dev-loop comparisons use `check bundleSize` instead.
+  Download ADO bundle-size artifacts for a PR's CI build and its baseline and emit their per-package, per-bundle
+  differences as JSON. Head-side artifacts come from the `Build - client packages` pipeline (runs on PR commits);
+  base-side artifacts come from the `Build - Client bundle size artifacts` pipeline (runs on main/release pushes). The
+  base commit is the target-branch commit the PR build actually built against — a PR build builds `refs/pull/<n>/merge`,
+  i.e. the PR HEAD merged into the target branch tip at queue time, so that tip (not the merge-base) is the only
+  baseline that isolates the PR's own delta. Intended for the PR-comment CI workflow; for local inner-dev-loop
+  comparisons use `check bundleSize` instead.
 ```
 
 _See code: [src/commands/report/comparePipelineBundleArtifacts.ts](https://github.com/microsoft/FluidFramework/blob/main/build-tools/packages/build-cli/src/commands/report/comparePipelineBundleArtifacts.ts)_

--- a/build-tools/packages/build-cli/src/commands/report/comparePipelineBundleArtifacts.ts
+++ b/build-tools/packages/build-cli/src/commands/report/comparePipelineBundleArtifacts.ts
@@ -4,7 +4,7 @@
  */
 
 import { Flags } from "@oclif/core";
-
+import { githubTokenFlag } from "../../flags.js";
 import { fluidframeworkAdoOrgUrl } from "../../library/azureDevops/constants.js";
 import {
 	type ArtifactLookupFailure,
@@ -16,12 +16,14 @@ import { getAzureDevopsApi } from "../../library/azureDevops/getAzureDevopsApi.j
 import {
 	type AnalyzerJsonByPackage,
 	bundleSizeArtifactsBaselinePipeline,
+	bundleSizeArtifactsGitHubRepo,
 	bundleSizeArtifactsPrPipeline,
 	compareJsonReportsByPackage,
 	extractAnalyzerJsonsFromArtifact,
 	type PackageComparison,
 } from "../../library/bundleSize/index.js";
 import { BaseCommand } from "../../library/commands/base.js";
+import { getCommitParents } from "../../library/githubRest.js";
 
 /**
  * Which side of a comparison we're operating on.
@@ -30,17 +32,24 @@ type ComparisonSide = "base" | "head";
 
 /**
  * Failure variants a {@link ComparePipelineBundleArtifactsResult} can surface.
- * Reuses the library's {@link ArtifactLookupFailure} kinds and adds a
- * command-level case for artifacts that downloaded but contain no
- * `analyzer.json` files.
+ * Reuses the library's {@link ArtifactLookupFailure} kinds and adds
+ * command-level cases for artifacts that downloaded but contain no
+ * `analyzer.json` files, and for a base commit that couldn't be derived from
+ * the PR build's test-merge commit.
  */
-type ComparePipelineSideFailure = ArtifactLookupFailure | { kind: "no-analyzer-jsons" };
+type ComparePipelineSideFailure =
+	| ArtifactLookupFailure
+	| { kind: "no-analyzer-jsons" }
+	| { kind: "no-base-commit" };
 
 /**
  * Result serialized to stdout by `--json`. Discriminated by `kind`:
  *
  * - `completed`: happy path with the structured per-package comparison.
  * - any other kind: failure, scoped to one `side` of the comparison so the consuming workflow can render an actionable sticky comment.
+ *
+ * `baseCommit` is present on failures too whenever it was resolved before the failure occurred, so
+ * the consuming workflow can report which baseline it tried to compare against.
  */
 type ComparePipelineBundleArtifactsResult =
 	| {
@@ -49,20 +58,22 @@ type ComparePipelineBundleArtifactsResult =
 			headCommit: string;
 			comparison: PackageComparison;
 	  }
-	| (ComparePipelineSideFailure & { side: ComparisonSide });
+	| (ComparePipelineSideFailure & {
+			side: ComparisonSide;
+			baseCommit?: string;
+	  });
 
 export default class ComparePipelineBundleArtifacts extends BaseCommand<
 	typeof ComparePipelineBundleArtifacts
 > {
 	static readonly description =
-		`Download ADO bundle-size artifacts for two commits and emit their per-package, per-bundle differences as JSON. Base-side artifacts come from the \`Build - Client bundle size artifacts\` pipeline (runs on main/release pushes); head-side artifacts come from the \`Build - client packages\` pipeline (runs on PR commits). Intended for the PR-comment CI workflow; for local inner-dev-loop comparisons use \`check bundleSize\` instead.`;
+		`Download ADO bundle-size artifacts for a PR's CI build and its baseline and emit their per-package, per-bundle differences as JSON. Head-side artifacts come from the \`Build - client packages\` pipeline (runs on PR commits); base-side artifacts come from the \`Build - Client bundle size artifacts\` pipeline (runs on main/release pushes). The base commit is the target-branch commit the PR build actually built against — a PR build builds \`refs/pull/<n>/merge\`, i.e. the PR HEAD merged into the target branch tip at queue time, so that tip (not the merge-base) is the only baseline that isolates the PR's own delta. Intended for the PR-comment CI workflow; for local inner-dev-loop comparisons use \`check bundleSize\` instead.`;
 
 	static readonly enableJsonFlag = true;
 
 	static readonly flags = {
-		base: Flags.string({
-			description:
-				"Base commit SHA — the merge-base on the target branch. The baseline of the comparison.",
+		githubToken: githubTokenFlag({
+			description: "GitHub access token used to resolve the PR build's test-merge commit.",
 			required: true,
 		}),
 		head: Flags.string({
@@ -74,7 +85,7 @@ export default class ComparePipelineBundleArtifacts extends BaseCommand<
 	} as const;
 
 	public async run(): Promise<ComparePipelineBundleArtifactsResult> {
-		const { base, head } = this.flags;
+		const { head, githubToken } = this.flags;
 
 		// Public ADO project — anonymous reads are fine at this command's scale.
 		const adoApi = getAzureDevopsApi(undefined, fluidframeworkAdoOrgUrl);
@@ -90,7 +101,8 @@ export default class ComparePipelineBundleArtifacts extends BaseCommand<
 				bundleAnalyzerJsonArtifactName: string;
 			},
 		): Promise<
-			{ kind: "completed"; jsons: AnalyzerJsonByPackage } | ComparePipelineSideFailure
+			| { kind: "completed"; jsons: AnalyzerJsonByPackage; sourceVersion: string | undefined }
+			| ComparePipelineSideFailure
 		> => {
 			const artifact = await getArtifactForCommit({
 				adoApi,
@@ -106,7 +118,7 @@ export default class ComparePipelineBundleArtifacts extends BaseCommand<
 			if (jsons.size === 0) {
 				return { kind: "no-analyzer-jsons" };
 			}
-			return { kind: "completed", jsons };
+			return { kind: "completed", jsons, sourceVersion: artifact.sourceVersion };
 		};
 
 		// Emit a per-side failure: outside `--json` mode print + non-zero exit
@@ -117,33 +129,87 @@ export default class ComparePipelineBundleArtifacts extends BaseCommand<
 			match: BuildMatch,
 			side: ComparisonSide,
 			failure: ComparePipelineSideFailure,
+			baseCommit?: string,
 		): ComparePipelineBundleArtifactsResult => {
 			if (!this.jsonEnabled()) {
 				const subject =
 					match.kind === "commit" ? `commit ${match.sha}` : `PR HEAD ${match.sha}`;
-				const message =
-					failure.kind === "no-analyzer-jsons"
-						? `${side === "base" ? "Base" : "Head"} artifact contains no analyzer.json files for ${subject}.`
-						: describeArtifactFailure(match, failure);
+				let message: string;
+				switch (failure.kind) {
+					case "no-analyzer-jsons": {
+						message = `${side === "base" ? "Base" : "Head"} artifact contains no analyzer.json files for ${subject}.`;
+						break;
+					}
+					case "no-base-commit": {
+						message = `Could not determine the base commit for ${subject}: the PR build's source version is missing, no longer reachable on GitHub, or not a merge commit. This usually means the build is old enough that its merge commit was garbage-collected; re-run the PR build to get a fresh comparison.`;
+						break;
+					}
+					default: {
+						message = describeArtifactFailure(match, failure);
+					}
+				}
 				this.error(message);
 			}
-			return { ...failure, side };
+			return {
+				...failure,
+				side,
+				...(baseCommit === undefined ? {} : { baseCommit }),
+			};
 		};
 
-		const baseMatch: BuildMatch = { kind: "commit", sha: base };
-		const baseResult = await fetchSide(baseMatch, bundleSizeArtifactsBaselinePipeline);
-		if (baseResult.kind !== "completed") {
-			return handleFailure(baseMatch, "base", baseResult);
-		}
-
+		// Head side first: the PR build identifies the commit the comparison must be based on.
 		const headMatch: BuildMatch = { kind: "prHead", sha: head };
 		const headResult = await fetchSide(headMatch, bundleSizeArtifactsPrPipeline);
 		if (headResult.kind !== "completed") {
 			return handleFailure(headMatch, "head", headResult);
 		}
 
+		// A PR build builds `refs/pull/<n>/merge` — the PR HEAD merged into the target branch tip
+		// as of queue time — so its artifact reflects the PR's changes *plus* everything on the
+		// target branch up to that tip. The tip is the merge commit's first parent, and is the only
+		// baseline that isolates the PR's own delta. The merge-base would leave every target-branch
+		// change since the branch last synced showing up as if the PR caused it.
+		const base = await resolveMergedTargetCommit(headResult.sourceVersion, githubToken);
+		if (base === undefined) {
+			return handleFailure(headMatch, "base", { kind: "no-base-commit" });
+		}
+
+		const baseMatch: BuildMatch = { kind: "commit", sha: base };
+		const baseResult = await fetchSide(baseMatch, bundleSizeArtifactsBaselinePipeline);
+		if (baseResult.kind !== "completed") {
+			return handleFailure(baseMatch, "base", baseResult, base);
+		}
+
 		const comparison = compareJsonReportsByPackage(baseResult.jsons, headResult.jsons);
 
 		return { kind: "completed", baseCommit: base, headCommit: head, comparison };
 	}
+}
+
+/**
+ * Resolve the target-branch commit a PR build built against — the first parent of the build's
+ * test-merge commit (`refs/pull/<n>/merge`), which GitHub creates by merging the PR HEAD into
+ * the target branch tip.
+ *
+ * @returns The target-branch commit SHA, or `undefined` when `sourceVersion` is missing, is no
+ * longer reachable on GitHub (unreferenced merge commits are eventually garbage-collected), or
+ * isn't a merge commit.
+ */
+async function resolveMergedTargetCommit(
+	sourceVersion: string | undefined,
+	token: string,
+): Promise<string | undefined> {
+	if (sourceVersion === undefined) {
+		return undefined;
+	}
+
+	const parents = await getCommitParents(
+		{ ...bundleSizeArtifactsGitHubRepo, token },
+		sourceVersion,
+	);
+	// A test-merge commit always has two parents: [target branch tip, PR HEAD].
+	if (parents === undefined || parents.length < 2) {
+		return undefined;
+	}
+	return parents[0];
 }

--- a/build-tools/packages/build-cli/src/library/azureDevops/getArtifactForCommit.ts
+++ b/build-tools/packages/build-cli/src/library/azureDevops/getArtifactForCommit.ts
@@ -46,7 +46,7 @@ function buildMatches(b: Build, match: BuildMatch): boolean {
 }
 
 /**
- * Failure variants shared by {@link FindBuildIdResult} and {@link GetArtifactForCommitResult}.
+ * Failure variants shared by {@link FindBuildResult} and {@link GetArtifactForCommitResult}.
  *
  * - `no-build`: no candidate builds matched the SHA — too stale, or never queued.
  * - `in-progress`: at least one candidate is actively running (NotStarted / InProgress / Postponed) and none have succeeded yet. Retrying later may help.
@@ -60,10 +60,12 @@ export type ArtifactLookupFailure =
 	| { kind: "no-id" };
 
 /**
- * Outcome of looking up a build for a {@link BuildMatch}. `completed` carries
- * the usable build's id; the failure variants are {@link ArtifactLookupFailure}.
+ * Outcome of looking up a build for a {@link BuildMatch}. `completed` carries the id of the usable
+ * build and the commit it checked out; the failure variants are {@link ArtifactLookupFailure}.
  */
-export type FindBuildIdResult = { kind: "completed"; buildId: number } | ArtifactLookupFailure;
+type FindBuildResult =
+	| { kind: "completed"; buildId: number; sourceVersion: string | undefined }
+	| ArtifactLookupFailure;
 
 /**
  * Find a usable build matching `match` — one with an id, status Completed,
@@ -71,7 +73,7 @@ export type FindBuildIdResult = { kind: "completed"; buildId: number } | Artifac
  * via re-runs/retries), not just the first. Prioritizes "still running" over
  * "all failed" in the failure cases since retrying later may help.
  */
-function findBuildId(builds: Build[], match: BuildMatch): FindBuildIdResult {
+function findBuild(builds: Build[], match: BuildMatch): FindBuildResult {
 	const candidates = builds.filter((b) => buildMatches(b, match));
 
 	if (candidates.length === 0) {
@@ -85,7 +87,7 @@ function findBuildId(builds: Build[], match: BuildMatch): FindBuildIdResult {
 			b.result === BuildResult.Succeeded,
 	);
 	if (usable !== undefined) {
-		return { kind: "completed", buildId: usable.id };
+		return { kind: "completed", buildId: usable.id, sourceVersion: usable.sourceVersion };
 	}
 
 	// Report the most actionable failure state. Actively-running gets priority
@@ -126,7 +128,16 @@ export interface GetArtifactForCommitArgs {
  * etc.) still propagate as thrown exceptions.
  */
 export type GetArtifactForCommitResult =
-	| { kind: "completed"; contents: ArtifactContents }
+	| {
+			kind: "completed";
+			contents: ArtifactContents;
+			/**
+			 * The `sourceVersion` of the build the artifact came from — the commit the build
+			 * actually checked out. For PR builds this is the ephemeral test-merge commit
+			 * (`refs/pull/<n>/merge`), *not* the PR HEAD.
+			 */
+			sourceVersion: string | undefined;
+	  }
 	| ArtifactLookupFailure;
 
 /**
@@ -147,13 +158,13 @@ export async function getArtifactForCommit(
 		definitions: [definitionId],
 		maxBuildsPerDefinition: recentBuildsToFetch,
 	});
-	const lookup = findBuildId(builds, match);
+	const lookup = findBuild(builds, match);
 	if (lookup.kind !== "completed") {
 		return lookup;
 	}
 
 	const contents = await downloadArtifact(adoApi, project, lookup.buildId, artifactName);
-	return { kind: "completed", contents };
+	return { kind: "completed", contents, sourceVersion: lookup.sourceVersion };
 }
 
 /**

--- a/build-tools/packages/build-cli/src/library/bundleSize/index.ts
+++ b/build-tools/packages/build-cli/src/library/bundleSize/index.ts
@@ -13,6 +13,7 @@ export { compareJsonReportsByPackage } from "./compareJsonReports.js";
 export { extractAnalyzerJsonsFromArtifact } from "./extractAnalyzerJsonsFromArtifact.js";
 export {
 	bundleSizeArtifactsBaselinePipeline,
+	bundleSizeArtifactsGitHubRepo,
 	bundleSizeArtifactsPrPipeline,
 } from "./pipelineConstants.js";
 export {

--- a/build-tools/packages/build-cli/src/library/bundleSize/pipelineConstants.ts
+++ b/build-tools/packages/build-cli/src/library/bundleSize/pipelineConstants.ts
@@ -25,3 +25,12 @@ export const bundleSizeArtifactsPrPipeline = {
 	definitionId: 11,
 	bundleAnalyzerJsonArtifactName: "bundleAnalyzerJson",
 } as const;
+
+/**
+ * The GitHub repo the pipelines above build, and therefore the one whose commits their
+ * `sourceVersion`s refer to.
+ */
+export const bundleSizeArtifactsGitHubRepo = {
+	owner: "microsoft",
+	repo: "FluidFramework",
+} as const;

--- a/build-tools/packages/build-cli/src/library/githubRest.ts
+++ b/build-tools/packages/build-cli/src/library/githubRest.ts
@@ -219,3 +219,27 @@ export async function getChangedFilePaths(
 	const fileNames = files.map((file) => file.filename);
 	return fileNames;
 }
+
+/**
+ * Get the parent commit SHAs of a commit, in order.
+ *
+ * @param github - Details about the GitHub repo and auth to use.
+ * @param sha - The commit to look up.
+ * @returns The parent SHAs, or `undefined` if the commit isn't found.
+ */
+export async function getCommitParents(
+	{ owner, repo, token }: GitHubProps,
+	sha: string,
+): Promise<string[] | undefined> {
+	const octokit = new Octokit({ auth: token });
+
+	try {
+		const { data } = await octokit.repos.getCommit({ owner, repo, ref: sha });
+		return data.parents.map((parent) => parent.sha);
+	} catch (error) {
+		if ((error as { status?: number }).status === 404) {
+			return undefined;
+		}
+		throw error;
+	}
+}

--- a/docs/content/Contributing/Testing/Bundle-Size-Test.md
+++ b/docs/content/Contributing/Testing/Bundle-Size-Test.md
@@ -18,7 +18,8 @@ Bundle size reporting is driven by the [pr-bundle-size-comments.yml](../../../..
 When a PR's build is queued, the workflow posts an initial "Pending" comment.
 Once the PR (head) and baseline artifacts are both available, it compares them using `flub report comparePipelineBundleArtifacts` and updates the comment with:
 
-- The **base** and **head** commit SHAs used for the comparison (the base is the PR's merge-base with its target branch).
+- The **base** and **head** commit SHAs used for the comparison.
+  Since a PR build builds the PR merged into the target branch tip, the base is that tip rather than the PR's merge-base.
 - A **Notable changes** summary listing bundles that were added, removed, or whose parsed size changed by at least 500 bytes.
 - A collapsible **Per-bundle deltas** section with the full inventory, showing both parsed and gzipped sizes for each bundle.
 


### PR DESCRIPTION
## Description

PR bundle-size comparisons were baselining on the PR's **merge base** with the target
branch. ADO PR builds don't build the branch head — they build `refs/pull/<n>/merge`, the
PR head merged into the target-branch tip at queue time. The head artifact therefore
already contains every target-branch change up to that tip, so a merge-base baseline
attributed all of main's drift since the branch last synced to the PR itself.

Reported by @jason-ha, who saw a large delta on a PR with near-zero real impact and
confirmed that comparing the stale merge-base analysis to the build's actual merge commit
accounted for the difference. Fixes [AB#80382](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/80382).

The correct baseline is the first parent of the ADO build's test-merge commit. That is now
derived by `flub report comparePipelineBundleArtifacts` itself, from the same build whose
artifact it downloaded, so the SHA and the artifact can never come from different builds.
All merge-base logic is gone from the workflow.

Notable changes:

- `comparePipelineBundleArtifacts` derives the base from the head build's `sourceVersion`
  and reports a new `no-base-commit` failure kind when that isn't resolvable. `--base` is
  removed (it can no longer be supplied meaningfully); `--githubToken` is now required.
- The pending sticky comment resolves and shows the real base commit up front, by reading
  the build id out of the check run's `details_url`.
- `identify-from-baseline-build` now selects candidate PRs by matching
  `potentialMergeCommit`'s first parent, via one paginated GraphQL query instead of
  ~250 REST calls.

Verified against live ADO and GitHub data: PR builds have `sourceBranch:
refs/pull/<n>/merge` with parents `[target tip, PR head]`, and an end-to-end run of the
command on a real head SHA resolved the expected base.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).
