### PR TITLE
docs: document client package publish pipeline

### DIFF
--- a/.claude/skills/fluid-release/SKILL.md
+++ b/.claude/skills/fluid-release/SKILL.md
@@ -34,7 +34,7 @@ Requirements:
 
 - **Version info upfront:** The user must provide all version numbers before starting (current release version and/or next version, depending on phase). Do not prompt for versions mid-flow. If the user doesn't provide versions, detect them from the schedule and repo state (see below).
 - **No confirmation pauses:** Create PRs, push branches, and run `flub release` without asking. Include clear commit messages and PR descriptions.
-- **Phase-scoped execution:** Each phase runs to completion, then reports what the user needs to do next (e.g., "queue the ADO build" or "wait for npm feeds, then re-invoke for type test updates").
+- **Phase-scoped execution:** Each phase runs to completion, then reports what the user needs to do next (e.g., "queue the ADO release build", "queue the ADO publish pipeline", or "wait for npm feeds, then re-invoke for type test updates").
 - **Fallback to issues:** If any step fails (permission errors, CI-safe command failures, git push rejected, or any other error that prevents progress), **stop and open a GitHub issue** in `microsoft/FluidFramework` describing what was completed, what failed, and what remains. Use the title format `Release <VERSION>: <brief description>` and label it with `release-blocking`. Include the exact commands remaining so a human can finish using the skill in interactive mode.
 
 #### Auto-detecting release state (autonomous mode and CI)
@@ -65,14 +65,22 @@ git tag -l 'client_v<NEXT_VERSION>'
 gh pr list --repo microsoft/FluidFramework --search "release-prep/<NEXT_VERSION>" --state all
 ```
 
+For a release branch with no completed release, also inspect ADO pipeline state:
+
+1. Find the **Build - client packages** (definition 12) run for the release branch tip with `releaseBuildOverride: release`.
+2. If that run succeeded, find the **Publish - client packages** (definition 219) run that selected it as the `candidate` and used `publishToPublicNpm: true`.
+3. If ADO pipeline state cannot be queried, do not infer which action is next. Report that a human must identify whether the release build or publish pipeline has completed.
+
 **Step 4: Determine the phase and act.**
 
 | State | Action |
 |-------|--------|
 | No release-prep branches, no release branch | Start **minor release prep** (Steps 1-5) |
 | Release-prep branches/PRs exist, some not merged | Resume **minor release prep** from where it left off |
-| Release branch exists, no release tag | Start **release execution** (Steps 6-7). In CI: the human must queue the ADO build. |
-| Release tag exists, no patch bump PR | Resume **release execution** — do the patch bump (Step 7) |
+| Release branch exists, no successful release build | Resume **release execution** — queue the ADO release build |
+| Successful release build exists, no successful public publish run | Resume **release execution** — queue the ADO publish pipeline using that build as the candidate |
+| Successful public publish run exists, exact GitHub/npm release not yet available | Wait for publication to propagate; investigate the publish run if it does not appear |
+| Exact GitHub/npm release verified, no patch bump PR | Resume **release execution** — do the patch bump (Step 7) |
 | Release tag exists, patch bump done, no type test PRs | Start **type test updates** (Steps 8-9) |
 | All phases complete | Report that the release is fully done and show the next scheduled release |
 
@@ -92,7 +100,7 @@ Ask the user which phase they need (or auto-detect in autonomous mode — see ab
 | Phase | When to use | CI-automatable? | Reference |
 |-------|-------------|-----------------|-----------|
 | **Minor release prep** | Starting a new minor release from `main` (Steps 1-5) | Yes (Steps 1-4 create PRs; Step 5 is a human step) | [minor-release-prep.md](references/minor-release-prep.md) |
-| **Release execution** | Running the release build + patch bump (Steps 6-7). Also used for **patch releases** on existing branches. | Partially (Step 6 = human queues ADO build; Step 7 = CI-automatable) | [release-execution.md](references/release-execution.md) |
+| **Release execution** | Running and publishing the release build + patch bump (Steps 6-7). Also used for **patch releases** on existing branches. | Partially (Step 6 = human queues ADO build and publish pipelines; Step 7 = CI-automatable) | [release-execution.md](references/release-execution.md) |
 | **Type test updates** | Day after release: update baselines on main and release branch (Steps 8-9) | Yes (must be resilient to failure if npm packages not yet available) | [type-test-updates.md](references/type-test-updates.md) |
 
 For **patch releases**, skip directly to release execution on an existing release branch.
@@ -104,7 +112,8 @@ These steps require human action and should be clearly reported in CI workflow l
 1. **Merge release-prep PRs** in the correct order (version bump last) after CI creates them
 2. **Create the release branch** (Step 5) — requires elevated permissions on the `release/` branch prefix
 3. **Queue the ADO release build** (Step 6) — choose the "release" option in ADO
-4. **Announce the release** in the Fluid Framework "General" Teams channel
+4. **Queue the ADO publish pipeline** (Step 6) — after the release build succeeds, select it as the candidate and enable public npm publication
+5. **Announce the release** in the Fluid Framework "General" Teams channel
 
 ## Key Context
 
@@ -192,7 +201,7 @@ Use the `build:` conventional commit prefix for all release PR titles (e.g., `bu
 | Running `flub release` | Pause and confirm | Run automatically |
 | Version determination | Ask user to confirm | Use version provided upfront or auto-detect |
 | Announcing releases | Remind user | Remind user (never auto-announce) |
-| ADO build queuing | Instruct user | Instruct user (cannot be automated) |
+| ADO release/publish pipeline queuing | Instruct user | Instruct user (cannot be automated) |
 
 ### Autonomous Mode: Phase Completion Reports
 

--- a/.claude/skills/fluid-release/references/release-execution.md
+++ b/.claude/skills/fluid-release/references/release-execution.md
@@ -55,7 +55,7 @@ Follow the tool's interactive prompts. The user will need to queue the ADO build
 
 **Autonomous mode:** After running `flub release`, report:
 
-> **Action required:** Queue [Build - client packages](https://dev.azure.com/fluidframework/internal/_build?definitionId=12) for the release branch and choose the "release" option. After it succeeds, queue the publish pipeline as described below.
+> **Action required:** Queue [Build - client packages](https://dev.azure.com/fluidframework/internal/_build?definitionId=12) for the release branch and choose the "release" option for the "Release Build" parameter. After it succeeds, queue the publish pipeline as described below.
 
 ### Publish the successful candidate build
 

--- a/.claude/skills/fluid-release/references/release-execution.md
+++ b/.claude/skills/fluid-release/references/release-execution.md
@@ -1,24 +1,24 @@
 # Release Execution (Steps 6-7)
 
-Run the release build and bump the release branch to the next patch version. This applies to both minor (X.X0.0) and patch releases.
+Run and publish the release build, then bump the release branch to the next patch version. This applies to both minor (X.X0.0) and patch releases.
 
 ## Autonomous Mode Notes
 
-In autonomous mode, run all commands without pausing. The user must still manually queue the ADO build — report this clearly at the end. Create the patch bump PR automatically.
+In autonomous mode, run all commands without pausing. The user must still manually queue the ADO release build and, after it succeeds, the ADO publish pipeline — report both actions clearly. Create the patch bump PR automatically after publication is verified.
 
 If any step fails, fall back to opening a GitHub issue describing what was completed, what failed, and the remaining steps with exact commands. Label with `release-blocking`.
 
 ## CI Note
 
-In CI, this phase is split into two parts separated by a human action:
-- **Step 6 (human):** A human queues the ADO release build and creates the release branch if needed.
+In CI, this phase is split into two parts separated by human actions:
+- **Step 6 (human):** A human creates the release branch if needed, queues the ADO release build, then queues the ADO publish pipeline after the build succeeds.
 - **Step 7 (automatable):** CI creates the patch bump PR after the release tag exists.
 
 CI should auto-detect which step is needed (see SKILL.md auto-detection logic).
 
-## Step 6: Run the Release Build
+## Step 6: Run and Publish the Release Build
 
-**CI note:** This step requires a human to queue the ADO build. In CI, check for the release tag. If it doesn't exist, report that the human needs to queue the ADO build and stop.
+**CI note:** This step requires a human to queue both ADO pipelines. Inspect ADO run state to determine whether the release build or publish pipeline is next. If ADO state cannot be queried, report that a human must identify the current checkpoint; do not infer it from tag absence alone.
 
 ### Switch to the release branch
 
@@ -55,19 +55,46 @@ Follow the tool's interactive prompts. The user will need to queue the ADO build
 
 **Autonomous mode:** After running `flub release`, report:
 
-> **Action required:** Queue the release build in ADO (choose the "release" option). After the build completes, a downstream publishing pipeline will publish the packages. Verify the release appears in GitHub releases and on npm, then re-invoke for the patch bump.
+> **Action required:** Queue [Build - client packages](https://dev.azure.com/fluidframework/internal/_build?definitionId=12) for the release branch and choose the "release" option. After it succeeds, queue the publish pipeline as described below.
+
+### Publish the successful candidate build
+
+After the release build succeeds, manually queue [Publish - client packages](https://dev.azure.com/fluidframework/internal/_build?definitionId=219):
+
+1. Select the successful **Build - client packages** release build from the previous step as the `candidate` pipeline resource.
+2. Enable **Publish to public npmjs.org** (`publishToPublicNpm: true`).
+3. Queue the publish run and wait for it to succeed.
+
+Before queueing, verify the candidate build used the expected `release/client/<MAJOR>.<MINOR>` branch and release commit. If the publish pipeline fails, stop and triage that run; do not proceed to verification or queue another candidate blindly.
+
+Do not assume that a successful release build automatically publishes packages. Do not proceed to release verification or the patch bump until the publish pipeline succeeds.
+
+**Autonomous mode:** After the release build succeeds, report:
+
+> **Action required:** Queue [Publish - client packages](https://dev.azure.com/fluidframework/internal/_build?definitionId=219), select release build `<BUILD_ID>` as the candidate, and enable **Publish to public npmjs.org**. After the publish run succeeds, verify GitHub and npm publication, then re-invoke for the patch bump.
 
 ### Verify the release
 
-After the build completes, confirm:
-- Listed in [GitHub releases](https://github.com/microsoft/FluidFramework/releases)
-- Published on [npm](https://www.npmjs.com/search?q=%40fluidframework)
+After the publish pipeline succeeds, verify the exact version:
+
+```bash
+gh release view client_v<VERSION> --repo microsoft/FluidFramework
+pnpm view @fluidframework/container-loader@<VERSION> version --registry=https://registry.npmjs.org/
+```
+
+Confirm the GitHub tag and npm result both match the version published by the selected candidate build. Checking a generic releases page or npm search is insufficient because an older release can make those checks appear successful.
 
 Once confirmed, remind the user to announce the release in the Fluid Framework "General" Teams channel with a link to the GitHub release. (Never auto-announce in either mode.)
 
 ## Step 7: Bump Release Branch to Next Patch
 
-Wait for the release tag to be added to the repo, then either:
+Do not start Step 7 until all of the following are true:
+
+- The **Publish - client packages** run succeeded with the expected candidate and `publishToPublicNpm: true`.
+- The exact `client_v<VERSION>` GitHub release exists.
+- The exact `<VERSION>` package is available from the public npm registry.
+
+Then either:
 
 ### Option A: Use flub release again (local only)
 
@@ -101,6 +128,7 @@ For the first release of a new minor (X.X0.0), this PR can optionally be combine
 
 > **Phase complete.**
 > - Patch bump PR created: [link]
-> - **Next step:** After the release is verified on GitHub/npm, announce it in Teams. Then wait until tomorrow for npm feeds to update, and re-invoke for type test updates.
+> - Release `<VERSION>` was verified on GitHub and public npm before the patch bump.
+> - **Next step:** Announce it in Teams. Then wait until tomorrow for npm feeds to update, and re-invoke for type test updates.
 
 After the release, proceed to [type test updates](type-test-updates.md) **the next day**.


### PR DESCRIPTION
## Description

Updates the client release skill to document the required manual publish step after a successful release build.

The guidance now:

- Distinguishes the Build - client packages and Publish - client packages pipelines.
- Requires selecting the successful release build as the publish candidate and enabling public npm publication.
- Uses ADO run state to identify the next release action instead of inferring it from tag absence.
- Blocks the patch bump until the exact GitHub release and public npm package version are verified.

## Reviewer Guidance

The review process is outlined in [the pull request guidelines](https://github.com/microsoft/FluidFramework/blob/main/docs/content/Contributing/PR-Guidelines.md#guidelines).

This is a documentation-only update based on the client 2.116.0 release workflow.
