### PR TITLE
fix(build-cli): select stable entry points for fluid imports

### DIFF
--- a/.changeset/kind-pandas-import.md
+++ b/.changeset/kind-pandas-import.md
@@ -1,0 +1,8 @@
+---
+"@fluid-tools/build-cli": minor
+"__section": fix
+---
+
+Fixed `flub modify fluid-imports` to select the most stable package entry point that actually exports each imported API.
+
+The modifier now checks public, beta, legacy, alpha, and internal entry points independently instead of inferring API membership from `/internal`.

--- a/build-tools/packages/build-cli/docs/modify.md
+++ b/build-tools/packages/build-cli/docs/modify.md
@@ -18,8 +18,8 @@ USAGE
 FLAGS
   --data=<value>          Optional path to a data file containing raw API level data. Overrides API levels extracted
                           from package data.
-  --onlyInternal          Move non-public APIs to /internal only for packages that expose an /internal entry point.
-                          Packages without /internal are skipped and left unchanged for compatibility.
+  --onlyInternal          Use /internal for non-public APIs only when the package exposes that entry point; packages
+                          without it are unchanged.
   --packageRegex=<value>  Regular expression filtering import packages to adjust
   --tsconfigs=<value>...  [default: ./tsconfig.json] Tsconfig file paths that will be used to load project files. When
                           multiple are given all must depend on the same version of packages; otherwise results are

--- a/build-tools/packages/build-cli/docs/modify.md
+++ b/build-tools/packages/build-cli/docs/modify.md
@@ -18,7 +18,8 @@ USAGE
 FLAGS
   --data=<value>          Optional path to a data file containing raw API level data. Overrides API levels extracted
                           from package data.
-  --onlyInternal          Use /internal for all non-public APIs instead of /beta or /legacy.
+  --onlyInternal          Move non-public APIs to /internal only for packages that expose an /internal entry point.
+                          Packages without /internal are skipped and left unchanged for compatibility.
   --packageRegex=<value>  Regular expression filtering import packages to adjust
   --tsconfigs=<value>...  [default: ./tsconfig.json] Tsconfig file paths that will be used to load project files. When
                           multiple are given all must depend on the same version of packages; otherwise results are

--- a/build-tools/packages/build-cli/src/commands/modify/fluid-imports.ts
+++ b/build-tools/packages/build-cli/src/commands/modify/fluid-imports.ts
@@ -97,7 +97,8 @@ export default class UpdateFluidImportsCommand extends BaseCommand<
 			exists: true,
 		}),
 		onlyInternal: Flags.boolean({
-			description: "Use /internal for all non-public APIs instead of /beta or /legacy.",
+			description:
+				"Use /internal for non-public APIs only when the package exposes that entry point; packages without it are unchanged.",
 		}),
 		...BaseCommand.flags,
 	};
@@ -660,95 +661,134 @@ class ApiLevelReader {
 	}
 
 	private loadPackageData(packageName: PackageName): NamedExportToPath | undefined {
-		const internalImport = this.tempSource.addImportDeclaration({
-			moduleSpecifier: `${packageName}/internal`,
-		});
-		const internalSource = internalImport.getModuleSpecifierSourceFile();
-		if (internalSource === undefined) {
-			this.log.warning(`no /internal export from ${packageName}`);
-			return undefined;
-		}
-		this.log.verbose(`Loading ${packageName} API data from ${internalSource.getFilePath()}`);
-
-		const exports = getApiExports(internalSource, "warnForMissing", this.log);
-		for (const name of exports.unknown.keys()) {
-			// Suppress any warning for EventEmitter as this export is currently a special case.
-			// See AB#7377 for replacement status upon which this can be removed.
-			if (name !== "EventEmitter") {
-				this.log.warning(`\t\t${packageName} ${name} API level was not recognized.`);
-			}
-		}
-
 		const memberData = new Map<string, ExportPath>();
-		addUniqueNamedExportsToMap(exports.public, memberData, ExportPath.Public);
-		if (this.onlyInternal) {
-			addUniqueNamedExportsToMap(exports.alpha, memberData, ExportPath.Internal);
-			addUniqueNamedExportsToMap(exports.beta, memberData, ExportPath.Internal);
+		const exportsByPath = new Map<ExportPath, ReturnType<typeof getApiExports>>();
+		const unknownExports = new Set<string>();
+		for (const exportPath of Object.values(ExportPath)) {
+			const sourceFile = this.resolvePackageEntryPoint(packageName, exportPath);
+			if (sourceFile === undefined) {
+				this.log.verbose(`No "${exportPath || "root"}" export from ${packageName}.`);
+				continue;
+			}
 
-			addUniqueNamedExportsToMap(exports.legacyAlpha, memberData, ExportPath.Internal);
-			addUniqueNamedExportsToMap(exports.legacyBeta, memberData, ExportPath.Internal);
-			addUniqueNamedExportsToMap(exports.legacyPublic, memberData, ExportPath.Internal);
-		} else {
-			// #region Handle imports for API levels that have had different historical path mappings (with backwards compatibility)
-
-			const exportSetsWithFallbacks = [
-				// @alpha APIs have been mapped to both "/alpha" and "/legacy" paths.
-				// Later @legacy tag was added explicitly.
-				// Check for a "/alpha" export to map @alpha as "/alpha".
-				// Otherwise, map all @alpha APIs to "/legacy".
-				{
-					apiLevel: ApiLevel.alpha,
-					preferredPath: ExportPath.Alpha,
-					fallbackPath: ExportPath.Legacy,
-				},
-
-				// Historically, all @legacy APIs were mapped to "/legacy".
-				// Now, we support separate paths for all release levels with @legacy APIs.
-				// Check for a "/legacy/alpha" export to map @legacy + @alpha as "legacy/alpha" and map @legacy + @beta to "/legacy".
-				// Otherwise, map all @legacy APIs to /legacy.
-				{
-					apiLevel: ApiLevel.legacyAlpha,
-					preferredPath: ExportPath.LegacyAlpha,
-					fallbackPath: ExportPath.Legacy,
-				},
-				{
-					apiLevel: ApiLevel.legacyBeta,
-					preferredPath: ExportPath.LegacyBeta,
-					fallbackPath: ExportPath.Legacy,
-				},
-			];
-
-			for (const { apiLevel: level, preferredPath, fallbackPath } of exportSetsWithFallbacks) {
-				const levelExports = exports[level];
-				if (levelExports.length > 0) {
-					const usePreferredExportPath =
-						this.tempSource
-							.addImportDeclaration({
-								moduleSpecifier: `${packageName}/${preferredPath}`,
-							})
-							.getModuleSpecifierSourceFile() !== undefined;
-
-					if (!usePreferredExportPath) {
-						this.log.verbose(
-							`Preferred export path "${preferredPath}" for level "${level}" was not found. Will use "${fallbackPath}" instead.`,
-						);
-					}
-
-					addUniqueNamedExportsToMap(
-						levelExports,
-						memberData,
-						usePreferredExportPath ? preferredPath : fallbackPath,
+			this.log.verbose(
+				`Loading ${packageName}${exportPath === "" ? "" : `/${exportPath}`} API data from ${sourceFile.getFilePath()}`,
+			);
+			const exports = getApiExports(sourceFile, "warnForMissing", this.log);
+			exportsByPath.set(exportPath, exports);
+			for (const name of exports.unknown.keys()) {
+				// Suppress any warning for EventEmitter as this export is currently a special case.
+				// See AB#7377 for replacement status upon which this can be removed.
+				if (name !== "EventEmitter" && !unknownExports.has(name)) {
+					unknownExports.add(name);
+					this.log.warning(
+						`\t\t${packageName}${exportPath === "" ? "" : `/${exportPath}`} ${name} API level was not recognized.`,
 					);
 				}
 			}
-
-			// #endregion
-
-			addUniqueNamedExportsToMap(exports.beta, memberData, ExportPath.Beta);
-			addUniqueNamedExportsToMap(exports.legacyPublic, memberData, ExportPath.Legacy);
 		}
-		addUniqueNamedExportsToMap(exports.internal, memberData, ExportPath.Internal);
+
+		const internalExports = exportsByPath.get(ExportPath.Internal);
+		if (this.onlyInternal && internalExports === undefined) {
+			this.log.warning(`no /internal export from ${packageName}`);
+			return undefined;
+		}
+		if (exportsByPath.size === 0) {
+			this.log.warning(`no recognized export paths from ${packageName}`);
+			return undefined;
+		}
+
+		addKnownExportsToMapWithPrecedence(
+			exportsByPath.get(ExportPath.Public),
+			memberData,
+			ExportPath.Public,
+		);
+		if (this.onlyInternal) {
+			addKnownExportsToMapWithPrecedence(internalExports, memberData, ExportPath.Internal);
+			return memberData;
+		}
+
+		addKnownExportsToMapWithPrecedence(
+			exportsByPath.get(ExportPath.Beta),
+			memberData,
+			ExportPath.Beta,
+		);
+
+		// Dedicated legacy entry points apply only to their matching release tags.
+		// /legacy remains the fallback when a dedicated entry point does not export a symbol.
+		addNamedExportsToMapWithPrecedence(
+			exportsByPath.get(ExportPath.LegacyBeta)?.legacyBeta,
+			memberData,
+			ExportPath.LegacyBeta,
+		);
+		addNamedExportsToMapWithPrecedence(
+			exportsByPath.get(ExportPath.LegacyAlpha)?.legacyAlpha,
+			memberData,
+			ExportPath.LegacyAlpha,
+		);
+		addKnownExportsToMapWithPrecedence(
+			exportsByPath.get(ExportPath.Legacy),
+			memberData,
+			ExportPath.Legacy,
+		);
+		addKnownExportsToMapWithPrecedence(
+			exportsByPath.get(ExportPath.Alpha),
+			memberData,
+			ExportPath.Alpha,
+		);
+		addKnownExportsToMapWithPrecedence(internalExports, memberData, ExportPath.Internal);
+
 		return memberData;
+	}
+
+	private resolvePackageEntryPoint(
+		packageName: PackageName,
+		exportPath: ExportPath,
+	): SourceFile | undefined {
+		const importDeclaration = this.tempSource.addImportDeclaration({
+			moduleSpecifier: `${packageName}${exportPath === "" ? "" : `/${exportPath}`}`,
+		});
+		try {
+			return importDeclaration.getModuleSpecifierSourceFile();
+		} finally {
+			importDeclaration.remove();
+		}
+	}
+}
+
+function addKnownExportsToMapWithPrecedence(
+	exports: ReturnType<typeof getApiExports> | undefined,
+	nameToExportPathMap: NamedExportToPath,
+	exportPath: ExportPath,
+): void {
+	if (exports === undefined) {
+		return;
+	}
+	for (const exportSet of [
+		exports.public,
+		exports.beta,
+		exports.alpha,
+		exports.internal,
+		exports.legacyPublic,
+		exports.legacyBeta,
+		exports.legacyAlpha,
+	]) {
+		addNamedExportsToMapWithPrecedence(exportSet, nameToExportPathMap, exportPath);
+	}
+}
+
+function addNamedExportsToMapWithPrecedence(
+	exports: { name: string }[] | undefined,
+	nameToExportPathMap: NamedExportToPath,
+	exportPath: ExportPath,
+): void {
+	if (exports === undefined) {
+		return;
+	}
+	for (const { name } of exports) {
+		if (!nameToExportPathMap.has(name)) {
+			nameToExportPathMap.set(name, exportPath);
+		}
 	}
 }
 

--- a/build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/package.json
+++ b/build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "flub-fluid-imports-fixture",
+	"private": true,
+	"type": "module"
+}

--- a/build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/package.json
+++ b/build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/package.json
@@ -1,5 +1,15 @@
 {
 	"name": "flub-fluid-imports-fixture",
+	"version": "1.0.0",
 	"private": true,
+	"description": "Test workspace for the fluid-imports modifier.",
+	"homepage": "https://fluidframework.com",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/microsoft/FluidFramework.git",
+		"directory": "build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports"
+	},
+	"license": "MIT",
+	"author": "Microsoft and contributors",
 	"type": "module"
 }

--- a/build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/packages/@fluidframework/flub-imports-fixture/flub-alpha.d.ts
+++ b/build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/packages/@fluidframework/flub-imports-fixture/flub-alpha.d.ts
@@ -1,0 +1,5 @@
+/** @alpha */
+export declare function alphaSymbol(): void;
+
+/** @alpha */
+export declare function legacyPreferredAlpha(): void;

--- a/build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/packages/@fluidframework/flub-imports-fixture/flub-alpha.d.ts
+++ b/build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/packages/@fluidframework/flub-imports-fixture/flub-alpha.d.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 /** @alpha */
 export declare function alphaSymbol(): void;
 

--- a/build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/packages/@fluidframework/flub-imports-fixture/flub-beta.d.ts
+++ b/build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/packages/@fluidframework/flub-imports-fixture/flub-beta.d.ts
@@ -1,0 +1,9 @@
+/** @beta */
+export interface BetaType {
+	readonly entryPoint: "beta";
+}
+
+/** @beta */
+export declare function betaSymbol(): BetaType;
+
+export declare function untaggedBetaSymbol(): BetaType;

--- a/build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/packages/@fluidframework/flub-imports-fixture/flub-beta.d.ts
+++ b/build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/packages/@fluidframework/flub-imports-fixture/flub-beta.d.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 /** @beta */
 export interface BetaType {
 	readonly entryPoint: "beta";

--- a/build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/packages/@fluidframework/flub-imports-fixture/flub-internal.d.ts
+++ b/build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/packages/@fluidframework/flub-imports-fixture/flub-internal.d.ts
@@ -1,0 +1,49 @@
+/** @internal */
+export interface InternalChildLogger {
+	readonly entryPoint: "internal";
+}
+
+/**
+ * @internal
+ * Intentionally distinct from the `/legacy` createChildLogger declaration.
+ */
+export declare function createChildLogger(): InternalChildLogger;
+
+/** @internal */
+export interface InternalOnly {
+	readonly entryPoint: "internal";
+}
+
+/** @internal */
+export declare function internalOnly(): InternalOnly;
+
+/** @internal */
+export declare function publicSymbol(): InternalChildLogger;
+
+/** @internal */
+export declare function betaSymbol(): InternalChildLogger;
+
+/** @internal */
+export interface BetaType {
+	readonly entryPoint: "internal";
+}
+
+/** @legacy @beta */
+export declare function dedicatedLegacyBeta(): InternalChildLogger;
+
+/** @legacy @alpha */
+export declare function dedicatedLegacyAlpha(): InternalChildLogger;
+
+/** @legacy @beta */
+export declare function legacyBetaFallback(): InternalChildLogger;
+
+/** @legacy @alpha */
+export declare function legacyAlphaFallback(): InternalChildLogger;
+
+/** @alpha */
+export declare function alphaSymbol(): InternalChildLogger;
+
+/** @alpha */
+export declare function legacyPreferredAlpha(): InternalChildLogger;
+
+export declare function untaggedBetaSymbol(): InternalChildLogger;

--- a/build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/packages/@fluidframework/flub-imports-fixture/flub-internal.d.ts
+++ b/build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/packages/@fluidframework/flub-imports-fixture/flub-internal.d.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 /** @internal */
 export interface InternalChildLogger {
 	readonly entryPoint: "internal";

--- a/build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/packages/@fluidframework/flub-imports-fixture/flub-legacy-alpha.d.ts
+++ b/build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/packages/@fluidframework/flub-imports-fixture/flub-legacy-alpha.d.ts
@@ -1,2 +1,7 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 /** @legacy @alpha */
 export declare function dedicatedLegacyAlpha(): void;

--- a/build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/packages/@fluidframework/flub-imports-fixture/flub-legacy-alpha.d.ts
+++ b/build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/packages/@fluidframework/flub-imports-fixture/flub-legacy-alpha.d.ts
@@ -1,0 +1,2 @@
+/** @legacy @alpha */
+export declare function dedicatedLegacyAlpha(): void;

--- a/build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/packages/@fluidframework/flub-imports-fixture/flub-legacy-beta.d.ts
+++ b/build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/packages/@fluidframework/flub-imports-fixture/flub-legacy-beta.d.ts
@@ -1,2 +1,7 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 /** @legacy @beta */
 export declare function dedicatedLegacyBeta(): void;

--- a/build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/packages/@fluidframework/flub-imports-fixture/flub-legacy-beta.d.ts
+++ b/build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/packages/@fluidframework/flub-imports-fixture/flub-legacy-beta.d.ts
@@ -1,0 +1,2 @@
+/** @legacy @beta */
+export declare function dedicatedLegacyBeta(): void;

--- a/build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/packages/@fluidframework/flub-imports-fixture/flub-legacy.d.ts
+++ b/build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/packages/@fluidframework/flub-imports-fixture/flub-legacy.d.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 /** @legacy @beta */
 export interface LegacyChildLogger {
 	readonly entryPoint: "legacy";

--- a/build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/packages/@fluidframework/flub-imports-fixture/flub-legacy.d.ts
+++ b/build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/packages/@fluidframework/flub-imports-fixture/flub-legacy.d.ts
@@ -1,0 +1,28 @@
+/** @legacy @beta */
+export interface LegacyChildLogger {
+	readonly entryPoint: "legacy";
+}
+
+/** @legacy @beta */
+export declare function createChildLogger(): LegacyChildLogger;
+
+/** @legacy @beta */
+export declare function publicSymbol(): LegacyChildLogger;
+
+/** @legacy @beta */
+export declare function betaSymbol(): LegacyChildLogger;
+
+/** @legacy @beta */
+export declare function dedicatedLegacyBeta(): LegacyChildLogger;
+
+/** @legacy @alpha */
+export declare function dedicatedLegacyAlpha(): LegacyChildLogger;
+
+/** @legacy @beta */
+export declare function legacyBetaFallback(): LegacyChildLogger;
+
+/** @legacy @alpha */
+export declare function legacyAlphaFallback(): LegacyChildLogger;
+
+/** @alpha */
+export declare function legacyPreferredAlpha(): LegacyChildLogger;

--- a/build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/packages/@fluidframework/flub-imports-fixture/index.d.ts
+++ b/build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/packages/@fluidframework/flub-imports-fixture/index.d.ts
@@ -1,0 +1,7 @@
+/** @public */
+export interface PublicResult {
+	readonly entryPoint: "root";
+}
+
+/** @public */
+export declare function publicSymbol(): PublicResult;

--- a/build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/packages/@fluidframework/flub-imports-fixture/index.d.ts
+++ b/build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/packages/@fluidframework/flub-imports-fixture/index.d.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 /** @public */
 export interface PublicResult {
 	readonly entryPoint: "root";

--- a/build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/packages/@fluidframework/flub-imports-fixture/package.json
+++ b/build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/packages/@fluidframework/flub-imports-fixture/package.json
@@ -1,6 +1,16 @@
 {
 	"name": "@fluidframework/flub-imports-fixture",
 	"version": "1.0.0",
+	"private": true,
+	"description": "Test package with Fluid API compatibility entry points.",
+	"homepage": "https://fluidframework.com",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/microsoft/FluidFramework.git",
+		"directory": "build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/packages/@fluidframework/flub-imports-fixture"
+	},
+	"license": "MIT",
+	"author": "Microsoft and contributors",
 	"type": "module",
 	"exports": {
 		".": {

--- a/build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/packages/@fluidframework/flub-imports-fixture/package.json
+++ b/build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/packages/@fluidframework/flub-imports-fixture/package.json
@@ -1,0 +1,28 @@
+{
+	"name": "@fluidframework/flub-imports-fixture",
+	"version": "1.0.0",
+	"type": "module",
+	"exports": {
+		".": {
+			"types": "./index.d.ts"
+		},
+		"./beta": {
+			"types": "./flub-beta.d.ts"
+		},
+		"./alpha": {
+			"types": "./flub-alpha.d.ts"
+		},
+		"./legacy": {
+			"types": "./flub-legacy.d.ts"
+		},
+		"./legacy/beta": {
+			"types": "./flub-legacy-beta.d.ts"
+		},
+		"./legacy/alpha": {
+			"types": "./flub-legacy-alpha.d.ts"
+		},
+		"./internal": {
+			"types": "./flub-internal.d.ts"
+		}
+	}
+}

--- a/build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/packages/@fluidframework/flub-imports-no-internal-fixture/flub-beta.d.ts
+++ b/build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/packages/@fluidframework/flub-imports-no-internal-fixture/flub-beta.d.ts
@@ -3,5 +3,5 @@
  * Licensed under the MIT License.
  */
 
-/** @public */
-export declare function NoInternalPublic(): void;
+/** @beta */
+export declare function NoInternalBeta(): void;

--- a/build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/packages/@fluidframework/flub-imports-no-internal-fixture/index.d.ts
+++ b/build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/packages/@fluidframework/flub-imports-no-internal-fixture/index.d.ts
@@ -1,0 +1,2 @@
+/** @public */
+export declare function NoInternalPublic(): void;

--- a/build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/packages/@fluidframework/flub-imports-no-internal-fixture/package.json
+++ b/build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/packages/@fluidframework/flub-imports-no-internal-fixture/package.json
@@ -1,13 +1,23 @@
 {
 	"name": "@fluidframework/flub-imports-no-internal-fixture",
 	"version": "1.0.0",
+	"private": true,
+	"description": "Test package without an internal entry point.",
+	"homepage": "https://fluidframework.com",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/microsoft/FluidFramework.git",
+		"directory": "build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/packages/@fluidframework/flub-imports-no-internal-fixture"
+	},
+	"license": "MIT",
+	"author": "Microsoft and contributors",
 	"type": "module",
 	"exports": {
 		".": {
 			"types": "./index.d.ts"
 		},
 		"./beta": {
-			"types": "./beta.d.ts"
+			"types": "./flub-beta.d.ts"
 		}
 	}
 }

--- a/build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/packages/@fluidframework/flub-imports-no-internal-fixture/package.json
+++ b/build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/packages/@fluidframework/flub-imports-no-internal-fixture/package.json
@@ -1,0 +1,13 @@
+{
+	"name": "@fluidframework/flub-imports-no-internal-fixture",
+	"version": "1.0.0",
+	"type": "module",
+	"exports": {
+		".": {
+			"types": "./index.d.ts"
+		},
+		"./beta": {
+			"types": "./beta.d.ts"
+		}
+	}
+}

--- a/build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/source.ts
+++ b/build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/source.ts
@@ -1,0 +1,40 @@
+/*!
+ * Header comment
+ */
+
+import type { InternalOnly as InternalOnlyType } from "@fluidframework/flub-imports-fixture/internal";
+// Keep this comment with the internal import.
+import {
+	alphaSymbol,
+	type BetaType as BetaTypeAlias,
+	betaSymbol,
+	dedicatedLegacyAlpha,
+	dedicatedLegacyBeta,
+	createChildLogger as internalChildLogger,
+	internalOnly,
+	legacyAlphaFallback,
+	legacyBetaFallback,
+	legacyPreferredAlpha,
+	publicSymbol as publicAlias,
+	untaggedBetaSymbol,
+} from "@fluidframework/flub-imports-fixture/internal";
+import { createChildLogger as legacyChildLogger } from "@fluidframework/flub-imports-fixture/legacy";
+import { NoInternalBeta } from "@fluidframework/flub-imports-no-internal-fixture";
+
+export {
+	alphaSymbol,
+	betaSymbol,
+	dedicatedLegacyAlpha,
+	dedicatedLegacyBeta,
+	internalOnly,
+	internalChildLogger,
+	legacyAlphaFallback,
+	legacyBetaFallback,
+	legacyChildLogger,
+	legacyPreferredAlpha,
+	NoInternalBeta,
+	publicAlias,
+	type BetaTypeAlias,
+	type InternalOnlyType,
+	untaggedBetaSymbol,
+};

--- a/build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/source.ts
+++ b/build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/source.ts
@@ -1,4 +1,9 @@
 /*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/*!
  * Header comment
  */
 

--- a/build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/tsconfig.json
+++ b/build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"compilerOptions": {
+		"module": "Node16",
+		"moduleResolution": "Node16",
+		"skipLibCheck": true,
+		"target": "ES2022",
+	},
+	"include": ["source.ts"],
+}

--- a/build-tools/packages/build-cli/src/test/commands/modify/fluid-imports.test.ts
+++ b/build-tools/packages/build-cli/src/test/commands/modify/fluid-imports.test.ts
@@ -1,0 +1,226 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { copyFile, mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect } from "chai";
+import execa from "execa";
+import { afterEach, beforeEach, describe, it } from "mocha";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const cliPath = path.resolve(__dirname, "../../../../bin/run.js");
+const testResourceDirectory = path.join(__dirname, "fixtures", "fluid-imports");
+const packageResourcePrefix = `packages${path.sep}`;
+const testResourceFiles = [
+	"package.json",
+	"source.ts",
+	"tsconfig.json",
+	"packages/@fluidframework/flub-imports-fixture/package.json",
+	"packages/@fluidframework/flub-imports-fixture/index.d.ts",
+	"packages/@fluidframework/flub-imports-fixture/flub-alpha.d.ts",
+	"packages/@fluidframework/flub-imports-fixture/flub-beta.d.ts",
+	"packages/@fluidframework/flub-imports-fixture/flub-internal.d.ts",
+	"packages/@fluidframework/flub-imports-fixture/flub-legacy.d.ts",
+	"packages/@fluidframework/flub-imports-fixture/flub-legacy-alpha.d.ts",
+	"packages/@fluidframework/flub-imports-fixture/flub-legacy-beta.d.ts",
+	"packages/@fluidframework/flub-imports-no-internal-fixture/package.json",
+	"packages/@fluidframework/flub-imports-no-internal-fixture/index.d.ts",
+	"packages/@fluidframework/flub-imports-no-internal-fixture/beta.d.ts",
+] as const;
+
+let testDirectory: string | undefined;
+let sourcePath: string;
+let tsconfigPath: string;
+
+async function runFluidImports(args: string[] = []): Promise<string> {
+	const result = await execa(
+		process.execPath,
+		[cliPath, "modify", "fluid-imports", "--tsconfigs", tsconfigPath, "--quiet", ...args],
+		{
+			cwd: testDirectory,
+			reject: false,
+		},
+	);
+	expect(result.exitCode, result.stderr).to.equal(0);
+
+	return readFile(sourcePath, "utf8");
+}
+
+async function createTestWorkspace(): Promise<string> {
+	const directory = await mkdtemp(path.join(tmpdir(), "fluid-imports-test-"));
+	try {
+		await Promise.all(
+			testResourceFiles.map(async (resourcePath) => {
+				const normalizedResourcePath = resourcePath.split("/").join(path.sep);
+				const destinationPath = normalizedResourcePath.startsWith(packageResourcePrefix)
+					? path.join(
+							directory,
+							"node_modules",
+							normalizedResourcePath.slice(packageResourcePrefix.length),
+						)
+					: path.join(directory, normalizedResourcePath);
+				await mkdir(path.dirname(destinationPath), { recursive: true });
+				await copyFile(
+					path.join(testResourceDirectory, normalizedResourcePath),
+					destinationPath,
+				);
+			}),
+		);
+		return directory;
+	} catch (error) {
+		await rm(directory, { recursive: true, force: true, maxRetries: 3 });
+		throw error;
+	}
+}
+
+function escapeRegExp(value: string): string {
+	return value.replace(/[$()*+.?[\\\]^{|}]/g, "\\$&");
+}
+
+function expectNamedImportFrom(source: string, name: string, moduleSpecifier: string): void {
+	expect(source).to.match(
+		new RegExp(
+			`import\\s*(?:type\\s*)?\\{[^}]*\\b${escapeRegExp(name)}\\b[^}]*\\}\\s*from "${escapeRegExp(moduleSpecifier)}";`,
+		),
+	);
+}
+
+describe("flub modify fluid-imports", () => {
+	beforeEach(async () => {
+		testDirectory = undefined;
+		testDirectory = await createTestWorkspace();
+		sourcePath = path.join(testDirectory, "source.ts");
+		tsconfigPath = path.join(testDirectory, "tsconfig.json");
+	});
+	afterEach(async () => {
+		if (testDirectory !== undefined) {
+			await rm(testDirectory, { recursive: true, force: true, maxRetries: 3 });
+		}
+	});
+
+	it("uses direct membership and legacy compatibility paths for each import", async () => {
+		const updatedSource = await runFluidImports();
+
+		expectNamedImportFrom(
+			updatedSource,
+			"createChildLogger as legacyChildLogger",
+			"@fluidframework/flub-imports-fixture/legacy",
+		);
+		expectNamedImportFrom(
+			updatedSource,
+			"createChildLogger as internalChildLogger",
+			"@fluidframework/flub-imports-fixture/legacy",
+		);
+		expectNamedImportFrom(
+			updatedSource,
+			"publicSymbol as publicAlias",
+			"@fluidframework/flub-imports-fixture",
+		);
+		expectNamedImportFrom(
+			updatedSource,
+			"type BetaType as BetaTypeAlias",
+			"@fluidframework/flub-imports-fixture/beta",
+		);
+		expectNamedImportFrom(
+			updatedSource,
+			"betaSymbol",
+			"@fluidframework/flub-imports-fixture/beta",
+		);
+		expectNamedImportFrom(
+			updatedSource,
+			"alphaSymbol",
+			"@fluidframework/flub-imports-fixture/alpha",
+		);
+		expectNamedImportFrom(
+			updatedSource,
+			"legacyPreferredAlpha",
+			"@fluidframework/flub-imports-fixture/legacy",
+		);
+		expectNamedImportFrom(
+			updatedSource,
+			"dedicatedLegacyBeta",
+			"@fluidframework/flub-imports-fixture/legacy/beta",
+		);
+		expectNamedImportFrom(
+			updatedSource,
+			"dedicatedLegacyAlpha",
+			"@fluidframework/flub-imports-fixture/legacy/alpha",
+		);
+		expectNamedImportFrom(
+			updatedSource,
+			"NoInternalBeta",
+			"@fluidframework/flub-imports-no-internal-fixture/beta",
+		);
+		expectNamedImportFrom(
+			updatedSource,
+			"legacyBetaFallback",
+			"@fluidframework/flub-imports-fixture/legacy",
+		);
+		expectNamedImportFrom(
+			updatedSource,
+			"legacyAlphaFallback",
+			"@fluidframework/flub-imports-fixture/legacy",
+		);
+		expect(updatedSource).to.include(
+			`import type { InternalOnly as InternalOnlyType } from "@fluidframework/flub-imports-fixture/internal";`,
+		);
+		expect(updatedSource).to.include("// Keep this comment with the internal import.");
+		expect(updatedSource).to.match(
+			/\/\/ Keep this comment with the internal import\.\s*import\s*{[\S\s]*internalOnly[\S\s]*}\s*from "@fluidframework\/flub-imports-fixture\/internal";/,
+		);
+
+		const typeInternalImport = updatedSource.indexOf(
+			`import type { InternalOnly as InternalOnlyType } from "@fluidframework/flub-imports-fixture/internal";`,
+		);
+		const rootImport = updatedSource.indexOf(`from "@fluidframework/flub-imports-fixture";`);
+		const internalImport = updatedSource.indexOf(
+			`// Keep this comment with the internal import.`,
+		);
+		const betaImport = updatedSource.indexOf(
+			`from "@fluidframework/flub-imports-fixture/beta";`,
+		);
+		const legacyImport = updatedSource.indexOf(
+			`from "@fluidframework/flub-imports-fixture/legacy";`,
+		);
+		expect(typeInternalImport).to.be.lessThan(rootImport);
+		expect(rootImport).to.be.lessThan(internalImport);
+		expect(internalImport).to.be.lessThan(betaImport);
+		expect(betaImport).to.be.lessThan(legacyImport);
+	});
+
+	it("keeps unknown-tag exports on the established root fallback", async () => {
+		const updatedSource = await runFluidImports();
+
+		expectNamedImportFrom(
+			updatedSource,
+			"untaggedBetaSymbol",
+			"@fluidframework/flub-imports-fixture",
+		);
+	});
+
+	it("keeps public imports public and maps every other API to internal with --onlyInternal", async () => {
+		const updatedSource = await runFluidImports(["--onlyInternal"]);
+
+		expectNamedImportFrom(
+			updatedSource,
+			"publicSymbol as publicAlias",
+			"@fluidframework/flub-imports-fixture",
+		);
+		expect(updatedSource).to.include("createChildLogger as legacyChildLogger");
+		expect(updatedSource).to.include("createChildLogger as internalChildLogger");
+		expect(updatedSource).to.include("type BetaType as BetaTypeAlias");
+		expect(updatedSource).to.not.include(
+			`from "@fluidframework/flub-imports-fixture/legacy";`,
+		);
+		expect(updatedSource).to.not.include(`from "@fluidframework/flub-imports-fixture/beta";`);
+		expectNamedImportFrom(
+			updatedSource,
+			"NoInternalBeta",
+			"@fluidframework/flub-imports-no-internal-fixture",
+		);
+	});
+});

--- a/build-tools/packages/build-cli/src/test/commands/modify/fluid-imports.test.ts
+++ b/build-tools/packages/build-cli/src/test/commands/modify/fluid-imports.test.ts
@@ -29,7 +29,7 @@ const testResourceFiles = [
 	"packages/@fluidframework/flub-imports-fixture/flub-legacy-beta.d.ts",
 	"packages/@fluidframework/flub-imports-no-internal-fixture/package.json",
 	"packages/@fluidframework/flub-imports-no-internal-fixture/index.d.ts",
-	"packages/@fluidframework/flub-imports-no-internal-fixture/beta.d.ts",
+	"packages/@fluidframework/flub-imports-no-internal-fixture/flub-beta.d.ts",
 ] as const;
 
 let testDirectory: string | undefined;

--- a/build-tools/packages/build-cli/src/test/tsconfig.json
+++ b/build-tools/packages/build-cli/src/test/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
 	"include": ["./**/*"],
-	"exclude": ["./data/**/*"],
+	"exclude": ["./commands/modify/fixtures/**/*", "./data/**/*"],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/fluidBuild.config.cjs
+++ b/fluidBuild.config.cjs
@@ -617,6 +617,7 @@ module.exports = {
 			],
 			"npm-private-packages": [
 				// test packages
+				"^build-tools/packages/build-cli/src/test/commands/modify/fixtures/fluid-imports/packages/",
 				"^build-tools/packages/build-infrastructure/src/test/data/testRepo/",
 			],
 			"pnpm-npm-package-json-preinstall": [


### PR DESCRIPTION
## Description

Fixes `flub modify fluid-imports` so imported APIs are mapped to the most stable package entry point that actually exports them.

Previously, the modifier built its API map solely from `/internal`. This conflated same-named facade and implementation declarations, such as `createChildLogger` in `@fluidframework/telemetry-utils`, and could incorrectly rewrite a supported `/legacy` import to `/internal`.

The modifier now inspects available package entry points independently and applies this precedence: public root, beta, legacy compatibility paths, alpha, then internal. Missing entry points are tolerated, while existing `--onlyInternal`, unknown-export fallback, aliases, type-only imports, comments, and import ordering behavior are preserved.

Command-level regression tests use isolated temporary workspaces with realistic package export maps, including same-named legacy/internal declarations, dedicated legacy paths, alpha precedence, internal-only APIs, and packages without `/internal`.

## Reviewer Guidance

The review process is outlined in [the pull request guidelines](../docs/content/Contributing/PR-Guidelines.md#guidelines).

Please focus on the entry-point precedence and historical legacy-beta/legacy-alpha compatibility handling.

## Testing

- `@fluid-tools/build-cli` CI readiness checks
- Build and test TypeScript compilation
- ESLint and API documentation generation
- Build-cli Mocha suite: 510 passing, 1 pending