### PR TITLE
feat(container-runtime): support reusable pending local state on containers without changes

### DIFF
--- a/.changeset/chatty-days-agree.md
+++ b/.changeset/chatty-days-agree.md
@@ -1,0 +1,17 @@
+---
+"@fluidframework/container-runtime": minor
+"__section": feature
+---
+Identify pending local state that can safely be reused
+
+The new `isPendingLocalStateReusable` helper conservatively identifies pending local state that
+contains no pending runtime state and can therefore be used to load multiple containers.
+
+```typescript
+import { isPendingLocalStateReusable } from "@fluidframework/container-runtime/legacy";
+
+const pendingLocalState = await container.getPendingLocalState();
+if (isPendingLocalStateReusable(pendingLocalState)) {
+	// The state can safely initialize more than one container.
+}
+```

--- a/packages/common/container-definitions/src/loader.ts
+++ b/packages/common/container-definitions/src/loader.ts
@@ -470,8 +470,14 @@ export interface IContainer extends IEventProvider<IContainerEvents> {
 	 * The container's {@link IContainer.closed} property must be false and the container must not
 	 * be {@link IContainer.disposed}; otherwise the implementation throws `UsageError`.
 	 *
-	 * WARNING: misuse of this API can result in duplicate op submission and potential
-	 * document corruption. To prevent container forking, callers must:
+	 * WARNING: Use `isPendingLocalStateReusable` from `@fluidframework/container-runtime/legacy` to
+	 * determine whether the returned state can safely be used to load multiple containers.
+	 * Reusable pending state is generally limited to containers that have not made edits. This can
+	 * be useful for communicating across processes or machines some exact container state to load
+	 *
+	 * Unless `isPendingLocalStateReusable` returns `true`, misuse of this API can result in
+	 * duplicate op submission and potential document corruption. To prevent container forking,
+	 * callers must:
 	 *
 	 * - Regenerate the serialization on every reconnect and replace any previously stored copy.
 	 * - Wait until the original container has been closed before rehydrating from its serialized state.
@@ -584,8 +590,12 @@ export interface ILoader extends Partial<IProvideLoader> {
 	 * When `pendingLocalState` is provided, the resolved container is rehydrated from a blob
 	 * previously produced by {@link IContainer.getPendingLocalState}.
 	 *
-	 * WARNING: misuse of `pendingLocalState` can result in duplicate op submission and potential
-	 * document corruption. To prevent container forking, callers must:
+	 * Use `isPendingLocalStateReusable` from `@fluidframework/container-runtime/legacy` to
+	 * determine whether `pendingLocalState` can safely be used to load multiple containers.
+	 *
+	 * Unless `isPendingLocalStateReusable` returns `true`, misuse of `pendingLocalState` can result
+	 * in duplicate op submission and potential document corruption. To prevent container forking,
+	 * callers must:
 	 *
 	 * - Pass the most recent blob produced for that container and discard any older serializations.
 	 * - Ensure the original container has been closed before rehydrating from its serialized state.

--- a/packages/runtime/container-runtime/api-report/container-runtime.legacy.alpha.api.md
+++ b/packages/runtime/container-runtime/api-report/container-runtime.legacy.alpha.api.md
@@ -207,6 +207,9 @@ export interface IRetriableFailureError extends Error {
 }
 
 // @beta @legacy
+export function isPendingLocalStateReusable(pendingLocalState: string): boolean;
+
+// @beta @legacy
 export interface ISubmitSummaryOpResult extends Omit<IUploadSummaryResult, "stage" | "error"> {
     readonly clientSequenceNumber: number;
     // (undocumented)

--- a/packages/runtime/container-runtime/api-report/container-runtime.legacy.beta.api.md
+++ b/packages/runtime/container-runtime/api-report/container-runtime.legacy.beta.api.md
@@ -207,6 +207,9 @@ export interface IRetriableFailureError extends Error {
 }
 
 // @beta @legacy
+export function isPendingLocalStateReusable(pendingLocalState: string): boolean;
+
+// @beta @legacy
 export interface ISubmitSummaryOpResult extends Omit<IUploadSummaryResult, "stage" | "error"> {
     readonly clientSequenceNumber: number;
     // (undocumented)

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -5657,6 +5657,17 @@ export class ContainerRuntime
 				eventName: "getPendingLocalState",
 			},
 			(event) => {
+				const pendingAttachmentBlobs = this.blobManager.getPendingBlobs();
+				if (!this.hasPendingMessages() && pendingAttachmentBlobs === undefined) {
+					// Sequenced saved ops can reconstruct the runtime state without carrying
+					// session-scoped state such as the IdCompressor's ongoing session.
+					event.end({
+						attachmentBlobsSize: 0,
+						pendingOpsSize: 0,
+					});
+					return undefined;
+				}
+
 				const { pending } = this.pendingStateManager.getLocalState(
 					props?.snapshotSequenceNumber,
 				);
@@ -5664,7 +5675,6 @@ export class ContainerRuntime
 					props?.sessionExpiryTimerStarted ?? this.garbageCollector.sessionExpiryTimerStarted;
 
 				const pendingIdCompressorState = this._idCompressor?.serialize(true);
-				const pendingAttachmentBlobs = this.blobManager.getPendingBlobs();
 
 				const pendingRuntimeState: IPendingRuntimeState = {
 					pending,

--- a/packages/runtime/container-runtime/src/index.ts
+++ b/packages/runtime/container-runtime/src/index.ts
@@ -123,6 +123,7 @@ export {
 	DefaultSummaryConfiguration,
 } from "./summary/index.js";
 export { type IChunkedOp, unpackRuntimeMessage } from "./opLifecycle/index.js";
+export { isPendingLocalStateReusable } from "./pendingLocalState.js";
 export {
 	type IVersionMarkResolver,
 	type ResolveResult,

--- a/packages/runtime/container-runtime/src/pendingLocalState.ts
+++ b/packages/runtime/container-runtime/src/pendingLocalState.ts
@@ -1,0 +1,40 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Determines whether a pending local state can safely be used to load multiple containers.
+ *
+ * @param pendingLocalState - A serialized pending local state returned by
+ * {@link @fluidframework/container-definitions#IContainer.getPendingLocalState}.
+ * @returns `true` only when the state is a valid attached-container state with no pending runtime
+ * state. Returns `false` for malformed state and whenever safety cannot be established.
+ *
+ * @legacy @beta
+ */
+export function isPendingLocalStateReusable(pendingLocalState: string): boolean {
+	let state: unknown;
+	try {
+		state = JSON.parse(pendingLocalState);
+	} catch (error) {
+		if (error instanceof SyntaxError) {
+			return false;
+		}
+		throw error;
+	}
+
+	return (
+		isRecord(state) &&
+		state.attached === true &&
+		typeof state.url === "string" &&
+		isRecord(state.baseSnapshot) &&
+		isRecord(state.snapshotBlobs) &&
+		Array.isArray(state.savedOps) &&
+		!Object.prototype.hasOwnProperty.call(state, "pendingRuntimeState")
+	);
+}

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -2409,8 +2409,8 @@ describe("Runtime", () => {
 				// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
 				(containerRuntime as any).pendingStateManager = mockPendingStateManager;
 
-				const state = containerRuntime.getPendingLocalState() as Partial<IPendingRuntimeState>;
-				assert.ok(state.sessionExpiryTimerStarted !== undefined);
+				const state = containerRuntime.getPendingLocalState();
+				assert.strictEqual(state, undefined);
 			});
 			it("No Props. Some pending state", async () => {
 				const logger = new MockLogger();
@@ -2478,12 +2478,11 @@ describe("Runtime", () => {
 					provideEntryPoint: mockProvideEntryPoint,
 				});
 
-				const state = (await containerRuntime.getPendingLocalState({
+				const state = containerRuntime.getPendingLocalState({
 					notifyImminentClosure: false,
 					sessionExpiryTimerStarted: 100,
-				})) as Partial<IPendingRuntimeState>;
-				assert.strictEqual(typeof state, "object");
-				assert.strictEqual(state.sessionExpiryTimerStarted, 100);
+				});
+				assert.strictEqual(state, undefined);
 			});
 
 			it("sessionExpiryTimerStarted. Some pending state", async () => {

--- a/packages/runtime/container-runtime/src/test/pendingLocalState.spec.ts
+++ b/packages/runtime/container-runtime/src/test/pendingLocalState.spec.ts
@@ -1,0 +1,46 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+
+import { isPendingLocalStateReusable } from "../pendingLocalState.js";
+
+function makePendingLocalState(pendingRuntimeState?: unknown): string {
+	return JSON.stringify({
+		attached: true,
+		baseSnapshot: {},
+		snapshotBlobs: {},
+		savedOps: [],
+		url: "fluid://example",
+		pendingRuntimeState,
+	});
+}
+
+describe("isPendingLocalStateReusable", () => {
+	it("returns true when pending runtime state is absent", () => {
+		assert.equal(isPendingLocalStateReusable(makePendingLocalState()), true);
+	});
+
+	for (const pendingRuntimeState of [{}, null, { pending: { pendingStates: [] } }]) {
+		it(`returns false when pending runtime state is ${JSON.stringify(pendingRuntimeState)}`, () => {
+			assert.equal(
+				isPendingLocalStateReusable(makePendingLocalState(pendingRuntimeState)),
+				false,
+			);
+		});
+	}
+
+	it("returns false for detached container state", () => {
+		const state = JSON.parse(makePendingLocalState()) as Record<string, unknown>;
+		state.attached = false;
+		assert.equal(isPendingLocalStateReusable(JSON.stringify(state)), false);
+	});
+
+	for (const malformedState of ["", "null", "{}", '{"attached":true}']) {
+		it(`returns false for malformed state ${JSON.stringify(malformedState)}`, () => {
+			assert.equal(isPendingLocalStateReusable(malformedState), false);
+		});
+	}
+});

--- a/packages/test/local-server-tests/src/test/forkedPendingState.spec.ts
+++ b/packages/test/local-server-tests/src/test/forkedPendingState.spec.ts
@@ -1,0 +1,212 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+
+import { ContainerRuntimeFactoryWithDefaultDataStore } from "@fluidframework/aqueduct/internal";
+import type { IContainer } from "@fluidframework/container-definitions/internal";
+import {
+	createDetachedContainer,
+	loadExistingContainer,
+	loadFrozenContainerFromPendingState,
+	type ILoaderProps,
+	waitContainerToCatchUp,
+} from "@fluidframework/container-loader/internal";
+import { isPendingLocalStateReusable } from "@fluidframework/container-runtime/legacy";
+import type { FluidObject, IFluidHandle } from "@fluidframework/core-interfaces/internal";
+import type {
+	LocalDocumentServiceFactory,
+	LocalResolver,
+} from "@fluidframework/local-driver/internal";
+import { SharedMap } from "@fluidframework/map/internal";
+import { LocalDeltaConnectionServer } from "@fluidframework/server-local-server";
+import {
+	getRequiredPendingLocalState,
+	TestFluidObjectFactory,
+	timeoutPromise,
+	type ITestFluidObject,
+	type LocalCodeLoader,
+	type TestFluidObject,
+} from "@fluidframework/test-utils/internal";
+import { SchemaFactory } from "@fluidframework/tree";
+import {
+	type ITree,
+	SharedTree,
+	TreeViewConfiguration,
+	type TreeView,
+} from "@fluidframework/tree/internal";
+
+import { createLoader } from "./utils.js";
+
+const schemaFactory = new SchemaFactory("forkedPendingState");
+
+class ForkedPendingStateRoot extends schemaFactory.object("ForkedPendingStateRoot", {
+	first: schemaFactory.string,
+	second: schemaFactory.string,
+}) {}
+
+const treeConfiguration = new TreeViewConfiguration({
+	schema: ForkedPendingStateRoot,
+});
+const treeKey = "forkedPendingStateTree";
+
+interface TestContext {
+	readonly baselineState: string;
+	readonly codeLoader: LocalCodeLoader;
+	readonly documentServiceFactory: LocalDocumentServiceFactory;
+	readonly loaderProps: ILoaderProps;
+	readonly url: string;
+	readonly urlResolver: LocalResolver;
+}
+
+async function waitForSaved(container: IContainer): Promise<void> {
+	await waitContainerToCatchUp(container);
+	if (container.isDirty) {
+		await timeoutPromise((resolve) => container.once("saved", () => resolve()));
+	}
+}
+
+async function getTestFluidObject(container: IContainer): Promise<ITestFluidObject> {
+	const entryPoint: FluidObject<TestFluidObject> = await container.getEntryPoint();
+	assert(
+		entryPoint.ITestFluidObject !== undefined,
+		"Expected entrypoint to be a valid TestFluidObject",
+	);
+	return entryPoint.ITestFluidObject;
+}
+
+async function getTreeView(
+	testFluidObject: ITestFluidObject,
+): Promise<TreeView<typeof ForkedPendingStateRoot>> {
+	const treeHandle = testFluidObject.root.get<IFluidHandle<ITree>>(treeKey);
+	assert(
+		treeHandle !== undefined,
+		"Expected the SharedTree handle to be stored in the root map",
+	);
+	const tree = await treeHandle.get();
+	return tree.viewWith(treeConfiguration);
+}
+
+async function createBaseline(): Promise<TestContext> {
+	const deltaConnectionServer = LocalDeltaConnectionServer.create();
+	const defaultDataStoreFactory = new TestFluidObjectFactory(
+		[
+			["map", SharedMap.getFactory()],
+			["tree", SharedTree.getFactory()],
+		],
+		"default",
+	);
+	const runtimeFactory = new ContainerRuntimeFactoryWithDefaultDataStore({
+		defaultFactory: defaultDataStoreFactory,
+		registryEntries: [
+			[defaultDataStoreFactory.type, Promise.resolve(defaultDataStoreFactory)],
+		],
+		runtimeOptions: {
+			enableRuntimeIdCompressor: "on",
+		},
+	});
+	const { urlResolver, codeDetails, codeLoader, loaderProps, documentServiceFactory } =
+		createLoader({ deltaConnectionServer, runtimeFactory });
+	const container = await createDetachedContainer({ codeDetails, ...loaderProps });
+	const testFluidObject = await getTestFluidObject(container);
+	const tree = SharedTree.create(testFluidObject.runtime, treeKey);
+	const view = tree.viewWith(treeConfiguration);
+	view.initialize({
+		first: "baseline first",
+		second: "baseline second",
+	});
+	view.dispose();
+	testFluidObject.root.set(treeKey, tree.handle);
+
+	await container.attach(urlResolver.createCreateNewRequest("test"));
+	await waitForSaved(container);
+	const url = await container.getAbsoluteUrl("");
+	assert(url !== undefined, "Expected container to provide a valid absolute URL");
+	const baselineState = await getRequiredPendingLocalState(container);
+	assert(
+		isPendingLocalStateReusable(baselineState),
+		"Saved state should be safe to load multiple times",
+	);
+	container.dispose();
+
+	return {
+		baselineState,
+		codeLoader,
+		documentServiceFactory,
+		loaderProps,
+		url,
+		urlResolver,
+	};
+}
+
+async function createForkedEdit(
+	context: TestContext,
+	field: "first" | "second",
+	value: string,
+): Promise<string> {
+	const frozenContainer = await loadFrozenContainerFromPendingState({
+		codeLoader: context.codeLoader,
+		documentServiceFactory: context.documentServiceFactory,
+		urlResolver: context.urlResolver,
+		request: { url: context.url },
+		pendingLocalState: context.baselineState,
+		readOnly: false,
+	});
+	const testFluidObject = await getTestFluidObject(frozenContainer);
+	const view = await getTreeView(testFluidObject);
+	view.root[field] = value;
+	view.dispose();
+	const pendingState = await getRequiredPendingLocalState(frozenContainer);
+	frozenContainer.dispose();
+	return pendingState;
+}
+
+async function replayPendingState(
+	context: TestContext,
+	pendingLocalState: string,
+): Promise<void> {
+	const container = await loadExistingContainer({
+		...context.loaderProps,
+		request: { url: context.url },
+		pendingLocalState,
+	});
+	await waitForSaved(container);
+	container.dispose();
+}
+
+async function readTree(context: TestContext): Promise<{
+	readonly first: string;
+	readonly second: string;
+}> {
+	const container = await loadExistingContainer({
+		...context.loaderProps,
+		request: { url: context.url },
+	});
+	await waitContainerToCatchUp(container);
+	const testFluidObject = await getTestFluidObject(container);
+	const view = await getTreeView(testFluidObject);
+	const result = {
+		first: view.root.first,
+		second: view.root.second,
+	};
+	view.dispose();
+	container.dispose();
+	return result;
+}
+
+describe("forked pending local state", () => {
+	it("preserves disjoint SharedTree edits replayed from the same baseline", async () => {
+		const context = await createBaseline();
+		const firstEdit = await createForkedEdit(context, "first", "edited first");
+		await replayPendingState(context, firstEdit);
+		const secondEdit = await createForkedEdit(context, "second", "edited second");
+		await replayPendingState(context, secondEdit);
+
+		assert.deepStrictEqual(await readTree(context), {
+			first: "edited first",
+			second: "edited second",
+		});
+	});
+});


### PR DESCRIPTION
[How contribute to this repo](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).

[Guidelines for Pull Requests](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

## Description

Allow pending local state without pending operations or attachment blobs to initialize multiple containers safely. Such captures omit session-scoped runtime state, including the ongoing ID compressor session, and instead reconstruct conceptual state from the snapshot and sequenced operations.

Add the `@legacy @beta` `isPendingLocalStateReusable` API so callers can conservatively detect reusable captures. Update pending-state documentation, generated API reports, tests, and release notes guidance accordingly.

This supports communicating an exact container state across processes or machines instead of loading the latest service state.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Please review the conservative reusable-state predicate and the decision to omit all pending runtime state for quiescent captures.
