### PR TITLE
Promote point-in-time APIs to legacy beta

### DIFF
--- a/packages/drivers/odsp-driver/api-report/odsp-driver.legacy.alpha.api.md
+++ b/packages/drivers/odsp-driver/api-report/odsp-driver.legacy.alpha.api.md
@@ -65,7 +65,7 @@ export function getHashedDocumentId(driveId: string, itemId: string): Promise<st
 // @beta @legacy
 export function getLocatorFromOdspUrl(url: URL, requireFluidSignature?: boolean): OdspFluidDataStoreLocator | undefined;
 
-// @alpha @legacy
+// @beta @legacy
 export function getOdspPointInTimeDocumentServiceFactory(getStorageToken: TokenFetcher<OdspResourceTokenFetchOptions>, getWebsocketToken: TokenFetcher<OdspResourceTokenFetchOptions> | undefined, persistedCache?: IPersistedCache, hostPolicy?: HostStoragePolicy): IPointInTimeDocumentServiceFactory;
 
 // @beta @legacy (undocumented)
@@ -113,7 +113,7 @@ export interface IPersistedFileCache {
     removeEntries(): Promise<void>;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IPointInTimeDocumentServiceFactory extends IDocumentServiceFactory {
     createPointInTimeDocumentService(resolvedUrl: IResolvedUrl, targetSequenceNumber: number, logger?: ITelemetryBaseLogger, clientIsSummarizer?: boolean): Promise<IDocumentService>;
 }

--- a/packages/drivers/odsp-driver/api-report/odsp-driver.legacy.beta.api.md
+++ b/packages/drivers/odsp-driver/api-report/odsp-driver.legacy.beta.api.md
@@ -65,6 +65,9 @@ export function getHashedDocumentId(driveId: string, itemId: string): Promise<st
 // @beta @legacy
 export function getLocatorFromOdspUrl(url: URL, requireFluidSignature?: boolean): OdspFluidDataStoreLocator | undefined;
 
+// @beta @legacy
+export function getOdspPointInTimeDocumentServiceFactory(getStorageToken: TokenFetcher<OdspResourceTokenFetchOptions>, getWebsocketToken: TokenFetcher<OdspResourceTokenFetchOptions> | undefined, persistedCache?: IPersistedCache, hostPolicy?: HostStoragePolicy): IPointInTimeDocumentServiceFactory;
+
 // @beta @legacy (undocumented)
 export interface ICacheAndTracker {
     // (undocumented)
@@ -108,6 +111,11 @@ export interface IPersistedFileCache {
     put(entry: IEntry, value: any): Promise<void>;
     // (undocumented)
     removeEntries(): Promise<void>;
+}
+
+// @beta @legacy
+export interface IPointInTimeDocumentServiceFactory extends IDocumentServiceFactory {
+    createPointInTimeDocumentService(resolvedUrl: IResolvedUrl, targetSequenceNumber: number, logger?: ITelemetryBaseLogger, clientIsSummarizer?: boolean): Promise<IDocumentService>;
 }
 
 // @beta @legacy (undocumented)

--- a/packages/drivers/odsp-driver/src/pointInTimeDriver/odspPointInTimeDocumentServiceFactory.ts
+++ b/packages/drivers/odsp-driver/src/pointInTimeDriver/odspPointInTimeDocumentServiceFactory.ts
@@ -46,7 +46,7 @@ import { OdspPointInTimeDocumentService } from "./odspPointInTimeDocumentService
  * The loader detects this capability structurally, so hosts can pass this factory directly to
  * `loadContainerToSequenceNumber`.
  *
- * @legacy @alpha
+ * @legacy @beta
  */
 export interface IPointInTimeDocumentServiceFactory extends IDocumentServiceFactory {
 	/**
@@ -243,7 +243,7 @@ class OdspPointInTimeDocumentServiceFactory
  * @param hostPolicy - Optional host storage policy.
  * @returns An ODSP document service factory with point-in-time loading capability.
  *
- * @legacy @alpha
+ * @legacy @beta
  */
 export function getOdspPointInTimeDocumentServiceFactory(
 	getStorageToken: TokenFetcher<OdspResourceTokenFetchOptions>,

--- a/packages/loader/container-loader/api-report/container-loader.legacy.alpha.api.md
+++ b/packages/loader/container-loader/api-report/container-loader.legacy.alpha.api.md
@@ -98,7 +98,7 @@ export interface IFluidModuleWithDetails {
     module: IFluidModule;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface ILoadContainerToSequenceNumberProps extends IContainerHostProps, IContainerDriverServices {
     readonly loadToSequenceNumber: number;
     readonly request: IRequest;
@@ -188,7 +188,7 @@ export interface IScribeProtocolState {
     values: [string, ICommittedProposal][];
 }
 
-// @alpha @legacy
+// @beta @legacy
 export function loadContainerToSequenceNumber(props: ILoadContainerToSequenceNumberProps): Promise<IContainer>;
 
 // @beta @legacy

--- a/packages/loader/container-loader/api-report/container-loader.legacy.beta.api.md
+++ b/packages/loader/container-loader/api-report/container-loader.legacy.beta.api.md
@@ -77,6 +77,13 @@ export interface IFluidModuleWithDetails {
 }
 
 // @beta @legacy
+export interface ILoadContainerToSequenceNumberProps extends IContainerHostProps, IContainerDriverServices {
+    readonly loadToSequenceNumber: number;
+    readonly request: IRequest;
+    readonly signal?: AbortSignal | undefined;
+}
+
+// @beta @legacy
 export interface ILoaderProps {
     readonly codeLoader: ICodeDetailsLoader;
     readonly configProvider?: IConfigProviderBase;
@@ -149,6 +156,9 @@ export interface IScribeProtocolState {
     // (undocumented)
     values: [string, ICommittedProposal][];
 }
+
+// @beta @legacy
+export function loadContainerToSequenceNumber(props: ILoadContainerToSequenceNumberProps): Promise<IContainer>;
 
 // @beta @legacy
 export class Loader implements IHostLoader {

--- a/packages/loader/container-loader/src/loadContainerToSequenceNumber.ts
+++ b/packages/loader/container-loader/src/loadContainerToSequenceNumber.ts
@@ -27,7 +27,7 @@ import {
  * point-in-time capability the loader detects. For ODSP, pass an
  * `IPointInTimeDocumentServiceFactory` created by `getOdspPointInTimeDocumentServiceFactory`.
  *
- * @legacy @alpha
+ * @legacy @beta
  */
 export interface ILoadContainerToSequenceNumberProps
 	extends IContainerHostProps,
@@ -66,7 +66,7 @@ export interface ILoadContainerToSequenceNumberProps
  * optional cancellation signal.
  * @returns A disconnected, read-only container materialized at the requested sequence number.
  *
- * @legacy @alpha
+ * @legacy @beta
  */
 export async function loadContainerToSequenceNumber(
 	props: ILoadContainerToSequenceNumberProps,

--- a/packages/runtime/container-runtime/api-report/container-runtime.legacy.alpha.api.md
+++ b/packages/runtime/container-runtime/api-report/container-runtime.legacy.alpha.api.md
@@ -338,7 +338,7 @@ export interface IUploadSummaryResult extends Omit<IGenerateSummaryTreeResult, "
     readonly uploadDuration: number;
 }
 
-// @alpha @legacy
+// @beta @legacy
 export interface IVersionMarkResolver {
     onBatchSequenced(listener: (batchId: string, sequenceNumber: number) => void): () => void;
     resolve(batchId: string, sequenceNumberLowerBound: number): Promise<ResolveResult>;
@@ -380,7 +380,7 @@ export type OpActionEventName = MessageType.Summarize | MessageType.SummaryAck |
 // @beta @deprecated @legacy
 export type ReadFluidDataStoreAttributes = IFluidDataStoreAttributes0 | IFluidDataStoreAttributes1 | IFluidDataStoreAttributes2;
 
-// @alpha @legacy
+// @beta @legacy
 export type ResolveResult = {
     readonly kind: "resolved";
     readonly sequenceNumber: number;
@@ -440,7 +440,7 @@ export type SummaryStage = SubmitSummaryResult["stage"] | "unknown";
 // @beta @legacy
 export const TombstoneResponseHeaderKey = "isTombstoned";
 
-// @alpha @legacy
+// @beta @legacy
 export type VersionMarkCapture = {
     readonly kind: "pending";
     readonly batchId: string;

--- a/packages/runtime/container-runtime/api-report/container-runtime.legacy.beta.api.md
+++ b/packages/runtime/container-runtime/api-report/container-runtime.legacy.beta.api.md
@@ -339,6 +339,13 @@ export interface IUploadSummaryResult extends Omit<IGenerateSummaryTreeResult, "
 }
 
 // @beta @legacy
+export interface IVersionMarkResolver {
+    onBatchSequenced(listener: (batchId: string, sequenceNumber: number) => void): () => void;
+    resolve(batchId: string, sequenceNumberLowerBound: number): Promise<ResolveResult>;
+    sealAndCaptureVersionMark(): VersionMarkCapture;
+}
+
+// @beta @legacy
 export function loadContainerRuntime(params: LoadContainerRuntimeParams): Promise<IContainerRuntime & IRuntime>;
 
 // @beta @legacy
@@ -367,6 +374,16 @@ export type OpActionEventName = MessageType.Summarize | MessageType.SummaryAck |
 
 // @beta @deprecated @legacy
 export type ReadFluidDataStoreAttributes = IFluidDataStoreAttributes0 | IFluidDataStoreAttributes1 | IFluidDataStoreAttributes2;
+
+// @beta @legacy
+export type ResolveResult = {
+    readonly kind: "resolved";
+    readonly sequenceNumber: number;
+} | {
+    readonly kind: "pending";
+} | {
+    readonly kind: "unresolvable";
+};
 
 // @beta @legacy
 export interface SubmitSummaryFailureData {
@@ -417,6 +434,16 @@ export type SummaryStage = SubmitSummaryResult["stage"] | "unknown";
 
 // @beta @legacy
 export const TombstoneResponseHeaderKey = "isTombstoned";
+
+// @beta @legacy
+export type VersionMarkCapture = {
+    readonly kind: "pending";
+    readonly batchId: string;
+    readonly sequenceNumberLowerBound: number;
+} | {
+    readonly kind: "resolved";
+    readonly sequenceNumber: number;
+};
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/runtime/container-runtime/src/versionMarks/versionMarkResolver.ts
+++ b/packages/runtime/container-runtime/src/versionMarks/versionMarkResolver.ts
@@ -33,7 +33,7 @@ export interface IHistoricalOpReader {
 /**
  * Result of resolving a pending batchId.
  *
- * @legacy @alpha
+ * @legacy @beta
  */
 export type ResolveResult =
 	| { readonly kind: "resolved"; readonly sequenceNumber: number }
@@ -46,7 +46,7 @@ export type ResolveResult =
  * work, so the mark already points at a durable sequence number. The app packs its own stored record from
  * this — the runtime does not define the stored locator shape.
  *
- * @legacy @alpha
+ * @legacy @beta
  */
 export type VersionMarkCapture =
 	| {
@@ -59,7 +59,7 @@ export type VersionMarkCapture =
 /**
  * Runtime-owned resolver for app-stored version mark locators.
  *
- * @legacy @alpha
+ * @legacy @beta
  */
 export interface IVersionMarkResolver {
 	/**


### PR DESCRIPTION
This PR promotes the point-in-time loading and version-mark resolver APIs from legacy alpha to legacy beta. 

Bohemia does not allow alpha API consumption and requires these APIs to integrate and test the point-in-time feature. They have been tested in the local Loop app.
This promotion makes them available under the standard legacy beta contract.

No API signatures or runtime behavior are changed. The generated alpha and beta API reports are updated for:
- `@fluidframework/container-loader`
- `@fluidframework/odsp-driver`
- `@fluidframework/container-runtime`
