### PR TITLE
feat(tree): add schema change telemetry

### DIFF
--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -136,8 +136,6 @@ import type { ISharedTreeEditor, SharedTreeEditBuilder } from "./sharedTreeEditB
 import { extractTransactionChangeProcessor } from "./transactionPostProcessor.js";
 import { SerializedChange } from "./serializedChange.js";
 
-const schemaChangeTelemetryEventName = "SchemaChangeApplied";
-
 /**
  * Yields all defined (non-`undefined`) labels from a {@link LabelTree}, depth-first.
  */
@@ -569,6 +567,11 @@ export class TreeCheckout implements ITreeCheckout {
 	 * @privateRemarks Exposed for testing purposes.
 	 */
 	public static readonly revertTelemetryEventName = "RevertRevertible";
+	/**
+	 * The name of the telemetry event logged when a schema change is applied.
+	 * @privateRemarks Exposed for testing purposes.
+	 */
+	public static readonly schemaChangeTelemetryEventName = "SchemaChangeApplied";
 
 	readonly #events = createEmitter<CheckoutEvents>();
 	public events: Listenable<CheckoutEvents> = this.#events;
@@ -1125,7 +1128,7 @@ export class TreeCheckout implements ITreeCheckout {
 				);
 				this.storedSchema.apply(newSchema);
 				this.logger?.sendTelemetryEvent({
-					eventName: schemaChangeTelemetryEventName,
+					eventName: TreeCheckout.schemaChangeTelemetryEventName,
 					...tagCodeArtifacts({
 						...telemetryMetrics,
 						isSharedBranch: this.isSharedBranch,

--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -11,7 +11,11 @@ import type {
 } from "@fluidframework/core-interfaces/internal";
 import { assert, unreachableCase, fail } from "@fluidframework/core-utils/internal";
 import type { IIdCompressor } from "@fluidframework/id-compressor";
-import { type TelemetryLoggerExt, UsageError } from "@fluidframework/telemetry-utils/internal";
+import {
+	type TelemetryLoggerExt,
+	UsageError,
+	tagCodeArtifacts,
+} from "@fluidframework/telemetry-utils/internal";
 
 import {
 	FluidClientVersion,
@@ -131,6 +135,8 @@ import type { SharedTreeChange } from "./sharedTreeChangeTypes.js";
 import type { ISharedTreeEditor, SharedTreeEditBuilder } from "./sharedTreeEditBuilder.js";
 import { extractTransactionChangeProcessor } from "./transactionPostProcessor.js";
 import { SerializedChange } from "./serializedChange.js";
+
+const schemaChangeTelemetryEventName = "SchemaChangeApplied";
 
 /**
  * Yields all defined (non-`undefined`) labels from a {@link LabelTree}, depth-first.
@@ -1111,7 +1117,20 @@ export class TreeCheckout implements ITreeCheckout {
 				// They will however be rebased over the rollback of the schema change. This rebasing will
 				// ensure that these data changes are muted if they would render some trees invalid under the
 				// original (reinstated) schema.
-				this.storedSchema.apply(innerChange.innerChange.schema.new);
+				const newSchema = innerChange.innerChange.schema.new;
+				const telemetryMetrics = getSchemaChangeTelemetryMetrics(
+					this.storedSchema,
+					newSchema,
+					innerChange.innerChange.isInverse,
+				);
+				this.storedSchema.apply(newSchema);
+				this.logger?.sendTelemetryEvent({
+					eventName: schemaChangeTelemetryEventName,
+					...tagCodeArtifacts({
+						...telemetryMetrics,
+						isSharedBranch: this.isSharedBranch,
+					}),
+				});
 			} else {
 				fail(0xad1 /* Unknown Shared Tree change type. */);
 			}
@@ -1781,6 +1800,54 @@ export class TreeCheckout implements ITreeCheckout {
 	}
 
 	// #endregion Enrichment
+}
+
+function getSchemaChangeTelemetryMetrics(
+	oldSchema: TreeStoredSchema,
+	newSchema: TreeStoredSchema,
+	isInverse: boolean,
+): {
+	changeKind: "initialize" | "upgrade" | "restriction" | "rollback";
+	isInverse: boolean;
+	oldNodeSchemaCount: number;
+	newNodeSchemaCount: number;
+	addedNodeSchemaCount: number;
+	removedNodeSchemaCount: number;
+	rootFieldKindChanged: boolean;
+	oldRootAllowedTypeCount: number;
+	newRootAllowedTypeCount: number;
+} {
+	let addedNodeSchemaCount = 0;
+	for (const identifier of newSchema.nodeSchema.keys()) {
+		if (!oldSchema.nodeSchema.has(identifier)) {
+			addedNodeSchemaCount++;
+		}
+	}
+
+	let removedNodeSchemaCount = 0;
+	for (const identifier of oldSchema.nodeSchema.keys()) {
+		if (!newSchema.nodeSchema.has(identifier)) {
+			removedNodeSchemaCount++;
+		}
+	}
+
+	return {
+		changeKind: isInverse
+			? "rollback"
+			: oldSchema.nodeSchema.size === 0
+				? "initialize"
+				: allowsRepoSuperset(defaultSchemaPolicy, oldSchema, newSchema)
+					? "upgrade"
+					: "restriction",
+		isInverse,
+		oldNodeSchemaCount: oldSchema.nodeSchema.size,
+		newNodeSchemaCount: newSchema.nodeSchema.size,
+		addedNodeSchemaCount,
+		removedNodeSchemaCount,
+		rootFieldKindChanged: oldSchema.rootFieldSchema.kind !== newSchema.rootFieldSchema.kind,
+		oldRootAllowedTypeCount: oldSchema.rootFieldSchema.types.size,
+		newRootAllowedTypeCount: newSchema.rootFieldSchema.types.size,
+	};
 }
 
 /**

--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -1130,8 +1130,10 @@ export class TreeCheckout implements ITreeCheckout {
 				this.logger?.sendTelemetryEvent({
 					eventName: TreeCheckout.schemaChangeTelemetryEventName,
 					...tagCodeArtifacts({
-						...telemetryMetrics,
-						isSharedBranch: this.isSharedBranch,
+						details: JSON.stringify({
+							...telemetryMetrics,
+							isSharedBranch: this.isSharedBranch,
+						}),
 					}),
 				});
 			} else {

--- a/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
@@ -8,6 +8,7 @@ import { strict as assert } from "node:assert";
 import {
 	type IMockLoggerExt,
 	createMockLoggerExt,
+	tagCodeArtifacts,
 } from "@fluidframework/telemetry-utils/internal";
 import { validateUsageError } from "@fluidframework/test-runtime-utils/internal";
 
@@ -20,7 +21,10 @@ import {
 	CommitKind,
 	EmptyKey,
 	type NormalizedFieldUpPath,
+	LeafNodeStoredSchema,
+	type TreeNodeSchemaIdentifier,
 	TreeStoredSchemaRepository,
+	ValueSchema,
 } from "../../core/index.js";
 import { FieldKinds, MockNodeIdentifierManager } from "../../feature-libraries/index.js";
 import {
@@ -77,6 +81,7 @@ const rootField: NormalizedFieldUpPath = {
 };
 
 const enableSchemaValidation = true;
+const schemaChangeTelemetryEventName = "SchemaChangeApplied";
 
 describe("sharedTreeView", () => {
 	describe("Events", () => {
@@ -1593,6 +1598,78 @@ describe("sharedTreeView", () => {
 				unsubscribe();
 			});
 		}
+
+		itView("logs privacy-safe schema change telemetry", ({ view, logger }) => {
+			const initialEvents = logger
+				.events()
+				.filter((event) => event.eventName.endsWith(schemaChangeTelemetryEventName));
+			assert.deepEqual(
+				initialEvents.map((event) => event.changeKind),
+				[
+					tagCodeArtifacts({ changeKind: "initialize" }).changeKind,
+					tagCodeArtifacts({ changeKind: "restriction" }).changeKind,
+				],
+			);
+			const initializationEvent = initialEvents[0];
+			assert.deepEqual(
+				{
+					isInverse: initializationEvent.isInverse,
+					oldNodeSchemaCount: initializationEvent.oldNodeSchemaCount,
+					newNodeSchemaCount: initializationEvent.newNodeSchemaCount,
+					addedNodeSchemaCount: initializationEvent.addedNodeSchemaCount,
+					removedNodeSchemaCount: initializationEvent.removedNodeSchemaCount,
+				},
+				tagCodeArtifacts({
+					isInverse: false,
+					oldNodeSchemaCount: 0,
+					newNodeSchemaCount: view.checkout.storedSchema.nodeSchema.size,
+					addedNodeSchemaCount: view.checkout.storedSchema.nodeSchema.size,
+					removedNodeSchemaCount: 0,
+				}),
+			);
+
+			const oldSchema = view.checkout.storedSchema.clone();
+			const addedIdentifier = brand<TreeNodeSchemaIdentifier>("schema-change-telemetry-test");
+			view.checkout.updateSchema({
+				rootFieldSchema: oldSchema.rootFieldSchema,
+				nodeSchema: new Map([
+					...oldSchema.nodeSchema,
+					[addedIdentifier, new LeafNodeStoredSchema(ValueSchema.Boolean)],
+				]),
+			});
+
+			const schemaChangeEvents = logger
+				.events()
+				.filter((event) => event.eventName.endsWith(schemaChangeTelemetryEventName));
+			const upgradeEvent = schemaChangeEvents.at(-1);
+			assert(upgradeEvent !== undefined, "Expected schema change telemetry.");
+			assert.deepEqual(
+				{
+					changeKind: upgradeEvent.changeKind,
+					isInverse: upgradeEvent.isInverse,
+					isSharedBranch: upgradeEvent.isSharedBranch,
+					oldNodeSchemaCount: upgradeEvent.oldNodeSchemaCount,
+					newNodeSchemaCount: upgradeEvent.newNodeSchemaCount,
+					addedNodeSchemaCount: upgradeEvent.addedNodeSchemaCount,
+					removedNodeSchemaCount: upgradeEvent.removedNodeSchemaCount,
+					rootFieldKindChanged: upgradeEvent.rootFieldKindChanged,
+					oldRootAllowedTypeCount: upgradeEvent.oldRootAllowedTypeCount,
+					newRootAllowedTypeCount: upgradeEvent.newRootAllowedTypeCount,
+				},
+				tagCodeArtifacts({
+					changeKind: "upgrade",
+					isInverse: false,
+					isSharedBranch: view.checkout.isSharedBranch,
+					oldNodeSchemaCount: oldSchema.nodeSchema.size,
+					newNodeSchemaCount: oldSchema.nodeSchema.size + 1,
+					addedNodeSchemaCount: 1,
+					removedNodeSchemaCount: 0,
+					rootFieldKindChanged: false,
+					oldRootAllowedTypeCount: oldSchema.rootFieldSchema.types.size,
+					newRootAllowedTypeCount: oldSchema.rootFieldSchema.types.size,
+				}),
+			);
+		});
 	});
 
 	describe("throws an error if it is in the middle of an edit when a user attempts to", () => {

--- a/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
@@ -81,7 +81,6 @@ const rootField: NormalizedFieldUpPath = {
 };
 
 const enableSchemaValidation = true;
-const schemaChangeTelemetryEventName = "SchemaChangeApplied";
 
 describe("sharedTreeView", () => {
 	describe("Events", () => {
@@ -1602,7 +1601,9 @@ describe("sharedTreeView", () => {
 		itView("logs privacy-safe schema change telemetry", ({ view, logger }) => {
 			const initialEvents = logger
 				.events()
-				.filter((event) => event.eventName.endsWith(schemaChangeTelemetryEventName));
+				.filter((event) =>
+					event.eventName.endsWith(TreeCheckout.schemaChangeTelemetryEventName),
+				);
 			assert.deepEqual(
 				initialEvents.map((event) => event.changeKind),
 				[
@@ -1640,7 +1641,9 @@ describe("sharedTreeView", () => {
 
 			const schemaChangeEvents = logger
 				.events()
-				.filter((event) => event.eventName.endsWith(schemaChangeTelemetryEventName));
+				.filter((event) =>
+					event.eventName.endsWith(TreeCheckout.schemaChangeTelemetryEventName),
+				);
 			const upgradeEvent = schemaChangeEvents.at(-1);
 			assert(upgradeEvent !== undefined, "Expected schema change telemetry.");
 			assert.deepEqual(

--- a/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/treeCheckout.spec.ts
@@ -7,8 +7,8 @@ import { strict as assert } from "node:assert";
 
 import {
 	type IMockLoggerExt,
+	TelemetryDataTag,
 	createMockLoggerExt,
-	tagCodeArtifacts,
 } from "@fluidframework/telemetry-utils/internal";
 import { validateUsageError } from "@fluidframework/test-runtime-utils/internal";
 
@@ -81,6 +81,24 @@ const rootField: NormalizedFieldUpPath = {
 };
 
 const enableSchemaValidation = true;
+
+function parseCodeArtifactDetails(details: unknown): Record<string, unknown> {
+	assert(typeof details === "object" && details !== null, "Expected telemetry details.");
+	assert(
+		"tag" in details && details.tag === TelemetryDataTag.CodeArtifact,
+		"Expected details to be tagged as a code artifact.",
+	);
+	assert(
+		"value" in details && typeof details.value === "string",
+		"Expected details to contain a JSON string.",
+	);
+	const parsed: unknown = JSON.parse(details.value);
+	assert(
+		typeof parsed === "object" && parsed !== null && !Array.isArray(parsed),
+		"Expected details to contain a JSON object.",
+	);
+	return parsed as Record<string, unknown>;
+}
 
 describe("sharedTreeView", () => {
 	describe("Events", () => {
@@ -1604,29 +1622,29 @@ describe("sharedTreeView", () => {
 				.filter((event) =>
 					event.eventName.endsWith(TreeCheckout.schemaChangeTelemetryEventName),
 				);
-			assert.deepEqual(
-				initialEvents.map((event) => event.changeKind),
-				[
-					tagCodeArtifacts({ changeKind: "initialize" }).changeKind,
-					tagCodeArtifacts({ changeKind: "restriction" }).changeKind,
-				],
+			const initialDetails = initialEvents.map((event) =>
+				parseCodeArtifactDetails(event.details),
 			);
-			const initializationEvent = initialEvents[0];
+			assert.deepEqual(
+				initialDetails.map((details) => details.changeKind),
+				["initialize", "restriction"],
+			);
+			const initializationDetails = initialDetails[0];
 			assert.deepEqual(
 				{
-					isInverse: initializationEvent.isInverse,
-					oldNodeSchemaCount: initializationEvent.oldNodeSchemaCount,
-					newNodeSchemaCount: initializationEvent.newNodeSchemaCount,
-					addedNodeSchemaCount: initializationEvent.addedNodeSchemaCount,
-					removedNodeSchemaCount: initializationEvent.removedNodeSchemaCount,
+					isInverse: initializationDetails.isInverse,
+					oldNodeSchemaCount: initializationDetails.oldNodeSchemaCount,
+					newNodeSchemaCount: initializationDetails.newNodeSchemaCount,
+					addedNodeSchemaCount: initializationDetails.addedNodeSchemaCount,
+					removedNodeSchemaCount: initializationDetails.removedNodeSchemaCount,
 				},
-				tagCodeArtifacts({
+				{
 					isInverse: false,
 					oldNodeSchemaCount: 0,
 					newNodeSchemaCount: view.checkout.storedSchema.nodeSchema.size,
 					addedNodeSchemaCount: view.checkout.storedSchema.nodeSchema.size,
 					removedNodeSchemaCount: 0,
-				}),
+				},
 			);
 
 			const oldSchema = view.checkout.storedSchema.clone();
@@ -1646,32 +1664,18 @@ describe("sharedTreeView", () => {
 				);
 			const upgradeEvent = schemaChangeEvents.at(-1);
 			assert(upgradeEvent !== undefined, "Expected schema change telemetry.");
-			assert.deepEqual(
-				{
-					changeKind: upgradeEvent.changeKind,
-					isInverse: upgradeEvent.isInverse,
-					isSharedBranch: upgradeEvent.isSharedBranch,
-					oldNodeSchemaCount: upgradeEvent.oldNodeSchemaCount,
-					newNodeSchemaCount: upgradeEvent.newNodeSchemaCount,
-					addedNodeSchemaCount: upgradeEvent.addedNodeSchemaCount,
-					removedNodeSchemaCount: upgradeEvent.removedNodeSchemaCount,
-					rootFieldKindChanged: upgradeEvent.rootFieldKindChanged,
-					oldRootAllowedTypeCount: upgradeEvent.oldRootAllowedTypeCount,
-					newRootAllowedTypeCount: upgradeEvent.newRootAllowedTypeCount,
-				},
-				tagCodeArtifacts({
-					changeKind: "upgrade",
-					isInverse: false,
-					isSharedBranch: view.checkout.isSharedBranch,
-					oldNodeSchemaCount: oldSchema.nodeSchema.size,
-					newNodeSchemaCount: oldSchema.nodeSchema.size + 1,
-					addedNodeSchemaCount: 1,
-					removedNodeSchemaCount: 0,
-					rootFieldKindChanged: false,
-					oldRootAllowedTypeCount: oldSchema.rootFieldSchema.types.size,
-					newRootAllowedTypeCount: oldSchema.rootFieldSchema.types.size,
-				}),
-			);
+			assert.deepEqual(parseCodeArtifactDetails(upgradeEvent.details), {
+				changeKind: "upgrade",
+				isInverse: false,
+				isSharedBranch: view.checkout.isSharedBranch,
+				oldNodeSchemaCount: oldSchema.nodeSchema.size,
+				newNodeSchemaCount: oldSchema.nodeSchema.size + 1,
+				addedNodeSchemaCount: 1,
+				removedNodeSchemaCount: 0,
+				rootFieldKindChanged: false,
+				oldRootAllowedTypeCount: oldSchema.rootFieldSchema.types.size,
+				newRootAllowedTypeCount: oldSchema.rootFieldSchema.types.size,
+			});
 		});
 	});
 


### PR DESCRIPTION
## Description

Adds a `SchemaChangeApplied` telemetry event whenever SharedTree applies an effective schema transition. The event classifies initialization, upgrade, restriction, and rollback transitions and records privacy-safe structural metrics without logging schema payloads or identifiers.

All computed event properties are tagged as code artifacts. Tests cover required-root initialization, which applies an intermediate schema, and a compatible schema expansion.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Please review the event shape and the decision to emit once per applied schema inner-change, including intermediate initialization transitions.
