### PR TITLE
docs(website): Update docs to use `ApiLink`

### DIFF
--- a/website/docs/build/packages.mdx
+++ b/website/docs/build/packages.mdx
@@ -3,14 +3,16 @@ title: Packages
 sidebar_position: 9
 ---
 
+import { PackageLink } from "@site/src/components/shortLinks";
+
 The Fluid Framework is a multi-layered system consisting of dozens of individual npm packages.
 Most developers will only need two or three of these packages for typical Fluid development:
-- The [fluid-framework][] package, which contains the public API for the Fluid Framework
-- A service-specific client package, such as the [@fluidframework/azure-client](../api/azure-client/index.md).
+- The <PackageLink packageName="fluid-framework" /> package, which contains the public API for the Fluid Framework
+- A service-specific client package, such as the <PackageLink packageName="azure-client">@fluidframework/azure-client</PackageLink>.
 
 ## Primary API: fluid-framework
 
-The [fluid-framework][] package consists primarily of two portions: the [FluidContainer][] object and a selection of
+The <PackageLink packageName="fluid-framework" /> package consists primarily of two portions: the [FluidContainer][] object and a selection of
 distributed data structures (DDSes).
 
 ### FluidContainer
@@ -21,7 +23,7 @@ It includes functionality to retrieve the Fluid data contained within itself, as
 ### Distributed Data Structures (DDSes)
 
 You'll use one or more DDSes in your container to model your collaborative data.
-The [fluid-framework][] package includes a few such data structures that cover a broad range of scenarios:
+The <PackageLink packageName="fluid-framework" /> package includes a few such data structures that cover a broad range of scenarios:
 
 - [SharedTree](../data-structures/tree/index.mdx): a collaborative tree data structure for building complex, hierarchical data models.
 	:::tip
@@ -49,7 +51,7 @@ Fluid Framework packages are published under one of the following npm scopes:
 -   @fluid-internal
 -   @fluid-tools
 
-In addition to the scoped packages, two unscoped packages are published: the [fluid-framework][] package, described earlier, and the `tinylicious` package, which contains a minimal Fluid server.
+In addition to the scoped packages, two unscoped packages are published: the <PackageLink packageName="fluid-framework" /> package, described earlier, and the `tinylicious` package, which contains a minimal Fluid server.
 For more information, see [Tinylicious](../testing/tinylicious.mdx).
 
 Unless you are contributing to the Fluid Framework, you should only need the unscoped packages and packages from the **@fluidframework** scope.
@@ -58,5 +60,4 @@ You can [read more about the scopes and their intent][scopes] in the Fluid Frame
 
 {/* Links */}
 [FluidContainer]: ./containers.mdx
-[fluid-framework]: ../api/fluid-framework/index.md
 [scopes]: https://github.com/microsoft/FluidFramework/blob/main/docs/content/Contributing/npm-Package-Scopes.md

--- a/website/docs/build/presence.mdx
+++ b/website/docs/build/presence.mdx
@@ -3,6 +3,8 @@ title: Presence
 sidebar_position: 10
 ---
 
+import { ApiLink } from "@site/src/components/shortLinks";
+
 ## Overview
 
 We are introducing a new way to power your ephemeral experiences with Fluid: the new Presence APIs (in beta as of version 2.42.0) that provide session-focused utilities for lightweight data sharing and messaging.
@@ -110,7 +112,7 @@ function logOthersPositions(positionTracker: Latest<PointXY>): void {
 #### LatestMap, LatestMapRaw use
 
 A change to the `local` property automatically initiates a broadcast of updates to other attendees.
-`local` is a [StateMap](../api/presence/statemap-interface.md) that mimics `Map` though it only supports `string | number` as property keys.
+`local` is a <ApiLink packageName="presence" apiName="StateMap" /> that mimics `Map` though it only supports `string | number` as property keys.
 
 ```typescript
 function updateCounter(counterTracker: LatestMap<number, string>, counterName: string, value: number): void {

--- a/website/docs/data-structures/tree/events.mdx
+++ b/website/docs/data-structures/tree/events.mdx
@@ -3,6 +3,8 @@ title: Events
 sidebar_position: 5
 ---
 
+import { ApiLink, PackageLink } from "@site/src/components/shortLinks";
+
 SharedTree's events are subscribed to via "on" methods which return an unsubscribe function.
 The returned unsubscribe function should be called when the event subscription is no longer needed.
 
@@ -15,12 +17,12 @@ unsubscribe();
 
 ## Whole-Tree Events
 
-[`TreeView`](../../api/fluid-framework/treeview-interface) exposes [events for the whole tree](../../api/fluid-framework/treeviewevents-interface).
+<ApiLink packageName="fluid-framework" apiName="TreeView">`TreeView`</ApiLink> exposes <ApiLink packageName="fluid-framework" apiName="TreeViewEvents">events for the whole tree</ApiLink>.
 
 ## Node-Level Events
 
-The [`Tree`](../../api/fluid-framework/#tree-variable) singleton provides [APIs for working with nodes](../../api/fluid-framework/treenodeapi-interface)
-including [events](../../api/fluid-framework/treechangeevents-interface).
+The <PackageLink packageName="fluid-framework" headingId="tree-variable">`Tree`</PackageLink> singleton provides <ApiLink packageName="fluid-framework" apiName="TreeNodeApi">APIs for working with nodes</ApiLink>
+including <ApiLink packageName="fluid-framework" apiName="TreeChangeEvents">events</ApiLink>.
 
 `Tree` supports two node-level events, subscribed to via `Tree.on`:
 

--- a/website/docs/data-structures/tree/node-types.mdx
+++ b/website/docs/data-structures/tree/node-types.mdx
@@ -3,30 +3,32 @@ title: Node Types
 sidebar_position: 2
 ---
 
+import { ApiLink } from "@site/src/components/shortLinks";
+
 Data on a [SharedTree](./index.mdx) is stored as a [node](./nodes.mdx) of one of the types described below.
 
 ## Leaf Nodes
 
-A [leaf](../../api/fluid-framework/nodekind-enum.md#leaf-enummember) holds an atomic value. The available leaf types are:
+A <ApiLink packageName="fluid-framework" apiName="NodeKind" headingId="leaf-enummember">leaf</ApiLink> holds an atomic value. The available leaf types are:
 
--   [**boolean**](../../api/fluid-framework/schemastatics-interface.md#boolean-propertysignature): a JavaScript boolean.
--   [**number**](../../api/fluid-framework/schemastatics-interface.md#number-propertysignature): a JavaScript number, but does not support `-0` (normalized to 0), `NaN`, or `Infinity` (normalized to `null` where allowed).
--   [**string**](../../api/fluid-framework/schemastatics-interface.md#string-propertysignature): a JavaScript string, but does not support unpaired UTF-16 surrogate pairs.
--   [**null**](../../api/fluid-framework/schemastatics-interface.md#null-propertysignature): JavaScript `null`.
--   [**FluidHandle**](../../api/fluid-framework/schemastatics-interface.md#handle-propertysignature): a handle to a Fluid DDS or Data Object. See [Handles](../../concepts/handles.mdx).
+-   <ApiLink packageName="fluid-framework" apiName="SchemaStatics" headingId="boolean-propertysignature">**boolean**</ApiLink>: a JavaScript boolean.
+-   <ApiLink packageName="fluid-framework" apiName="SchemaStatics" headingId="number-propertysignature">**number**</ApiLink>: a JavaScript number, but does not support `-0` (normalized to 0), `NaN`, or `Infinity` (normalized to `null` where allowed).
+-   <ApiLink packageName="fluid-framework" apiName="SchemaStatics" headingId="string-propertysignature">**string**</ApiLink>: a JavaScript string, but does not support unpaired UTF-16 surrogate pairs.
+-   <ApiLink packageName="fluid-framework" apiName="SchemaStatics" headingId="null-propertysignature">**null**</ApiLink>: JavaScript `null`.
+-   <ApiLink packageName="fluid-framework" apiName="SchemaStatics" headingId="handle-propertysignature">**FluidHandle**</ApiLink>: a handle to a Fluid DDS or Data Object. See [Handles](../../concepts/handles.mdx).
 
 ## TreeNodes
 
-There are multiple [kinds](https://fluidframework.com/docs/api/fluid-framework/nodekind-enum) of [TreeNode](../../api/fluid-framework/treenode-class.md), each of which manage and expose their children differently.
+There are multiple <ApiLink packageName="fluid-framework" apiName="NodeKind">kinds</ApiLink> of <ApiLink packageName="fluid-framework" apiName="TreeNode" />, each of which manage and expose their children differently.
 
 ### Object Nodes
 
-An [object node](../../api/fluid-framework/treeobjectnode-typealias.md) has zero or more named child [fields](../../api/fluid-framework/fieldschema-class.md) exposed as properties.
+An <ApiLink packageName="fluid-framework" apiName="TreeObjectNode">object node</ApiLink> has zero or more named child <ApiLink packageName="fluid-framework" apiName="FieldSchema">fields</ApiLink> exposed as properties.
 Different object nodes in the same tree can have different schemas.
 The schema specifies whether each property is
-[required](../../api/fluid-framework/schemastatics-interface.md#required-propertysignature),
-[optional](../../api/fluid-framework/schemastatics-interface.md#optional-propertysignature),
-or an [identifier](../../api/fluid-framework/schemafactory-class.md#identifier-property),
+<ApiLink packageName="fluid-framework" apiName="SchemaStatics" headingId="required-propertysignature">required</ApiLink>,
+<ApiLink packageName="fluid-framework" apiName="SchemaStatics" headingId="optional-propertysignature">optional</ApiLink>,
+or an <ApiLink packageName="fluid-framework" apiName="SchemaFactory" headingId="identifier-property">identifier</ApiLink>,
 and which node types are allowed (e.g., a property could allow `number` or `string`).
 
 ### Map Nodes

--- a/website/docs/data-structures/tree/nodes.mdx
+++ b/website/docs/data-structures/tree/nodes.mdx
@@ -3,16 +3,18 @@ title: Tree Nodes
 sidebar_position: 1
 ---
 
+import { ApiLink, PackageLink } from "@site/src/components/shortLinks";
+
 A [SharedTree](./index.mdx)'s data is organized into a tree of nodes.
 See [node types](./node-types.mdx) for details on the available node types.
 
 ## Node Utilities
 
-The [`Tree`](../../api/fluid-framework/#tree-variable) singleton provides utilities for inspecting and navigating nodes — methods that can't live on [`TreeNode`](../../api/fluid-framework/treenode-class) directly due to the risk of name collisions with object-node fields.
-The following covers commonly used ones; see the [API documentation](../../api/fluid-framework/#tree-variable) for the full list.
+The <PackageLink packageName="fluid-framework" headingId="tree-variable">`Tree`</PackageLink> singleton provides utilities for inspecting and navigating nodes — methods that can't live on <ApiLink packageName="fluid-framework" apiName="TreeNode">`TreeNode`</ApiLink> directly due to the risk of name collisions with object-node fields.
+The following covers commonly used ones; see the <PackageLink packageName="fluid-framework" headingId="tree-variable">API documentation</PackageLink> for the full list.
 
 
--   [`Tree.parent`](../../api/fluid-framework/treenodeapi-interface#parent-methodsignature) —
+-   <ApiLink packageName="fluid-framework" apiName="TreeNodeApi" headingId="parent-methodsignature">`Tree.parent`</ApiLink> —
     Returns the parent node.
     Useful when you need to act on a node's container rather than the node itself — for example, to remove it:
 
@@ -25,29 +27,29 @@ The following covers commonly used ones; see the [API documentation](../../api/f
     }
     ```
 
--   [`Tree.contains`](../../api/fluid-framework/tree-interface#contains-methodsignature) —
+-   <ApiLink packageName="fluid-framework" apiName="Tree" apiType="Interface" headingId="contains-methodsignature">`Tree.contains`</ApiLink> —
     Returns whether a node is a descendant of another — for example, to confirm a node belongs to a particular section, or to guard against creating a cycle when moving a node.
 
--   [`Tree.status`](../../api/fluid-framework/treenodeapi-interface#status-methodsignature) —
-    Returns the [`TreeStatus`](../../api/fluid-framework/treestatus-enum) of a node.
+-   <ApiLink packageName="fluid-framework" apiName="TreeNodeApi" headingId="status-methodsignature">`Tree.status`</ApiLink> —
+    Returns the <ApiLink packageName="fluid-framework" apiName="TreeStatus" /> of a node.
     Many editing operations require a specific status.
-    -   [`New`](../../api/fluid-framework/treestatus-enum#new-enummember) — created but not yet inserted into the tree
-    -   [`InDocument`](../../api/fluid-framework/treestatus-enum#indocument-enummember) — parented under the root field
-    -   [`Removed`](../../api/fluid-framework/treestatus-enum#removed-enummember) — not under the root field, but can be added back
-    -   [`Deleted`](../../api/fluid-framework/treestatus-enum#deleted-enummember) — removed and cannot be added back
+    -   <ApiLink packageName="fluid-framework" apiName="TreeStatus" headingId="new-enummember">`New`</ApiLink> — created but not yet inserted into the tree
+    -   <ApiLink packageName="fluid-framework" apiName="TreeStatus" headingId="indocument-enummember">`InDocument`</ApiLink> — parented under the root field
+    -   <ApiLink packageName="fluid-framework" apiName="TreeStatus" headingId="removed-enummember">`Removed`</ApiLink> — not under the root field, but can be added back
+    -   <ApiLink packageName="fluid-framework" apiName="TreeStatus" headingId="deleted-enummember">`Deleted`</ApiLink> — removed and cannot be added back
 
--   [`Tree.schema`](../../api/fluid-framework/treenodeapi-interface#schema-methodsignature) —
-    Returns the [`TreeNodeSchema`](../../api/fluid-framework/treenodeschema-typealias) for a node; useful when the node's type isn't statically known.
+-   <ApiLink packageName="fluid-framework" apiName="TreeNodeApi" headingId="schema-methodsignature">`Tree.schema`</ApiLink> —
+    Returns the <ApiLink packageName="fluid-framework" apiName="TreeNodeSchema" /> for a node; useful when the node's type isn't statically known.
 
--   [`Tree.shortId`](../../api/fluid-framework/treenodeapi-interface#shortid-methodsignature) —
-    Returns the [identifier](../../api/fluid-framework/schemafactory-class#identifier-property) for a node defined with a `SchemaFactory.identifier` field — useful for cross-referencing nodes by stable ID rather than position.
+-   <ApiLink packageName="fluid-framework" apiName="TreeNodeApi" headingId="shortid-methodsignature">`Tree.shortId`</ApiLink> —
+    Returns the <ApiLink packageName="fluid-framework" apiName="SchemaFactory" headingId="identifier-property">identifier</ApiLink> for a node defined with a `SchemaFactory.identifier` field — useful for cross-referencing nodes by stable ID rather than position.
 
--   [`Tree.on`](../../api/fluid-framework/treenodeapi-interface#on-methodsignature) —
+-   <ApiLink packageName="fluid-framework" apiName="TreeNodeApi" headingId="on-methodsignature">`Tree.on`</ApiLink> —
     Subscribes to change events on a node.
     See [Events](./events.mdx) for details.
 
--   [`Tree.is`](../../api/fluid-framework/treenodeapi-interface#is-methodsignature) —
-    Narrows a node's type to a specific [`SchemaFactory`](../../api/fluid-framework/schemafactory-class)-derived class.
+-   <ApiLink packageName="fluid-framework" apiName="TreeNodeApi" headingId="is-methodsignature">`Tree.is`</ApiLink> —
+    Narrows a node's type to a specific <ApiLink packageName="fluid-framework" apiName="SchemaFactory" />-derived class.
     Use when the node's type is unknown:
 
     ```typescript

--- a/website/docs/data-structures/tree/reading-and-editing.mdx
+++ b/website/docs/data-structures/tree/reading-and-editing.mdx
@@ -3,6 +3,8 @@ title: Reading and Editing
 sidebar_position: 4
 ---
 
+import { ApiLink } from "@site/src/components/shortLinks";
+
 The `TreeView` object and its children expose properties and methods that allow applications read and edit the tree.
 The APIs have been designed to match as much as possible the syntax of TypeScript primitives, objects, maps, and arrays (although some editing APIs are different for the sake of making the merge semantics clearer).
 
@@ -69,7 +71,7 @@ Optional properties can be cleared by assigning `undefined` to them.
 proposal.text = undefined;
 ```
 
-Note that if the new value is a node (as opposed to a primitive), then its [status](../../api/fluid-framework/treestatus-enum) must be `TreeStatus.New`,
+Note that if the new value is a node (as opposed to a primitive), then its <ApiLink packageName="fluid-framework" apiName="TreeStatus">status</ApiLink> must be `TreeStatus.New`,
 In other words, it is not possible to set a node that has already been inserted in the tree in the past, even if that node has since been removed.
 
 ## Map Node APIs
@@ -126,7 +128,7 @@ set(key: string, value: T)
 The `set()` method sets/changes the value of the item with the specified key. If the key is not present, the item is added to the map. Note the following:
 
 -   The `T` can be any type that conforms to the map node's schema. For example, if the schema was defined with `class MyMap extends sf.map([sf.number, sf.string]);`, then `T` could be `number` or `string`.
--   If the `value` argument is a node (as opposed to a primitive), then its [status](../../api/fluid-framework/treestatus-enum) must be `TreeStatus.New`,
+-   If the `value` argument is a node (as opposed to a primitive), then its <ApiLink packageName="fluid-framework" apiName="TreeStatus">status</ApiLink> must be `TreeStatus.New`,
     In other words, it is not possible to set a node that has already been inserted in the tree in the past, even if that node has since been removed.
 -   If multiple clients set the same key simultaneously, the key gets the value set by the last edit to apply. For the meaning of "simultaneously", see [Types of distributed data structures](../overview.mdx).
 
@@ -161,7 +163,7 @@ Array nodes have three methods that insert items into the array.
 Note the following:
 
 -   In all of the following, the `T` can be any type that conforms to the array node's schema. For example, if the schema was defined with `class MyArray extends sf.array([sf.number, sf.string]);`, then `T` could be `number` or `string`.
--   Inserted values that are nodes (as opposed to a primitive), must have a [status](../../api/fluid-framework/treestatus-enum) equal `TreeStatus.New`.
+-   Inserted values that are nodes (as opposed to a primitive), must have a <ApiLink packageName="fluid-framework" apiName="TreeStatus">status</ApiLink> equal `TreeStatus.New`.
     In other words, it is not possible to set a node that has already been inserted in the tree in the past, even if that node has since been removed.
 
 ```typescript
@@ -212,7 +214,7 @@ Note the following about these methods:
 
 -   If multiple clients simultaneously move an item, then that item will be moved to the destination indicated by the move of the client whose edit is ordered last.
 -   A moved item may be removed as a result of a simultaneous remove operation from another client. For example, if one client moves items 3-5, and another client simultaneously removes items 4 and 5, then, if the remove operation is ordered last, items 4 and 5 are removed from their destination by the remove operation. If the move operation is ordered last, then all three items will be moved to the destination.
--   Moved items that are nodes (as opposed to a primitives), must have a [status](../../api/fluid-framework/treestatus-enum) equal `TreeStatus.InDocument`.
+-   Moved items that are nodes (as opposed to a primitives), must have a <ApiLink packageName="fluid-framework" apiName="TreeStatus">status</ApiLink> equal `TreeStatus.InDocument`.
 -   We also expose variations of these methods for moving a single item.
 
 For the meaning of "simultaneously", see [Types of distributed data structures](../overview.mdx).
@@ -236,4 +238,4 @@ moveRangeToIndex(destinationGap: number, sourceStartIndex: number, sourceEndInde
 Moves the items to the specified `destinationGap` in the destination array.
 Specify a `source` array if it is different from the destination array.
 If the items are being moved within the same array, the `destinationGap` position is interpreted including the items being moved (as if a new copy of the moved items were being inserted, without removing the originals).
-See [the doc comments](../../api/fluid-framework/treearraynode-interface.md#moverangetoindex-methodsignature) for details.
+See <ApiLink packageName="fluid-framework" apiName="TreeArrayNode" headingId="moverangetoindex-methodsignature">the doc comments</ApiLink> for details.

--- a/website/docs/data-structures/tree/schema-definition/default-field-values.mdx
+++ b/website/docs/data-structures/tree/schema-definition/default-field-values.mdx
@@ -3,15 +3,17 @@ title: Default Field Values
 sidebar_position: 2
 ---
 
+import { ApiLink } from "@site/src/components/shortLinks";
+
 # Default Field Values
 
-The [`withDefault`](../../../api/fluid-framework/schemastaticsalpha-interface.md#withdefault-propertysignature) API is available on [`SchemaFactoryAlpha`](../../../api/fluid-framework/schemafactoryalpha-class). It allows you to specify default values for fields,
-making them optional in constructors even when the field is marked as [`required`](../../../api/fluid-framework/schemastatics-interface.md#required-propertysignature) in the schema.
+The <ApiLink packageName="fluid-framework" apiName="SchemaStaticsAlpha" headingId="withdefault-propertysignature">`withDefault`</ApiLink> API is available on <ApiLink packageName="fluid-framework" apiName="SchemaFactoryAlpha" />. It allows you to specify default values for fields,
+making them optional in constructors even when the field is marked as <ApiLink packageName="fluid-framework" apiName="SchemaStatics" headingId="required-propertysignature">`required`</ApiLink> in the schema.
 This provides a better developer experience by reducing boilerplate when creating objects.
 
-[`withDefault`](../../../api/fluid-framework/schemastaticsalpha-interface.md#withdefault-propertysignature) wraps a field schema and defines a default value to use when the field is not provided during
+<ApiLink packageName="fluid-framework" apiName="SchemaStaticsAlpha" headingId="withdefault-propertysignature">`withDefault`</ApiLink> wraps a field schema and defines a default value to use when the field is not provided during
 construction. The default value must be of an allowed type of the field. You can provide defaults in two ways
-(see [`NodeProvider`](../../../api/fluid-framework/nodeprovider-typealias)):
+(see <ApiLink packageName="fluid-framework" apiName="NodeProvider" />):
 
 - **A value**: When a value is provided directly, the data is copied for each use to ensure independence between instances.
 - **A generator function**: A function that is called each time to produce a fresh value.
@@ -45,7 +47,7 @@ const admin = new Person({ name: "Bob", age: 30, role: "admin" });
 
 ## Optional Fields with Custom Defaults
 
-[Optional fields](./index.mdx#setting-properties-as-optional) ([`sf.optional`](../../../api/fluid-framework/schemastatics-interface.md#optional-propertysignature)) already default to `undefined`, but `withDefault` allows you to specify a different
+[Optional fields](./index.mdx#setting-properties-as-optional) (<ApiLink packageName="fluid-framework" apiName="SchemaStatics" headingId="optional-propertysignature">`sf.optional`</ApiLink>) already default to `undefined`, but `withDefault` allows you to specify a different
 default value:
 
 ```typescript
@@ -165,7 +167,7 @@ class GameState extends sf.objectAlpha("GameState", {
 
 ## Recursive Types
 
-[`withDefaultRecursive`](../../../api/fluid-framework/schemastaticsalpha-interface.md#withdefaultrecursive-propertysignature) is available for use inside [recursive schemas](./index.mdx#recursive-schema). Use `objectRecursiveAlpha` (rather than
+<ApiLink packageName="fluid-framework" apiName="SchemaStaticsAlpha" headingId="withdefaultrecursive-propertysignature">`withDefaultRecursive`</ApiLink> is available for use inside [recursive schemas](./index.mdx#recursive-schema). Use `objectRecursiveAlpha` (rather than
 `objectRecursive`) when defining recursive schemas with defaults, as it correctly makes defaulted fields optional in
 the constructor for all field kinds including `requiredRecursive`. It works the same as `withDefault` but is
 necessary to avoid TypeScript's circular reference limitations.
@@ -256,8 +258,8 @@ sf.withDefault(sf.optional(sf.string), () => 8080);
 - [Schema Definition](./index.mdx) — Overview of defining schemas with `SchemaFactory`
 - [Setting Properties as Optional](./index.mdx#setting-properties-as-optional) — Using `sf.optional()` for optional fields
 - [Recursive Schema](./index.mdx#recursive-schema) — Defining recursive types with `objectRecursive()`
-- [`withDefault` API reference](../../../api/fluid-framework/schemastaticsalpha-interface.md#withdefault-propertysignature) — Type signatures and parameter details
-- [`withDefaultRecursive` API reference](../../../api/fluid-framework/schemastaticsalpha-interface.md#withdefaultrecursive-propertysignature) — Recursive variant
-- [`NodeProvider` API reference](../../../api/fluid-framework/nodeprovider-typealias) — The type used for default values
-- [`SchemaFactoryAlpha` API](../../../api/fluid-framework/schemafactoryalpha-class) — Full API reference for `SchemaFactoryAlpha`
+- <ApiLink packageName="fluid-framework" apiName="SchemaStaticsAlpha" headingId="withdefault-propertysignature">`withDefault` API reference</ApiLink> — Type signatures and parameter details
+- <ApiLink packageName="fluid-framework" apiName="SchemaStaticsAlpha" headingId="withdefaultrecursive-propertysignature">`withDefaultRecursive` API reference</ApiLink> — Recursive variant
+- <ApiLink packageName="fluid-framework" apiName="NodeProvider">`NodeProvider` API reference</ApiLink> — The type used for default values
+- <ApiLink packageName="fluid-framework" apiName="SchemaFactoryAlpha">`SchemaFactoryAlpha` API</ApiLink> — Full API reference for `SchemaFactoryAlpha`
 - [Schema Evolution](../schema-evolution/index.mdx) — Safely updating schemas over time

--- a/website/docs/data-structures/tree/schema-evolution/allowed-types-rollout.mdx
+++ b/website/docs/data-structures/tree/schema-evolution/allowed-types-rollout.mdx
@@ -5,7 +5,7 @@ sidebar_position: 3
 
 import { ApiLink, PackageLink } from "@site/src/components/shortLinks";
 
-This guide shows how to safely add a new <ApiLink packageName="fluid-framework" apiName="TreeNodeSchema" /> to an existing <ApiLink packageName="tree" apiName="AllowedTypes" /> field without breaking [forwards compatibility](./index.mdx#forwards-compatibility).
+This guide shows how to safely add a new <ApiLink packageName="fluid-framework" apiName="TreeNodeSchema" /> to an existing <ApiLink packageName="fluid-framework" apiName="AllowedTypes" /> field without breaking [forwards compatibility](./index.mdx#forwards-compatibility).
 
 Adding a new allowed type directly would break old clients as they cannot read documents containing it.
 The staged process below avoids this.

--- a/website/docs/data-structures/tree/schema-evolution/allowed-types-rollout.mdx
+++ b/website/docs/data-structures/tree/schema-evolution/allowed-types-rollout.mdx
@@ -3,12 +3,14 @@ title: Rolling Out New Allowed Types
 sidebar_position: 3
 ---
 
-This guide shows how to safely add a new [TreeNodeSchema](../../../api/fluid-framework/treenodeschema-typealias) to an existing [AllowedTypes](../../../api/tree/allowedtypes-typealias) field without breaking [forwards compatibility](./index.mdx#forwards-compatibility).
+import { ApiLink, PackageLink } from "@site/src/components/shortLinks";
+
+This guide shows how to safely add a new <ApiLink packageName="fluid-framework" apiName="TreeNodeSchema" /> to an existing <ApiLink packageName="tree" apiName="AllowedTypes" /> field without breaking [forwards compatibility](./index.mdx#forwards-compatibility).
 
 Adding a new allowed type directly would break old clients as they cannot read documents containing it.
 The staged process below avoids this.
 
-A [`snapshotSchemaCompatibility`](../../../api/fluid-framework/#snapshotschemacompatibility-function) test is recommended to verify that all relevant client versions can collaborate correctly through the rollout.
+A <PackageLink packageName="fluid-framework" headingId="snapshotschemacompatibility-function">`snapshotSchemaCompatibility`</PackageLink> test is recommended to verify that all relevant client versions can collaborate correctly through the rollout.
 
 ## Step-by-Step Guide
 
@@ -22,7 +24,7 @@ const mySchema = SchemaFactoryBeta.optional([SchemaFactoryBeta.number]);
 
 ### Step 1: Define and Stage the New Allowed Type
 
-Use [`staged`](../../../api/fluid-framework/schemafactorybeta-class#staged-property) to add support for future documents containing the new type.
+Use <ApiLink packageName="fluid-framework" apiName="SchemaFactoryBeta" headingId="staged-property">`staged`</ApiLink> to add support for future documents containing the new type.
 This version still creates documents that only allow the old types, but can work with documents created in Step 3 that contain the new type.
 Any code using this schema must correctly handle the presence of the new type, even though it cannot be added to documents yet.
 
@@ -33,7 +35,7 @@ const mySchema = SchemaFactoryBeta.optional(SchemaFactoryBeta.types([
 ]));
 ```
 
-No schema upgrade is performed at this step: [`staged`](../../../api/fluid-framework/schemafactorybeta-class#staged-property) types are excluded from stored schemas, so `upgradeSchema()` is a no-op and the new type cannot be added to documents yet:
+No schema upgrade is performed at this step: <ApiLink packageName="fluid-framework" apiName="SchemaFactoryBeta" headingId="staged-property">`staged`</ApiLink> types are excluded from stored schemas, so `upgradeSchema()` is a no-op and the new type cannot be added to documents yet:
 
 ```typescript
 // Assuming `view` is a TreeView configured with `mySchema`:
@@ -52,7 +54,7 @@ See [staged rollouts](./index.mdx#staged-rollouts) for more detail.
 
 ### Step 3: Enable Inserting the New Type
 
-Remove the [`staged()`](../../../api/fluid-framework/schemafactorybeta-class#staged-property) wrapper and call [`upgradeSchema()`](../../../api/fluid-framework/treeview-interface#upgradeschema-methodsignature) to update the stored schema:
+Remove the <ApiLink packageName="fluid-framework" apiName="SchemaFactoryBeta" headingId="staged-property">`staged()`</ApiLink> wrapper and call <ApiLink packageName="fluid-framework" apiName="TreeView" headingId="upgradeschema-methodsignature">`upgradeSchema()`</ApiLink> to update the stored schema:
 
 ```typescript
 // number or string, both fully allowed
@@ -77,11 +79,11 @@ view.root = "test";
 Code that writes the new allowed type can be deployed in this step.
 
 This step changes the stored schema, which is why the wait in Step 2 is necessary: once a document is upgraded, clients on the original schema can no longer open it.
-If you have a [`snapshotSchemaCompatibility`](../../../api/fluid-framework/#snapshotschemacompatibility-function) test (strongly recommended for any schema change), update the [minVersionForCollaboration](../../../api/fluid-framework/snapshotschemacompatibilityoptions-interface#minversionforcollaboration-propertysignature) to the version released in Step 1 and take a new snapshot.
+If you have a <PackageLink packageName="fluid-framework" headingId="snapshotschemacompatibility-function">`snapshotSchemaCompatibility`</PackageLink> test (strongly recommended for any schema change), update the <ApiLink packageName="fluid-framework" apiName="SnapshotSchemaCompatibilityOptions" headingId="minversionforcollaboration-propertysignature">minVersionForCollaboration</ApiLink> to the version released in Step 1 and take a new snapshot.
 
 ## See Also
 
-- [`SchemaFactoryBeta.staged()` API](../../../api/fluid-framework/schemafactorybeta-class#staged-property) - API documentation
+- <ApiLink packageName="fluid-framework" apiName="SchemaFactoryBeta" headingId="staged-property">`SchemaFactoryBeta.staged()` API</ApiLink> - API documentation
 - [Enabling Schema Upgrades with Feature Flags](./feature-flag-schema-upgrades.mdx) - Using runtime upgrades in production
 - [Testing Schema Upgrades](./testing-schema-upgrades.mdx) - Create test documents that simulate future schema states
 - [Schema Definition](../schema-definition/index.mdx) - How to define schemas

--- a/website/docs/data-structures/tree/schema-evolution/feature-flag-schema-upgrades.mdx
+++ b/website/docs/data-structures/tree/schema-evolution/feature-flag-schema-upgrades.mdx
@@ -21,7 +21,7 @@ Import them from `@fluidframework/tree/alpha`.
 
 ## How It Works
 
-When you define a [staged schema upgrade](./index.mdx#staged-schema-upgrades) (using <ApiLink packageName="fluid-framework" apiName="SchemaFactoryBeta" headingId="staged-property">`staged()`</ApiLink> for allowed types or <ApiLink packageName="tree" apiName="SchemaFactoryAlpha" headingId="stagedoptional-property">`stagedOptional()`</ApiLink> for field optionality), the staged parts are excluded from stored schema by default.
+When you define a [staged schema upgrade](./index.mdx#staged-schema-upgrades) (using <ApiLink packageName="fluid-framework" apiName="SchemaFactoryBeta" headingId="staged-property">`staged()`</ApiLink> for allowed types or <ApiLink packageName="fluid-framework" apiName="SchemaFactoryAlpha" headingId="stagedoptional-property">`stagedOptional()`</ApiLink> for field optionality), the staged parts are excluded from stored schema by default.
 
 With `TreeViewConfigurationAlpha`, you can selectively enable specific staged upgrades at view construction time:
 

--- a/website/docs/data-structures/tree/schema-evolution/feature-flag-schema-upgrades.mdx
+++ b/website/docs/data-structures/tree/schema-evolution/feature-flag-schema-upgrades.mdx
@@ -3,6 +3,8 @@ title: How to Enable Staged Schema Upgrades with Feature Flags
 sidebar\_position: 6
 ---
 
+import { ApiLink, PackageLink } from "@site/src/components/shortLinks";
+
 # How to Enable Staged Schema Upgrades with Feature Flags
 
 The standard [staged rollout](./index.mdx#staged-rollouts) strategy requires two separate code deployments: one to add reading support, and another to enable writing.
@@ -19,7 +21,7 @@ Import them from `@fluidframework/tree/alpha`.
 
 ## How It Works
 
-When you define a [staged schema upgrade](./index.mdx#staged-schema-upgrades) (using [`staged()`](../../../api/fluid-framework/schemafactorybeta-class#staged-property) for allowed types or [`stagedOptional()`](../../../api/tree/schemafactoryalpha-class#stagedoptional-property) for field optionality), the staged parts are excluded from stored schema by default.
+When you define a [staged schema upgrade](./index.mdx#staged-schema-upgrades) (using <ApiLink packageName="fluid-framework" apiName="SchemaFactoryBeta" headingId="staged-property">`staged()`</ApiLink> for allowed types or <ApiLink packageName="tree" apiName="SchemaFactoryAlpha" headingId="stagedoptional-property">`stagedOptional()`</ApiLink> for field optionality), the staged parts are excluded from stored schema by default.
 
 With `TreeViewConfigurationAlpha`, you can selectively enable specific staged upgrades at view construction time:
 
@@ -187,7 +189,7 @@ Plan your rollout with this in mind: ensure that all active clients have the sta
   Use [testing schema upgrades](./testing-schema-upgrades.mdx) to verify your code handles the upgraded schema correctly before turning on the flag in production.
 
 - **Use `snapshotSchemaCompatibility` tests.**
-  Write [`snapshotSchemaCompatibility`](../../../api/fluid-framework/#snapshotschemacompatibility-function) tests to verify compatibility across all schema states in your rollout. Only use schema configurations in production that are covered by these tests.
+    Write <PackageLink packageName="fluid-framework" headingId="snapshotschemacompatibility-function">`snapshotSchemaCompatibility`</PackageLink> tests to verify compatibility across all schema states in your rollout. Only use schema configurations in production that are covered by these tests.
 
 - **Avoid diverging upgrade paths.**
   `snapshotSchemaCompatibility` assumes a linear version history and cannot model branching upgrade paths. If different documents enable different combinations of staged upgrades (e.g., one enables A+C while another enables B+C), the resulting schema states diverge and cannot be validated in a single snapshot test. Keep your rollout linear — enable staged upgrades in the same order for all documents — so that every schema state you encounter in production is covered by your compatibility tests.

--- a/website/docs/data-structures/tree/schema-evolution/index.mdx
+++ b/website/docs/data-structures/tree/schema-evolution/index.mdx
@@ -3,11 +3,13 @@ title: Schema Evolution
 sidebar_position: 8
 ---
 
+import { ApiLink, PackageLink } from "@site/src/components/shortLinks";
+
 # Schema Evolution
 
 As your application (or library) grows and evolves, you may need to modify the structure of your [SharedTree](../index.mdx) data.
 SharedTree makes it possible to update your [schemas](../schema-definition/index.mdx) in ways that allow an app to load or upgrade documents created or edited by earlier versions of the app (see [understanding compatibility](./index.mdx#understanding-compatibility)).
-To ensure such changes to maintain the ability to open existing documents and collaborate with other deployed application versions, write a test using [`snapshotSchemaCompatibility`](../../../api/fluid-framework/#snapshotschemacompatibility-function).
+To ensure such changes to maintain the ability to open existing documents and collaborate with other deployed application versions, write a test using <PackageLink packageName="fluid-framework" headingId="snapshotschemacompatibility-function">`snapshotSchemaCompatibility`</PackageLink>.
 
 :::note
 For detailed information about which types of changes are safe versus breaking, see [types of schema changes](./types-of-changes.mdx).
@@ -17,7 +19,7 @@ For detailed information about which types of changes are safe versus breaking, 
 
 When updating your schema, it's important to understand the difference between the two types of schemas:
 
-- **View Schema**: The schema defined in your application code using [`SchemaFactory`](../../../api/fluid-framework/schemafactory-class)
+- **View Schema**: The schema defined in your application code using <ApiLink packageName="fluid-framework" apiName="SchemaFactory" />
 - **Stored Schema**: The schema persisted with each document. It describes what type of tree can be stored in the document.
 
 When a document is first created, its stored schema is set using the given view schema.
@@ -50,7 +52,7 @@ Therefore, a Fluid application should be prepared to encounter any version of a 
 When you open a document, SharedTree compares your application's view schema with the document's stored schema to determine compatibility:
 
 - **Compatible**: Document can be opened and used normally
-- **Upgradeable**: Document can be upgraded to match your view schema using [`view.upgradeSchema()`](../../../api/fluid-framework/treeview-interface#upgradeschema-methodsignature)
+- **Upgradeable**: Document can be upgraded to match your view schema using <ApiLink packageName="fluid-framework" apiName="TreeView" headingId="upgradeschema-methodsignature">`view.upgradeSchema()`</ApiLink>
 - **Incompatible**: Document cannot be opened with or upgraded to match your current view schema
 
 They must be compatible or upgradeable in order for the application to work - otherwise, it cannot read or write data from/to the document.
@@ -108,9 +110,9 @@ To prevent this, the application can employ a [staged rollout](./index.mdx#stage
 
 ### Checking Compatibility
 
-Use [`TreeView.compatibility`](../../../api/fluid-framework/treeview-interface#compatibility-propertysignature) to check if your schema changes are compatible with existing documents.
+Use <ApiLink packageName="fluid-framework" apiName="TreeView" headingId="compatibility-propertysignature">`TreeView.compatibility`</ApiLink> to check if your schema changes are compatible with existing documents.
 
-Generally, the most important properties of the `compatibility` object to monitor are [`canView`](../../../api/fluid-framework/schemacompatibilitystatus-interface#canview-propertysignature) and [`canUpgrade`](../../../api/fluid-framework/schemacompatibilitystatus-interface#canupgrade-propertysignature).
+Generally, the most important properties of the `compatibility` object to monitor are <ApiLink packageName="fluid-framework" apiName="SchemaCompatibilityStatus" headingId="canview-propertysignature">`canView`</ApiLink> and <ApiLink packageName="fluid-framework" apiName="SchemaCompatibilityStatus" headingId="canupgrade-propertysignature">`canUpgrade`</ApiLink>.
 `canView` indicates that the view schema is [compatible](./index.mdx#schema-compatibility) with the stored schema while `canUpgrade` indicates that it is valid to [upgrade the schema](./index.mdx#schema-upgrade-process).
 
 ### Monitoring Remote Schema Changes
@@ -127,7 +129,7 @@ view.events.on("schemaChanged", () => {
 
 ## Schema Upgrade Process
 
-When you make [backwards compatible](./index.mdx#understanding-compatibility) changes to your schema, you can upgrade existing documents to use the new schema using [`view.upgradeSchema()`](../../../api/fluid-framework/treeview-interface#upgradeschema-methodsignature):
+When you make [backwards compatible](./index.mdx#understanding-compatibility) changes to your schema, you can upgrade existing documents to use the new schema using <ApiLink packageName="fluid-framework" apiName="TreeView" headingId="upgradeschema-methodsignature">`view.upgradeSchema()`</ApiLink>:
 
 ```typescript
 import { SchemaFactory, TreeViewConfiguration } from "@fluidframework/tree";
@@ -168,8 +170,8 @@ A **staged schema upgrade** is a schema change that is declared in the view sche
 This allows your application code to understand and handle the new schema shape (reading documents that contain it) before the upgrade is activated for writes.
 
 SharedTree provides two mechanisms for defining staged schema upgrades:
-- [`staged()`](../../../api/fluid-framework/schemafactorybeta-class#staged-property) -- marks a new allowed type as staged
-- [`stagedOptional()`](../../../api/tree/schemafactoryalpha-class#stagedoptional-property) -- marks a field as optionally present during migration from required to optional
+- <ApiLink packageName="fluid-framework" apiName="SchemaFactoryBeta" headingId="staged-property">`staged()`</ApiLink> -- marks a new allowed type as staged
+- <ApiLink packageName="tree" apiName="SchemaFactoryAlpha" headingId="stagedoptional-property">`stagedOptional()`</ApiLink> -- marks a field as optionally present during migration from required to optional
 
 Staged schema upgrades are the building blocks of [staged rollouts](#staged-rollouts) and [feature-flag-driven upgrades](./feature-flag-schema-upgrades.mdx).
 

--- a/website/docs/data-structures/tree/schema-evolution/index.mdx
+++ b/website/docs/data-structures/tree/schema-evolution/index.mdx
@@ -171,7 +171,7 @@ This allows your application code to understand and handle the new schema shape 
 
 SharedTree provides two mechanisms for defining staged schema upgrades:
 - <ApiLink packageName="fluid-framework" apiName="SchemaFactoryBeta" headingId="staged-property">`staged()`</ApiLink> -- marks a new allowed type as staged
-- <ApiLink packageName="tree" apiName="SchemaFactoryAlpha" headingId="stagedoptional-property">`stagedOptional()`</ApiLink> -- marks a field as optionally present during migration from required to optional
+- <ApiLink packageName="fluid-framework" apiName="SchemaFactoryAlpha" headingId="stagedoptional-property">`stagedOptional()`</ApiLink> -- marks a field as optionally present during migration from required to optional
 
 Staged schema upgrades are the building blocks of [staged rollouts](#staged-rollouts) and [feature-flag-driven upgrades](./feature-flag-schema-upgrades.mdx).
 

--- a/website/docs/data-structures/tree/schema-evolution/testing-schema-upgrades.mdx
+++ b/website/docs/data-structures/tree/schema-evolution/testing-schema-upgrades.mdx
@@ -3,9 +3,11 @@ title: Testing Schema Upgrades
 sidebar\_position: 5
 ---
 
+import { ApiLink, PackageLink } from "@site/src/components/shortLinks";
+
 # Testing Schema Upgrades
 
-When you define a [staged schema upgrade](./index.mdx#staged-schema-upgrades) (using [`staged()`](../../../api/fluid-framework/schemafactorybeta-class#staged-property) or [`stagedOptional()`](../../../api/tree/schemafactoryalpha-class#stagedoptional-property)), you need to verify that your current code works correctly with documents that a *future* version will produce.
+When you define a [staged schema upgrade](./index.mdx#staged-schema-upgrades) (using <ApiLink packageName="fluid-framework" apiName="SchemaFactoryBeta" headingId="staged-property">`staged()`</ApiLink> or <ApiLink packageName="tree" apiName="SchemaFactoryAlpha" headingId="stagedoptional-property">`stagedOptional()`</ApiLink>), you need to verify that your current code works correctly with documents that a *future* version will produce.
 
 Runtime schema upgrades let you create test documents whose stored schema matches a future state.
 
@@ -169,7 +171,7 @@ This is useful for verifying that each phase of your rollout maintains the expec
 - **Use `independentView`** for isolated tests that don't require a Fluid service connection.
 - **Use `StagedSchemaUpgradePolicy.permissive`** to enable *all* staged upgrades at once — useful for broad integration tests that exercise the fully-upgraded schema without listing individual tokens.
 - **Test all schema states**: original → staged → upgraded → cleanup (staged wrappers removed). Each transition should maintain compatibility.
-- **Combine with** [**`snapshotSchemaCompatibility`**](../../../api/fluid-framework/#snapshotschemacompatibility-function) tests to catch regressions when your schema changes across releases.
+- **Combine with** <PackageLink packageName="fluid-framework" headingId="snapshotschemacompatibility-function">**`snapshotSchemaCompatibility`**</PackageLink> tests to catch regressions when your schema changes across releases.
 - **Test edge cases**: What happens when a staged field is absent? When a staged type appears in a sequence? Ensure your application logic handles these gracefully.
 
 ## See Also

--- a/website/docs/data-structures/tree/schema-evolution/testing-schema-upgrades.mdx
+++ b/website/docs/data-structures/tree/schema-evolution/testing-schema-upgrades.mdx
@@ -7,7 +7,7 @@ import { ApiLink, PackageLink } from "@site/src/components/shortLinks";
 
 # Testing Schema Upgrades
 
-When you define a [staged schema upgrade](./index.mdx#staged-schema-upgrades) (using <ApiLink packageName="fluid-framework" apiName="SchemaFactoryBeta" headingId="staged-property">`staged()`</ApiLink> or <ApiLink packageName="tree" apiName="SchemaFactoryAlpha" headingId="stagedoptional-property">`stagedOptional()`</ApiLink>), you need to verify that your current code works correctly with documents that a *future* version will produce.
+When you define a [staged schema upgrade](./index.mdx#staged-schema-upgrades) (using <ApiLink packageName="fluid-framework" apiName="SchemaFactoryBeta" headingId="staged-property">`staged()`</ApiLink> or <ApiLink packageName="fluid-framework" apiName="SchemaFactoryAlpha" headingId="stagedoptional-property">`stagedOptional()`</ApiLink>), you need to verify that your current code works correctly with documents that a *future* version will produce.
 
 Runtime schema upgrades let you create test documents whose stored schema matches a future state.
 

--- a/website/docs/data-structures/tree/schema-evolution/types-of-changes.mdx
+++ b/website/docs/data-structures/tree/schema-evolution/types-of-changes.mdx
@@ -3,10 +3,12 @@ title: Types of Schema Changes
 sidebar_position: 2
 ---
 
+import { ApiLink, PackageLink } from "@site/src/components/shortLinks";
+
 # Types of Schema Changes
 
 Understanding which types of schema changes are safe versus breaking is crucial for evolving your [SharedTree](../index.mdx) schemas without disrupting existing applications.
-Writing a test using [`snapshotSchemaCompatibility`](../../../api/fluid-framework/#snapshotschemacompatibility-function) is highly recommended to ensure any schema changes maintain your compatibility requirements.
+Writing a test using <PackageLink packageName="fluid-framework" headingId="snapshotschemacompatibility-function">`snapshotSchemaCompatibility`</PackageLink> is highly recommended to ensure any schema changes maintain your compatibility requirements.
 Knowledge of the details below will still be needed to design schemas such that the required future changes can be compatible, and to understand any errors detected by the test.
 
 All the examples below are modifying this schema:
@@ -38,7 +40,7 @@ class Note extends factory.object("Note", {
 }) {}
 ```
 
-To ensure [forwards compatibility](./index.mdx#understanding-compatibility), use [`allowUnknownOptionalFields`](../../../api/fluid-framework/objectschemaoptions-interface.md#allowunknownoptionalfields-propertysignature) to handle new optional fields added by newer clients.
+To ensure [forwards compatibility](./index.mdx#understanding-compatibility), use <ApiLink packageName="fluid-framework" apiName="ObjectSchemaOptions" headingId="allowunknownoptionalfields-propertysignature">`allowUnknownOptionalFields`</ApiLink> to handle new optional fields added by newer clients.
 Note that this needs to already be set on the old clients before the field is added.
 If it's not already set, then adding a new optional field at the same time as enabling `allowUnknownOptionalFields` is not forwards compatible, since old clients without `allowUnknownOptionalFields` will reject the unknown field.
 In that case, a [staged rollout](./index.mdx#staged-rollouts) is needed: first release a version that enables `allowUnknownOptionalFields`, then add the new field in a subsequent release.

--- a/website/docs/data-structures/tree/transactions.mdx
+++ b/website/docs/data-structures/tree/transactions.mdx
@@ -3,6 +3,8 @@ title: Transactions
 sidebar_position: 6
 ---
 
+import { ApiLink } from "@site/src/components/shortLinks";
+
 If you want the `SharedTree` to treat a set of changes atomically, then you can wrap these changes in a transaction.
 Using a transaction guarantees that (if applied) all of the changes will be applied together synchronously and no other changes (either from this client or from a remote client) can be interleaved with those changes.
 Note that the Fluid Framework guarantees this already for any sequence of changes that are submitted synchronously.
@@ -11,7 +13,7 @@ However, using a transaction has the following additional implications:
 -   It is also more efficient for SharedTree to process and transmit a large number of changes as a transaction rather than as changes submitted separately.
 -   It is possible to specify constraints on a transaction so that the transaction will be ignored if one or more of these constraints are not met.
 
-To create a transaction use [Tree.runTransaction](../../api/fluid-framework/tree-interface#runtransaction-propertysignature).
+To create a transaction use <ApiLink packageName="fluid-framework" apiName="Tree" apiType="Interface" headingId="runtransaction-propertysignature">Tree.runTransaction</ApiLink>.
 You can cancel a transaction from within the callback function by returning the special "rollback object", available via `Tree.runTransaction.rollback`.
 If an error occurs within the callback, the transaction will be canceled automatically before propagating the error.
 
@@ -44,18 +46,18 @@ There are example transactions here: [Shared Tree Demo](https://github.com/micro
 
 The APIs described in this section are currently `@alpha` and may change in future releases.
 
-Unlike [Tree.runTransaction](../../api/fluid-framework/tree-interface#runtransaction-propertysignature), the Alpha [runTransaction](../../api/fluid-framework/treebranchalpha-interface#runtransaction-methodsignature) does **not** automatically roll back the transaction if the callback throws an error.
+Unlike <ApiLink packageName="fluid-framework" apiName="Tree" apiType="Interface" headingId="runtransaction-propertysignature">Tree.runTransaction</ApiLink>, the Alpha <ApiLink packageName="fluid-framework" apiName="TreeBranchAlpha" headingId="runtransaction-methodsignature">runTransaction</ApiLink> does **not** automatically roll back the transaction if the callback throws an error.
 If your callback may throw, you should handle errors explicitly and return `{ rollback: true }` when required.
 
 :::
 
-The alpha APIs introduce [UntypedTreeViewAlpha.runTransaction](../../api/fluid-framework/treebranchalpha-interface#runtransaction-methodsignature) as a replacement for `Tree.runTransaction`.
+The alpha APIs introduce <ApiLink packageName="fluid-framework" apiName="TreeBranchAlpha" headingId="runtransaction-methodsignature">UntypedTreeViewAlpha.runTransaction</ApiLink> as a replacement for `Tree.runTransaction`.
 This new API exists to solve correctness issues where errors being thrown in runTransaction could result in an undefined state.
 This new API enables developers to customize how their application handles this error case.
 
 ### Running a Transaction
 
-For a node in a tree, use [TreeAlpha.context](../../api/fluid-framework/treealpha-interface#context-methodsignature) to get its [TreeContextAlpha](../../api/fluid-framework/treecontextalpha-interface), then call [runTransaction](../../api/fluid-framework/treecontextalpha-interface#runtransaction-methodsignature) on that context.
+For a node in a tree, use <ApiLink packageName="fluid-framework" apiName="TreeAlpha" headingId="context-methodsignature">TreeAlpha.context</ApiLink> to get its <ApiLink packageName="fluid-framework" apiName="TreeContextAlpha" />, then call <ApiLink packageName="fluid-framework" apiName="TreeContextAlpha" headingId="runtransaction-methodsignature">runTransaction</ApiLink> on that context.
 
 ```typescript
 import { TreeAlpha } from "@fluidframework/tree/alpha";
@@ -106,7 +108,7 @@ if (result.success) {
 
 ### Asynchronous Transactions
 
-[runTransactionAsync](../../api/fluid-framework/treebranchalpha-interface#runtransactionasync-methodsignature) works like [runTransaction](../../api/fluid-framework/treebranchalpha-interface#runtransaction-methodsignature) but accepts an `async` callback.
+<ApiLink packageName="fluid-framework" apiName="TreeBranchAlpha" headingId="runtransactionasync-methodsignature">runTransactionAsync</ApiLink> works like <ApiLink packageName="fluid-framework" apiName="TreeBranchAlpha" headingId="runtransaction-methodsignature">runTransaction</ApiLink> but accepts an `async` callback.
 
 ```typescript
 const result = await view.runTransactionAsync(async () => {
@@ -139,7 +141,7 @@ If transactions are nested, only the outermost transaction's label is used.
 
 ### Nested Transactions
 
-[runTransaction](../../api/fluid-framework/treebranchalpha-interface#runtransaction-methodsignature) and [runTransactionAsync](../../api/fluid-framework/treebranchalpha-interface#runtransactionasync-methodsignature) can be called from within the callback of another transaction, with some limitations.
+<ApiLink packageName="fluid-framework" apiName="TreeBranchAlpha" headingId="runtransaction-methodsignature">runTransaction</ApiLink> and <ApiLink packageName="fluid-framework" apiName="TreeBranchAlpha" headingId="runtransactionasync-methodsignature">runTransactionAsync</ApiLink> can be called from within the callback of another transaction, with some limitations.
 Nested transactions have the following behavior:
 
 -   If the inner transaction rolls back, only the inner transaction's changes are discarded. The outer transaction continues.

--- a/website/docs/migration.mdx
+++ b/website/docs/migration.mdx
@@ -3,6 +3,8 @@ title: Migration
 sidebar_position: 9
 ---
 
+import { ApiLink, PackageLink } from "@site/src/components/shortLinks";
+
 ## Migrating existing usage from 1.x to 2.x
 
 Data in containers created using Fluid Framework 1.x can be loaded compatibly by Fluid Framework 2.x with no special effort required.
@@ -11,7 +13,7 @@ If your deployment strategy takes time to roll out, you'll want to ensure Fluid 
 
 ### Specifying compatibility mode
 
-In Fluid Framework 2.x, the [createContainer](./api/azure-client/azureclient-class.md#createcontainer-method) and getContainer APIs on [AzureClient](./api/azure-client/index.md) and [TinyliciousClient](./api/tinylicious-client/index.md) have a new parameter compatibilityMode which may be set to "1" or "2". When set to "1", the 2.x client can safely collaborate with 1.x clients.
+In Fluid Framework 2.x, the <ApiLink packageName="azure-client" apiName="AzureClient" headingId="createcontainer-method">createContainer</ApiLink> and getContainer APIs on <PackageLink packageName="azure-client">AzureClient</PackageLink> and <PackageLink packageName="tinylicious-client">TinyliciousClient</PackageLink> have a new parameter compatibilityMode which may be set to "1" or "2". When set to "1", the 2.x client can safely collaborate with 1.x clients.
 
 ```ts
 const azureClient = new AzureClient(/* ... */);
@@ -36,4 +38,4 @@ Once "2" mode is enabled, clients will use the new 2.x features that will improv
 
 New containers can and should be created directly in "2" mode if clients running 1.x will not need to collaborate on them.
 Moving straight from 1.x to 2.x running in "2" mode is supported, but runs the risk that any 1.x clients will not be able to collaborate until they are upgraded. If your deployment strategy is not concerned with this risk, you can migrate directly from 1.x to 2.x in "2" mode.
-Some features of 2.x must be enabled at container creation and cannot be enabled after attach. Most notably, this includes [id compression](./api/id-compressor/index.md) which is a requirement for use of [SharedTree](./data-structures/tree/index.mdx). As a result, SharedTree is not supported on documents created in 1.x or on 2.x running in "1" mode.
+Some features of 2.x must be enabled at container creation and cannot be enabled after attach. Most notably, this includes <PackageLink packageName="id-compressor">id compression</PackageLink> which is a requirement for use of [SharedTree](./data-structures/tree/index.mdx). As a result, SharedTree is not supported on documents created in 1.x or on 2.x running in "1" mode.


### PR DESCRIPTION
Update API links in `.mdx` documents to leverage our `ApiLink` and `PackageLink` "shortcode" components. These are more robust to future changes, including versioning snapshots (like we're about to do for the 3.0 release).

Also updates some links that pointed to the `tree` package's API docs to point to `fluid-framework` instead (as that is the package we recommend external users import from).