### PR TITLE
docs: define Under-Development Beta API policy

### DIFF
--- a/docs/content/Contributing/API-Deprecation.md
+++ b/docs/content/Contributing/API-Deprecation.md
@@ -36,6 +36,16 @@ When you deprecate a public or beta (including legacy) API:
 1. You _must_ introduce a [changeset](./Breaking-vs-Non-Breaking-Changes/Changesets.md) calling attention to the change (see also [changeset FAQ](./Breaking-vs-Non-Breaking-Changes/Changesets-FAQ.md)). If an issue was filed, you may keep changeset light and reference the issue.
    Otherwise, add details to the changeset.
 
+#### Under-Development Beta APIs
+
+An `@beta` API may be exempt from advance deprecation and communication when it is exposed only through a documented, feature-specific entrypoint under `/dev`, such as `@fluidframework/container-runtime/dev/version-mark`, and its absence is part of its compatibility contract.
+
+Such an API may be changed or removed without prior deprecation only in a release where Beta breaking changes are permitted.
+The breaking change must still be documented by a changeset and in the release notes.
+
+Once an API is exported from the standard `/beta` entrypoint, this exemption no longer applies.
+See [Under-Development Beta entrypoints](./Breaking-vs-Non-Breaking-Changes/Beta-Break-Process.md#under-development-beta-entrypoints) for the complete requirements.
+
 #### Creating a GitHub Issue
 
 For public client API, issue should be created as sub-issue of next major breaking changes issue, currently [Client 4.0 Breaking Changes](https://github.com/microsoft/FluidFramework/issues/27453).

--- a/docs/content/Contributing/Breaking-vs-Non-Breaking-Changes/Beta-Break-Process.md
+++ b/docs/content/Contributing/Breaking-vs-Non-Breaking-Changes/Beta-Break-Process.md
@@ -4,6 +4,35 @@ Beta and Legacy+Beta APIs are both used in production by partners and not settle
 They are supported under an agreement that allows them to be carefully changed ahead of major version bumps.
 **New deprecations** should follow [API Deprecation](../API-Deprecation.md) leveraging the table below to schedule removal.
 
+## Under-Development Beta entrypoints
+
+An API may be designated **Under-Development Beta** when it needs more stability than Alpha permits but is not ready for the standard `/beta` entrypoint.
+Under-Development Beta APIs follow the normal Beta breaking-change schedule but do not require advance deprecation or announcement.
+
+This exception applies only when:
+
+- The API is tagged `@beta`.
+- The API is exported only through a documented, feature-specific `/dev/<feature>` entrypoint, such as:
+
+    ```typescript
+    import { captureVersionMark } from "@fluidframework/container-runtime/dev/version-mark";
+    ```
+
+- The API is not also available from the package root or standard `/beta` entrypoint.
+- The capability is optional from a compatibility perspective: consumers must tolerate it being unavailable, and mixed-version interactions must continue to work without it.
+- The API documentation states that the API is Under-Development Beta and may be changed or removed at a Beta-breaking release without advance notice.
+
+Under-Development Beta APIs may be changed or removed at a Beta-breaking release without:
+
+- Publishing an earlier release that marks the API as deprecated.
+- Advance announcement through the Beta-break tracking process.
+- Providing a replacement API or migration path.
+
+The breaking change must still receive normal API review and be documented in a changeset and the release notes.
+Partner repositories must also be checked as part of release validation.
+
+Once an API is exported from the standard `/beta` entrypoint, this exception no longer applies and the API follows the ordinary Beta deprecation and communication process.
+
 ## To Create Issue for an **Existing** Deprecation
 
 _ONLY_ if the API deprecation does not have an issue per [API Deprecation](../API-Deprecation.md) (preferred), use these steps to track without duplicating a lot of information.


### PR DESCRIPTION
[How contribute to this repo](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).

[Guidelines for Pull Requests](../docs/content/Contributing/PR-Guidelines.md#guidelines).

## Description

Define an Under-Development Beta category for APIs that need Beta compatibility between breaking releases but are not ready for the standard \`/beta\` entrypoint.

Under-Development Beta APIs must be exposed through a documented, feature-specific \`/dev/<feature>\` entrypoint and remain optional for compatibility. They may be changed or removed at a Beta-breaking release without advance deprecation, announcement, replacement, or migration guidance. Normal API review, changesets, release notes, and partner validation remain required.

The policy also clarifies that exporting an API through the standard \`/beta\` entrypoint ends this exception.

## Reviewer Guidance

The review process is outlined in [the pull request guidelines](../docs/content/Contributing/PR-Guidelines.md#guidelines).

Please review whether the eligibility requirements preserve the expected stability of ordinary Beta APIs while allowing under-development features to iterate without the full advance deprecation process.