### PR TITLE
fix(build-cli): accept partially successful bundle builds

### DIFF
--- a/.github/workflows/pr-bundle-size-comments.yml
+++ b/.github/workflows/pr-bundle-size-comments.yml
@@ -416,17 +416,21 @@ jobs:
               throw new Error("ADO PR build lookup returned no build list");
             }
 
-            // The response is newest-first. Match flub's selection by retaining the first
-            // completed, successful PR build with an id for each PR HEAD.
+            // Match flub's selection by retaining the newest completed PR build with an id for
+            // each PR HEAD. Prefer fully successful builds, then fall back to partially successful
+            // builds whose bundle artifact flub will validate before using.
             const retainedPrBuildByHeadSha = new Map();
             for (const prBuild of adoPrBuilds) {
               const prHeadSha = prBuild.triggerInfo?.["pr.sourceSha"];
+              const currentlyRetainedBuild = retainedPrBuildByHeadSha.get(prHeadSha);
               if (
                 prHeadSha &&
-                !retainedPrBuildByHeadSha.has(prHeadSha) &&
                 prBuild.id !== undefined &&
                 prBuild.status === "completed" &&
-                prBuild.result === "succeeded"
+                ["succeeded", "partiallySucceeded"].includes(prBuild.result) &&
+                (currentlyRetainedBuild === undefined ||
+                  (currentlyRetainedBuild.result === "partiallySucceeded" &&
+                    prBuild.result === "succeeded"))
               ) {
                 retainedPrBuildByHeadSha.set(prHeadSha, prBuild);
               }

--- a/build-tools/packages/build-cli/src/library/azureDevops/getArtifactForCommit.ts
+++ b/build-tools/packages/build-cli/src/library/azureDevops/getArtifactForCommit.ts
@@ -49,9 +49,9 @@ function buildMatches(b: Build, match: BuildMatch): boolean {
  * Failure variants shared by {@link FindBuildResult} and {@link GetArtifactForCommitResult}.
  *
  * - `no-build`: no candidate builds matched the SHA — too stale, or never queued.
- * - `in-progress`: at least one candidate is actively running (NotStarted / InProgress / Postponed) and none have succeeded yet. Retrying later may help.
- * - `all-failed`: every candidate completed but none succeeded.
- * - `no-id`: at least one candidate Succeeded but is missing an `id` — an ADO state anomaly that shouldn't happen in practice.
+ * - `in-progress`: at least one candidate is actively running (NotStarted / InProgress / Postponed) and none are usable yet. Retrying later may help.
+ * - `all-failed`: every candidate completed but none succeeded or partially succeeded.
+ * - `no-id`: at least one candidate succeeded or partially succeeded but is missing an `id` — an ADO state anomaly that shouldn't happen in practice.
  */
 export type ArtifactLookupFailure =
 	| { kind: "no-build" }
@@ -63,29 +63,34 @@ export type ArtifactLookupFailure =
  * Outcome of looking up a build for a {@link BuildMatch}. `completed` carries the id of the usable
  * build and the commit it checked out; the failure variants are {@link ArtifactLookupFailure}.
  */
-type FindBuildResult =
+export type FindBuildResult =
 	| { kind: "completed"; buildId: number; sourceVersion: string | undefined }
 	| ArtifactLookupFailure;
 
 /**
  * Find a usable build matching `match` — one with an id, status Completed,
- * and result Succeeded. Scans all matches (a SHA can map to multiple builds
- * via re-runs/retries), not just the first. Prioritizes "still running" over
- * "all failed" in the failure cases since retrying later may help.
+ * and result Succeeded or PartiallySucceeded. Scans all matches (a SHA can
+ * map to multiple builds via re-runs/retries), not just the first. Fully
+ * successful builds are preferred over partially successful builds, whose
+ * required artifact is still validated by the download and parsing paths.
+ * Prioritizes "still running" over "all failed" in the failure cases since
+ * retrying later may help.
  */
-function findBuild(builds: Build[], match: BuildMatch): FindBuildResult {
+export function findBuild(builds: Build[], match: BuildMatch): FindBuildResult {
 	const candidates = builds.filter((b) => buildMatches(b, match));
 
 	if (candidates.length === 0) {
 		return { kind: "no-build" };
 	}
 
-	const usable = candidates.find(
-		(b): b is Build & { id: number } =>
-			b.id !== undefined &&
-			b.status === BuildStatus.Completed &&
-			b.result === BuildResult.Succeeded,
-	);
+	const findCompletedBuild = (result: BuildResult): (Build & { id: number }) | undefined =>
+		candidates.find(
+			(b): b is Build & { id: number } =>
+				b.id !== undefined && b.status === BuildStatus.Completed && b.result === result,
+		);
+	const usable =
+		findCompletedBuild(BuildResult.Succeeded) ??
+		findCompletedBuild(BuildResult.PartiallySucceeded);
 	if (usable !== undefined) {
 		return { kind: "completed", buildId: usable.id, sourceVersion: usable.sourceVersion };
 	}
@@ -100,11 +105,13 @@ function findBuild(builds: Build[], match: BuildMatch): FindBuildResult {
 	if (candidates.some(isActivelyRunning)) {
 		return { kind: "in-progress" };
 	}
-	if (candidates.every((b) => b.result !== BuildResult.Succeeded)) {
+	const isAcceptableResult = (b: Build): boolean =>
+		b.result === BuildResult.Succeeded || b.result === BuildResult.PartiallySucceeded;
+	if (candidates.every((b) => !isAcceptableResult(b))) {
 		return { kind: "all-failed" };
 	}
-	// At least one candidate Succeeded but is missing an `id` — an ADO state
-	// anomaly that shouldn't happen, but `id` is typed `number | undefined`.
+	// At least one candidate succeeded or partially succeeded but is missing an
+	// `id` — an ADO state anomaly, but `id` is typed `number | undefined`.
 	return { kind: "no-id" };
 }
 
@@ -180,9 +187,9 @@ export function describeArtifactFailure(
 		case "no-build":
 			return `No build found for ${subject}.`;
 		case "in-progress":
-			return `Found an in-progress build for ${subject}; none have succeeded yet.`;
+			return `Found an in-progress build for ${subject}; none are usable yet.`;
 		case "all-failed":
-			return `All builds for ${subject} have completed but none succeeded.`;
+			return `All builds for ${subject} have completed but none succeeded or partially succeeded.`;
 		case "no-id":
 			return `No build for ${subject} has a usable build id.`;
 		default:

--- a/build-tools/packages/build-cli/src/test/library/azureDevops/getArtifactForCommit.test.ts
+++ b/build-tools/packages/build-cli/src/test/library/azureDevops/getArtifactForCommit.test.ts
@@ -1,0 +1,79 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import type { Build } from "azure-devops-node-api/interfaces/BuildInterfaces.js";
+import { BuildResult, BuildStatus } from "azure-devops-node-api/interfaces/BuildInterfaces.js";
+import { assert } from "chai";
+import { describe, it } from "mocha";
+
+import { findBuild } from "../../../library/azureDevops/getArtifactForCommit.js";
+
+const headSha = "pr-head";
+const match = { kind: "prHead", sha: headSha } as const;
+
+function makeBuild(overrides: Partial<Build> = {}): Build {
+	const build: Build & { triggerInfo: Record<string, string> } = {
+		id: 1,
+		status: BuildStatus.Completed,
+		result: BuildResult.Succeeded,
+		sourceVersion: "merge-commit",
+		triggerInfo: { "pr.sourceSha": headSha },
+		...overrides,
+	};
+	return build;
+}
+
+describe("azureDevops/getArtifactForCommit", () => {
+	it("accepts a partially successful build", () => {
+		const result = findBuild(
+			[makeBuild({ id: 2, result: BuildResult.PartiallySucceeded })],
+			match,
+		);
+
+		assert.deepEqual(result, {
+			kind: "completed",
+			buildId: 2,
+			sourceVersion: "merge-commit",
+		});
+	});
+
+	it("prefers a fully successful build over a newer partially successful build", () => {
+		const result = findBuild(
+			[
+				makeBuild({
+					id: 2,
+					result: BuildResult.PartiallySucceeded,
+					sourceVersion: "newer-partial",
+				}),
+				makeBuild({ id: 1, sourceVersion: "older-success" }),
+			],
+			match,
+		);
+
+		assert.deepEqual(result, {
+			kind: "completed",
+			buildId: 1,
+			sourceVersion: "older-success",
+		});
+	});
+
+	it("reports all failed when no build succeeded or partially succeeded", () => {
+		const result = findBuild(
+			[makeBuild({ result: BuildResult.Failed }), makeBuild({ result: BuildResult.Canceled })],
+			match,
+		);
+
+		assert.deepEqual(result, { kind: "all-failed" });
+	});
+
+	it("reports a missing id for a partially successful build", () => {
+		const result = findBuild(
+			[makeBuild({ id: undefined, result: BuildResult.PartiallySucceeded })],
+			match,
+		);
+
+		assert.deepEqual(result, { kind: "no-id" });
+	});
+});


### PR DESCRIPTION
## Description

Bundle-size comparisons currently reject Azure DevOps builds with a `partiallySucceeded` result even when they published valid bundle analyzer artifacts. This can prevent an otherwise valid comparison when an unrelated pipeline step fails.

This occurred for [PR #27815](https://github.com/microsoft/FluidFramework/pull/27815). Its [ADO PR build 417895](https://dev.azure.com/fluidframework/public/_build/results?buildId=417895) was marked `partiallySucceeded` because an unrelated Defender signature-update step failed, but both that build and baseline build 417887 published valid `bundleAnalyzerJson` artifacts. Using those artifacts produced a valid comparison.

Accept completed, partially successful builds as a fallback while continuing to prefer fully successful builds. The baseline-completion fan-out workflow uses the same preference when matching PR builds. Artifact download and analyzer parsing still validate that the required output is usable.

Focused tests cover accepting partial success, preferring full success, rejecting failed builds, and handling missing build IDs.

Fixes [AB#80734](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/80734).

## Reviewer Guidance

The review process is outlined in [the pull request guidelines](../docs/content/Contributing/PR-Guidelines.md#guidelines).

Please verify that the build-selection priority remains consistent between `getArtifactForCommit` and the baseline fan-out workflow.