### PR TITLE
fix(external-data): fix flaky webhook relay tests using fixed delays

### DIFF
--- a/examples/external-data/src/test/customerService.test.ts
+++ b/examples/external-data/src/test/customerService.test.ts
@@ -18,7 +18,7 @@ import {
 import { externalDataServicePort } from "../mock-external-data-service-interface/index.js";
 import type { ITaskData } from "../model-interface/index.js";
 
-import { closeServer, delay } from "./utilities.js";
+import { closeServer, delay, waitForCondition } from "./utilities.js";
 
 const localServicePort = 5002;
 const externalTaskListId = "task-list-1";
@@ -175,7 +175,10 @@ describe("mock-customer-service", () => {
 
 	// We have omitted `@types/supertest` due to cross-package build issue.
 	// So for these tests we have to live with `any`.
-	it("register-for-webhook: Complete data flow", async () => {
+	it("register-for-webhook: Complete data flow", async function () {
+		// waitForCondition's internal timeout can exceed mocha's default per-test timeout;
+		// give this test enough headroom to let waitForCondition fail on its own terms.
+		this.timeout(10000);
 		// Set up mock local service, which will be registered as webhook listener
 		const localServiceApp = initializeMockFluidService(express());
 		const tenantId = "tinylicious";
@@ -217,8 +220,10 @@ describe("mock-customer-service", () => {
 			const dataUpdateResponse = await updateExternalData(taskDataUpdate, externalTaskListId);
 			assert.equal(dataUpdateResponse.status, 200);
 
-			// Delay for a bit to ensure time enough for our webhook listener to have been called.
-			await delay(1000);
+			// Wait for our webhook listener to have been called. The notification is relayed
+			// asynchronously (fire-and-forget) across multiple service hops, so a fixed delay is
+			// not reliable under load; poll for the flag instead.
+			await waitForCondition(() => wasFluidNotifiedForChange);
 
 			// 4. Verify our listener was notified of data change.
 			assert.equal(wasFluidNotifiedForChange, true);
@@ -229,7 +234,10 @@ describe("mock-customer-service", () => {
 	});
 	/* eslint-enable @typescript-eslint/no-non-null-assertion */
 
-	it("register-session-url: Complete data flow", async () => {
+	it("register-session-url: Complete data flow", async function () {
+		// waitForCondition's internal timeout can exceed mocha's default per-test timeout;
+		// give this test enough headroom to let waitForCondition fail on its own terms.
+		this.timeout(10000);
 		// Set up mock local Fluid service, which will be registered as webhook listener
 		const localServiceApp = initializeMockFluidService(express());
 		const tenantId = "tinylicious";
@@ -267,8 +275,10 @@ describe("mock-customer-service", () => {
 				console.log(`Data update failed. Code: ${dataUpdateResponse.status}`);
 			}
 
-			// Delay for a bit to ensure time enough for our webhook listener to have been called.
-			await delay(1000);
+			// Wait for our webhook listener to have been called. The notification is relayed
+			// asynchronously (fire-and-forget) across multiple service hops, so a fixed delay is
+			// not reliable under load; poll for the notification instead.
+			await waitForCondition(() => webhookChangeNotification !== undefined);
 
 			// Verify our listener was notified of data change.
 			assertWebhookChangeNotification(webhookChangeNotification);
@@ -316,8 +326,10 @@ describe("mock-customer-service", () => {
 			const dataUpdateResponse = await updateExternalData(taskDataUpdate, externalTaskListId);
 			assert.equal(dataUpdateResponse.status, 200);
 
-			// Delay for a bit to ensure time enough for our webhook listener to have been called.
-			await delay(1000);
+			// Wait for our webhook listener to have been called. The notification is relayed
+			// asynchronously (fire-and-forget) across multiple service hops, so a fixed delay is
+			// not reliable under load; poll for the notification instead.
+			await waitForCondition(() => webhookChangeNotification !== undefined);
 
 			// Verify our listener was notified of data change.
 			assertWebhookChangeNotification(webhookChangeNotification);

--- a/examples/external-data/src/test/externalDataService.test.ts
+++ b/examples/external-data/src/test/externalDataService.test.ts
@@ -18,7 +18,7 @@ import {
 import { externalDataServicePort } from "../mock-external-data-service-interface/index.js";
 import { type ITaskData, assertValidTaskData } from "../model-interface/index.js";
 
-import { closeServer, delay } from "./utilities.js";
+import { closeServer, waitForCondition } from "./utilities.js";
 
 const externalTaskListId = "task-list-1";
 
@@ -246,7 +246,10 @@ describe("mock-external-data-service: webhook", () => {
 		await closeServer(_externalDataService);
 	});
 
-	it("register-for-webhook", async () => {
+	it("register-for-webhook", async function () {
+		// waitForCondition's internal timeout can exceed mocha's default per-test timeout;
+		// give this test enough headroom to let waitForCondition fail on its own terms.
+		this.timeout(10000);
 		// Set up mock local service, which will be registered as webhook listener
 		const localServicePort = 5002;
 		const localServiceApp = express();
@@ -311,8 +314,9 @@ describe("mock-external-data-service: webhook", () => {
 				`Data update failed. Code: ${dataUpdateResponse.status}.`,
 			);
 
-			// Delay for a bit to ensure time enough for our webhook listener to have been called.
-			await delay(1000);
+			// Notification is relayed asynchronously (fire-and-forget), so a fixed delay is not
+			// reliable under load; poll for the flag instead.
+			await waitForCondition(() => wasHookNotifiedForChange);
 
 			// Verify our listener was notified of data change.
 			assert.equal(wasHookNotifiedForChange, true);

--- a/examples/external-data/src/test/utilities.ts
+++ b/examples/external-data/src/test/utilities.ts
@@ -27,3 +27,32 @@ export async function closeServer(server: Server): Promise<void> {
  */
 export const delay = async (timeMs: number): Promise<void> =>
 	new Promise((resolve) => setTimeout(() => resolve(), timeMs));
+
+/**
+ * Polls `condition` at `pollIntervalMs` intervals until it returns `true`, or until `timeoutMs`
+ * has elapsed, in which case an error is thrown.
+ *
+ * @remarks
+ * Useful for waiting on the completion of async, out-of-band side effects (e.g. webhook
+ * notifications delivered via a chain of unawaited `fetch` calls) that don't offer a promise to
+ * await directly. Prefer this over a fixed `delay`, since a fixed delay is either a source of
+ * flakiness (too short under load) or wasted test time (too long to be safe).
+ *
+ * @param condition - Function polled until it returns `true`.
+ * @param timeoutMs - Maximum time in milliseconds to wait for `condition` to become `true`.
+ * @param pollIntervalMs - Interval in milliseconds between polls of `condition`.
+ * @internal
+ */
+export const waitForCondition = async (
+	condition: () => boolean,
+	timeoutMs: number = 5000,
+	pollIntervalMs: number = 50,
+): Promise<void> => {
+	const startTime = Date.now();
+	while (!condition()) {
+		if (Date.now() - startTime >= timeoutMs) {
+			throw new Error(`Condition was not satisfied within ${timeoutMs}ms timeout.`);
+		}
+		await delay(pollIntervalMs);
+	}
+};

--- a/examples/external-data/src/test/utilities.ts
+++ b/examples/external-data/src/test/utilities.ts
@@ -51,6 +51,11 @@ export const waitForCondition = async (
 	const startTime = Date.now();
 	while (!condition()) {
 		if (Date.now() - startTime >= timeoutMs) {
+			// Final check in case `condition` flipped to true between the loop check above and
+			// this timeout check, to avoid spuriously throwing right at the timeout boundary.
+			if (condition()) {
+				return;
+			}
 			throw new Error(`Condition was not satisfied within ${timeoutMs}ms timeout.`);
 		}
 		await delay(pollIntervalMs);


### PR DESCRIPTION
## Description

Fixes intermittent CI failures in `examples/external-data` tests, e.g. `register-session-url: Complete data flow`, `register-for-webhook: Complete data flow`/`register-for-webhook` (seen in both public PR builds and internal ADO CI — e.g. build 418109 / build 418015).

Root cause: `MockWebhook.notifySubscribers` and `echoExternalDataWebhookToFluid` relay webhook notifications as fire-and-forget (`fetch(...).catch(...)`, unawaited). Several tests waited a fixed `delay(1000)` before asserting the notification arrived — under CI load/slowness this isn't always enough time, causing races (`TypeError: Cannot read properties of undefined (reading 'signalContent')`, or `wasFluidNotifiedForChange`/`wasHookNotifiedForChange` assertion failures).

Fix: added a `waitForCondition(condition, timeoutMs, pollIntervalMs)` polling helper in `src/test/utilities.ts` and replaced the fixed `delay(1000)` + assert pattern with it in the three affected tests (`customerService.test.ts`: `register-for-webhook`, `register-session-url`; `externalDataService.test.ts`: `register-for-webhook`). Also bumped `this.timeout(...)` on these tests since `waitForCondition`'s internal timeout budget can exceed mocha's default per-test timeout.

**Repro/verification:** Reproduced the failures reliably by temporarily injecting an artificial delay (via a local-only env var) into both fire-and-forget relay hops. At 2x the original fixed wait (2000ms), the original code failed consistently with the same errors seen in CI; with this fix applied, 5 consecutive runs at the same simulated delay all passed with zero failures. A normal (no injected delay) run remains fast (~300ms total).

## Reviewer Guidance

The review process is outlined in [the pull request guidelines](../docs/content/Contributing/PR-Guidelines.md#guidelines).