### PR TITLE
fix(container-loader): Include websocket ops in captureFullContainerState

### DIFF
--- a/.changeset/fresh-deltas-capture.md
+++ b/.changeset/fresh-deltas-capture.md
@@ -1,0 +1,8 @@
+---
+"@fluidframework/container-loader": minor
+"__section": fix
+---
+Full container state capture now includes recently sequenced operations
+
+`captureFullContainerState` now connects to the delta stream and catches up through the latest operation known when the connection is established.
+This prevents captured state from omitting operations that have been broadcast over the websocket but have not yet reached delta storage.

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -111,7 +111,7 @@ import {
 	runRetriableAttachProcess,
 } from "./attachment.js";
 import { Audience } from "./audience.js";
-import { ConnectionManager } from "./connectionManager.js";
+import type { ConnectionManager } from "./connectionManager.js";
 import { ConnectionState } from "./connectionState.js";
 import {
 	type IConnectionStateHandler,
@@ -121,12 +121,12 @@ import { ContainerContext } from "./containerContext.js";
 import { ContainerStorageAdapter } from "./containerStorageAdapter.js";
 import {
 	type IConnectionDetailsInternal,
-	type IConnectionManagerFactoryArgs,
 	type IConnectionStateChangeReason,
 	ReconnectMode,
 	getPackageName,
 } from "./contracts.js";
-import { DeltaManager, type IConnectionArgs } from "./deltaManager.js";
+import type { DeltaManager, IConnectionArgs } from "./deltaManager.js";
+import { createDeltaManager } from "./deltaManagerFactory.js";
 import type { ILoaderServices } from "./loader.js";
 import { RelativeLoader } from "./loader.js";
 import {
@@ -2021,21 +2021,15 @@ export class Container
 		const serviceProvider = (): IDocumentService | undefined => this.service;
 		const disableLoadConnectionRetries =
 			this.mc.config.getBoolean("Fluid.Container.DisableLoadConnectionRetries") === true;
-		const deltaManager = new DeltaManager<ConnectionManager>(
+		const deltaManager = createDeltaManager({
 			serviceProvider,
-			createChildLogger({ logger: this.subLogger, namespace: "DeltaManager" }),
-			() => this.activeConnection(),
-			(props: IConnectionManagerFactoryArgs) =>
-				new ConnectionManager(
-					serviceProvider,
-					() => this.isDirty,
-					this.client,
-					this._canReconnect,
-					createChildLogger({ logger: this.subLogger, namespace: "ConnectionManager" }),
-					props,
-					disableLoadConnectionRetries ? 1 : undefined /* maxInitialConnectionAttempts */,
-				),
-		);
+			logger: this.subLogger,
+			active: () => this.activeConnection(),
+			containerDirty: () => this.isDirty,
+			client: this.client,
+			reconnectAllowed: this._canReconnect,
+			maxInitialConnectionAttempts: disableLoadConnectionRetries ? 1 : undefined,
+		});
 
 		// Disable inbound queues as Container is not ready to accept any ops until we are fully loaded!
 		// eslint-disable-next-line @typescript-eslint/no-floating-promises

--- a/packages/loader/container-loader/src/createAndLoadContainerUtils.ts
+++ b/packages/loader/container-loader/src/createAndLoadContainerUtils.ts
@@ -545,6 +545,7 @@ export interface ICaptureFullContainerStateProps {
  * is a known consumer and end-to-end coverage, the capture refuses rather
  * than silently producing pending state that omits group data.
  *
+ * @privateRemarks
  * Note: if a new snapshot lands between the snapshot fetch and delta catch-up,
  * the returned state may not reflect the very latest snapshot, but remains
  * internally consistent: ops are anchored to the snapshot that was captured.

--- a/packages/loader/container-loader/src/createAndLoadContainerUtils.ts
+++ b/packages/loader/container-loader/src/createAndLoadContainerUtils.ts
@@ -617,6 +617,10 @@ export async function captureFullContainerState({
 	deltaManager.connect({
 		reason: { text: "captureFullContainerState" },
 		mode: "read",
+		// Ops will be fetched from storage using the later "attachOpHandler" call. Attempting to fetch here is a no-op anyway as
+		// no op handler is yet attached.
+		// Fetching the snapshot first such that an op handler could be attached using its sequence number information may simplify
+		// the code, but doing it this way allows parallelization of snapshot fetch and establishing a connection.
 		fetchOpsFromStorage: false,
 	});
 	try {

--- a/packages/loader/container-loader/src/createAndLoadContainerUtils.ts
+++ b/packages/loader/container-loader/src/createAndLoadContainerUtils.ts
@@ -18,7 +18,7 @@ import type {
 } from "@fluidframework/core-interfaces";
 import type { AllOrNone } from "@fluidframework/core-interfaces/internal";
 import { validateAllOrNone } from "@fluidframework/core-utils/internal";
-import type { IClientDetails } from "@fluidframework/driver-definitions";
+import type { IClient, IClientDetails } from "@fluidframework/driver-definitions";
 import type {
 	IDocumentServiceFactory,
 	IResolvedUrl,
@@ -32,6 +32,7 @@ import { getSnapshotTree } from "@fluidframework/driver-utils/internal";
 import {
 	GenericError,
 	UsageError,
+	createChildLogger,
 	normalizeError,
 	createChildMonitoringContext,
 	mixinMonitoringContext,
@@ -51,7 +52,9 @@ import {
 	unreferencedAttachmentBlobLocalIds,
 	type IBlobAttachReference,
 } from "./captureReferencedContents.js";
+import { CatchUpMonitor } from "./catchUpMonitor.js";
 import { DebugLogger } from "./debugLogger.js";
+import { createDeltaManager } from "./deltaManagerFactory.js";
 import { createFrozenDocumentServiceFactory } from "./frozenServices.js";
 import { Loader } from "./loader.js";
 import { pkgVersion } from "./packageVersion.js";
@@ -518,7 +521,10 @@ export interface ICaptureFullContainerStateProps {
  * the latest snapshot, inlined contents of every blob reachable through
  * referenced subtrees, inlined contents of every referenced attachment blob
  * keyed by storage id, and all ops with sequence numbers after the base
- * snapshot's sequence number (as read from its attributes blob).
+ * snapshot's sequence number through the point observed when the delta stream
+ * connects. The same DeltaManager catch-up path used by container loading
+ * combines delta-storage and delta-stream ops, so recently sequenced ops do
+ * not need to have reached durable delta storage before capture.
  *
  * Reachability respects GC. Snapshot subtrees flagged `unreferenced: true`
  * are skipped (their contents are not inlined). Attachment blobs that GC has
@@ -539,7 +545,7 @@ export interface ICaptureFullContainerStateProps {
  * is a known consumer and end-to-end coverage, the capture refuses rather
  * than silently producing pending state that omits group data.
  *
- * Note: if a new snapshot lands between the snapshot fetch and the ops fetch,
+ * Note: if a new snapshot lands between the snapshot fetch and delta catch-up,
  * the returned state may not reflect the very latest snapshot, but remains
  * internally consistent: ops are anchored to the snapshot that was captured.
  *
@@ -579,6 +585,39 @@ export async function captureFullContainerState({
 		resolvedUrl,
 		logger,
 	);
+	const captureLogger = createChildLogger({ logger, namespace: "captureFullContainerState" });
+	const client: IClient = {
+		details: { capabilities: { interactive: true } },
+		mode: "read",
+		permission: [],
+		scopes: [],
+		user: { id: "" },
+	};
+	const deltaManager = createDeltaManager({
+		serviceProvider: () => documentService,
+		logger: captureLogger,
+		active: () => false,
+		containerDirty: () => false,
+		client,
+		reconnectAllowed: true,
+	});
+	const connectedP = new Promise<void>((resolve) => {
+		deltaManager.once("connect", () => resolve());
+	});
+	const closedP = new Promise<never>((_resolve, reject) => {
+		deltaManager.once("closed", (error) => {
+			reject(
+				error === undefined
+					? new GenericError("DeltaManager closed while capturing container state")
+					: normalizeError(error),
+			);
+		});
+	});
+	deltaManager.connect({
+		reason: { text: "captureFullContainerState" },
+		mode: "read",
+		fetchOpsFromStorage: false,
+	});
 	try {
 		const storage = await documentService.connectToStorage();
 
@@ -621,31 +660,28 @@ export async function captureFullContainerState({
 			captureReferencedAttachmentBlobs(baseSnapshot, storage, gcData), // base64 encoded
 		]);
 
-		const deltaStorage = await documentService.connectToDeltaStorage();
-		const opsStream = deltaStorage.fetchMessages(
-			attributes.sequenceNumber + 1,
-			undefined,
-			undefined,
-			false,
-			"captureFullContainerState",
-		);
 		const savedOps: ISequencedDocumentMessage[] = [];
+		const attachP = deltaManager.attachOpHandler(
+			attributes.minimumSequenceNumber,
+			attributes.sequenceNumber,
+			{
+				process: (message) => savedOps.push(message),
+				processSignal: () => {},
+			},
+			"all",
+		);
+		await Promise.race([Promise.all([connectedP, attachP]), closedP]);
+		await Promise.race([waitForCatchUp(deltaManager), closedP]);
+		deltaManager.dispose();
+
 		const postSnapshotBlobReferences: IBlobAttachReference[] = [];
-		let opsResult = await opsStream.read();
-		while (!opsResult.done) {
-			for (const op of opsResult.value) {
-				savedOps.push(op);
-				// Blobs uploaded after the base snapshot are not in its
-				// `.blobs` redirect table, so `captureReferencedAttachmentBlobs`
-				// did not see them. The wire-format BlobAttach op carries
-				// `(localId, storageId)` in its metadata; collect those here so
-				// we can backfill the bytes before sealing the artifact.
-				const refs = extractBlobAttachReferences(op);
-				if (refs.length > 0) {
-					postSnapshotBlobReferences.push(...refs);
-				}
-			}
-			opsResult = await opsStream.read();
+		for (const op of savedOps) {
+			// Blobs uploaded after the base snapshot are not in its
+			// `.blobs` redirect table, so `captureReferencedAttachmentBlobs`
+			// did not see them. The wire-format BlobAttach op carries
+			// `(localId, storageId)` in its metadata; collect those here so
+			// we can backfill the bytes before sealing the artifact.
+			postSnapshotBlobReferences.push(...extractBlobAttachReferences(op));
 		}
 
 		if (postSnapshotBlobReferences.length > 0) {
@@ -671,8 +707,21 @@ export async function captureFullContainerState({
 		};
 		return JSON.stringify(pendingState);
 	} finally {
+		deltaManager.dispose();
 		documentService.dispose();
 	}
+}
+
+async function waitForCatchUp(
+	deltaManager: ReturnType<typeof createDeltaManager>,
+): Promise<void> {
+	await new Promise<void>((resolve) => {
+		const monitor = new CatchUpMonitor(deltaManager, () => {
+			monitor.dispose();
+			resolve();
+		});
+		monitor.start();
+	});
 }
 
 /**

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -566,10 +566,22 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 	}
 
 	/**
-	 * Sets the sequence number from which inbound messages should be returned
-	 * @param snapshotSequenceNumber - The sequence number of the snapshot at which the document loaded from.
-	 * @param lastProcessedSequenceNumber - The last processed sequence number, for offline, it should be greater than the sequence number.
-	 * Setting lastProcessedSequenceNumber allows the DeltaManager to skip downloading and processing ops that have already been processed.
+	 * Initializes sequence number tracking, attaches the handler for inbound ops and signals, and
+	 * resumes the inbound queues.
+	 *
+	 * @param minSequenceNumber - The document's current minimum sequence number. This is used for client-side
+	 * protocol validation.
+	 * @param snapshotSequenceNumber - The sequence number of the snapshot from which the document
+	 * was loaded.
+	 * @param handler - The op/signal handler to attach.
+	 * @param prefetchType - Controls how missing ops are fetched before the returned promise resolves:
+	 * `"none"` does not initiate a fetch; `"all"` waits for all available missing ops from storage;
+	 * and `"cached"` waits only for cached ops before continuing the remaining storage fetch in the
+	 * background.
+	 * @param lastProcessedSequenceNumber - The latest sequence number already reflected in the
+	 * loaded state. It defaults to `snapshotSequenceNumber`. Offline loads may provide a later
+	 * sequence number so the DeltaManager skips downloading and processing ops already included in
+	 * that state.
 	 */
 	public async attachOpHandler(
 		minSequenceNumber: number,

--- a/packages/loader/container-loader/src/deltaManagerFactory.ts
+++ b/packages/loader/container-loader/src/deltaManagerFactory.ts
@@ -1,0 +1,53 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import type { IClient } from "@fluidframework/driver-definitions";
+import type { IDocumentService } from "@fluidframework/driver-definitions/internal";
+import {
+	createChildLogger,
+	type TelemetryLoggerExt,
+} from "@fluidframework/telemetry-utils/internal";
+
+import { ConnectionManager } from "./connectionManager.js";
+import { DeltaManager } from "./deltaManager.js";
+
+export interface ICreateDeltaManagerProps {
+	readonly serviceProvider: () => IDocumentService | undefined;
+	readonly logger: TelemetryLoggerExt;
+	readonly active: () => boolean;
+	readonly containerDirty: () => boolean;
+	readonly client: IClient;
+	readonly reconnectAllowed: boolean;
+	readonly maxInitialConnectionAttempts?: number;
+}
+
+/**
+ * Creates the DeltaManager and ConnectionManager pair used by container loading.
+ */
+export function createDeltaManager({
+	serviceProvider,
+	logger,
+	active,
+	containerDirty,
+	client,
+	reconnectAllowed,
+	maxInitialConnectionAttempts,
+}: ICreateDeltaManagerProps): DeltaManager<ConnectionManager> {
+	return new DeltaManager<ConnectionManager>(
+		serviceProvider,
+		createChildLogger({ logger, namespace: "DeltaManager" }),
+		active,
+		(props) =>
+			new ConnectionManager(
+				serviceProvider,
+				containerDirty,
+				client,
+				reconnectAllowed,
+				createChildLogger({ logger, namespace: "ConnectionManager" }),
+				props,
+				maxInitialConnectionAttempts,
+			),
+	);
+}

--- a/packages/test/local-server-tests/src/test/captureFullContainerState.spec.ts
+++ b/packages/test/local-server-tests/src/test/captureFullContainerState.spec.ts
@@ -85,6 +85,13 @@ function makeFactoryWithFailingReadBlob(
 	};
 }
 
+/**
+ * Simulates a document service factory that hasn't flushed any ops to storage.
+ *
+ * This implementation works by intercepting storage fetches and delta stream connection attempts,
+ * where the storage fetch is stubbed to return an empty stream, and the delta stream connection is wrapped
+ * to begin with the ops fetched from the inner storage factory.
+ */
 function makeFactoryWithSocketOnlyOps(
 	inner: IDocumentServiceFactory,
 ): IDocumentServiceFactory {

--- a/packages/test/local-server-tests/src/test/captureFullContainerState.spec.ts
+++ b/packages/test/local-server-tests/src/test/captureFullContainerState.spec.ts
@@ -19,6 +19,7 @@ import type {
 	IDocumentServiceFactory,
 	IDocumentStorageService,
 	IResolvedUrl,
+	ISequencedDocumentMessage,
 	IUrlResolver,
 } from "@fluidframework/driver-definitions/internal";
 import type {
@@ -82,6 +83,76 @@ function makeFactoryWithFailingReadBlob(
 		createDocumentService: async (...args) =>
 			wrapService(await inner.createDocumentService(...args)),
 	};
+}
+
+function makeFactoryWithSocketOnlyOps(
+	inner: IDocumentServiceFactory,
+): IDocumentServiceFactory {
+	const wrapService = (svc: IDocumentService): IDocumentService =>
+		new Proxy(svc, {
+			get: (target, prop, receiver) => {
+				if (prop === "connectToDeltaStorage") {
+					return async () => ({
+						fetchMessages: () => ({
+							read: async () => ({ done: true as const }),
+						}),
+					});
+				}
+				if (prop === "connectToDeltaStream") {
+					return async (...args: Parameters<IDocumentService["connectToDeltaStream"]>) => {
+						const [connection, socketOnlyOps] = await Promise.all([
+							target.connectToDeltaStream(...args),
+							readAllOps(await target.connectToDeltaStorage()),
+						]);
+						const initialMessages = socketOnlyOps;
+						const checkpointSequenceNumber =
+							initialMessages[initialMessages.length - 1]?.sequenceNumber ??
+							connection.checkpointSequenceNumber;
+						return new Proxy(connection, {
+							get: (connectionTarget, connectionProp) => {
+								if (connectionProp === "initialMessages") {
+									return initialMessages;
+								}
+								if (connectionProp === "checkpointSequenceNumber") {
+									return checkpointSequenceNumber;
+								}
+								const value = Reflect.get(
+									connectionTarget,
+									connectionProp,
+									connectionTarget,
+								) as unknown;
+								if (typeof value !== "function") {
+									return value;
+								}
+								const method = value as (...methodArgs: unknown[]) => unknown;
+								return (...methodArgs: unknown[]): unknown =>
+									method.apply(connectionTarget, methodArgs);
+							},
+						});
+					};
+				}
+				return Reflect.get(target, prop, receiver) as unknown;
+			},
+		});
+
+	return {
+		createContainer: async (...args) => wrapService(await inner.createContainer(...args)),
+		createDocumentService: async (...args) =>
+			wrapService(await inner.createDocumentService(...args)),
+	};
+}
+
+async function readAllOps(
+	deltaStorage: Awaited<ReturnType<IDocumentService["connectToDeltaStorage"]>>,
+): Promise<ISequencedDocumentMessage[]> {
+	const stream = deltaStorage.fetchMessages(1, undefined);
+	const ops: ISequencedDocumentMessage[] = [];
+	let result = await stream.read();
+	while (!result.done) {
+		ops.push(...result.value);
+		result = await stream.read();
+	}
+	return ops;
 }
 
 const initialize = async (): Promise<{
@@ -239,6 +310,55 @@ describe("captureFullContainerState", () => {
 				`frozen container should replay op for post-snapshot-${i}`,
 			);
 		}
+	});
+
+	it("includes websocket ops that are not yet available from delta storage", async () => {
+		const { container, testFluidObject, urlResolver, codeLoader, documentServiceFactory } =
+			await initialize();
+
+		await container.attach(urlResolver.createCreateNewRequest("test"));
+		if (container.isDirty) {
+			await timeoutPromise((resolve) => container.once("saved", () => resolve()));
+		}
+
+		testFluidObject.root.set("websocket-only", "captured");
+		if (container.isDirty) {
+			await timeoutPromise((resolve) => container.once("saved", () => resolve()));
+		}
+
+		const url = await container.getAbsoluteUrl("");
+		assert(url !== undefined, "Expected container to provide a valid absolute URL");
+
+		const pendingLocalState = await captureFullContainerState({
+			urlResolver,
+			documentServiceFactory: makeFactoryWithSocketOnlyOps(documentServiceFactory),
+			request: { url },
+		});
+		const parsed = JSON.parse(pendingLocalState) as {
+			savedOps: { sequenceNumber: number }[];
+		};
+		assert(
+			parsed.savedOps.length > 0,
+			"savedOps should include ops delivered by the delta stream",
+		);
+
+		const frozenContainer = await loadFrozenContainerFromPendingState({
+			codeLoader,
+			documentServiceFactory,
+			urlResolver,
+			request: { url },
+			pendingLocalState,
+		});
+		const frozenEntryPoint: FluidObject<TestFluidObject> =
+			await frozenContainer.getEntryPoint();
+		assert(
+			frozenEntryPoint.ITestFluidObject !== undefined,
+			"Expected frozen container entrypoint to be a valid TestFluidObject",
+		);
+		assert.strictEqual(
+			frozenEntryPoint.ITestFluidObject.root.get("websocket-only"),
+			"captured",
+		);
 	});
 
 	it("captures DDS and blob references written before capture", async () => {

--- a/packages/test/test-end-to-end-tests/src/test/offline/frozenOfflineRoundTrip.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/offline/frozenOfflineRoundTrip.spec.ts
@@ -168,5 +168,59 @@ describeCompat(
 				);
 			}
 		});
+
+		it("captures recently sequenced ops for a fully offline frozen load", async () => {
+			const recentEntries = new Map<string, string>();
+			for (let i = 0; i < 10; i++) {
+				const key = `recent-${i}`;
+				const value = `value-${i}`;
+				recentEntries.set(key, value);
+				map1.set(key, value);
+			}
+			map1.set("recent-overwrite", "initial");
+			map1.set("recent-overwrite", "final");
+			recentEntries.set("recent-overwrite", "final");
+
+			// Wait only until the operations are sequenced, then capture immediately.
+			// On ODSP this deliberately exercises the window where PUSH has broadcast
+			// the operations but delta storage may not expose them yet.
+			if (container1.isDirty) {
+				await new Promise<void>((resolve) => {
+					container1.once("saved", () => resolve());
+				});
+			}
+
+			const capturedFullState = await captureFullContainerState({
+				urlResolver: provider.urlResolver,
+				documentServiceFactory: provider.documentServiceFactory,
+				request: { url },
+			});
+			const parsedState = JSON.parse(capturedFullState) as {
+				savedOps: unknown[];
+			};
+			assert(
+				parsedState.savedOps.length > 0,
+				"Expected recent changes to be represented by post-snapshot operations",
+			);
+
+			const codeLoader = new LocalCodeLoader([
+				[provider.defaultCodeDetails, provider.createFluidEntryPoint(testContainerConfig)],
+			]);
+			const offlineContainer = await loadFrozenContainerFromPendingState({
+				codeLoader,
+				pendingLocalState: capturedFullState,
+			});
+			const offlineEntry = (await offlineContainer.getEntryPoint()) as ITestFluidObject;
+			const offlineMap = await offlineEntry.getSharedObject<ISharedMap>(mapId);
+
+			for (const [key, value] of recentEntries) {
+				assert.strictEqual(
+					offlineMap.get(key),
+					value,
+					`Expected offline capture to include ${key}`,
+				);
+			}
+			offlineContainer.close();
+		});
 	},
 );


### PR DESCRIPTION
## Description

`captureFullContainerState` previously retrieved operations only from delta storage. On services such as ODSP, recently sequenced operations may still be available through the delta stream but not yet persisted to storage, causing the captured state to omit recent changes.

This change reuses the container load path's `DeltaManager` and `ConnectionManager` construction to merge operations from storage and the live delta stream. Capture waits through the latest sequence known by the connection, then disposes the delta manager to freeze the operation set before serializing the artifact.

The added coverage includes a deterministic socket-only operation test and a real-service frozen offline round-trip test. Against ODSP, the new test passes with this change and fails against the previous implementation because the captured artifact contains no post-snapshot operations.

## Reviewer Guidance

The review process is outlined in [the pull request guidelines](../docs/content/Contributing/PR-Guidelines.md#guidelines).

Please focus on the synchronization and cutoff semantics in `captureFullContainerState`, particularly whether disposing the delta manager immediately after catch-up provides the intended stable capture boundary.