### PR TITLE
Custom Test Endpoints in the Routerlicious Test Driver

### DIFF
--- a/packages/test/test-driver-definitions/src/interfaces.ts
+++ b/packages/test/test-driver-definitions/src/interfaces.ts
@@ -28,7 +28,12 @@ export type TestDriverTypes =
  * These values are replicated in {@link @fluid-private/test-version-utils#compatOptions.d.ts}. Ensure that any revisions here are also reflected in test-version-utils.
  * @internal
  */
-export type RouterliciousEndpoint = "frs" | "frsCanary" | "r11s" | "docker";
+export type RouterliciousEndpoint =
+	| "frs"
+	| "frsCanary"
+	| "r11s"
+	| "docker"
+	| "custom";
 
 /**
  * Types of Odsp endpoints.

--- a/packages/test/test-driver-definitions/src/interfaces.ts
+++ b/packages/test/test-driver-definitions/src/interfaces.ts
@@ -28,12 +28,7 @@ export type TestDriverTypes =
  * These values are replicated in {@link @fluid-private/test-version-utils#compatOptions.d.ts}. Ensure that any revisions here are also reflected in test-version-utils.
  * @internal
  */
-export type RouterliciousEndpoint =
-	| "frs"
-	| "frsCanary"
-	| "r11s"
-	| "docker"
-	| "custom";
+export type RouterliciousEndpoint = "frs" | "frsCanary" | "r11s" | "docker" | "custom";
 
 /**
  * Types of Odsp endpoints.

--- a/packages/test/test-drivers/README.md
+++ b/packages/test/test-drivers/README.md
@@ -60,6 +60,27 @@ E.g.
 npm run test:realsvc:run -- --driver=r11s --r11sEndpointName=docker
 ```
 
+### Custom server endpoints
+
+Set `fluid__test__driver__<r11sEndpointName>` to a JSON configuration when running against a
+deployment with custom server endpoints. Existing configurations can continue to use `host`, which derives
+the Alfred, Historian, and Nexus URLs by replacing `www` in the host name.
+
+For deployments with unique service URLs, specify all three service URLs:
+
+```bash
+export fluid__test__driver__custom='{
+	"host": "https://app.example.com",
+	"tenantId": "fluid",
+	"tenantSecret": "<tenant-secret>",
+	"ordererUrl": "https://alfred.example.com",
+	"deltaStorageUrl": "https://historian.example.com",
+	"deltaStreamUrl": "https://nexus.example.com"
+}'
+
+npm run test:realsvc:run -- --driver=r11s --r11sEndpointName=custom
+```
+
 <!-- AUTO-GENERATED-CONTENT:START (README_FOOTER) -->
 
 <!-- prettier-ignore-start -->

--- a/packages/test/test-drivers/src/routerliciousTestDriver.ts
+++ b/packages/test/test-drivers/src/routerliciousTestDriver.ts
@@ -79,8 +79,14 @@ function getConfig(
 		ordererUrl !== undefined || deltaStorageUrl !== undefined || deltaStreamUrl !== undefined;
 	if (hasCustomServiceEndpoints) {
 		assert(typeof ordererUrl === "string" && ordererUrl !== "", "Missing orderer URL");
-		assert(typeof deltaStorageUrl === "string" && deltaStorageUrl !== "", "Missing delta storage URL");
-		assert(typeof deltaStreamUrl === "string" && deltaStreamUrl !== "", "Missing delta stream URL");
+		assert(
+			typeof deltaStorageUrl === "string" && deltaStorageUrl !== "",
+			"Missing delta storage URL",
+		);
+		assert(
+			typeof deltaStreamUrl === "string" && deltaStreamUrl !== "",
+			"Missing delta stream URL",
+		);
 		return {
 			serviceEndpoint: {
 				hostUrl: fluidHost,

--- a/packages/test/test-drivers/src/routerliciousTestDriver.ts
+++ b/packages/test/test-drivers/src/routerliciousTestDriver.ts
@@ -78,9 +78,9 @@ function getConfig(
 	const hasCustomServiceEndpoints =
 		ordererUrl !== undefined || deltaStorageUrl !== undefined || deltaStreamUrl !== undefined;
 	if (hasCustomServiceEndpoints) {
-		assert(ordererUrl !== undefined, "Missing orderer URL");
-		assert(deltaStorageUrl !== undefined, "Missing delta storage URL");
-		assert(deltaStreamUrl !== undefined, "Missing delta stream URL");
+		assert(typeof ordererUrl === "string" && ordererUrl !== "", "Missing orderer URL");
+		assert(typeof deltaStorageUrl === "string" && deltaStorageUrl !== "", "Missing delta storage URL");
+		assert(typeof deltaStreamUrl === "string" && deltaStreamUrl !== "", "Missing delta stream URL");
 		return {
 			serviceEndpoint: {
 				hostUrl: fluidHost,

--- a/packages/test/test-drivers/src/routerliciousTestDriver.ts
+++ b/packages/test/test-drivers/src/routerliciousTestDriver.ts
@@ -52,6 +52,9 @@ function getConfig(
 	fluidHost?: string,
 	tenantId?: string,
 	tenantSecret?: string,
+	ordererUrl?: string,
+	deltaStorageUrl?: string,
+	deltaStreamUrl?: string,
 	driverPolicies?: IRouterliciousDriverPolicies,
 ): IConfig {
 	assert(tenantId !== undefined, "Missing tenantId");
@@ -72,6 +75,24 @@ function getConfig(
 		};
 	}
 	assert(fluidHost !== undefined, "Missing Fluid host");
+	const hasCustomServiceEndpoints =
+		ordererUrl !== undefined || deltaStorageUrl !== undefined || deltaStreamUrl !== undefined;
+	if (hasCustomServiceEndpoints) {
+		assert(ordererUrl !== undefined, "Missing orderer URL");
+		assert(deltaStorageUrl !== undefined, "Missing delta storage URL");
+		assert(deltaStreamUrl !== undefined, "Missing delta stream URL");
+		return {
+			serviceEndpoint: {
+				hostUrl: fluidHost,
+				ordererUrl,
+				deltaStorageUrl,
+				deltaStreamUrl,
+			},
+			tenantId,
+			tenantSecret,
+			...(driverPolicies !== undefined ? { driverPolicies } : {}),
+		};
+	}
 	return {
 		serviceEndpoint: {
 			hostUrl: fluidHost,
@@ -111,6 +132,9 @@ function getEndpointConfigFromEnv(r11sEndpointName: RouterliciousEndpoint): ICon
 		config.host,
 		config.tenantId,
 		config.tenantSecret,
+		config.ordererUrl,
+		config.deltaStorageUrl,
+		config.deltaStreamUrl,
 		config.driverPolicies,
 	);
 }
@@ -139,7 +163,8 @@ export function assertRouterliciousEndpoint(
 		endpoint === "frs" ||
 		endpoint === "frsCanary" ||
 		endpoint === "r11s" ||
-		endpoint === "docker"
+		endpoint === "docker" ||
+		endpoint === "custom"
 	) {
 		return;
 	}


### PR DESCRIPTION
## Description
Updates the routerlicious test driver so custom service URLs can be used.

The user can use the "custom" endpoint and provide the test information which will be used when running the end-to-end tests.

```
export fluid__test__driver__custom='{
	"host": "https://app.example.com",
	"tenantId": "fluid",
	"tenantSecret": "<tenant-secret>",
	"ordererUrl": "https://alfred.example.com",
	"deltaStorageUrl": "https://historian.example.com",
	"deltaStreamUrl": "https://nexus.example.com"
}'

npm run test:realsvc:run -- --driver=r11s --r11sEndpointName=custom
```
