### PR TITLE
feat(tree): optional commit validation

### DIFF
--- a/.changeset/ninety-canyons-smile.md
+++ b/.changeset/ninety-canyons-smile.md
@@ -6,8 +6,8 @@
 Additional change validation options
 
 Adds the following new options to `SharedTreeOptions` (alpha):
-- validateCommitsOnFirstSubmission: (default: `false`) When `true`, validates that commits being submitted for the first time can be applied without errors to a view.
-- validateRebasedCommitsBeforeResubmission: (default: `false`) When `true`, validates that the commits being resubmitted can be applied without errors to a view.
+- `validateCommitsOnFirstSubmission`: (default: `false`) When `true`, validates that commits being submitted for the first time can be applied without errors to a view.
+- `validateRebasedCommitsBeforeResubmission`: (default: `false`) When `true`, validates that the commits being resubmitted can be applied without errors to a view.
 
 In the event that a commit cannot be applied, SharedTree will throw an error and will enter a "broken" state, preventing the offending commit (and any further commits) from being submitted.
 This can be enabled (at the cost of performance) to improve safety against document corruption in the event of a bug in the SharedTree code:

--- a/.changeset/ninety-canyons-smile.md
+++ b/.changeset/ninety-canyons-smile.md
@@ -1,0 +1,18 @@
+---
+"fluid-framework": minor
+"@fluidframework/tree": minor
+"__section": feature
+---
+Additional change validation options
+
+Adds the following new options to `SharedTreeOptions` (alpha):
+- validateCommitsOnFirstSubmission: (default: `false`) When `true`, validates that commits being submitted for the first time can be applied without errors to a view.
+- validateRebasedCommitsBeforeResubmission: (default: `false`) When `true`, validates that the commits being resubmitted can be applied without errors to a view.
+
+In the event that a commit cannot be applied, SharedTree will throw an error and will enter a "broken" state, preventing the offending commit (and any further commits) from being submitted.
+This can be enabled (at the cost of performance) to improve safety against document corruption in the event of a bug in the SharedTree code:
+when the additional validation is enabled, a client will error instead of potentially corrupting the document.
+
+These flags are experimental.
+We recommend turning them on (first `validateRebasedCommitsBeforeResubmission` and, if needed, `validateCommitsOnFirstSubmission`)
+when trying to mitigate bugs in SharedTree or performing root cause analysis.

--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -1398,6 +1398,8 @@ export interface SharedTreeOptions extends SharedTreeOptionsBeta, Partial<CodecW
     readonly enableSharedBranches?: boolean;
     readonly retainHistory?: boolean;
     shouldEncodeIncrementally?: IncrementalEncodingPolicy;
+    readonly validateCommitsOnFirstSubmission?: boolean;
+    readonly validateRebasedCommitsBeforeResubmission?: boolean;
 }
 
 // @beta @input

--- a/packages/dds/tree/src/shared-tree-core/branchCommitEnricher.ts
+++ b/packages/dds/tree/src/shared-tree-core/branchCommitEnricher.ts
@@ -28,12 +28,18 @@ export class BranchCommitEnricher<TChange> {
 	/**
 	 * Process the given commits for later {@link BranchCommitEnricher.retrieveChange | retrieval}.
 	 * @param commits - The commits to prepare.
+	 * @param forceValidation - Whether to force the application of the enriched commits to a side checkout.
+	 * This is useful to reduce the likelihood of an invalid commit being generated
+	 * (either due to the given `commits` being invalid or because of an error in the enrichment logic).
 	 */
-	public prepareChanges(commits: readonly GraphCommit<TChange>[]): void {
+	public prepareChanges(
+		commits: readonly GraphCommit<TChange>[],
+		forceValidation: boolean,
+	): void {
 		if (hasSome(commits)) {
 			const startingState = commits[0].parent;
 			assert(startingState !== undefined, 0xcc1 /* New commits must have a parent. */);
-			const enrichedCommits = this.enricher.enrich(startingState, commits);
+			const enrichedCommits = this.enricher.enrich(startingState, commits, forceValidation);
 			for (const [index, commit] of commits.entries()) {
 				const enrichedCommit = enrichedCommits[index];
 				assert(enrichedCommit !== undefined, 0xcc2 /* Missing enriched commit. */);

--- a/packages/dds/tree/src/shared-tree-core/changeEnricher.ts
+++ b/packages/dds/tree/src/shared-tree-core/changeEnricher.ts
@@ -13,7 +13,14 @@ export interface ChangeEnricher<TChange> {
 	 * Runs a batch of change enrichments.
 	 * @param context - The branch head after which the `changes` would apply.
 	 * @param changes - The changes to be enriched.
+	 * @param forceValidation - Whether to force the application of the enriched changes to a side checkout.
+	 * This is useful to reduce the likelihood of an invalid change being generated
+	 * (either due to the given `changes` being invalid or because of an error in the enrichment logic).
 	 * @returns The enriched changes.
 	 */
-	enrich(context: GraphCommit<TChange>, changes: readonly TaggedChange<TChange>[]): TChange[];
+	enrich(
+		context: GraphCommit<TChange>,
+		changes: readonly TaggedChange<TChange>[],
+		forceValidation: boolean,
+	): TChange[];
 }

--- a/packages/dds/tree/src/shared-tree-core/defaultResubmitMachine.ts
+++ b/packages/dds/tree/src/shared-tree-core/defaultResubmitMachine.ts
@@ -37,6 +37,12 @@ export class DefaultResubmitMachine<TChange> implements ResubmitMachine<TChange>
 		 * commits are applied and automatically rebased).
 		 */
 		private readonly enricher: ChangeEnricher<TChange>,
+		/**
+		 * Whether to force the application of commits that have been rebased and enriched to a side checkout.
+		 * This is useful to reduce the likelihood of an invalid commit being generated
+		 * (either due to the original commits being invalid or because of an error in the rebase or enrichment logic).
+		 */
+		private readonly forceValidation: boolean,
 	) {}
 
 	public onCommitSubmitted(commit: GraphCommit<TChange>): void {
@@ -95,6 +101,7 @@ export class DefaultResubmitMachine<TChange> implements ResubmitMachine<TChange>
 		const enriched = this.enricher.enrich(
 			startingState,
 			newCommits.slice(0, staleChanges.length),
+			this.forceValidation,
 		);
 		for (const [index, { pending, newCommit }] of staleChanges.entries()) {
 			const enrichedChange = enriched[index];

--- a/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
+++ b/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
@@ -84,6 +84,15 @@ export interface SharedTreeCoreOptionsInternal extends CodecWriteOptions {
 	 * {@inheritDoc SharedTreeOptions.retainHistory}
 	 */
 	readonly retainHistory?: boolean;
+
+	/**
+	 * {@inheritDoc SharedTreeOptions.validateCommitsOnFirstSubmission}
+	 */
+	readonly validateCommitsOnFirstSubmission?: boolean;
+	/**
+	 * {@inheritDoc SharedTreeOptions.validateRebasedCommitsBeforeResubmission}
+	 */
+	readonly validateRebasedCommitsBeforeResubmission?: boolean;
 }
 
 export interface EnrichmentConfig<TChange> {
@@ -154,7 +163,7 @@ export class SharedTreeCore<
 		public readonly submitLocalMessage: (content: unknown, localOpMetadata?: unknown) => void,
 		summarizables: readonly Summarizable[],
 		protected readonly changeFamily: ChangeFamily<TEditor, TChange, TChangeProcessingContext>,
-		options: SharedTreeCoreOptionsInternal,
+		private readonly coreOptions: SharedTreeCoreOptionsInternal,
 		changeFormatVersionForEditManager: DependentFormatVersion<EditManagerFormatVersion>,
 		changeFormatVersionForMessage: DependentFormatVersion<MessageFormatVersion>,
 		protected readonly idCompressor: IIdCompressor,
@@ -165,7 +174,7 @@ export class SharedTreeCore<
 	) {
 		super(
 			summarizablesTreeKey,
-			minVersionToSharedTreeSummaryFormatVersion(options.minVersionForCollab),
+			minVersionToSharedTreeSummaryFormatVersion(coreOptions.minVersionForCollab),
 			supportedSharedTreeSummaryFormatVersions,
 			true /* supportPreVersioningFormat */,
 		);
@@ -195,14 +204,14 @@ export class SharedTreeCore<
 			this.mintRevisionTag,
 			(branchId) => this.registerSharedBranch(branchId),
 			rebaseLogger,
-			options.retainHistory ?? false,
+			coreOptions.retainHistory ?? false,
 		);
 
 		this.registerSharedBranch("main");
 
 		const revisionTagCodec = new RevisionTagCodec(idCompressor);
 		const editManagerCodec = makeEditManagerCodecBuilder<TChange>().build({
-			...options,
+			...coreOptions,
 			changeCodecs: this.editManager.changeFamily.codecs,
 			dependentChangeFormatVersion: changeFormatVersionForEditManager,
 			revisionTagCodec,
@@ -212,9 +221,9 @@ export class SharedTreeCore<
 				this.editManager,
 				editManagerCodec,
 				this.idCompressor,
-				options.minVersionForCollab,
+				coreOptions.minVersionForCollab,
 				this.schemaAndPolicy,
-				options.healUnresolvableIdentifiersOnDecode === true
+				coreOptions.healUnresolvableIdentifiersOnDecode === true
 					? { sharedObjectId: sharedObject.id, logger }
 					: undefined,
 			),
@@ -226,7 +235,7 @@ export class SharedTreeCore<
 		);
 
 		this.messageCodec = makeMessageCodecBuilder<TChange>().build({
-			...options,
+			...coreOptions,
 			changeCodecs: changeFamily.codecs,
 			dependentChangeFormatVersion: changeFormatVersionForMessage,
 			revisionTagCodec: new RevisionTagCodec(idCompressor),
@@ -336,7 +345,10 @@ export class SharedTreeCore<
 			if (change.type === "append") {
 				if (this.detachedRevision === undefined) {
 					// Commit enrichment is only necessary for changes that will be submitted as ops, and changes issued while detached are not submitted.
-					this.getCommitEnricher(branchId).prepareChanges(change.newCommits);
+					this.getCommitEnricher(branchId).prepareChanges(
+						change.newCommits,
+						this.coreOptions.validateCommitsOnFirstSubmission ?? false,
+					);
 				}
 
 				for (const commit of change.newCommits) {
@@ -682,7 +694,12 @@ export class SharedTreeCore<
 		assert(!this.enrichers.has(branchId), 0xc6d /* Branch already registered */);
 		this.enrichers.set(branchId, {
 			enricher: commitEnricher,
-			resubmitMachine: resubmitMachine ?? new DefaultResubmitMachine(enricher),
+			resubmitMachine:
+				resubmitMachine ??
+				new DefaultResubmitMachine(
+					enricher,
+					this.coreOptions.validateRebasedCommitsBeforeResubmission ?? false,
+				),
 		});
 	}
 

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -667,18 +667,25 @@ export interface SharedTreeOptions
 	/**
 	 * @defaultValue `false`
 	 *
-	 * When `true`, validates that the commits being submitted can be applied to a view (assuming no concurrent changes).
+	 * When `true`, validates that commits being submitted for the first time can be applied without errors to a view.
 	 * In the event that a commit cannot be applied, SharedTree will throw an error and will enter a "broken" state, preventing the offending commit (and any further commits) from being submitted.
-	 * This can be enabled (at the cost of performance) to improve safety against document corruption in the event of a bug in the SharedTree code.
+	 *
+	 * This can be enabled (at the cost of performance) to improve safety against document corruption in the event of a bug in the SharedTree code:
+	 * when the additional validation is enabled, a client will error instead of potentially corrupting the document.
+	 *
+	 * @remarks
+	 * This validation is more expensive than {@link SharedTreeOptions.validateRebasedCommitsBeforeResubmission} because it is likely to be performed more often.
 	 */
 	readonly validateCommitsOnFirstSubmission?: boolean;
 
 	/**
 	 * @defaultValue `false`
 	 *
-	 * When `true`, validates that the commits being resubmitted can be applied to a view (assuming no concurrent changes).
+	 * When `true`, validates that the commits being resubmitted can be applied without errors to a view.
 	 * In the event that a commit cannot be applied, SharedTree will throw an error and will enter a "broken" state, preventing the offending commit (and any further commits) from being submitted.
-	 * This can be enabled (at the cost of performance) to improve safety against document corruption in the event of a bug in the SharedTree code.
+	 *
+	 * This can be enabled (at the cost of performance) to improve safety against document corruption in the event of a bug in the SharedTree code:
+	 * when the additional validation is enabled, a client will error instead of potentially corrupting the document.
 	 */
 	readonly validateRebasedCommitsBeforeResubmission?: boolean;
 }

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -663,6 +663,24 @@ export interface SharedTreeOptions
 	 * lifetime of the client, which increases memory usage over time and should be used with care.
 	 */
 	readonly retainHistory?: boolean;
+
+	/**
+	 * @defaultValue `false`
+	 *
+	 * When `true`, validates that the commits being submitted can be applied to a view (assuming no concurrent changes).
+	 * In the event that a commit cannot be applied, SharedTree will throw an error and will enter a "broken" state, preventing the offending commit (and any further commits) from being submitted.
+	 * This can be enabled (at the cost of performance) to improve safety against document corruption in the event of a bug in the SharedTree code.
+	 */
+	readonly validateCommitsOnFirstSubmission?: boolean;
+
+	/**
+	 * @defaultValue `false`
+	 *
+	 * When `true`, validates that the commits being resubmitted can be applied to a view (assuming no concurrent changes).
+	 * In the event that a commit cannot be applied, SharedTree will throw an error and will enter a "broken" state, preventing the offending commit (and any further commits) from being submitted.
+	 * This can be enabled (at the cost of performance) to improve safety against document corruption in the event of a bug in the SharedTree code.
+	 */
+	readonly validateRebasedCommitsBeforeResubmission?: boolean;
 }
 
 export interface SharedTreeOptionsInternal
@@ -812,6 +830,8 @@ export const defaultSharedTreeOptions: Required<SharedTreeOptionsInternal> = {
 	writeVersionOverrides: new Map(),
 	allowPossiblyIncompatibleWriteVersionOverrides: false,
 	retainHistory: false,
+	validateCommitsOnFirstSubmission: false,
+	validateRebasedCommitsBeforeResubmission: false,
 };
 
 /**

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -665,13 +665,13 @@ export interface SharedTreeOptions
 	readonly retainHistory?: boolean;
 
 	/**
-	 * @defaultValue `false`
-	 *
 	 * When `true`, validates that commits being submitted for the first time can be applied without errors to a view.
 	 * In the event that a commit cannot be applied, SharedTree will throw an error and will enter a "broken" state, preventing the offending commit (and any further commits) from being submitted.
 	 *
 	 * This can be enabled (at the cost of performance) to improve safety against document corruption in the event of a bug in the SharedTree code:
 	 * when the additional validation is enabled, a client will error instead of potentially corrupting the document.
+	 *
+	 * @defaultValue `false`
 	 *
 	 * @remarks
 	 * This validation is more expensive than {@link SharedTreeOptions.validateRebasedCommitsBeforeResubmission} because it is likely to be performed more often.
@@ -679,13 +679,13 @@ export interface SharedTreeOptions
 	readonly validateCommitsOnFirstSubmission?: boolean;
 
 	/**
-	 * @defaultValue `false`
-	 *
 	 * When `true`, validates that the commits being resubmitted can be applied without errors to a view.
 	 * In the event that a commit cannot be applied, SharedTree will throw an error and will enter a "broken" state, preventing the offending commit (and any further commits) from being submitted.
 	 *
 	 * This can be enabled (at the cost of performance) to improve safety against document corruption in the event of a bug in the SharedTree code:
 	 * when the additional validation is enabled, a client will error instead of potentially corrupting the document.
+	 *
+	 * @defaultValue `false`
 	 */
 	readonly validateRebasedCommitsBeforeResubmission?: boolean;
 }

--- a/packages/dds/tree/src/shared-tree/sharedTreeChangeEnricher.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTreeChangeEnricher.ts
@@ -110,7 +110,10 @@ export class SharedTreeChangeEnricher {
 		this.changeQueue.push(typeof change === "function" ? change : () => change);
 	}
 
-	private purgeChangeQueue(): void {
+	/**
+	 * Applies all queued changes.
+	 */
+	public purgeChangeQueue(): void {
 		if (this.changeQueue.length === 0) {
 			return;
 		}

--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -1766,11 +1766,7 @@ export class TreeCheckout implements ITreeCheckout {
 			// This is useful for catching bugs in the enrichment logic and in the rebasing logic that may have been involved in producing the changes.
 			// Note that we cannot guarantee that the enriched change will be applied successfully even in the absence of concurrent changes,
 			// because the checkout state we are applying this enriched change to was derived from the state of the checkout, which may be different from that of a peer.
-			try {
-				enricher.purgeChangeQueue();
-			} catch (error) {
-				throw new Error(`Error during enrichment validation: ${error}`);
-			}
+			enricher.purgeChangeQueue();
 		}
 		enricher[disposeSymbol]();
 		return enrichedChanges;

--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -1720,6 +1720,7 @@ export class TreeCheckout implements ITreeCheckout {
 	public enrich(
 		context: GraphCommit<SharedTreeChange>,
 		changes: readonly TaggedChange<SharedTreeChange>[],
+		forceValidation: boolean,
 	): SharedTreeChange[] {
 		if (!hasSome(changes)) {
 			return [];
@@ -1750,13 +1751,29 @@ export class TreeCheckout implements ITreeCheckout {
 				return makeAnonChange(diff);
 			});
 		}
-		const enriched: SharedTreeChange[] = [];
+		const enrichedChanges: SharedTreeChange[] = [];
 		for (const change of changes) {
-			enriched.push(enricher.enrich(change.change));
-			enricher.enqueueChange(change);
+			const enrichedChange = enricher.enrich(change.change);
+			enrichedChanges.push(enrichedChange);
+			// We could either apply the original or the enriched change: either should allow subsequent changes to be enriched correctly.
+			// We choose to apply the enriched change in order to more closely replicate what a peer will experience (assuming no concurrent changes).
+			// This make it more likely that we'll detect a bug in the enrichment logic.
+			// Note that enqueueing the change does not guarantee that it will be applied unless `forceValidation` is enabled.
+			enricher.enqueueChange(tagChange(enrichedChange, change.revision));
+		}
+		if (forceValidation) {
+			// Ensure that all changes can be applied successfully.
+			// This is useful for catching bugs in the enrichment logic and and in the rebasing logic that may have been involved in producing the changes.
+			// Note that we cannot guarantee that the enriched change will be applied successfully even in the absence of concurrent changes,
+			// because the checkout state we are applying this enriched change to was derived from the state of the checkout, which may be different from that of a peer.
+			try {
+				enricher.purgeChangeQueue();
+			} catch (error) {
+				throw new Error(`Error during enrichment validation: ${error}`);
+			}
 		}
 		enricher[disposeSymbol]();
-		return enriched;
+		return enrichedChanges;
 	}
 
 	public get mainBranch(): SharedTreeBranch<

--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -1757,13 +1757,13 @@ export class TreeCheckout implements ITreeCheckout {
 			enrichedChanges.push(enrichedChange);
 			// We could either apply the original or the enriched change: either should allow subsequent changes to be enriched correctly.
 			// We choose to apply the enriched change in order to more closely replicate what a peer will experience (assuming no concurrent changes).
-			// This make it more likely that we'll detect a bug in the enrichment logic.
+			// This makes it more likely that we'll detect a bug in the enrichment logic.
 			// Note that enqueueing the change does not guarantee that it will be applied unless `forceValidation` is enabled.
 			enricher.enqueueChange(tagChange(enrichedChange, change.revision));
 		}
 		if (forceValidation) {
 			// Ensure that all changes can be applied successfully.
-			// This is useful for catching bugs in the enrichment logic and and in the rebasing logic that may have been involved in producing the changes.
+			// This is useful for catching bugs in the enrichment logic and in the rebasing logic that may have been involved in producing the changes.
 			// Note that we cannot guarantee that the enriched change will be applied successfully even in the absence of concurrent changes,
 			// because the checkout state we are applying this enriched change to was derived from the state of the checkout, which may be different from that of a peer.
 			try {

--- a/packages/dds/tree/src/test/shared-tree-core/branchCommitEnricher.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/branchCommitEnricher.spec.ts
@@ -75,7 +75,7 @@ describe("BranchCommitEnricher", () => {
 	it("Can enrich zero commits", () => {
 		const changeEnricher = new MockChangeEnricher();
 		const branchEnricher = new BranchCommitEnricher(changeEnricher);
-		branchEnricher.prepareChanges([]);
+		branchEnricher.prepareChanges([], false);
 		assert.equal(changeEnricher.calls, 0);
 		assert.equal(changeEnricher.enriched, 0);
 		assert.equal(changeEnricher.applied, 0);
@@ -84,7 +84,7 @@ describe("BranchCommitEnricher", () => {
 	it("Can enrich a single commit", () => {
 		const changeEnricher = new MockChangeEnricher();
 		const branchEnricher = new BranchCommitEnricher(changeEnricher);
-		branchEnricher.prepareChanges([commit1]);
+		branchEnricher.prepareChanges([commit1], false);
 		const actualEnriched1 = branchEnricher.retrieveChange(commit1);
 		assert.deepEqual(actualEnriched1, expectedEnriched1);
 		assert.equal(changeEnricher.calls, 1);
@@ -95,7 +95,7 @@ describe("BranchCommitEnricher", () => {
 	it("Can enrich multiple commits", () => {
 		const changeEnricher = new MockChangeEnricher();
 		const branchEnricher = new BranchCommitEnricher(changeEnricher);
-		branchEnricher.prepareChanges([commit1, commit2, commit3]);
+		branchEnricher.prepareChanges([commit1, commit2, commit3], false);
 		const actualEnriched1 = branchEnricher.retrieveChange(commit1);
 		assert.deepEqual(actualEnriched1, expectedEnriched1);
 		const actualEnriched2 = branchEnricher.retrieveChange(commit2);

--- a/packages/dds/tree/src/test/shared-tree-core/defaultResubmitMachine.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/defaultResubmitMachine.spec.ts
@@ -96,7 +96,7 @@ describe("DefaultResubmitMachine", () => {
 	describe("omits already sequenced commits from resubmit phase", () => {
 		it("omits sequenced commits that were not rebased", () => {
 			const enricher = new MockChangeEnricher();
-			const machine = new DefaultResubmitMachine(enricher);
+			const machine = new DefaultResubmitMachine(enricher, true);
 			machine.onCommitSubmitted(commit1);
 			machine.onCommitSubmitted(commit2);
 			// Simulate the sequencing of commit 1
@@ -114,7 +114,7 @@ describe("DefaultResubmitMachine", () => {
 
 		it("omits sequenced commits that were rebased", () => {
 			const enricher = new MockChangeEnricher();
-			const machine = new DefaultResubmitMachine(enricher);
+			const machine = new DefaultResubmitMachine(enricher, true);
 			machine.onCommitSubmitted(commit1);
 			machine.onCommitSubmitted(commit2);
 			// Simulate the sequencing of a peer commit. This would lead to the rebasing of commits 1 and 2.
@@ -140,7 +140,7 @@ describe("DefaultResubmitMachine", () => {
 
 	it("can resubmit a subset of commits (skipping the first)", () => {
 		const enricher = new MockChangeEnricher();
-		const machine = new DefaultResubmitMachine(enricher);
+		const machine = new DefaultResubmitMachine(enricher, true);
 
 		// Submit three commits in order
 		machine.onCommitSubmitted(commit1);
@@ -174,7 +174,7 @@ describe("DefaultResubmitMachine", () => {
 	describe("enriches commits for resubmit", () => {
 		it("when the commits do not undergo rebasing", () => {
 			const enricher = new MockChangeEnricher();
-			const machine = new DefaultResubmitMachine(enricher);
+			const machine = new DefaultResubmitMachine(enricher, true);
 			machine.onCommitSubmitted(commit1);
 			machine.onCommitSubmitted(commit2);
 
@@ -199,7 +199,7 @@ describe("DefaultResubmitMachine", () => {
 		for (const scenario of ["only", "and before"]) {
 			it(`when the commits undergo rebasing at resubmit time ${scenario}`, () => {
 				const enricher = new MockChangeEnricher();
-				const machine = new DefaultResubmitMachine(enricher);
+				const machine = new DefaultResubmitMachine(enricher, true);
 				machine.onCommitSubmitted(commit1);
 
 				if (scenario === "and before") {
@@ -277,7 +277,7 @@ describe("DefaultResubmitMachine", () => {
 
 		it("when the commits undergo rebasing before resubmit time", () => {
 			const enricher = new MockChangeEnricher();
-			const machine = new DefaultResubmitMachine(enricher);
+			const machine = new DefaultResubmitMachine(enricher, true);
 			machine.onCommitSubmitted(commit1);
 			machine.onCommitSubmitted(commit2);
 
@@ -366,7 +366,7 @@ describe("DefaultResubmitMachine", () => {
 
 		it("enriches only rebased commits when resubmitting a subset", () => {
 			const enricher = new MockChangeEnricher();
-			const machine = new DefaultResubmitMachine(enricher);
+			const machine = new DefaultResubmitMachine(enricher, true);
 
 			// Submit three commits in order
 			machine.onCommitSubmitted(commit1);

--- a/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
@@ -1748,7 +1748,11 @@ describe("sharedTreeView", () => {
 				assert.equal(change.newCommits.length, 1);
 				const commit = change.newCommits[0];
 				view1.checkout.resetEnrichmentStats();
-				const enriched = view1.checkout.enrich(commit.parent ?? assert.fail(), [commit]);
+				const enriched = view1.checkout.enrich(
+					commit.parent ?? assert.fail(),
+					[commit],
+					false,
+				);
 				assertEnrichmentCount(enriched[0], 1);
 				assert.deepEqual(view1.checkout.getEnrichmentStats(), {
 					batches: 1,
@@ -1776,7 +1780,11 @@ describe("sharedTreeView", () => {
 				assert.equal(change.newCommits.length, 1);
 				const commit = change.newCommits[0];
 				view1.checkout.resetEnrichmentStats();
-				const enriched = view1.checkout.enrich(commit.parent ?? assert.fail(), [commit]);
+				const enriched = view1.checkout.enrich(
+					commit.parent ?? assert.fail(),
+					[commit],
+					false,
+				);
 				assertEnrichmentCount(enriched[0], 1);
 				assert.deepEqual(view1.checkout.getEnrichmentStats(), {
 					batches: 1,
@@ -1813,6 +1821,7 @@ describe("sharedTreeView", () => {
 				const enriched = view1.checkout.enrich(
 					change.newCommits[0].parent ?? assert.fail(),
 					change.newCommits,
+					false,
 				);
 				assertEnrichmentCount(enriched[0], 1);
 				assertEnrichmentCount(enriched[1], 0);
@@ -1851,6 +1860,7 @@ describe("sharedTreeView", () => {
 				const enriched = view1.checkout.enrich(
 					change.newCommits[0].parent ?? assert.fail(),
 					change.newCommits,
+					false,
 				);
 				assertEnrichmentCount(enriched[0], 1);
 				assertEnrichmentCount(enriched[1], 0);
@@ -1880,7 +1890,11 @@ describe("sharedTreeView", () => {
 				assert.equal(change.newCommits.length, 1);
 				const commit = change.newCommits[0];
 				view1.checkout.resetEnrichmentStats();
-				const enriched = view1.checkout.enrich(commit.parent ?? assert.fail(), [commit]);
+				const enriched = view1.checkout.enrich(
+					commit.parent ?? assert.fail(),
+					[commit],
+					false,
+				);
 				assertEnrichmentCount(enriched[0], 0);
 				assert.deepEqual(view1.checkout.getEnrichmentStats(), {
 					batches: 1,
@@ -1913,7 +1927,11 @@ describe("sharedTreeView", () => {
 				assert.equal(change.newCommits.length, 1);
 				const commit = change.newCommits[0];
 				view1.checkout.resetEnrichmentStats();
-				const enriched = view1.checkout.enrich(commit.parent ?? assert.fail(), [commit]);
+				const enriched = view1.checkout.enrich(
+					commit.parent ?? assert.fail(),
+					[commit],
+					false,
+				);
 				assertEnrichmentCount(enriched[0], 0);
 				assert.deepEqual(view1.checkout.getEnrichmentStats(), {
 					batches: 1,
@@ -1944,9 +1962,11 @@ describe("sharedTreeView", () => {
 			view1.root.insertAtEnd({ id: "C" });
 
 			view1.checkout.resetEnrichmentStats();
-			const enriched = view1.checkout.enrich(revertCommit.parent ?? assert.fail(), [
-				revertCommit,
-			]);
+			const enriched = view1.checkout.enrich(
+				revertCommit.parent ?? assert.fail(),
+				[revertCommit],
+				false,
+			);
 			assertEnrichmentCount(enriched[0], 1);
 			assert.deepEqual(view1.checkout.getEnrichmentStats(), {
 				batches: 1,
@@ -1969,7 +1989,11 @@ describe("sharedTreeView", () => {
 				assert.equal(change.newCommits.length, 1);
 				const commit = change.newCommits[0];
 				view1.checkout.resetEnrichmentStats();
-				const enriched = view1.checkout.enrich(commit.parent ?? assert.fail(), [commit]);
+				const enriched = view1.checkout.enrich(
+					commit.parent ?? assert.fail(),
+					[commit],
+					false,
+				);
 				assertEnrichmentCount(enriched[0], 0);
 				assert.deepEqual(view1.checkout.getEnrichmentStats(), {
 					batches: 1,
@@ -2002,7 +2026,11 @@ describe("sharedTreeView", () => {
 				assert.equal(change.newCommits.length, 1);
 				const commit = change.newCommits[0];
 				view1.checkout.resetEnrichmentStats();
-				const enriched = view1.checkout.enrich(commit.parent ?? assert.fail(), [commit]);
+				const enriched = view1.checkout.enrich(
+					commit.parent ?? assert.fail(),
+					[commit],
+					false,
+				);
 				assertEnrichmentCount(enriched[0], 0);
 				assert.deepEqual(view1.checkout.getEnrichmentStats(), {
 					batches: 1,
@@ -2042,7 +2070,11 @@ describe("sharedTreeView", () => {
 					assert.equal(change.newCommits.length, 1);
 					const commit = change.newCommits[0];
 					view1.checkout.resetEnrichmentStats();
-					const enriched = view1.checkout.enrich(commit.parent ?? assert.fail(), [commit]);
+					const enriched = view1.checkout.enrich(
+						commit.parent ?? assert.fail(),
+						[commit],
+						false,
+					);
 					assertEnrichmentCount(enriched[0], 2);
 					assert.deepEqual(view1.checkout.getEnrichmentStats(), {
 						batches: 1,
@@ -2075,7 +2107,11 @@ describe("sharedTreeView", () => {
 					assert.equal(change.newCommits.length, 1);
 					const commit = change.newCommits[0];
 					view1.checkout.resetEnrichmentStats();
-					const enriched = view1.checkout.enrich(commit.parent ?? assert.fail(), [commit]);
+					const enriched = view1.checkout.enrich(
+						commit.parent ?? assert.fail(),
+						[commit],
+						false,
+					);
 					assertEnrichmentCount(enriched[0], 2);
 					assert.deepEqual(view1.checkout.getEnrichmentStats(), {
 						batches: 1,
@@ -2090,7 +2126,7 @@ describe("sharedTreeView", () => {
 			assert.equal(callCount, 1);
 		});
 
-		it("delays diff computation if no refresher is needed", () => {
+		it("when validation is off, delays diff computation if no refresher is needed", () => {
 			const { view1 } = setup([]);
 			view1.root.insertAtEnd({ id: "A" });
 			const commit = view1.checkout.mainBranch.getHead();
@@ -2098,7 +2134,7 @@ describe("sharedTreeView", () => {
 			view1.root.insertAtEnd({ id: "C" });
 
 			view1.checkout.resetEnrichmentStats();
-			view1.checkout.enrich(commit.parent ?? assert.fail(), [commit]);
+			view1.checkout.enrich(commit.parent ?? assert.fail(), [commit], false);
 			assert.deepEqual(view1.checkout.getEnrichmentStats(), {
 				batches: 1,
 				diffs: 0,
@@ -2109,7 +2145,7 @@ describe("sharedTreeView", () => {
 			});
 		});
 
-		it("delays apply changes if no refresher is needed", () => {
+		it("when validation is off, delays apply changes if no refresher is needed", () => {
 			const { view1 } = setup([]);
 			const start = view1.checkout.mainBranch.getHead();
 			view1.root.insertAtEnd({ id: "A" });
@@ -2120,7 +2156,7 @@ describe("sharedTreeView", () => {
 			const commit3 = view1.checkout.mainBranch.getHead();
 
 			view1.checkout.resetEnrichmentStats();
-			view1.checkout.enrich(start, [commit1, commit2, commit3]);
+			view1.checkout.enrich(start, [commit1, commit2, commit3], false);
 			assert.deepEqual(view1.checkout.getEnrichmentStats(), {
 				batches: 1,
 				diffs: 0,
@@ -2129,6 +2165,46 @@ describe("sharedTreeView", () => {
 				forks: 0,
 				applied: 0,
 			});
+		});
+
+		it("when validation is on, applies changes even if no refresher is needed", () => {
+			const { view1 } = setup([]);
+			const start = view1.checkout.mainBranch.getHead();
+			view1.root.insertAtEnd({ id: "A" });
+			const commit1 = view1.checkout.mainBranch.getHead();
+			view1.root.insertAtEnd({ id: "B" });
+			const commit2 = view1.checkout.mainBranch.getHead();
+			view1.root.insertAtEnd({ id: "C" });
+			const commit3 = view1.checkout.mainBranch.getHead();
+
+			view1.checkout.resetEnrichmentStats();
+			view1.checkout.enrich(start, [commit1, commit2, commit3], true);
+			assert.deepEqual(view1.checkout.getEnrichmentStats(), {
+				batches: 1,
+				diffs: 1,
+				commitsEnriched: 3,
+				refreshers: 0,
+				forks: 1,
+				applied: 4,
+			});
+		});
+
+		it("when validation is on, throws an error if validation fails", () => {
+			const { view1 } = setup([]);
+			const fork = view1.fork();
+
+			fork.root.insertAtEnd({ id: "A" });
+
+			// This hides the commit that inserted "A".
+			fork.checkout.mainBranch.setHead(view1.checkout.mainBranch.getHead());
+
+			fork.root.removeAt(0);
+
+			// The merge will fail because only the commit that removes "A" will be merged.
+			assert.throws(() => view1.merge(fork));
+
+			assert.throws(() => view1.checkout.breaker.use());
+			assert.throws(() => view1.breaker.use());
 		});
 	});
 

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -1992,6 +1992,8 @@ export interface SharedTreeOptions extends SharedTreeOptionsBeta, Partial<CodecW
     readonly enableSharedBranches?: boolean;
     readonly retainHistory?: boolean;
     shouldEncodeIncrementally?: IncrementalEncodingPolicy;
+    readonly validateCommitsOnFirstSubmission?: boolean;
+    readonly validateRebasedCommitsBeforeResubmission?: boolean;
 }
 
 // @beta @input


### PR DESCRIPTION
## Description

Adds the following new options to `SharedTreeOptions` (alpha):
- 1validateCommitsOnFirstSubmission1: (default: `false`) When `true`, validates that commits being submitted for the first time can be applied without errors to a view.
- 1validateRebasedCommitsBeforeResubmission`: (default: `false`) When `true`, validates that the commits being resubmitted can be applied without errors to a view.

In the event that a commit cannot be applied, SharedTree will throw an error and will enter a "broken" state, preventing the offending commit (and any further commits) from being submitted.
This can be enabled (at the cost of performance) to improve safety against document corruption in the event of a bug in the SharedTree code:
when the additional validation is enabled, a client will error instead of potentially corrupting the document.

## Breaking Changes

None

## Reviewer Guidance

It's likely that we'll want to enable one or both flags by default in the future. This should be done after we've had the chance to use the new flags, evaluate/improve their perf impact, and consider different validation strategies.