### PR TITLE
feat(tinylicious): Support command line port specification

### DIFF
--- a/server/routerlicious/.changeset/calm-ports-listen.md
+++ b/server/routerlicious/.changeset/calm-ports-listen.md
@@ -1,0 +1,8 @@
+---
+"tinylicious": minor
+"__section": feature
+---
+Tinylicious can now be started on a specific port using `--port <number>` or `--port=<number>`.
+
+The port must be an integer between 0 and 65535.
+When selecting a port, Tinylicious uses the command-line argument first, followed by the `PORT` environment variable, and then the default port of 7070.

--- a/server/routerlicious/packages/tinylicious/README.md
+++ b/server/routerlicious/packages/tinylicious/README.md
@@ -29,10 +29,16 @@ pnpm stop
 
 ### Port
 
-Tinylicious uses port 7070 by default. You can change the port number by setting an environment
-variable named PORT to the desired number. For example:
+Tinylicious uses port 7070 by default.
+You can change the port number by passing a `--port` command line argument, or by setting an environment variable named PORT to the desired number.
+If both are provided, the `--port` argument takes precedence.
+For example:
 
 ```sh
+# Using the command line argument:
+pnpm start -- --port 6502
+
+# Using the environment variable:
 $env:PORT=6502
 pnpm start
 ```

--- a/server/routerlicious/packages/tinylicious/src/index.ts
+++ b/server/routerlicious/packages/tinylicious/src/index.ts
@@ -60,8 +60,49 @@ const configPath = path.join(__dirname, "../config.json");
 
 configureLogging(configPath);
 
+/**
+ * The maximum valid TCP port number (2^16 - 1).
+ * Valid ports range from 0 to this value (inclusive).
+ */
+const maxPort = 65535;
+
+/**
+ * Validates a raw `--port` value and returns it as a number.
+ * @throws If the value is not an integer between 0 and {@link maxPort}.
+ */
+function validatePort(rawPort: string | undefined): number {
+	const port = rawPort !== undefined && /^\d+$/u.test(rawPort) ? Number(rawPort) : Number.NaN;
+	if (!Number.isInteger(port) || port < 0 || port > maxPort) {
+		throw new Error(
+			`Invalid --port value "${
+				rawPort ?? ""
+			}"; expected an integer between 0 and ${maxPort}.`,
+		);
+	}
+	return port;
+}
+
+/**
+ * Parses an optional `--port <number>` (or `--port=<number>`) command line argument specifying the port for
+ * Tinylicious to listen on.
+ * @returns The specified port, or `undefined` when the argument is not present.
+ */
+function parsePortArg(args: readonly string[]): number | undefined {
+	const flagIndex = args.indexOf("--port");
+	if (flagIndex !== -1) {
+		return validatePort(args[flagIndex + 1]);
+	}
+
+	const inlineArg = args.find((arg) => arg.startsWith("--port="));
+	if (inlineArg !== undefined) {
+		return validatePort(inlineArg.slice("--port=".length));
+	}
+
+	return undefined;
+}
+
 runService(
-	new TinyliciousResourcesFactory(),
+	new TinyliciousResourcesFactory(parsePortArg(process.argv.slice(2))),
 	new TinyliciousRunnerFactory(),
 	winston,
 	"tinylicious",

--- a/server/routerlicious/packages/tinylicious/src/resourcesFactory.ts
+++ b/server/routerlicious/packages/tinylicious/src/resourcesFactory.ts
@@ -32,13 +32,22 @@ import {
 const defaultTinyliciousPort = 7070;
 
 export class TinyliciousResourcesFactory implements IResourcesFactory<TinyliciousResources> {
+	public constructor(
+		/**
+		 * Optional port for Tinylicious to listen on.
+		 * @remarks Takes precedence over the `PORT` environment variable and the default port.
+		 */
+		private readonly port?: number,
+	) {}
+
 	public async create(
 		config: Provider,
 		customizations?: Record<string, any>,
 	): Promise<TinyliciousResources> {
 		const globalDbEnabled = false;
-		// Pull in the default port off the config
-		const port = utils.normalizePort(process.env.PORT ?? defaultTinyliciousPort);
+		// Resolve the port to listen on, preferring (in order): a port passed to this factory (e.g. from the
+		// `--port` command line argument), the `PORT` environment variable, then the default port.
+		const port = utils.normalizePort(this.port ?? process.env.PORT ?? defaultTinyliciousPort);
 		const collectionNames = config.get("mongo:collectionNames");
 
 		const tenantManager = new TenantManager(`http://localhost:${port}`);


### PR DESCRIPTION
Tinylicious can now be started on a specific port using `--port <number>` or `--port=<number>`.

The port must be an integer between 0 and 65535.
When selecting a port, Tinylicious uses the command-line argument first, followed by the `PORT` environment variable, and then the default port of 7070.