### PR TITLE
docs(tree): add spec for persisted commit metadata

### DIFF
--- a/packages/dds/tree/docs/wip/persisted-commit-metadata.md
+++ b/packages/dds/tree/docs/wip/persisted-commit-metadata.md
@@ -106,11 +106,28 @@ Metadata supplied to a nested transaction is ignored, mirroring how `label` reso
 
 ### Transactions that produce no commit
 
-A transaction whose body makes no changes produces no commit.
-`transaction.ts` gates commit creation on `transactionSteps.length > 0`.
+Metadata describes the commit a transaction produces.
+A transaction that produces no commit has no commit to describe, and its metadata is discarded without error.
 
-When such a transaction supplies `persistedMetadata`, throw a `UsageError`.
-Silently discarding the metadata would present as data loss with no diagnostic.
+Two paths reach this.
+A transaction whose body makes no changes produces no commit, because `transaction.ts` gates commit
+creation on `transactionSteps.length > 0`.
+A transaction that is explicitly rolled back likewise produces nothing.
+
+This is defined behavior rather than an oversight, for three reasons.
+
+Rollback is a sanctioned outcome, not a fault.
+Applications roll a transaction back when they detect an invalid edit part way through, and that path
+returns an error to their own caller; raising from the tree would convert a handled result into an
+exception.
+
+Whether a body will produce a change is not knowable before running it, so any other rule forces every
+annotated transaction to be wrapped defensively.
+
+An application whose "no change means no checkpoint" rule is the point of annotating in the first place
+gets that behavior for free.
+
+Callers that need to detect the case can compare `branchHistory.getHeadCommit()` across the call.
 
 ### Reading
 
@@ -316,7 +333,9 @@ Metadata survives the stashed op path via `getRequiredPendingLocalState`.
 
 Metadata is removed on rollback.
 
-A transaction supplying metadata but making no changes throws a `UsageError`.
+A transaction supplying metadata but making no changes discards the metadata and does not throw.
+
+A transaction supplying metadata that is explicitly rolled back discards the metadata and does not throw.
 
 Nested transactions resolve to the outermost transaction's metadata.
 

--- a/packages/dds/tree/docs/wip/persisted-commit-metadata.md
+++ b/packages/dds/tree/docs/wip/persisted-commit-metadata.md
@@ -1,0 +1,273 @@
+# Persisted Commit Metadata
+
+This document specifies a mechanism for attaching arbitrary, application-defined metadata to a commit,
+persisting that metadata in the document,
+and querying it later.
+
+The metadata shares the lifetime of the commit it is attached to:
+once the commit is evicted from the trunk, the metadata is dropped.
+This keeps growth bounded without requiring any additional garbage collection policy.
+
+The design deliberately avoids introducing a new persisted format version.
+It achieves this by using two extension points that already tolerate additive change:
+optional properties on the op envelope, and a new sub-tree in the summary.
+
+## Goals
+
+Attach a JSON-serializable value to the commit produced by a transaction.
+
+Replicate that value to all collaborating clients.
+
+Persist that value in the document so that a client loading from a summary recovers it.
+
+Drop that value automatically when the associated commit leaves the collaboration window.
+
+Ship without bumping `MessageFormatVersion`, `EditManagerFormatVersion`, or `minVersionForCollab`.
+
+## Terminology
+
+"Metadata" in this document always means the new persisted commit metadata.
+
+Note that `CommitMetadata` is already an exported interface in `core/rebase/types.ts` describing a commit's `kind` and `isLocal` flags.
+New types introduced by this feature must not reuse that name.
+Use `PersistedCommitMetadata` for the value type.
+
+## Data model
+
+The metadata is keyed by `RevisionTag`.
+
+This is the correct key for three reasons.
+A revision tag is stable across rebase, as documented on `GraphCommit.revision`.
+All commits within a single transaction share one revision tag, which `transaction.ts` enforces with assert `0xcaf`.
+A revision tag is available at every point in the pipeline where the metadata must be read or written.
+
+The in-memory store is a map from `RevisionTag` to an entry containing both the metadata and the originating session ID:
+
+```typescript
+interface PersistedCommitMetadataEntry {
+	readonly sessionId: SessionId;
+	readonly metadata: JsonCompatibleReadOnlyObject;
+}
+```
+
+The session ID must be stored alongside the metadata.
+Encoding a `RevisionTag` requires an `originatorId`, as seen in `encodeCommit` in `editManagerCodecsCommons.ts`,
+which passes `originatorId: commit.sessionId` into `revisionTagCodec.encode`.
+Without the session ID, the index cannot encode its own keys at summarization time.
+
+## Public API
+
+Add an optional field to `RunTransactionParamsAlpha` in `simple-tree/api/transactionTypes.ts`:
+
+```typescript
+readonly persistedMetadata?: JsonCompatibleReadOnlyObject;
+```
+
+Type it as `JsonCompatibleReadOnlyObject` rather than `unknown`.
+The existing `label` field is `unknown` because it never leaves memory.
+Persisted metadata must round-trip through JSON, so the constraint belongs in the type system rather than being discovered at encode time.
+
+Thread the parameter through `runTransaction` and `runTransactionAsync` along the same path that `label` already takes.
+
+The transaction API is the only entry point.
+An application that wants to annotate a single edit wraps that edit in a transaction of one.
+
+### Nested transactions
+
+The metadata supplied to the outermost transaction is the metadata for the resulting commit.
+
+Metadata supplied to a nested transaction is ignored, mirroring how `label` resolves to the outermost transaction.
+
+### Transactions that produce no commit
+
+A transaction whose body makes no changes produces no commit.
+`transaction.ts` gates commit creation on `transactionSteps.length > 0`.
+
+When such a transaction supplies `persistedMetadata`, throw a `UsageError`.
+Silently discarding the metadata would present as data loss with no diagnostic.
+
+### Reading
+
+Expose a lookup on the alpha tree surface:
+
+```typescript
+getPersistedCommitMetadata(revision: RevisionTag): JsonCompatibleReadOnlyObject | undefined;
+```
+
+Return `undefined` for revisions that were never annotated,
+for commits that predate this feature,
+and for commits whose metadata has been evicted.
+
+Callers correlate a commit to its revision through the existing change events.
+
+## Op format
+
+`Message` in `shared-tree-core/messageFormatV1ToV4.ts` is SharedTree's own op payload type.
+Its TypeBox schema is declared with a bare `Type.Object({...})` and no `ObjectOptions`,
+so additional properties are permitted by both the TypeBox compiler and the AJV validator used in tests.
+A client that does not know about the new field will validate the message successfully and ignore the field,
+because the codec's `decode` destructures only the properties it names.
+
+Add the field explicitly rather than relying on an undeclared property.
+
+Add to the `Message` interface and to the schema returned by the `Message` factory function:
+
+```typescript
+readonly persistedMetadata?: JsonCompatibleReadOnlyObject;
+```
+
+```typescript
+persistedMetadata: Type.Optional(JsonCompatibleReadOnlyObjectSchema),
+```
+
+Apply the same change to `messageFormatVSharedBranches.ts`.
+
+Add a comment on both schemas recording that additional properties are intentionally permitted,
+and that adding `additionalProperties: false` would break forward compatibility for this field.
+
+Add the field to `CommitMessage` in `shared-tree-core/messageTypes.ts`.
+
+Update `encode` and `decode` in `messageCodecV1ToV4.ts` and the shared-branches equivalent to carry the field through.
+
+Do not introduce a new `MessageFormatVersion`.
+Existing clients speaking the same version accept and ignore the new field.
+
+## Summary format
+
+Add a new `Summarizable` with the key `"CommitMetadata"`.
+Register it in the summarizables array constructed in `shared-tree/sharedTree.ts`,
+alongside `SchemaSummarizer`, `ForestSummarizer`, and `DetachedFieldIndexSummarizer`.
+
+The summarizable persists the full map.
+Encode each `RevisionTag` key with `RevisionTagCodec`, supplying `originatorId` from the stored session ID and the runtime's `IIdCompressor`.
+
+Build the summarizable on the `versionedSummarizer` pattern so that its blob carries its own format version from the outset.
+
+`loadInternal` in `sharedTreeCore.ts` iterates the client's own summarizables and looks each key up under `indexes/`.
+It never enumerates the keys present in the snapshot.
+A client that does not know about this summarizable therefore ignores the sub-tree entirely.
+
+The `load` implementation must call `await services.contains(...)` and return early when the blob is absent.
+`scopeStorageService` asserts `0xc20` inside `getSnapshotTree()` when a scoped path is missing,
+so a summarizable that reaches for storage unconditionally will fail against every document created before this feature shipped.
+
+Do not introduce a new `EditManagerFormatVersion`.
+The existing `Commit` and `SequencedCommit` schemas are sealed with `additionalProperties: false` and are not modified.
+
+## Lifecycle
+
+### Local commit
+
+`TreeCheckout` records the metadata for the commit the active transaction is about to produce.
+
+Ordering is safe.
+`SharedTreeCore.registerSharedBranch` submits from the branch's `beforeChange` event during the apply,
+which runs before the `finally` block in `runWithTransactionLabel` that clears the transaction's label state.
+
+`submitCommit` looks up the metadata by revision and includes it on the outgoing message.
+
+Write the entry into the index at submit time so that it is present for local reads before sequencing.
+
+### Remote commit
+
+`processMessagesCore` decodes each message and writes any metadata into the index,
+keyed by the decoded revision and the message's originator session ID.
+
+Do this for both local and remote messages so that the index is populated identically on every client.
+
+### Resubmit
+
+`reSubmitCore` decodes the stored op only to recover the revision,
+then re-submits the in-memory enriched commit through `submitCommit`.
+
+`submitCommit` must therefore read the metadata from the index by revision.
+Reading it back off the decoded op will not work, because the decoded message is discarded.
+
+### Stashed ops
+
+`applyStashedOp` reconstructs the commit from `{ revision, change }` alone.
+
+Extend it to write the decoded metadata into the index,
+so that metadata attached before a disconnect survives the pending-state round trip.
+
+### Rollback
+
+`rollback` removes the commit from the local branch.
+Delete the corresponding index entry.
+
+### Eviction
+
+Subscribe to the `ancestryTrimmed` event, which `EditManager` emits with the exact `RevisionTag[]` being trimmed.
+Delete those revisions from the index.
+
+This is what bounds growth, and it is the only removal path in steady-state operation.
+
+### Load
+
+Two sources compose to reconstruct the index on a loading client.
+
+Commits at or before the summary's reference sequence number come from the summarizable.
+
+Trailing ops, meaning those sequenced after the last summary, carry their metadata inline and are replayed through `processMessagesCore` during load.
+
+No special ordering work is required.
+`loadInternal` completes before the runtime delivers trailing ops.
+
+## Compatibility characteristics
+
+These are the consequences of the additive approach and should be understood before adopting the feature.
+
+A client that does not implement this feature will, when it produces a summary,
+write a summary containing no `"CommitMetadata"` sub-tree.
+All persisted metadata in the document is lost at that point, with no error.
+
+The same client ignores the metadata on incoming ops.
+Combined with the above, this means metadata is best-effort in a mixed-version collaboration session.
+Applications must not depend on it for correctness.
+
+Metadata is absent for all commits created before the feature ships.
+Every read path must handle `undefined`.
+
+Metadata travels on every annotated op and is retained in the summary for the width of the collaboration window.
+Treat it as a size-sensitive field and document a recommended budget.
+
+Expect op and summary snapshot tests to require regeneration.
+
+## Testing
+
+Cover the following.
+
+Metadata attached to a transaction is readable on the local client immediately.
+
+Metadata replicates to a peer and is readable there after synchronization.
+
+Metadata survives a summary round trip to a freshly loaded client.
+
+Metadata on trailing ops is recovered by a client that loads from a summary predating those ops.
+
+A client loading a summary that contains no `"CommitMetadata"` sub-tree loads successfully.
+
+Metadata is dropped once the associated commit is trimmed, verified by advancing the collaboration window.
+
+Metadata survives a disconnect and reconnect, exercising `reSubmitCore`.
+
+Metadata survives the stashed op path via `getRequiredPendingLocalState`.
+
+Metadata is removed on rollback.
+
+A transaction supplying metadata but making no changes throws a `UsageError`.
+
+Nested transactions resolve to the outermost transaction's metadata.
+
+## Work items
+
+1. Add `persistedMetadata` to `RunTransactionParamsAlpha` and thread it through the transaction entry points.
+2. Record pending metadata in `TreeCheckout` for the commit under construction.
+3. Implement the `"CommitMetadata"` summarizable, including revision tag encoding and the `contains` guard on load.
+4. Register the summarizable in `sharedTree.ts`.
+5. Add the optional field to both message formats, `CommitMessage`, and both message codecs.
+6. Populate and read the index across `submitCommit`, `processMessagesCore`, `reSubmitCore`, `applyStashedOp`, and `rollback`.
+7. Prune the index on `ancestryTrimmed`.
+8. Expose `getPersistedCommitMetadata` on the alpha surface.
+9. Add tests per the section above.
+10. Regenerate API reports, add a changeset, and update op and summary snapshots.

--- a/packages/dds/tree/docs/wip/persisted-commit-metadata.md
+++ b/packages/dds/tree/docs/wip/persisted-commit-metadata.md
@@ -5,12 +5,16 @@ persisting that metadata in the document,
 and querying it later.
 
 The metadata shares the lifetime of the commit it is attached to:
-once the commit is evicted from the trunk, the metadata is dropped.
+once the commit is trimmed from the trunk, the metadata goes with it.
 This keeps growth bounded without requiring any additional garbage collection policy.
 
-The design deliberately avoids introducing a new persisted format version.
-It achieves this by using two extension points that already tolerate additive change:
-optional properties on the op envelope, and a new sub-tree in the summary.
+The metadata is persisted inline on the commits in the `EditManager` summary.
+Storing it on the commit itself is what makes the shared lifetime automatic,
+keeps the persisted metadata consistent with the trunk by construction,
+and allows the metadata to be paged alongside its commits if summary history is virtualized later.
+
+Both the op format and the summary format carry the metadata under new format versions,
+so a document only ever contains metadata once every collaborating client understands it.
 
 ## Goals
 
@@ -20,9 +24,9 @@ Replicate that value to all collaborating clients.
 
 Persist that value in the document so that a client loading from a summary recovers it.
 
-Drop that value automatically when the associated commit leaves the collaboration window.
+Drop that value automatically when the associated commit is trimmed from the trunk.
 
-Ship without bumping `MessageFormatVersion`, `EditManagerFormatVersion`, or `minVersionForCollab`.
+Guarantee that metadata written to a document is understood by every client that can open the document.
 
 ## Terminology
 
@@ -34,26 +38,32 @@ Use `PersistedCommitMetadata` for the value type.
 
 ## Data model
 
-The metadata is keyed by `RevisionTag`.
+The metadata is keyed by `RevisionTag` in memory, in a map from `RevisionTag` to `JsonCompatibleReadOnlyObject`.
 
-This is the correct key for three reasons.
+`RevisionTag` is the correct key for three reasons.
 A revision tag is stable across rebase, as documented on `GraphCommit.revision`.
 All commits within a single transaction share one revision tag, which `transaction.ts` enforces with assert `0xcaf`.
 A revision tag is available at every point in the pipeline where the metadata must be read or written.
 
-The in-memory store is a map from `RevisionTag` to an entry containing both the metadata and the originating session ID:
+### Keep the metadata off `GraphCommit`
+
+Attach the metadata to the in-memory index, not to the `GraphCommit` object.
+
+This is worth stating explicitly because putting it on the commit object is the intuitive move,
+and it silently loses data.
+`rebaseBranch` in `core/rebase/utils.ts` constructs rebased commits as fresh object literals:
 
 ```typescript
-interface PersistedCommitMetadataEntry {
-	readonly sessionId: SessionId;
-	readonly metadata: JsonCompatibleReadOnlyObject;
-}
+newHead = {
+	revision: c.revision,
+	change,
+	parent: newHead,
+};
 ```
 
-The session ID must be stored alongside the metadata.
-Encoding a `RevisionTag` requires an `originatorId`, as seen in `encodeCommit` in `editManagerCodecsCommons.ts`,
-which passes `originatorId: commit.sessionId` into `revisionTagCodec.encode`.
-Without the session ID, the index cannot encode its own keys at summarization time.
+There is no spread, so any additional property on a `GraphCommit` is dropped the first time the commit is rebased.
+The revision tag survives rebase; the object identity does not.
+Keeping the index keyed by `RevisionTag` and joining the two only at encode and decode time keeps this correct.
 
 ## Public API
 
@@ -100,17 +110,32 @@ and for commits whose metadata has been evicted.
 
 Callers correlate a commit to its revision through the existing change events.
 
+## Format versions
+
+Both the op format and the summary format gain a new version for this feature.
+
+Add `v7: 7` to `MessageFormatVersion` in `shared-tree-core/messageFormatV1ToV4.ts`
+and to `EditManagerFormatVersion` in `shared-tree-core/editManagerFormatCommons.ts`,
+following the precedent set by `v6`, which was introduced and made available for writing in 2.80.0.
+Add `v7` to `supportedEditManagerFormatVersions` and to the message equivalent.
+
+Add the corresponding entries to `changeFormatVersionForEditManager` and `changeFormatVersionForMessage`
+in `shared-tree/sharedTree.ts`, mapping `v7` to the same `SharedTreeChangeFormatVersion` that `v6` maps to.
+
+The write version is selected from the configured oldest supported client,
+via `getCodecTreeForEditManagerFormat(clientVersion: OldestSupportedClientVersion)` and its message counterpart.
+A client therefore only begins writing metadata
+once `minVersionForCollab` is raised to a version that includes this feature.
+
+This is what makes the metadata dependable.
+A document containing metadata can only be opened by a client that understands and preserves it,
+so metadata written to a document stays there.
+Applications adopting this feature raise `minVersionForCollab` once their clients are saturated.
+
 ## Op format
 
-`Message` in `shared-tree-core/messageFormatV1ToV4.ts` is SharedTree's own op payload type.
-Its TypeBox schema is declared with a bare `Type.Object({...})` and no `ObjectOptions`,
-so additional properties are permitted by both the TypeBox compiler and the AJV validator used in tests.
-A client that does not know about the new field will validate the message successfully and ignore the field,
-because the codec's `decode` destructures only the properties it names.
-
-Add the field explicitly rather than relying on an undeclared property.
-
-Add to the `Message` interface and to the schema returned by the `Message` factory function:
+Add the field to the `Message` interface and to the schema returned by the `Message` factory function
+in `shared-tree-core/messageFormatV1ToV4.ts`:
 
 ```typescript
 readonly persistedMetadata?: JsonCompatibleReadOnlyObject;
@@ -122,37 +147,35 @@ persistedMetadata: Type.Optional(JsonCompatibleReadOnlyObjectSchema),
 
 Apply the same change to `messageFormatVSharedBranches.ts`.
 
-Add a comment on both schemas recording that additional properties are intentionally permitted,
-and that adding `additionalProperties: false` would break forward compatibility for this field.
-
 Add the field to `CommitMessage` in `shared-tree-core/messageTypes.ts`.
 
-Update `encode` and `decode` in `messageCodecV1ToV4.ts` and the shared-branches equivalent to carry the field through.
-
-Do not introduce a new `MessageFormatVersion`.
-Existing clients speaking the same version accept and ignore the new field.
+Update `encode` and `decode` in `messageCodecV1ToV4.ts` and the shared-branches equivalent to carry the field through,
+writing the field only when encoding at `v7` or later.
 
 ## Summary format
 
-Add a new `Summarizable` with the key `"CommitMetadata"`.
-Register it in the summarizables array constructed in `shared-tree/sharedTree.ts`,
-alongside `SchemaSummarizer`, `ForestSummarizer`, and `DetachedFieldIndexSummarizer`.
+The metadata is persisted inline on the commits in the `EditManager` summary.
 
-The summarizable persists the full map.
-Encode each `RevisionTag` key with `RevisionTagCodec`, supplying `originatorId` from the stored session ID and the runtime's `IIdCompressor`.
+`CommitBase` in `shared-tree-core/editManagerFormatCommons.ts` is composed with `noAdditionalProps`
+into both `Commit` and `SequencedCommit`, so the new field is declared on the schema itself:
 
-Build the summarizable on the `versionedSummarizer` pattern so that its blob carries its own format version from the outset.
+```typescript
+persistedMetadata: Type.Optional(JsonCompatibleReadOnlyObjectSchema),
+```
 
-`loadInternal` in `sharedTreeCore.ts` iterates the client's own summarizables and looks each key up under `indexes/`.
-It never enumerates the keys present in the snapshot.
-A client that does not know about this summarizable therefore ignores the sub-tree entirely.
+Add the matching optional property to the `Commit` and `EncodedCommit` interfaces in the same file.
+This covers the trunk via `SequencedCommit`, peer local branches via `SummarySessionBranch.commits`,
+and shared branches via `EncodedSharedBranch`.
 
-The `load` implementation must call `await services.contains(...)` and return early when the blob is absent.
-`scopeStorageService` asserts `0xc20` inside `getSnapshotTree()` when a scoped path is missing,
-so a summarizable that reaches for storage unconditionally will fail against every document created before this feature shipped.
+`encodeCommit` in `editManagerCodecsCommons.ts` already has everything it needs.
+It holds the commit's `revision` and `sessionId`, so it looks the metadata up in the index by revision
+and writes it onto the encoded commit with no additional key encoding.
+`decodeCommit` reverses this, writing any decoded metadata into the index keyed by the decoded revision.
 
-Do not introduce a new `EditManagerFormatVersion`.
-The existing `Commit` and `SequencedCommit` schemas are sealed with `additionalProperties: false` and are not modified.
+Emit the field only when encoding at `EditManagerFormatVersion.v7` or later.
+
+Because the metadata travels with the commit, no separate index is persisted,
+and the persisted metadata is exactly the set of commits present in the summary.
 
 ## Lifecycle
 
@@ -171,7 +194,7 @@ Write the entry into the index at submit time so that it is present for local re
 ### Remote commit
 
 `processMessagesCore` decodes each message and writes any metadata into the index,
-keyed by the decoded revision and the message's originator session ID.
+keyed by the decoded revision.
 
 Do this for both local and remote messages so that the index is populated identically on every client.
 
@@ -197,38 +220,36 @@ Delete the corresponding index entry.
 
 ### Eviction
 
-Subscribe to the `ancestryTrimmed` event, which `EditManager` emits with the exact `RevisionTag[]` being trimmed.
-Delete those revisions from the index.
+The persisted side needs no work.
+A trimmed commit is not serialized, so its metadata leaves the document with it.
 
-This is what bounds growth, and it is the only removal path in steady-state operation.
+Subscribe to the `ancestryTrimmed` event, which `EditManager` emits with the exact `RevisionTag[]` being trimmed,
+and delete those revisions from the in-memory index so that memory tracks the trunk.
 
 ### Load
 
 Two sources compose to reconstruct the index on a loading client.
 
-Commits at or before the summary's reference sequence number come from the summarizable.
+Commits at or before the summary's reference sequence number carry their metadata inline,
+and `decodeCommit` writes it into the index as the summary is decoded.
 
 Trailing ops, meaning those sequenced after the last summary, carry their metadata inline and are replayed through `processMessagesCore` during load.
 
 No special ordering work is required.
 `loadInternal` completes before the runtime delivers trailing ops.
 
-## Compatibility characteristics
+## Characteristics
 
-These are the consequences of the additive approach and should be understood before adopting the feature.
+These are the consequences of the design and should be understood before adopting the feature.
 
-A client that does not implement this feature will, when it produces a summary,
-write a summary containing no `"CommitMetadata"` sub-tree.
-All persisted metadata in the document is lost at that point, with no error.
-
-The same client ignores the metadata on incoming ops.
-Combined with the above, this means metadata is best-effort in a mixed-version collaboration session.
-Applications must not depend on it for correctness.
-
-Metadata is absent for all commits created before the feature ships.
+Metadata is absent for all commits created before the feature is enabled.
 Every read path must handle `undefined`.
 
-Metadata travels on every annotated op and is retained in the summary for the width of the collaboration window.
+Metadata is retained for exactly as long as its commit is retained.
+Under the default trunk eviction policy that is the width of the collaboration window;
+under `retainHistory` it is the lifetime of the document.
+
+Metadata travels on every annotated op and occupies space in the summary for as long as its commit survives.
 Treat it as a size-sensitive field and document a recommended budget.
 
 Expect op and summary snapshot tests to require regeneration.
@@ -245,9 +266,15 @@ Metadata survives a summary round trip to a freshly loaded client.
 
 Metadata on trailing ops is recovered by a client that loads from a summary predating those ops.
 
-A client loading a summary that contains no `"CommitMetadata"` sub-tree loads successfully.
+A client loading a summary written before this feature was enabled loads successfully,
+and reads back `undefined` for every commit in it.
 
 Metadata is dropped once the associated commit is trimmed, verified by advancing the collaboration window.
+
+Metadata for a commit retained under `retainHistory` survives a summary round trip.
+
+Metadata survives rebase,
+verified by annotating a local commit and then sequencing a concurrent remote commit ahead of it.
 
 Metadata survives a disconnect and reconnect, exercising `reSubmitCore`.
 
@@ -263,11 +290,14 @@ Nested transactions resolve to the outermost transaction's metadata.
 
 1. Add `persistedMetadata` to `RunTransactionParamsAlpha` and thread it through the transaction entry points.
 2. Record pending metadata in `TreeCheckout` for the commit under construction.
-3. Implement the `"CommitMetadata"` summarizable, including revision tag encoding and the `contains` guard on load.
-4. Register the summarizable in `sharedTree.ts`.
-5. Add the optional field to both message formats, `CommitMessage`, and both message codecs.
+3. Add `v7` to `MessageFormatVersion` and `EditManagerFormatVersion`, register it as supported,
+   and add the `changeFormatVersionFor*` entries.
+4. Add the optional field to both message formats, `CommitMessage`, and both message codecs.
+5. Add the optional field to `CommitBase` and to the `Commit` and `EncodedCommit` interfaces,
+   and carry it through `encodeCommit` and `decodeCommit`.
 6. Populate and read the index across `submitCommit`, `processMessagesCore`, `reSubmitCore`, `applyStashedOp`, and `rollback`.
-7. Prune the index on `ancestryTrimmed`.
+7. Prune the in-memory index on `ancestryTrimmed`.
 8. Expose `getPersistedCommitMetadata` on the alpha surface.
 9. Add tests per the section above.
 10. Regenerate API reports, add a changeset, and update op and summary snapshots.
+

--- a/packages/dds/tree/docs/wip/persisted-commit-metadata.md
+++ b/packages/dds/tree/docs/wip/persisted-commit-metadata.md
@@ -8,8 +8,9 @@ The metadata shares the lifetime of the commit it is attached to:
 once the commit is trimmed from the trunk, the metadata goes with it.
 This keeps growth bounded without requiring any additional garbage collection policy.
 
-The metadata is persisted inline on the commits in the `EditManager` summary.
-Storing it on the commit itself is what makes the shared lifetime automatic,
+The metadata lives directly on the commit — on `GraphCommit` in memory and inline on the commits in the
+`EditManager` summary. There is no separate index to populate, reconcile, or prune.
+Storing it on the commit is what makes the shared lifetime automatic,
 keeps the persisted metadata consistent with the trunk by construction,
 and allows the metadata to be paged alongside its commits if summary history is virtualized later.
 
@@ -38,20 +39,28 @@ Use `PersistedCommitMetadata` for the value type.
 
 ## Data model
 
-The metadata is keyed by `RevisionTag` in memory, in a map from `RevisionTag` to `JsonCompatibleReadOnlyObject`.
+Add the metadata to `GraphCommit` in `core/rebase/types.ts` as a **required** property:
 
-`RevisionTag` is the correct key for three reasons.
-A revision tag is stable across rebase, as documented on `GraphCommit.revision`.
-All commits within a single transaction share one revision tag, which `transaction.ts` enforces with assert `0xcaf`.
-A revision tag is available at every point in the pipeline where the metadata must be read or written.
+```typescript
+readonly persistedMetadata: JsonCompatibleReadOnlyObject | undefined;
+```
 
-### Keep the metadata off `GraphCommit`
+Required, not optional. The value may be `undefined`, but the property must always be written.
+`GraphCommit` does not appear in any API report, so this is an internal change.
 
-Attach the metadata to the in-memory index, not to the `GraphCommit` object.
+### Why required
 
-This is worth stating explicitly because putting it on the commit object is the intuitive move,
-and it silently loses data.
-`rebaseBranch` in `core/rebase/utils.ts` constructs rebased commits as fresh object literals:
+Two places rebuild a commit from its parts rather than spreading it, and both would silently drop an
+optional property.
+
+`mintCommit` in `core/rebase/types.ts`:
+
+```typescript
+const { revision, change } = commit;
+return { revision, change, parent };
+```
+
+and `rebaseBranch` in `core/rebase/utils.ts`:
 
 ```typescript
 newHead = {
@@ -61,25 +70,29 @@ newHead = {
 };
 ```
 
-There is no spread, so any additional property on a `GraphCommit` is dropped the first time the commit is rebased.
-The revision tag survives rebase; the object identity does not.
-Keeping the index keyed by `RevisionTag` and joining the two only at encode and decode time keeps this correct.
+Declaring the property required turns both into compile errors, so the type system enumerates every
+site that has to make a decision instead of leaving the loss silent.
 
-### One index per tree, shared by every branch
+### Propagate at the rebuild sites — do not write `undefined` to satisfy the compiler
 
-The index belongs to the `SharedTreeCore` instance, not to an individual `TreeCheckout`.
+This is the one way to get this wrong.
 
-A transaction can run on any branch. An application that renders from a fork and publishes by merging
-that fork into the main branch will annotate its transactions on the fork, and those commits reach the
-wire only when the merge submits them. `submitCommit` must therefore find metadata that a *different*
-checkout recorded.
+A rebased or re-parented commit is the **same logical commit** as its source: same revision, same
+change, same metadata. Both sites above must copy `persistedMetadata` from the commit they are
+rebuilding. Writing `persistedMetadata: undefined` there compiles cleanly and reintroduces exactly
+the data loss the required property exists to prevent.
 
-Keying by `RevisionTag` is what makes this work: merging and rebasing preserve each commit's revision,
-so a lookup by revision remains valid after the commit moves between branches. A checkout records into
-the shared index; every other stage of the pipeline reads from that same index by revision.
+`undefined` is correct only where a genuinely new commit is minted that no caller annotated — the
+inverse commit produced by reverting, and rollback commits.
 
-Delete an entry only on rollback or eviction, not on branch disposal.
-A commit whose fork has been disposed may already have been merged into another branch.
+### Why the commit and not a side index
+
+The metadata is reachable wherever a commit is, which is every point in the pipeline that needs it.
+It is garbage collected with its commit, so trimming needs no participation. It cannot drift out of
+sync with the commit graph, because there is no second structure to keep in sync. And it survives
+moving between branches for free: an application that renders from a fork and publishes by merging
+that fork into the main branch carries its metadata along with the commits it merges, with no
+cross-branch bookkeeping.
 
 ## Public API
 
@@ -131,17 +144,34 @@ Callers that need to detect the case can compare `branchHistory.getHeadCommit()`
 
 ### Reading
 
-Expose a lookup on the alpha tree surface:
+Expose the metadata on `TreeBranchCommitMetadata` in `simple-tree/api/tree.ts`, the per-commit object
+introduced alongside `TreeBranchHistory`:
 
 ```typescript
-getPersistedCommitMetadata(revision: RevisionTag): JsonCompatibleReadOnlyObject | undefined;
+readonly persistedMetadata: JsonCompatibleReadOnlyObject | undefined;
 ```
 
-Return `undefined` for revisions that were never annotated,
-for commits that predate this feature,
-and for commits whose metadata has been evicted.
+`LazyTreeBranchCommitMetadata` in `shared-tree/history.ts` wraps the `GraphCommit` it describes, so
+this reads straight through to the commit.
 
-Callers correlate a commit to its revision through the existing change events.
+Reading is therefore a property of history navigation rather than a separate lookup. A caller reaches
+a commit through `branchHistory.getHeadCommit()` and the `parent` chain, and the metadata is already
+there:
+
+```typescript
+for (
+	let commit = view.branchHistory.getHeadCommit();
+	commit !== undefined;
+	commit = commit.parent
+) {
+	const metadata = commit.persistedMetadata;
+}
+```
+
+The value is `undefined` for commits that were never annotated and for commits created before the
+feature was enabled. There is deliberately no lookup by revision: a caller holding only a revision
+walks the chain to find its commit. Adding a revision-keyed accessor would require a side index, which
+is the structure this design removes.
 
 ## Format versions
 
@@ -201,9 +231,8 @@ This covers the trunk via `SequencedCommit`, peer local branches via `SummarySes
 and shared branches via `EncodedSharedBranch`.
 
 `encodeCommit` in `editManagerCodecsCommons.ts` already has everything it needs.
-It holds the commit's `revision` and `sessionId`, so it looks the metadata up in the index by revision
-and writes it onto the encoded commit with no additional key encoding.
-`decodeCommit` reverses this, writing any decoded metadata into the index keyed by the decoded revision.
+It holds the commit, so it reads `persistedMetadata` directly and writes it onto the encoded commit.
+`decodeCommit` reverses this, setting `persistedMetadata` on the `GraphCommit` it reconstructs.
 
 Emit the field only when encoding at `EditManagerFormatVersion.v7` or later.
 
@@ -212,72 +241,74 @@ and the persisted metadata is exactly the set of commits present in the summary.
 
 ## Lifecycle
 
+Because the metadata is a property of the commit, most stages need no bookkeeping at all: anything that
+already carries a commit carries its metadata. What follows is limited to the places that construct a
+commit and must therefore supply the property.
+
 ### Local commit
 
-`TreeCheckout` records the metadata for the commit the active transaction is about to produce.
+`TreeCheckout` holds the metadata supplied to the active transaction and attaches it to the commit that
+transaction produces, so the commit carries it from the moment it exists.
 
 Ordering is safe.
 `SharedTreeCore.registerSharedBranch` submits from the branch's `beforeChange` event during the apply,
 which runs before the `finally` block in `runWithTransactionLabel` that clears the transaction's label state.
 
-`submitCommit` looks up the metadata by revision and includes it on the outgoing message.
+`submitCommit` reads `persistedMetadata` off the commit and includes it on the outgoing message.
 
-Write the entry into the index at record time so that it is present for local reads before sequencing,
-and so that it is already there when a commit made on a fork is later submitted by a merge.
+Because the metadata is present on the commit before sequencing, local reads through the branch history
+see it immediately.
 
 ### Commits made on a branch
 
-A transaction that runs on a fork produces a commit that is not submitted until the fork is merged
-into a branch that submits.
+A transaction that runs on a fork produces a commit that is not submitted until the fork is merged into
+a branch that submits.
 
-No extra bookkeeping is required, provided the index is shared across the tree as described in the
-data model. The recording checkout writes the entry keyed by revision; the merge preserves that
-revision; `submitCommit` finds the entry when the commit finally goes to the wire.
+This requires no special handling. The metadata is on the commit, and merging carries the commit
+across, so the metadata arrives with it — provided the rebuild sites propagate rather than reset the
+property, per the data model.
 
 This path is worth testing directly, because an application that renders from a fork exercises it on
 every edit.
 
 ### Remote commit
 
-`processMessagesCore` decodes each message and writes any metadata into the index,
-keyed by the decoded revision.
-
-Do this for both local and remote messages so that the index is populated identically on every client.
+`processMessagesCore` decodes each message and sets the decoded metadata on the commit it constructs.
 
 ### Resubmit
 
 `reSubmitCore` decodes the stored op only to recover the revision,
 then re-submits the in-memory enriched commit through `submitCommit`.
 
-`submitCommit` must therefore read the metadata from the index by revision.
-Reading it back off the decoded op will not work, because the decoded message is discarded.
+That in-memory commit already carries its metadata, so `submitCommit` re-reads it from the commit and
+nothing has to be recovered from the decoded message.
 
 ### Stashed ops
 
 `applyStashedOp` reconstructs the commit from `{ revision, change }` alone.
 
-Extend it to write the decoded metadata into the index,
+Extend it to set `persistedMetadata` from the decoded op,
 so that metadata attached before a disconnect survives the pending-state round trip.
 
 ### Rollback
 
-`rollback` removes the commit from the local branch.
-Delete the corresponding index entry.
+`rollback` removes the commit from the local branch, and the metadata goes with it.
+Nothing else to do.
 
 ### Eviction
 
-The persisted side needs no work.
-A trimmed commit is not serialized, so its metadata leaves the document with it.
+Nothing to do, on either side.
 
-Subscribe to the `ancestryTrimmed` event, which `EditManager` emits with the exact `RevisionTag[]` being trimmed,
-and delete those revisions from the in-memory index so that memory tracks the trunk.
+A trimmed commit is not serialized, so its metadata leaves the document with it. In memory, the
+metadata is a property of the commit object and is collected with it, so no `ancestryTrimmed`
+subscription is required.
 
 ### Load
 
-Two sources compose to reconstruct the index on a loading client.
+Two sources compose on a loading client, and both attach the metadata as the commit is built.
 
 Commits at or before the summary's reference sequence number carry their metadata inline,
-and `decodeCommit` writes it into the index as the summary is decoded.
+and `decodeCommit` sets it on each `GraphCommit` as the summary is decoded.
 
 Trailing ops, meaning those sequenced after the last summary, carry their metadata inline and are replayed through `processMessagesCore` during load.
 
@@ -321,6 +352,7 @@ Metadata for a commit retained under `retainHistory` survives a summary round tr
 
 Metadata survives rebase,
 verified by annotating a local commit and then sequencing a concurrent remote commit ahead of it.
+This is the regression test for the rebuild sites described in the data model.
 
 Metadata attached to a transaction on a fork is readable after that fork is merged into the main
 branch, and reaches a peer once the merge is sequenced.
@@ -342,16 +374,18 @@ Nested transactions resolve to the outermost transaction's metadata.
 ## Work items
 
 1. Add `persistedMetadata` to `RunTransactionParamsAlpha` and thread it through the transaction entry points.
-2. Record pending metadata in `TreeCheckout` for the commit under construction.
-3. Add `v7` to `MessageFormatVersion` and `EditManagerFormatVersion`, register it as supported,
+2. Add the required `persistedMetadata` property to `GraphCommit`, then work through the resulting
+   compile errors. Propagate at `mintCommit` and `rebaseBranch`; set `undefined` only where a genuinely
+   new commit is minted.
+3. Carry the transaction's metadata onto the commit it produces in `TreeCheckout`.
+4. Add `v7` to `MessageFormatVersion` and `EditManagerFormatVersion`, register it as supported,
    and add the `changeFormatVersionFor*` entries.
-4. Add the optional field to both message formats, `CommitMessage`, and both message codecs.
-5. Add the optional field to `CommitBase` and to the `Commit` and `EncodedCommit` interfaces,
+5. Add the optional field to both message formats, `CommitMessage`, and both message codecs.
+6. Add the optional field to `CommitBase` and to the `Commit` and `EncodedCommit` interfaces,
    and carry it through `encodeCommit` and `decodeCommit`.
-6. Populate and read the index across `submitCommit`, `processMessagesCore`, `reSubmitCore`, `applyStashedOp`, and `rollback`.
-   Hold the index on `SharedTreeCore` so every checkout of the tree shares it.
-7. Prune the in-memory index on `ancestryTrimmed`.
-8. Expose `getPersistedCommitMetadata` on the alpha surface.
+7. Set the property on the commits built by `processMessagesCore` and `applyStashedOp`, and read it
+   from the commit in `submitCommit`.
+8. Expose `persistedMetadata` on `TreeBranchCommitMetadata`, reading through from the wrapped commit.
 9. Add tests per the section above.
 10. Regenerate API reports, add a changeset, and update op and summary snapshots.
 

--- a/packages/dds/tree/docs/wip/persisted-commit-metadata.md
+++ b/packages/dds/tree/docs/wip/persisted-commit-metadata.md
@@ -65,6 +65,22 @@ There is no spread, so any additional property on a `GraphCommit` is dropped the
 The revision tag survives rebase; the object identity does not.
 Keeping the index keyed by `RevisionTag` and joining the two only at encode and decode time keeps this correct.
 
+### One index per tree, shared by every branch
+
+The index belongs to the `SharedTreeCore` instance, not to an individual `TreeCheckout`.
+
+A transaction can run on any branch. An application that renders from a fork and publishes by merging
+that fork into the main branch will annotate its transactions on the fork, and those commits reach the
+wire only when the merge submits them. `submitCommit` must therefore find metadata that a *different*
+checkout recorded.
+
+Keying by `RevisionTag` is what makes this work: merging and rebasing preserve each commit's revision,
+so a lookup by revision remains valid after the commit moves between branches. A checkout records into
+the shared index; every other stage of the pipeline reads from that same index by revision.
+
+Delete an entry only on rollback or eviction, not on branch disposal.
+A commit whose fork has been disposed may already have been merged into another branch.
+
 ## Public API
 
 Add an optional field to `RunTransactionParamsAlpha` in `simple-tree/api/transactionTypes.ts`:
@@ -189,7 +205,20 @@ which runs before the `finally` block in `runWithTransactionLabel` that clears t
 
 `submitCommit` looks up the metadata by revision and includes it on the outgoing message.
 
-Write the entry into the index at submit time so that it is present for local reads before sequencing.
+Write the entry into the index at record time so that it is present for local reads before sequencing,
+and so that it is already there when a commit made on a fork is later submitted by a merge.
+
+### Commits made on a branch
+
+A transaction that runs on a fork produces a commit that is not submitted until the fork is merged
+into a branch that submits.
+
+No extra bookkeeping is required, provided the index is shared across the tree as described in the
+data model. The recording checkout writes the entry keyed by revision; the merge preserves that
+revision; `submitCommit` finds the entry when the commit finally goes to the wire.
+
+This path is worth testing directly, because an application that renders from a fork exercises it on
+every edit.
 
 ### Remote commit
 
@@ -276,6 +305,11 @@ Metadata for a commit retained under `retainHistory` survives a summary round tr
 Metadata survives rebase,
 verified by annotating a local commit and then sequencing a concurrent remote commit ahead of it.
 
+Metadata attached to a transaction on a fork is readable after that fork is merged into the main
+branch, and reaches a peer once the merge is sequenced.
+
+Metadata attached on a fork is still readable after the fork itself is disposed.
+
 Metadata survives a disconnect and reconnect, exercising `reSubmitCore`.
 
 Metadata survives the stashed op path via `getRequiredPendingLocalState`.
@@ -296,6 +330,7 @@ Nested transactions resolve to the outermost transaction's metadata.
 5. Add the optional field to `CommitBase` and to the `Commit` and `EncodedCommit` interfaces,
    and carry it through `encodeCommit` and `decodeCommit`.
 6. Populate and read the index across `submitCommit`, `processMessagesCore`, `reSubmitCore`, `applyStashedOp`, and `rollback`.
+   Hold the index on `SharedTreeCore` so every checkout of the tree shares it.
 7. Prune the in-memory index on `ancestryTrimmed`.
 8. Expose `getPersistedCommitMetadata` on the alpha surface.
 9. Add tests per the section above.


### PR DESCRIPTION
## Description

Adds a design specification for attaching arbitrary, application-defined metadata to a commit,
persisting it in the document, and querying it later.
The metadata shares the lifetime of the commit it is attached to, so it is dropped once that commit
leaves the collaboration window.

The spec covers the transaction API surface, keying by `RevisionTag`, the op envelope change,
a new summarizable index, and the behavior required across submit, remote receipt, resubmit,
stashed ops, rollback, eviction, and load.

This is documentation only; no product code is changed.
The design is written to avoid introducing a new persisted format version, and the compatibility
section records the consequences of that choice.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

This is a draft for design feedback rather than an implementation proposal.
Two areas would benefit most from scrutiny:

-   The op envelope approach relies on the `Message` schemas permitting additional properties.
    Existing clients tolerate this, but it is not currently documented as a guarantee, so the spec
    proposes declaring the field explicitly and annotating the schemas so the behavior is preserved.
-   The summarizable is invisible to clients that do not implement it, which means such a client
    silently drops the metadata when it summarizes. The "Compatibility characteristics" section
    spells this out; please confirm the best-effort guarantee is acceptable.
