### PR TITLE
fix: resolve Mocha reporter from consuming package

### DIFF
--- a/packages/test/mocha-test-setup/src/mocharcCommon.ts
+++ b/packages/test/mocha-test-setup/src/mocharcCommon.ts
@@ -4,6 +4,7 @@
  */
 
 import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
 import path from "node:path";
 
 /**
@@ -118,7 +119,7 @@ export function getFluidTestMochaConfig(
 		const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
 			name: string;
 		};
-		config.reporter = `mocha-multi-reporters`;
+		config.reporter = createRequire(packageJsonPath).resolve("mocha-multi-reporters");
 		// See https://www.npmjs.com/package/mocha-multi-reporters#cmroutput-option
 		const outputFilePrefix = reportPrefix !== undefined ? `${reportPrefix}-` : "";
 		if (process.env.SILENT_TEST_OUTPUT === undefined) {


### PR DESCRIPTION
## Description

Resolve `mocha-multi-reporters` from each consuming package before passing it to Mocha.

Mocha resolves a bare reporter name relative to its own installation. With pnpm's isolated dependency layout, the reporter can be available to the package running tests but unavailable from Mocha's virtual-store location, causing `ERR_MOCHA_INVALID_REPORTER`.

Resolving the reporter from the consuming package's `package.json` preserves package dependency ownership while making reporter loading independent of pnpm hoisting.

This error can also coincide with stale peer links in `node_modules/.pnpm`, particularly after dependency graph or peer-context changes. In the observed case, `pnpm install --force` did not repair the stale link. If reporter loading succeeds but another dependency fails with `MODULE_NOT_FOUND`, regenerate the installation from the repository root:

```bash
rm -rf node_modules
pnpm install --frozen-lockfile
```

This PR prevents reporter resolution from depending on pnpm's physical layout; it does not repair stale pnpm virtual-store links.

We do not know the source of the node_modules corruption, and it isn't repaired by `pnpm install --force` in pnpm 11 (but it is in the upcoming 12 release, though only when using --force, see https://github.com/pnpm/pnpm/issues/9758#issuecomment-5377786538)

## Reviewer Guidance

The review process is outlined in [the pull request guidelines](../docs/content/Contributing/PR-Guidelines.md#guidelines).

