### PR TITLE
build: fix merge-tree changeset for 2.116.0 release

### DIFF
--- a/.changeset/great-walls-walk.md
+++ b/.changeset/great-walls-walk.md
@@ -1,5 +1,5 @@
 ---
-"@fluidframework/merge-tree": patch
+"@fluidframework/merge-tree": minor
 "__section": fix
 ---
 Fix LocalReferenceCollection.walkReferences skipping the starting reference


### PR DESCRIPTION
## Description

Changes the merge-tree bug-fix changeset from `patch` to `minor`, matching the client release tooling's expected bump type.

This allows the fix from [PR 27947](https://github.com/microsoft/FluidFramework/pull/27947) to appear in the generated 2.116.0 release notes. This PR must merge before [PR 27991](https://github.com/microsoft/FluidFramework/pull/27991) is regenerated.

## Reviewer Guidance

The review process is outlined in [the pull request guidelines](https://github.com/microsoft/FluidFramework/blob/main/docs/content/Contributing/PR-Guidelines.md#guidelines).

The only source change is the changeset bump type.
