### PR TITLE
test(client-import-testing): cleanup possible with TS6

### DIFF
--- a/examples/utils/import-testing/src/test/build.spec.ts
+++ b/examples/utils/import-testing/src/test/build.spec.ts
@@ -5,31 +5,15 @@
 
 import { strict as assert } from "node:assert";
 import { execFile } from "node:child_process";
-import { readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import * as path from "node:path";
 import { env } from "node:process";
 import { promisify } from "node:util";
 
-// When available (typescript 5.8+), update dynamic parsing to static import
-// import typescriptHostPackageJson from "@fluid-example/typescript-versions-host/package.json"; : with { type: "json" };
-
-/**
- * Minimal shape of the parts of package.json this test reads.
- *
- * @remarks
- * Declared locally rather than imported from `@fluidframework/build-tools` because that package is
- * ESM-only: its CommonJS `exports` condition resolves to a stub that does not include
- * `PackageJson`, and this file is also compiled as CommonJS.
- *
- * TODO: AB#80348: once this test's CommonJS compilation is able to import ESM, remove this
- * interface and restore `import type { PackageJson } from "@fluidframework/build-tools"`. That
- * requires both a `module-sync` export condition in build-tools and a TypeScript upgrade:
- * 5.4.5 fails under `node16` and `nodenext` alike, while 5.9 resolves it under `nodenext`.
- */
-interface PackageJsonDevDependencies {
-	readonly devDependencies: Readonly<Record<string, string>>;
-}
+// eslint-disable-next-line import-x/no-internal-modules -- how else would one import a package.json file?
+import typescriptHostPackageJson from "@fluid-example/typescript-versions-host/package.json" with {
+	type: "json",
+};
 
 // Resolve the typescript-versions-host package which hosts the aliased TypeScript versions.
 // Use process.cwd() as the base for createRequire so this works in both ESM
@@ -42,14 +26,12 @@ const typescriptHostDir = path.dirname(
 	nodeRequire.resolve("@fluid-example/typescript-versions-host/package.json"),
 );
 
-const typescriptHostPackageJson = JSON.parse(
-	readFileSync(path.join(typescriptHostDir, "package.json"), "utf8"),
-) as PackageJsonDevDependencies;
-
-// All are expected to match, but be cautious.
-const typescriptVersions = Object.entries(typescriptHostPackageJson.devDependencies).filter(
-	([name]) => name.startsWith("typescript-"),
-);
+const typescriptVersions =
+	// Assert all entries are in the expected format
+	typescriptHostPackageJson.devDependencies satisfies Record<
+		`typescript-${bigint}.${bigint}`,
+		string
+	>;
 
 const execFileAsync = promisify(execFile);
 
@@ -86,7 +68,7 @@ async function compileTest(
 describe("build tests", () => {
 	// Skip these tests when using CJS, as this only build for ESM, so running in both modes would be redundant.
 	if (env.FLUID_TEST_MODULE_SYSTEM !== "CJS") {
-		for (const [name, version] of typescriptVersions) {
+		for (const [name, version] of Object.entries(typescriptVersions)) {
 			it(`can build with ${name} (${version})`, async () => {
 				await compileTest(name, []);
 			});


### PR DESCRIPTION
import package.json directly.
filter can be removed and package.json content expectation asserted.