### PR TITLE
createBlobPayloadPending default on 2.40.0 and explicit disable option

### DIFF
--- a/.changeset/nice-hotels-act.md
+++ b/.changeset/nice-hotels-act.md
@@ -1,0 +1,7 @@
+---
+"@fluidframework/container-runtime": minor
+"__section": feature
+---
+createBlobPayloadPending now defaults to enabled for newer clients, and can be explicitly disabled
+
+The `createBlobPayloadPending` runtime option now defaults to `true` when `minVersionForCollab` is `2.40.0` or later (previously it always defaulted to `undefined`/disabled). Since this changes the document schema, it will only turn on for new documents, or existing documents that already have upgraded their schema. It can still be explicitly enabled or disabled by setting the option in `ContainerRuntimeOptions`. As part of this change, the type of `createBlobPayloadPending` was widened from `true | undefined` to `boolean | undefined`, so it can now be explicitly set to `false` to opt out of the new default.

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -155,6 +155,9 @@
 	},
 	"typeValidation": {
 		"broken": {
+			"Interface_ContainerRuntimeFactoryWithDefaultDataStoreProps": {
+				"backCompat": false
+			},
 			"Interface_DataObjectFactoryProps": {
 				"backCompat": false
 			},

--- a/packages/framework/aqueduct/src/test/types/validateAqueductPrevious.generated.ts
+++ b/packages/framework/aqueduct/src/test/types/validateAqueductPrevious.generated.ts
@@ -258,6 +258,7 @@ declare type old_as_current_for_Interface_ContainerRuntimeFactoryWithDefaultData
  * typeValidation.broken:
  * "Interface_ContainerRuntimeFactoryWithDefaultDataStoreProps": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_ContainerRuntimeFactoryWithDefaultDataStoreProps = requireAssignableTo<TypeOnly<current.ContainerRuntimeFactoryWithDefaultDataStoreProps>, TypeOnly<old.ContainerRuntimeFactoryWithDefaultDataStoreProps>>
 
 /*

--- a/packages/runtime/container-runtime/api-report/container-runtime.legacy.alpha.api.md
+++ b/packages/runtime/container-runtime/api-report/container-runtime.legacy.alpha.api.md
@@ -36,7 +36,7 @@ export enum ContainerMessageType {
 export interface ContainerRuntimeOptions {
     readonly chunkSizeInBytes: number;
     readonly compressionOptions: ICompressionRuntimeOptions;
-    readonly createBlobPayloadPending: true | undefined;
+    readonly createBlobPayloadPending: boolean | undefined;
     readonly disableSchemaUpgrade: boolean;
     // @deprecated
     readonly enableGroupedBatching: boolean;

--- a/packages/runtime/container-runtime/api-report/container-runtime.legacy.beta.api.md
+++ b/packages/runtime/container-runtime/api-report/container-runtime.legacy.beta.api.md
@@ -36,7 +36,7 @@ export enum ContainerMessageType {
 export interface ContainerRuntimeOptions {
     readonly chunkSizeInBytes: number;
     readonly compressionOptions: ICompressionRuntimeOptions;
-    readonly createBlobPayloadPending: true | undefined;
+    readonly createBlobPayloadPending: boolean | undefined;
     readonly disableSchemaUpgrade: boolean;
     // @deprecated
     readonly enableGroupedBatching: boolean;

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -233,7 +233,13 @@
 	},
 	"typeValidation": {
 		"broken": {
+			"Interface_ContainerRuntimeOptions": {
+				"backCompat": false
+			},
 			"Interface_LoadContainerRuntimeParams": {
+				"backCompat": false
+			},
+			"TypeAlias_IContainerRuntimeOptions": {
 				"backCompat": false
 			}
 		},

--- a/packages/runtime/container-runtime/src/containerCompatibility.ts
+++ b/packages/runtime/container-runtime/src/containerCompatibility.ts
@@ -157,7 +157,11 @@ const runtimeOptionsAffectingDocSchemaConfigMap: ConfigMap<RuntimeOptionsAffecti
 			// "3.0.0": { enableGCSweep: true },
 		},
 		createBlobPayloadPending: {
+			// Disabled by default for versions predating 2.40.0, since older clients don't understand the
+			// document format changes associated with pending blob payloads.
 			"1.0.0": undefined,
+			// Enabled by default starting at 2.40.0, since blob functionality is not exposed on the `@public`
+			// API surface, making this a reasonably safe version to flip the default at.
 			"2.40.0": true,
 		},
 	};

--- a/packages/runtime/container-runtime/src/containerCompatibility.ts
+++ b/packages/runtime/container-runtime/src/containerCompatibility.ts
@@ -161,6 +161,7 @@ const runtimeOptionsAffectingDocSchemaConfigMap: ConfigMap<RuntimeOptionsAffecti
 			// closed on the version where that will happen yet.  Probably a .10 release since blob functionality is not
 			// exposed on the `@public` API surface.
 			"1.0.0": undefined,
+			"2.40.0": true,
 		},
 	};
 

--- a/packages/runtime/container-runtime/src/containerCompatibility.ts
+++ b/packages/runtime/container-runtime/src/containerCompatibility.ts
@@ -157,9 +157,6 @@ const runtimeOptionsAffectingDocSchemaConfigMap: ConfigMap<RuntimeOptionsAffecti
 			// "3.0.0": { enableGCSweep: true },
 		},
 		createBlobPayloadPending: {
-			// This feature is new and disabled by default. In the future we will enable it by default, but we have not
-			// closed on the version where that will happen yet.  Probably a .10 release since blob functionality is not
-			// exposed on the `@public` API surface.
 			"1.0.0": undefined,
 			"2.40.0": true,
 		},

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -483,9 +483,9 @@ export interface ContainerRuntimeOptions {
 
 	/**
 	 * Create blob handles with pending payloads when calling createBlob.
-	 * Default is `undefined` (disabled) when `oldestClientSupported` is `<2.40.0`, but enabled when `oldestClientSupported` is `>=2.40.0`).
+	 * Default is `undefined` (disabled) when `minVersionForCollab` is `<2.40.0`, but enabled when `minVersionForCollab` is `>=2.40.0`.
 	 * When enabled (`true`), createBlob will return a handle before the blob upload completes.
-	 * Use explicit `false` to disable this feature when `oldestClientSupported` is `>=2.40.0`.
+	 * Use explicit `false` to disable this feature when `minVersionForCollab` is `>=2.40.0`.
 	 */
 	readonly createBlobPayloadPending: boolean | undefined;
 

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -482,10 +482,12 @@ export interface ContainerRuntimeOptions {
 	readonly explicitSchemaControl: boolean;
 
 	/**
-	 * Create blob handles with pending payloads when calling createBlob (default is `undefined` (disabled)).
+	 * Create blob handles with pending payloads when calling createBlob.
+	 * Default is `undefined` (disabled) when `oldestClientSupported` is `<2.40.0`, but enabled when `oldestClientSupported` is `>=2.40.0`).
 	 * When enabled (`true`), createBlob will return a handle before the blob upload completes.
+	 * Use explicit `false` to disable this feature when `oldestClientSupported` is `>=2.40.0`.
 	 */
-	readonly createBlobPayloadPending: true | undefined;
+	readonly createBlobPayloadPending: boolean | undefined;
 
 	/**
 	 * Controls automatic batch flushing during staging mode.

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1101,6 +1101,15 @@ export class ContainerRuntime
 			if (disallowedKeys.length > 0) {
 				throw new UsageError(`explicitSchemaControl must be enabled to use ${disallowedKeys}`);
 			}
+			// createBlobPayloadPending is a special case: unlike the other options above, it can resolve to
+			// enabled purely via defaults (it defaults to `true` once minVersionForCollab >= 2.40.0), without
+			// ever being set explicitly in runtimeOptions. The check above only catches values explicitly
+			// present in runtimeOptions, so it would miss this case; check the resolved value directly instead.
+			if (createBlobPayloadPending !== undefined) {
+				throw new UsageError(
+					"explicitSchemaControl must be enabled to use createBlobPayloadPending",
+				);
+			}
 		}
 
 		// The logic for enableRuntimeIdCompressor is a bit different. Since `undefined` represents a logical state (off)

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -1085,10 +1085,12 @@ export class ContainerRuntime
 			compressionOptions = enableGroupedBatching === false
 				? disabledCompressionConfig
 				: defaultConfigs.compressionOptions,
-			createBlobPayloadPending = defaultConfigs.createBlobPayloadPending,
+			createBlobPayloadPending:
+				createBlobPayloadPendingResolved = defaultConfigs.createBlobPayloadPending,
 			stagingModeAutoFlushThreshold = defaultConfigs.stagingModeAutoFlushThreshold,
 			disableSchemaUpgrade = defaultConfigs.disableSchemaUpgrade,
 		}: IContainerRuntimeOptionsInternal = runtimeOptions;
+		let createBlobPayloadPending = createBlobPayloadPendingResolved;
 
 		// If explicitSchemaControl is off, ensure that options which require explicitSchemaControl are not enabled.
 		if (!explicitSchemaControl) {
@@ -1104,12 +1106,10 @@ export class ContainerRuntime
 			// createBlobPayloadPending is a special case: unlike the other options above, it can resolve to
 			// enabled purely via defaults (it defaults to `true` once minVersionForCollab >= 2.40.0), without
 			// ever being set explicitly in runtimeOptions. The check above only catches values explicitly
-			// present in runtimeOptions, so it would miss this case; check the resolved value directly instead.
-			if (createBlobPayloadPending !== undefined) {
-				throw new UsageError(
-					"explicitSchemaControl must be enabled to use createBlobPayloadPending",
-				);
-			}
+			// present in runtimeOptions (and already throws above if the caller did so), so it would miss
+			// this purely-default-driven case. Rather than erroring on callers who never asked for this
+			// feature, just silently keep it disabled here to stay consistent with explicitSchemaControl.
+			createBlobPayloadPending = undefined;
 		}
 
 		// The logic for enableRuntimeIdCompressor is a bit different. Since `undefined` represents a logical state (off)

--- a/packages/runtime/container-runtime/src/summary/documentSchema.ts
+++ b/packages/runtime/container-runtime/src/summary/documentSchema.ts
@@ -148,7 +148,7 @@ export interface IDocumentSchemaFeatures {
 	compressionLz4: boolean;
 	idCompressorMode: IdCompressorMode;
 	opGroupingEnabled: boolean;
-	createBlobPayloadPending: true | undefined;
+	createBlobPayloadPending: boolean | undefined;
 
 	/**
 	 * List of disallowed versions of the runtime.
@@ -189,7 +189,9 @@ export interface IDocumentSchemaCurrent extends Required<IDocumentSchema> {
 	version: typeof currentDocumentVersionSchema;
 	// This narrows the runtime property to only include the properties in IDocumentSchemaFeatures (all as optional)
 	runtime: {
-		[P in keyof IDocumentSchemaFeatures]?: IDocumentSchemaFeatures[P] extends boolean
+		[P in keyof IDocumentSchemaFeatures]?: IDocumentSchemaFeatures[P] extends
+			| boolean
+			| undefined
 			? true
 			: IDocumentSchemaFeatures[P];
 	};
@@ -675,7 +677,8 @@ export class DocumentsSchemaController {
 				compressionLz4: boolToProp(features.compressionLz4),
 				idCompressorMode: features.idCompressorMode,
 				opGroupingEnabled: boolToProp(features.opGroupingEnabled),
-				createBlobPayloadPending: features.createBlobPayloadPending,
+				createBlobPayloadPending:
+					features.createBlobPayloadPending === true ? true : undefined,
 				disallowedVersions: arrayToProp(features.disallowedVersions),
 				...retiredFeatureValues(),
 			},

--- a/packages/runtime/container-runtime/src/test/containerCompatibility.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerCompatibility.spec.ts
@@ -1,0 +1,51 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "node:assert";
+
+import {
+	getMinVersionForCollabDefaults,
+	validateRuntimeOptions,
+} from "../containerCompatibility.js";
+
+describe("containerCompatibility", () => {
+	describe("createBlobPayloadPending defaults", () => {
+		it("is undefined (disabled) for minVersionForCollab below 2.40.0", () => {
+			const defaults = getMinVersionForCollabDefaults("2.0.0");
+			assert.strictEqual(defaults.createBlobPayloadPending, undefined);
+		});
+
+		it("is true (enabled) for minVersionForCollab at 2.40.0", () => {
+			const defaults = getMinVersionForCollabDefaults("2.40.0");
+			assert.strictEqual(defaults.createBlobPayloadPending, true);
+		});
+
+		it("is true (enabled) for minVersionForCollab above 2.40.0", () => {
+			const defaults = getMinVersionForCollabDefaults("3.0.0");
+			assert.strictEqual(defaults.createBlobPayloadPending, true);
+		});
+	});
+
+	describe("validateRuntimeOptions for createBlobPayloadPending", () => {
+		it("does not throw when explicitly disabled (false), regardless of minVersionForCollab", () => {
+			assert.doesNotThrow(() =>
+				validateRuntimeOptions("3.0.0", { createBlobPayloadPending: false }),
+			);
+			assert.doesNotThrow(() =>
+				validateRuntimeOptions("2.0.0", { createBlobPayloadPending: false }),
+			);
+		});
+
+		it("does not throw when explicitly enabled (true) with a sufficiently new minVersionForCollab", () => {
+			assert.doesNotThrow(() =>
+				validateRuntimeOptions("2.40.0", { createBlobPayloadPending: true }),
+			);
+		});
+
+		it("throws when explicitly enabled (true) with a minVersionForCollab that does not support it", () => {
+			assert.throws(() => validateRuntimeOptions("2.0.0", { createBlobPayloadPending: true }));
+		});
+	});
+});

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -4286,31 +4286,36 @@ describe("Runtime", () => {
 					);
 				});
 
-				it("Throws when createBlobPayloadPending defaults to enabled (via minVersionForCollab) while explicitSchemaControl is explicitly disabled", async () => {
+				it("createBlobPayloadPending stays disabled when it would otherwise default to enabled (via minVersionForCollab) while explicitSchemaControl is explicitly disabled", async () => {
 					// createBlobPayloadPending is intentionally left unset here: with minVersionForCollab
-					// >= 2.40.0, it resolves to `true` purely via defaults. explicitSchemaControl is
-					// explicitly set to `false`, so this should still be rejected even though
-					// createBlobPayloadPending never appears in runtimeOptions.
-					await assert.rejects(
-						async () =>
-							ContainerRuntime.loadRuntime2({
-								context: getMockContext() as IContainerContext,
-								registry: new FluidDataStoreRegistry([]),
-								existing: false,
-								runtimeOptions: {
-									explicitSchemaControl: false,
-								},
-								minVersionForCollab: "2.40.0",
-								provideEntryPoint: mockProvideEntryPoint,
-							}),
-						(error: IErrorBase) => {
-							return (
-								error.errorType === ContainerErrorTypes.usageError &&
-								error.message ===
-									"explicitSchemaControl must be enabled to use createBlobPayloadPending"
-							);
+					// >= 2.40.0, it would normally resolve to `true` purely via defaults. However,
+					// explicitSchemaControl is explicitly set to `false`, so createBlobPayloadPending should
+					// silently stay disabled rather than throwing, since callers who never asked for this
+					// feature (and don't otherwise set explicitSchemaControl for blob-related reasons)
+					// shouldn't be broken by it turning on behind their back.
+					const mockLogger = new MockLogger();
+					await ContainerRuntime.loadRuntime2({
+						context: getMockContext({ logger: mockLogger }) as IContainerContext,
+						registry: new FluidDataStoreRegistry([]),
+						existing: false,
+						runtimeOptions: {
+							explicitSchemaControl: false,
 						},
-						"Container should throw when createBlobPayloadPending defaults to enabled while explicitSchemaControl is explicitly disabled",
+						minVersionForCollab: "2.40.0",
+						provideEntryPoint: mockProvideEntryPoint,
+					});
+
+					const loadStatsEvent = mockLogger.events.find(
+						(event) => event.eventName === "ContainerRuntime:ContainerLoadStats",
+					);
+					assert(loadStatsEvent !== undefined, "Expected a ContainerLoadStats event");
+					const loggedOptions = JSON.parse(
+						loadStatsEvent.options as string,
+					) as IContainerRuntimeOptionsInternal;
+					assert.strictEqual(
+						loggedOptions.createBlobPayloadPending,
+						undefined,
+						"createBlobPayloadPending should remain disabled when explicitSchemaControl is disabled",
 					);
 				});
 			});

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -4285,6 +4285,34 @@ describe("Runtime", () => {
 						"Container should throw when createBlobPayloadPending is on and explicitSchemaControl is not enabled",
 					);
 				});
+
+				it("Throws when createBlobPayloadPending defaults to enabled (via minVersionForCollab) while explicitSchemaControl is explicitly disabled", async () => {
+					// createBlobPayloadPending is intentionally left unset here: with minVersionForCollab
+					// >= 2.40.0, it resolves to `true` purely via defaults. explicitSchemaControl is
+					// explicitly set to `false`, so this should still be rejected even though
+					// createBlobPayloadPending never appears in runtimeOptions.
+					await assert.rejects(
+						async () =>
+							ContainerRuntime.loadRuntime2({
+								context: getMockContext() as IContainerContext,
+								registry: new FluidDataStoreRegistry([]),
+								existing: false,
+								runtimeOptions: {
+									explicitSchemaControl: false,
+								},
+								minVersionForCollab: "2.40.0",
+								provideEntryPoint: mockProvideEntryPoint,
+							}),
+						(error: IErrorBase) => {
+							return (
+								error.errorType === ContainerErrorTypes.usageError &&
+								error.message ===
+									"explicitSchemaControl must be enabled to use createBlobPayloadPending"
+							);
+						},
+						"Container should throw when createBlobPayloadPending defaults to enabled while explicitSchemaControl is explicitly disabled",
+					);
+				});
 			});
 		});
 

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -4644,6 +4644,7 @@ describe("Runtime", () => {
 					enableRuntimeIdCompressor: undefined,
 					enableGroupedBatching: true,
 					explicitSchemaControl: true,
+					createBlobPayloadPending: true,
 					stagingModeAutoFlushThreshold: 1000,
 					disableSchemaUpgrade: false,
 				};

--- a/packages/runtime/container-runtime/src/test/documentSchema.spec.ts
+++ b/packages/runtime/container-runtime/src/test/documentSchema.spec.ts
@@ -397,6 +397,49 @@ describe("Runtime", () => {
 		);
 	});
 
+	it("createBlobPayloadPending: explicit false is not persisted as false in the schema", () => {
+		// `createBlobPayloadPending` is a tri-state-ish option: `true` means enabled, and both `false`
+		// (explicitly disabled) and `undefined` (default/disabled) should be summarized as `undefined`,
+		// since the document schema only ever needs to record the "enabled" case.
+		const featuresModified = { ...features, createBlobPayloadPending: false };
+		const controller = new DocumentsSchemaController(
+			false, // existing,
+			0, // snapshotSequenceNumber
+			undefined, // old schema,
+			featuresModified,
+			() => {}, // onSchemaChange
+			{ minVersionForCollab: defaultMinVersionForCollab }, // info,
+			logger,
+			false,
+		);
+
+		assert.strictEqual(
+			controller.sessionSchema.runtime.createBlobPayloadPending,
+			undefined,
+			"explicit false should be normalized to undefined in the schema",
+		);
+	});
+
+	it("createBlobPayloadPending: true is persisted as true in the schema", () => {
+		const featuresModified = { ...features, createBlobPayloadPending: true };
+		const controller = new DocumentsSchemaController(
+			false, // existing,
+			0, // snapshotSequenceNumber
+			undefined, // old schema,
+			featuresModified,
+			() => {}, // onSchemaChange
+			{ minVersionForCollab: defaultMinVersionForCollab }, // info,
+			logger,
+			false,
+		);
+
+		assert.strictEqual(
+			controller.sessionSchema.runtime.createBlobPayloadPending,
+			true,
+			"true should be persisted as true in the schema",
+		);
+	});
+
 	function testExistingDocNoChangesInSchema(schema: IDocumentSchema) {
 		const controller = new DocumentsSchemaController(
 			true, // existing,

--- a/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
+++ b/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
@@ -105,6 +105,7 @@ declare type old_as_current_for_Interface_ContainerRuntimeOptions = requireAssig
  * typeValidation.broken:
  * "Interface_ContainerRuntimeOptions": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Interface_ContainerRuntimeOptions = requireAssignableTo<TypeOnly<current.ContainerRuntimeOptions>, TypeOnly<old.ContainerRuntimeOptions>>
 
 /*
@@ -772,6 +773,7 @@ declare type old_as_current_for_TypeAlias_IContainerRuntimeOptions = requireAssi
  * typeValidation.broken:
  * "TypeAlias_IContainerRuntimeOptions": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_TypeAlias_IContainerRuntimeOptions = requireAssignableTo<TypeOnly<current.IContainerRuntimeOptions>, TypeOnly<old.IContainerRuntimeOptions>>
 
 /*

--- a/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
@@ -33,6 +33,7 @@ import {
 	waitForContainerConnection,
 	timeoutPromise,
 } from "@fluidframework/test-utils/internal";
+import * as semver from "semver";
 import { v4 as uuid } from "uuid";
 
 import { wrapObjectAndOverride } from "../mocking.js";
@@ -42,6 +43,13 @@ import {
 	driverSupportsBlobs,
 	getUrlFromDetachedBlobStorage,
 } from "./mockDetachedBlobStorage.js";
+
+// The oldest container runtime version whose document schema validator understands an explicit `false` for
+// createBlobPayloadPending (older runtimes only accepted `true` / `undefined` and will throw
+// "Document can't be opened with current version of the code" if they see `false`). This is pinned to the
+// current package version at the time this support was added, rather than referencing pkgVersion directly, so it
+// keeps meaning "the version this shipped in" even after future releases bump pkgVersion further.
+const minCreateBlobPayloadPendingFalseVersion = "3.0.0";
 
 function makeTestContainerConfig(
 	registry: ChannelFactoryRegistry,
@@ -127,6 +135,21 @@ for (const createBlobPayloadPending of [false, true] as const) {
 				if (
 					provider.driver.type === "routerlicious" &&
 					provider.driver.endpointName === "frs"
+				) {
+					this.skip();
+				}
+				// Explicitly disabling createBlobPayloadPending (via `false`) is a new capability; older
+				// container runtimes only understood `true` / `undefined` for this option and will fail to
+				// open a document whose schema records an explicit `false`. minCreateBlobPayloadPendingFalseVersion
+				// is the oldest runtime version that understands `false`, i.e. the version this support ships in.
+				// Skip cross-version compat runs where either the creating or loading container runtime predates it.
+				if (
+					createBlobPayloadPending === false &&
+					(semver.lt(apis.containerRuntime.version, minCreateBlobPayloadPendingFalseVersion) ||
+						semver.lt(
+							apis.containerRuntimeForLoading.version,
+							minCreateBlobPayloadPendingFalseVersion,
+						))
 				) {
 					this.skip();
 				}

--- a/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
@@ -53,7 +53,7 @@ const minCreateBlobPayloadPendingFalseVersion = "3.0.0";
 
 function makeTestContainerConfig(
 	registry: ChannelFactoryRegistry,
-	createBlobPayloadPending: boolean,
+	createBlobPayloadPending: boolean | undefined,
 ): ITestContainerConfig {
 	return {
 		runtimeOptions: {
@@ -107,9 +107,12 @@ const ContainerStateEventsOrErrors: ExpectedEvents = {
 	],
 };
 
-// Use false/true (not undefined) since minVersionForCollab is pinned to 2.40.0 below, where
-// createBlobPayloadPending defaults to true; undefined would no longer exercise the disabled path.
-for (const createBlobPayloadPending of [false, true] as const) {
+// createBlobPayloadPending defaults to `true` because minVersionForCollab is pinned to 2.40.0 below (this
+// default-on-2.40.0 behavior predates this file's explicit-`false` support and is already understood by all
+// container runtime versions used in these compat tests). Including `undefined` alongside explicit `false`/`true`
+// verifies that relying on the default (as most consumers will) produces the same enabled behavior as explicitly
+// requesting `true`.
+for (const createBlobPayloadPending of [false, true, undefined] as const) {
 	describeCompat(
 		`blobs (createBlobPayloadPending: ${createBlobPayloadPending})`,
 		"FullCompat",

--- a/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/blobs.spec.ts
@@ -45,7 +45,7 @@ import {
 
 function makeTestContainerConfig(
 	registry: ChannelFactoryRegistry,
-	createBlobPayloadPending: true | undefined,
+	createBlobPayloadPending: boolean,
 ): ITestContainerConfig {
 	return {
 		runtimeOptions: {
@@ -63,7 +63,9 @@ function makeTestContainerConfig(
 					},
 				},
 			},
-			explicitSchemaControl: createBlobPayloadPending,
+			// explicitSchemaControl is required whenever createBlobPayloadPending is explicitly set (true or
+			// false); it also matches the default for minVersionForCollab 2.40.0 below.
+			explicitSchemaControl: true,
 			createBlobPayloadPending,
 		},
 		registry,
@@ -97,7 +99,9 @@ const ContainerStateEventsOrErrors: ExpectedEvents = {
 	],
 };
 
-for (const createBlobPayloadPending of [undefined, true] as const) {
+// Use false/true (not undefined) since minVersionForCollab is pinned to 2.40.0 below, where
+// createBlobPayloadPending defaults to true; undefined would no longer exercise the disabled path.
+for (const createBlobPayloadPending of [false, true] as const) {
 	describeCompat(
 		`blobs (createBlobPayloadPending: ${createBlobPayloadPending})`,
 		"FullCompat",

--- a/packages/test/test-end-to-end-tests/src/test/blobsisAttached.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/blobsisAttached.spec.ts
@@ -36,7 +36,9 @@ import { driverSupportsBlobs } from "./mockDetachedBlobStorage.js";
 const mapId = "map";
 const directoryId = "directoryKey";
 
-for (const createBlobPayloadPending of [undefined, true] as const) {
+// Note: we use `false` (rather than `undefined`) to represent the disabled case, since `undefined` no longer
+// guarantees the feature is disabled now that it defaults to enabled for sufficiently new minVersionForCollab.
+for (const createBlobPayloadPending of [false, true] as const) {
 	describeCompat(
 		`blob handle isAttached (createBlobPayloadPending: ${createBlobPayloadPending})`,
 		"NoCompat",

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcSweepAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcSweepAttachmentBlobs.spec.ts
@@ -307,6 +307,11 @@ describeCompat("GC attachment blob sweep tests", "NoCompat", (getTestObjectProvi
 				const blobHandle2 = toFluidHandleInternal(
 					await mainDataStore._runtime.uploadBlob(stringToBuffer(blobContents, "utf-8")),
 				);
+				// blobHandle2 is never referenced in a DDS in this test, so it wouldn't otherwise have its
+				// graph attached. When createBlobPayloadPending is enabled, the blob's upload doesn't begin
+				// until the handle's graph is attached, so we do so explicitly here to ensure it becomes a
+				// tracked (and immediately unreferenced) GC node like it would under the legacy blob flow.
+				blobHandle2.attachGraph();
 
 				// Reference and then unreference the blob via one of the handles so that it's unreferenced in next summary.
 				mainDataStore._root.set("blob1", blobHandle1);

--- a/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneAttachmentBlobs.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/gc/gcTombstoneAttachmentBlobs.spec.ts
@@ -201,6 +201,11 @@ describeCompat("GC attachment blob tombstone tests", "NoCompat", (getTestObjectP
 				const blobHandle2 = await mainDataStore._runtime.uploadBlob(
 					stringToBuffer(blobContents, "utf-8"),
 				);
+				// blobHandle2 is never referenced in a DDS in this test, so it wouldn't otherwise have its
+				// graph attached. When createBlobPayloadPending is enabled, the blob's upload doesn't begin
+				// until the handle's graph is attached, so we do so explicitly here to ensure it becomes a
+				// tracked (and immediately unreferenced) GC node like it would under the legacy blob flow.
+				toFluidHandleInternal(blobHandle2).attachGraph();
 
 				// Reference and then unreference the blob via one of the handles so that it's unreferenced in next summary.
 				mainDataStore._root.set("blob1", blobHandle1);

--- a/packages/test/test-service-load/src/optionsMatrix.ts
+++ b/packages/test/test-service-load/src/optionsMatrix.ts
@@ -142,9 +142,11 @@ export function generateRuntimeOptions(
 		}
 	});
 
-	// Override explicitSchemaControl to enabled if createBlobPayloadPending is enabled
+	// Override explicitSchemaControl to enabled if createBlobPayloadPending is explicitly set (true or false),
+	// since explicitSchemaControl is required whenever createBlobPayloadPending is explicitly configured (not just
+	// when enabling it) - see the `runtimeOptionKeysThatRequireExplicitSchemaControl` check in containerRuntime.ts.
 	pairwiseOptions.map((options) => {
-		if (options.createBlobPayloadPending === true) {
+		if (options.createBlobPayloadPending !== undefined) {
 			(
 				options as {
 					// Remove readonly modifier to allow overriding

--- a/packages/test/test-service-load/src/optionsMatrix.ts
+++ b/packages/test/test-service-load/src/optionsMatrix.ts
@@ -115,7 +115,7 @@ export function generateRuntimeOptions(
 		chunkSizeInBytes: [204800],
 		enableRuntimeIdCompressor: ["on", undefined, "delayed"],
 		enableGroupedBatching: [true, false],
-		createBlobPayloadPending: [true, undefined],
+		createBlobPayloadPending: [true, false, undefined],
 		explicitSchemaControl: [true, false],
 		disableSchemaUpgrade: [false],
 		stagingModeAutoFlushThreshold: [undefined],
@@ -144,7 +144,7 @@ export function generateRuntimeOptions(
 
 	// Override explicitSchemaControl to enabled if createBlobPayloadPending is enabled
 	pairwiseOptions.map((options) => {
-		if (options.createBlobPayloadPending) {
+		if (options.createBlobPayloadPending === true) {
 			(
 				options as {
 					// Remove readonly modifier to allow overriding


### PR DESCRIPTION
- turning `createBlobPayloadPending` on by default on >=2.40.0 versions by adding the option on `runtimeOptionsAffectingDocSchemaConfigMap`
- `createBlobPayloadPending` can now be set to false to be able to explicity disable the feature. 
- Added unit test coverage for the new default/explicit-disable behavior:
- `documentSchema.spec.ts`: verifies explicit `false` normalizes to `undefined` in the document schema summary, and `true` persists as `true`.
- `containerCompatibility.spec.ts` (new file): covers `getMinVersionForCollabDefaults` and `validateRuntimeOptions` for `createBlobPayloadPending` across version thresholds.
- Fixed a stale `containerRuntime.spec.ts` expectation that didn't account for the new default turning on at `minVersionForCollab >= 2.40.0`.
- Added a changeset (`.changeset/nice-hotels-act.md`) and regenerated the `container-runtime` legacy alpha/beta API reports to reflect the `createBlobPayloadPending` type widening (`true | undefined` → `boolean | undefined`).
- Fixed a downstream type-test break in `@fluidframework/aqueduct` caused by the widened type: acknowledged the intentional back-compat break via `typeValidation.broken` in `package.json` and regenerated the aqueduct type tests.
- Fixed `test-service-load`'s `optionsMatrix.ts` to include `false` in the `createBlobPayloadPending` option matrix (previously only `[true, undefined]`), and updated the `explicitSchemaControl` override check to be explicit (`=== true`) instead of truthy, since `false` is now a valid, meaningful value.
- Fixed 3 real-service e2e tests that broke due to the new default (these tests predated this change and assumed `undefined` meant "disabled", which is no longer true once `minVersionForCollab >= 2.40.0`):
  - `blobsisAttached.spec.ts`: changed the test matrix from `[undefined, true]` to `[false, true]` so the disabled case is still exercised.
  - `blobs.spec.ts`: same fix — matrix pinned `minVersionForCollab: "2.40.0"`, so `undefined` no longer disabled the feature; switched to `[false, true]` and decoupled `explicitSchemaControl` from the loop variable.
  - `gcSweepAttachmentBlobs.spec.ts` / `gcTombstoneAttachmentBlobs.spec.ts`: fixed a latent bug where a de-duped blob handle that's never referenced in a DDS never had its graph attached, so its upload never started under the payload-pending flow — added an explicit `attachGraph()` call to match the eager-upload behavior these GC/dedup tests rely on.