### PR TITLE
perf(odsp-driver): lazy-load point-in-time code to avoid eager bundle cost

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentServiceFactoryCore.ts
@@ -63,12 +63,7 @@ import {
 	toInstrumentedOdspStorageTokenFetcher,
 	toInstrumentedOdspTokenFetcher,
 } from "./odspUtils.js";
-// eslint-disable-next-line import-x/no-internal-modules
-import { OdspPointInTimeDocumentService } from "./pointInTimeDriver/odspPointInTimeDocumentService.js";
-import {
-	createOdspVersionManager,
-	type IOdspVersionManager,
-} from "./odspVersionManager/index.js";
+import type { IOdspVersionManager } from "./odspVersionManager/index.js";
 
 /**
  * An ODSP document service factory that supports point-in-time (sequence-number-based) loading.
@@ -355,7 +350,7 @@ export class OdspDocumentServiceFactoryCore
 				clientIsSummarizer,
 			);
 
-			const versionManager = this.createVersionManager(
+			const versionManager = await this.createVersionManager(
 				odspResolvedUrl,
 				extLogger,
 				cacheAndTracker.epochTracker,
@@ -389,6 +384,13 @@ export class OdspDocumentServiceFactoryCore
 				cacheAndTracker,
 				clientIsSummarizer,
 			);
+			// Delay-load the point-in-time service into its own chunk, fetched only when a
+			// consumer actually performs a point-in-time load.
+			const { OdspPointInTimeDocumentService } = await import(
+				/* webpackChunkName: "odspPointInTime" */
+				// eslint-disable-next-line import-x/no-internal-modules -- deep import needed to split point-in-time code into its own lazy chunk
+				"./pointInTimeDriver/odspPointInTimeDocumentService.js"
+			);
 			return new OdspPointInTimeDocumentService(
 				recoverableResolvedUrl,
 				recoverableDocumentService,
@@ -400,11 +402,11 @@ export class OdspDocumentServiceFactoryCore
 	/**
 	 * Creates the version manager used to select the closest file version at or before the target.
 	 */
-	private createVersionManager(
+	private async createVersionManager(
 		odspResolvedUrl: IOdspResolvedUrl,
 		logger: TelemetryLoggerExt,
 		epochTracker: EpochTracker,
-	): IOdspVersionManager {
+	): Promise<IOdspVersionManager> {
 		const urlParts: IOdspUrlParts = {
 			siteUrl: odspResolvedUrl.siteUrl,
 			driveId: odspResolvedUrl.driveId,
@@ -414,6 +416,9 @@ export class OdspDocumentServiceFactoryCore
 			logger,
 			urlParts,
 			this.getStorageToken,
+		);
+		const { createOdspVersionManager } = await import(
+			/* webpackChunkName: "odspPointInTime" */ "./odspVersionManager/index.js"
 		);
 		return createOdspVersionManager({
 			urlParts,

--- a/packages/drivers/odsp-driver/src/test/odspPointInTimeDocumentServiceFactory.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspPointInTimeDocumentServiceFactory.spec.ts
@@ -117,7 +117,7 @@ describe("OdspPointInTimeDocumentServiceFactory lineage guard", () => {
 			odspResolvedUrl: IOdspResolvedUrl,
 			logger: unknown,
 			epochTracker: EpochTracker,
-		) => IOdspVersionManager;
+		) => Promise<IOdspVersionManager>;
 		resolveFileVersion: (
 			resolvedUrl: IResolvedUrl,
 			fileVersion: string,
@@ -140,7 +140,7 @@ describe("OdspPointInTimeDocumentServiceFactory lineage guard", () => {
 				odspResolvedUrl: IOdspResolvedUrl,
 				logger: unknown,
 				epochTracker: EpochTracker,
-			) => IOdspVersionManager;
+			) => Promise<IOdspVersionManager>;
 			resolveFileVersion: (
 				resolvedUrl: IResolvedUrl,
 				fileVersion: string,
@@ -163,7 +163,7 @@ describe("OdspPointInTimeDocumentServiceFactory lineage guard", () => {
 				},
 			}),
 		};
-		stub(internals, "createVersionManager").callsFake((_url, _logger, epochTracker) => {
+		stub(internals, "createVersionManager").callsFake(async (_url, _logger, epochTracker) => {
 			versionManagerEpochTracker = epochTracker;
 			return fakeManager;
 		});
@@ -241,7 +241,7 @@ describe("OdspPointInTimeDocumentServiceFactory lineage guard", () => {
 		const realManager = new OdspVersionManager(
 			fakeFetcher({ liveEpoch: "epoch-live", versionEpoch: "epoch-old" }),
 		);
-		stub(internals, "createVersionManager").returns(realManager);
+		stub(internals, "createVersionManager").resolves(realManager);
 		const resolveFileVersion = stub(internals, "resolveFileVersion");
 		const createDocumentServiceCore = stub(internals, "createDocumentServiceCore");
 
@@ -281,7 +281,7 @@ describe("OdspPointInTimeDocumentServiceFactory lineage guard", () => {
 		const realManager = new OdspVersionManager(
 			fakeFetcher({ liveEpoch: "epoch-A", versionEpoch: "epoch-A" }),
 		);
-		stub(internals, "createVersionManager").returns(realManager);
+		stub(internals, "createVersionManager").resolves(realManager);
 		stub(internals, "resolveFileVersion").resolves(recoverableResolvedUrl);
 		const createDocumentServiceCore = stub(internals, "createDocumentServiceCore").callsFake(
 			async () => fakeDocumentService(),
@@ -308,7 +308,7 @@ describe("OdspPointInTimeDocumentServiceFactory lineage guard", () => {
 			const factory = getOdspPointInTimeDocumentServiceFactory(getStorageToken, undefined);
 			const resolvedUrl = await makeResolvedUrl();
 			const internals = factory as unknown as FactoryInternals;
-			stub(internals, "createVersionManager").returns({
+			stub(internals, "createVersionManager").resolves({
 				findBaseForSeq: async (): Promise<BaseForSeq> =>
 					oldestResolvedSeq === undefined
 						? { kind: "noBaseVersion" }
@@ -348,7 +348,11 @@ describe("OdspPointInTimeDocumentServiceFactory lineage guard", () => {
 			createChildLogger(),
 		);
 
-		const manager = internals.createVersionManager(resolvedUrl, createChildLogger(), tracker);
+		const manager = await internals.createVersionManager(
+			resolvedUrl,
+			createChildLogger(),
+			tracker,
+		);
 		assert.equal(typeof manager.findBaseForSeq, "function");
 
 		const versionedUrl = (await internals.resolveFileVersion(


### PR DESCRIPTION
## Description

Moving point-in-time loading into `OdspDocumentServiceFactoryCore` ([#28007](https://github.com/microsoft/FluidFramework/pull/28007)) added static imports of the point-in-time-only code paths — `OdspPointInTimeDocumentService` and the version manager (whose file-version fetcher is point-in-time-only). Because every ODSP consumer imports the core factory, all of that code became eagerly bundled into `odspDriver.js` regardless of whether the consumer uses point-in-time loading (~+9.9KB parsed / +2.8KB gzip regression).

This converts both to dynamic `import()` calls behind a shared `webpackChunkName: "odspPointInTime"`, so the point-in-time code splits into a single separate chunk that is only fetched when a consumer actually performs a point-in-time load. This keeps the unified single-factory API from #28007 while removing the eager size cost, and matches the existing lazy-load pattern already used in odsp-driver (`createNewModule`, `odspDocumentStorageManager`, `odspDocumentService`).

`createVersionManager` becomes `async` as a result (it now awaits the dynamic import). This is an internal `private` method with a single already-async caller, so there is **no public API change** — `createPointInTimeDocumentService`'s signature is unchanged and no API report is affected.

## Testing

- Full odsp-driver unit suite passes (304 passing), including the point-in-time factory lineage-guard and version-manager tests.
- The private-seam stubs for `createVersionManager` in `odspPointInTimeDocumentServiceFactory.spec.ts` were updated to resolve (async).
- Bundle-size impact is validated via the CI bundle-size report and the office-bohemia integration pipeline. (WIP)
