### PR TITLE
fix(tree): no-change constraint on reverts now violated by changes to removed trees

### DIFF
--- a/.changeset/shy-weeks-press.md
+++ b/.changeset/shy-weeks-press.md
@@ -1,0 +1,12 @@
+---
+"@fluidframework/tree": minor
+"fluid-framework": minor
+"__section": tree
+---
+Fixed bug in `no-change` constraint revert precondition
+
+The [`no-change` constraint](https://fluidframework.com/docs/api/fluid-framework/nochangeconstraint-interface),
+when evaluated as a [precondition to revert](https://fluidframework.com/docs/api/fluid-framework/transactioncallbackstatusalpha-typealias),
+is now violated by concurrent changes made to already removed content.
+Before this version, it was only violated by concurrent changes made in the document tree.
+This shift makes the behavior of the constraint consistent across revert and non-revert usages.

--- a/.changeset/shy-weeks-press.md
+++ b/.changeset/shy-weeks-press.md
@@ -3,7 +3,7 @@
 "fluid-framework": minor
 "__section": tree
 ---
-Fixed bug in `no-change` constraint revert precondition
+Fixed bug in no-change constraint revert precondition
 
 The [`no-change` constraint](https://fluidframework.com/docs/api/fluid-framework/nochangeconstraint-interface),
 when evaluated as a [precondition to revert](https://fluidframework.com/docs/api/fluid-framework/transactioncallbackstatusalpha-typealias),

--- a/packages/dds/tree/src/core/index.ts
+++ b/packages/dds/tree/src/core/index.ts
@@ -108,8 +108,9 @@ export {
 	DetachedFieldIndexFormatVersion,
 	detachedFieldIndexCodecBuilder,
 	areDetachedNodeIdsEqual,
-	deltaFieldMapHasVisibleChanges,
-	deltaFieldChangesHaveVisibleChanges,
+	deltaFieldMapHasChanges,
+	deltaFieldChangesHaveChanges,
+	getDeltaChangeProfile,
 	forEachNodeSubsequence,
 } from "./tree/index.js";
 

--- a/packages/dds/tree/src/core/tree/deltaUtil.ts
+++ b/packages/dds/tree/src/core/tree/deltaUtil.ts
@@ -59,11 +59,19 @@ export function areDetachedNodeIdsEqual(a: DetachedNodeId, b: DetachedNodeId): b
 	return a.major === b.major && a.minor === b.minor;
 }
 
+/**
+ * Describes the types of changes present in a delta.
+ */
 export interface DeltaChangeProfile {
+	/** Whether the delta includes any build operations. */
 	hasBuilds: boolean;
+	/** Whether the delta includes any destroy operations. */
 	hasDestroys: boolean;
+	/** Whether the delta includes any rename operations. */
 	hasRenames: boolean;
+	/** Whether the delta includes any changes in the document tree. */
 	hasChangesInDocumentTree: boolean;
+	/** Whether the delta includes any changes in detached trees. */
 	hasChangesInDetachedTrees: boolean;
 }
 

--- a/packages/dds/tree/src/core/tree/deltaUtil.ts
+++ b/packages/dds/tree/src/core/tree/deltaUtil.ts
@@ -59,17 +59,45 @@ export function areDetachedNodeIdsEqual(a: DetachedNodeId, b: DetachedNodeId): b
 	return a.major === b.major && a.minor === b.minor;
 }
 
+export interface DeltaChangeProfile {
+	hasBuilds: boolean;
+	hasDestroys: boolean;
+	hasRenames: boolean;
+	hasChangesInDocumentTree: boolean;
+	hasChangesInDetachedTrees: boolean;
+}
+
 /**
- * Returns true if a delta field map contains any changes that would be visible in the document (i.e., a detach or an attach)
- * @param fields - Delta FieldMap to check for visible changes
- * @returns True if change map contains any changes that would be visible in the document, false otherwise
+ * Reports the kinds of changes present in a delta.
+ * @param delta - The delta to analyze.
+ * @returns An object indicating which kinds of changes are present.
  */
-export function deltaFieldMapHasVisibleChanges(fields: FieldMap | undefined): boolean {
+export function getDeltaChangeProfile(delta: Root): DeltaChangeProfile {
+	const profile: DeltaChangeProfile = {
+		hasBuilds: delta.build !== undefined && delta.build.length > 0,
+		hasDestroys: delta.destroy !== undefined && delta.destroy.length > 0,
+		hasRenames: delta.rename !== undefined && delta.rename.length > 0,
+		hasChangesInDocumentTree: deltaFieldMapHasChanges(delta.fields),
+		hasChangesInDetachedTrees:
+			delta.global?.some((detachedNodeChanges) =>
+				deltaFieldMapHasChanges(detachedNodeChanges.fields),
+			) === true,
+	};
+	return profile;
+}
+
+/**
+ * Returns true if a delta field map contains any changes.
+ * Note that the changes may not be noticeable to the user (e.g., a change that replaces a node with another structurally identical node).
+ * @param fields - Delta FieldMap to check for changes
+ * @returns True if change map contains any changes, false otherwise
+ */
+export function deltaFieldMapHasChanges(fields: FieldMap | undefined): boolean {
 	if (fields === undefined || fields.size === 0) {
 		return false;
 	}
 	for (const [, fieldChanges] of fields) {
-		if (deltaFieldChangesHaveVisibleChanges(fieldChanges)) {
+		if (deltaFieldChangesHaveChanges(fieldChanges)) {
 			return true;
 		}
 	}
@@ -77,16 +105,17 @@ export function deltaFieldMapHasVisibleChanges(fields: FieldMap | undefined): bo
 }
 
 /**
- * Returns true if the given field changes contains any changes that would be visible in the document (i.e., a detach or an attach)
- * @param fieldChanges - Field changes to check for visible changes
- * @returns True if the field changes contain any changes that would be visible in the document, false otherwise
+ * Returns true if a delta field map contains any changes.
+ * Note that the changes may not be noticeable to the user (e.g., a change that replaces a node with another structurally identical node).
+ * @param fieldChanges - Field changes to check for changes
+ * @returns True if the field changes contain any changes, false otherwise
  */
-export function deltaFieldChangesHaveVisibleChanges(fieldChanges: FieldChanges): boolean {
+export function deltaFieldChangesHaveChanges(fieldChanges: FieldChanges): boolean {
 	for (const mark of fieldChanges.marks) {
 		if (
 			mark.attach !== undefined ||
 			mark.detach !== undefined ||
-			deltaFieldMapHasVisibleChanges(mark.fields)
+			deltaFieldMapHasChanges(mark.fields)
 		) {
 			return true;
 		}

--- a/packages/dds/tree/src/core/tree/deltaUtil.ts
+++ b/packages/dds/tree/src/core/tree/deltaUtil.ts
@@ -105,7 +105,7 @@ export function deltaFieldMapHasChanges(fields: FieldMap | undefined): boolean {
 }
 
 /**
- * Returns true if a delta field map contains any changes.
+ * Returns true if the given field changes contain any changes.
  * Note that the changes may not be noticeable to the user (e.g., a change that replaces a node with another structurally identical node).
  * @param fieldChanges - Field changes to check for changes
  * @returns True if the field changes contain any changes, false otherwise

--- a/packages/dds/tree/src/core/tree/index.ts
+++ b/packages/dds/tree/src/core/tree/index.ts
@@ -109,8 +109,9 @@ export {
 	offsetDetachId,
 	emptyDelta,
 	areDetachedNodeIdsEqual,
-	deltaFieldMapHasVisibleChanges,
-	deltaFieldChangesHaveVisibleChanges,
+	deltaFieldMapHasChanges,
+	deltaFieldChangesHaveChanges,
+	getDeltaChangeProfile,
 } from "./deltaUtil.js";
 
 export {

--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -59,10 +59,10 @@ import {
 	type ReadOnlyDetachedFieldIndex,
 	makeAnonChange,
 	type TaggedChange,
-	deltaFieldMapHasVisibleChanges,
 	findCommonAncestor,
 	rebaseBranch,
 	type LocalCommitEvents,
+	getDeltaChangeProfile,
 } from "../core/index.js";
 import {
 	type FieldBatchCodec,
@@ -1546,7 +1546,7 @@ export class TreeCheckout implements ITreeCheckout {
 				headCommit,
 				this.mintRevisionTag,
 			);
-			const ignoreNoChangeViolation = !sharedTreeChangeHasVisibleChanges(diff);
+			const ignoreNoChangeViolation = !sharedTreeChangeHasApplicationFacingChanges(diff);
 
 			change = tagChange(
 				rebaseChange(
@@ -1888,19 +1888,19 @@ function verboseFromCursor(
 }
 
 /**
- * Enumerates through a shared tree change, looking for schema change and field changes that result in visible changes to the tree (e.g. an insert, move, delete).
- * This function also considers changes to detached roots to be visible changes, but not renames of roots or builds of new roots.
+ * Whether the change contains any application-facing changes.
  *
  * @param change - The change to analyze.
- * @returns True if the change contains any schema changes or any field changes that result in visible changes to the tree, false otherwise.
+ * @returns True if the change contains any schema changes or any field changes (either in the document tree or in detached trees), false otherwise.
  */
-function sharedTreeChangeHasVisibleChanges(change: SharedTreeChange): boolean {
+function sharedTreeChangeHasApplicationFacingChanges(change: SharedTreeChange): boolean {
 	for (const inner of change.changes) {
 		if (inner.type === "schema") {
 			return true;
 		}
 		const delta = intoDelta(tagChange(inner.innerChange, undefined));
-		if (deltaFieldMapHasVisibleChanges(delta.fields)) {
+		const profile = getDeltaChangeProfile(delta);
+		if (profile.hasChangesInDocumentTree || profile.hasChangesInDetachedTrees) {
 			return true;
 		}
 	}

--- a/packages/dds/tree/src/test/shared-tree/editing.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/editing.spec.ts
@@ -3409,7 +3409,7 @@ describe("Editing", () => {
 		});
 
 		describe("No Change constraint on revert", () => {
-			it("Should not revert when constraint is violated", () => {
+			it("Should be violated when rebasing over an edit to the attached document tree", () => {
 				const tree = makeTreeFromJsonSequence(["A", "B"], {
 					codecOptions: { minVersionForCollab: FluidClientVersion.v2_80 },
 				});
@@ -3426,7 +3426,7 @@ describe("Editing", () => {
 				assert(revertible !== undefined, "Missing revertible");
 				revertible.revert();
 
-				// Revert should go through on the branch since the constraint shouldnt be violated yet
+				// Revert should go through on the branch since the constraint shouldn't be violated yet
 				expectJsonTree(branch, ["A", "B"]);
 
 				// Make an edit on the main tree to force a rebase
@@ -3437,6 +3437,46 @@ describe("Editing", () => {
 				// and the revert transaction should be dropped
 				branch.rebaseOnto(tree);
 				expectJsonTree(branch, ["Y", "A", "X", "B"]);
+				unsubscribe();
+			});
+
+			it("Should be violated when rebasing over an edit to detached trees", () => {
+				const tree = makeTreeFromJsonSequence([{ value: "initial" }], {
+					codecOptions: { minVersionForCollab: FluidClientVersion.v2_80 },
+				});
+
+				const branchWithEdit = tree.fork();
+				branchWithEdit.editor
+					.valueField({ field: brand("value"), parent: rootNode })
+					.set(chunkFromJsonTrees(["updated"]));
+				expectJsonTree(branchWithEdit, [{ value: "updated" }]);
+
+				tree.editor.sequenceField(rootField).remove(0, 1);
+				expectJsonTree(tree, []);
+
+				const branch = tree.fork();
+				// Add a No Change constraint and make an edit
+				const { undoStack, unsubscribe } = createTestUndoRedoStacks(branch.events);
+				branch.transaction.start();
+				branch.editor.sequenceField(rootField).insert(0, chunkFromJsonTrees(["X"]));
+				branch.editor.addNoChangeConstraintOnRevert();
+				branch.transaction.commit();
+				expectJsonTree(branch, ["X"]);
+				const revertible = undoStack.pop();
+				assert(revertible !== undefined, "Missing revertible");
+				revertible.revert();
+
+				// Revert should go through on the branch since the constraint shouldn't be violated yet
+				expectJsonTree(branch, []);
+
+				// Merge the branch edit to impact the detached object
+				tree.merge(branchWithEdit);
+
+				// When rebasing, the No Change constraint should be violated
+				// and the revert transaction should be dropped
+				tree.merge(branch, false);
+				branch.rebaseOnto(tree);
+				expectJsonTree(branch, ["X"]);
 				unsubscribe();
 			});
 
@@ -3461,7 +3501,7 @@ describe("Editing", () => {
 				unsubscribe();
 			});
 
-			it("Should not be violated when there are multiple inserts reverted", () => {
+			it("Should not be violated when rebasing over inserts and their reversals", () => {
 				const tree = makeTreeFromJsonSequence(["A", "B"], {
 					codecOptions: { minVersionForCollab: FluidClientVersion.v2_80 },
 				});
@@ -3492,14 +3532,17 @@ describe("Editing", () => {
 				undo1.revert();
 				const undo2 = undoStack.pop() ?? assert.fail("Missing undo");
 				undo2.revert();
+
+				// Act
 				const undo3 = undoStack.pop() ?? assert.fail("Missing undo");
 				undo3.revert();
 
+				// Verify
 				expectJsonTree(branch, ["A", "X", "B"]);
 				unsubscribe();
 			});
 
-			it("Should not be violated when there are multiple moves reverted", () => {
+			it("Should not be violated when rebasing over moves and their reversals", () => {
 				const tree = makeTreeFromJsonSequence([{ "A": 1, "B": 2, "C": 3 }], {
 					codecOptions: { minVersionForCollab: FluidClientVersion.v2_80 },
 				});
@@ -3544,11 +3587,16 @@ describe("Editing", () => {
 				const undo2 = undoStack.pop() ?? assert.fail("Missing undo");
 				undo2.revert();
 
-				expectJsonTree(branch, [{ "X": 1, "B": 2, "C": 3 }]);
+				// Act
+				const undo3 = undoStack.pop() ?? assert.fail("Missing undo");
+				undo3.revert();
+
+				// Verify
+				expectJsonTree(branch, [{ "A": 1, "B": 2, "C": 3 }]);
 				unsubscribe();
 			});
 
-			it("Should not be violated when a non-constrained edit is inserted but then removed by later edits", () => {
+			it("Should not be violated when content is inserted then removed by later edits", () => {
 				const tree = makeTreeFromJsonSequence([], {
 					codecOptions: { minVersionForCollab: FluidClientVersion.v2_80 },
 				});


### PR DESCRIPTION
## Description

The [`no-change` constraint](https://fluidframework.com/docs/api/fluid-framework/nochangeconstraint-interface), when evaluated as a [precondition to revert](https://fluidframework.com/docs/api/fluid-framework/transactioncallbackstatusalpha-typealias), was not violated by concurrent changes made to already removed content. This was incorrect.

## Breaking Changes

This should not be a breaking change: applications that depended on the old (incorrect) behavior will now experience more reverts being dropped, but this is something they must already support.