### PR TITLE
refactor(container-loader): export mixinDebugLogger as a free function

### DIFF
--- a/packages/loader/container-loader/src/createAndLoadContainerUtils.ts
+++ b/packages/loader/container-loader/src/createAndLoadContainerUtils.ts
@@ -54,7 +54,7 @@ import {
 	type IGcSnapshotData,
 } from "./captureReferencedContents.js";
 import { CatchUpMonitor } from "./catchUpMonitor.js";
-import { DebugLogger } from "./debugLogger.js";
+import { mixinDebugLogger } from "./debugLogger.js";
 import { createDeltaManager } from "./deltaManagerFactory.js";
 import { createFrozenDocumentServiceFactory } from "./frozenServices.js";
 import { Loader } from "./loader.js";
@@ -793,7 +793,7 @@ async function loadSummarizerContainerAndMakeSummaryInternal(
 	};
 
 	const subMc = mixinMonitoringContext(
-		DebugLogger.mixinDebugLogger("fluid:telemetry", logger, {
+		mixinDebugLogger("fluid:telemetry", logger, {
 			all: telemetryProps,
 		}),
 		sessionStorageConfigProvider.value,

--- a/packages/loader/container-loader/src/debugLogger.ts
+++ b/packages/loader/container-loader/src/debugLogger.ts
@@ -25,46 +25,8 @@ const { debug: registerDebug } = debugPkg;
 /**
  * Implementation of debug logger
  */
-export class DebugLogger implements ITelemetryBaseLogger {
-	/**
-	 * Mix in debug logger with another logger.
-	 * Returned logger will output events to both newly created debug logger, as well as base logger
-	 * @param namespace - Telemetry event name prefix to add to all events
-	 * @param properties - Base properties to add to all events
-	 * @param propertyGetters - Getters to add additional properties to all events
-	 * @param baseLogger - Base logger to output events (in addition to debug logger being created). Can be undefined.
-	 */
-	public static mixinDebugLogger(
-		namespace: string,
-		baseLogger?: ITelemetryBaseLogger,
-		properties?: ITelemetryLoggerPropertyBags,
-	): TelemetryLoggerExt {
-		// Setup base logger upfront, such that host can disable it (if needed)
-		const debug = registerDebug(namespace);
-
-		// Create one for errors that is always enabled
-		// It can be silenced by replacing console.error if the debug namespace is not enabled.
-		const debugErr = registerDebug(namespace);
-		debugErr.log = function (...args: unknown[]): void {
-			if (debug.enabled === true) {
-				// if the namespace is enabled, just use the default logger
-				registerDebug.log(...args);
-			} else {
-				// other wise, use the console logger (which could be replaced and silenced)
-				console.error(...args);
-			}
-		};
-		debugErr.enabled = true;
-
-		return createMultiSinkLogger({
-			namespace,
-			loggers: [baseLogger, new DebugLogger(debug, debugErr)],
-			properties,
-			tryInheritProperties: true,
-		});
-	}
-
-	private constructor(
+class DebugLogger implements ITelemetryBaseLogger {
+	public constructor(
 		private readonly debug: IDebugger,
 		private readonly debugErr: IDebugger,
 	) {}
@@ -118,4 +80,41 @@ export class DebugLogger implements ITelemetryBaseLogger {
 		// eslint-disable-next-line @typescript-eslint/no-base-to-string
 		logger(`${name} ${payload} ${tick} ${stack}`);
 	}
+}
+
+/**
+ * Mix in debug logger with another logger.
+ * Returned logger will output events to both newly created debug logger, as well as base logger
+ * @param namespace - Telemetry event name prefix to add to all events
+ * @param baseLogger - Base logger to output events (in addition to debug logger being created). Can be undefined.
+ * @param properties - Base properties to add to all events
+ */
+export function mixinDebugLogger(
+	namespace: string,
+	baseLogger?: ITelemetryBaseLogger,
+	properties?: ITelemetryLoggerPropertyBags,
+): TelemetryLoggerExt {
+	// Setup base logger upfront, such that host can disable it (if needed)
+	const debug = registerDebug(namespace);
+
+	// Create one for errors that is always enabled
+	// It can be silenced by replacing console.error if the debug namespace is not enabled.
+	const debugErr = registerDebug(namespace);
+	debugErr.log = function (...args: unknown[]): void {
+		if (debug.enabled === true) {
+			// if the namespace is enabled, just use the default logger
+			registerDebug.log(...args);
+		} else {
+			// other wise, use the console logger (which could be replaced and silenced)
+			console.error(...args);
+		}
+	};
+	debugErr.enabled = true;
+
+	return createMultiSinkLogger({
+		namespace,
+		loggers: [baseLogger, new DebugLogger(debug, debugErr)],
+		properties,
+		tryInheritProperties: true,
+	});
 }

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -38,7 +38,7 @@ import type { ITelemetryLoggerExt } from "@fluidframework/telemetry-utils/legacy
 import { v4 as uuid } from "uuid";
 
 import { Container } from "./container.js";
-import { DebugLogger } from "./debugLogger.js";
+import { mixinDebugLogger } from "./debugLogger.js";
 import { pkgVersion } from "./packageVersion.js";
 import type { ProtocolHandlerBuilder } from "./protocol.js";
 import type { IPendingContainerState } from "./serializedStateManager.js";
@@ -255,7 +255,7 @@ export class Loader implements IHostLoader {
 		};
 
 		const subMc = mixinMonitoringContext(
-			DebugLogger.mixinDebugLogger("fluid:telemetry", logger, {
+			mixinDebugLogger("fluid:telemetry", logger, {
 				all: telemetryProps,
 			}),
 			sessionStorageConfigProvider.value,


### PR DESCRIPTION
## Description

`DebugLogger` in `container-loader` is exported only to serve as a namespace for a single static method, `mixinDebugLogger`. Nothing can actually use the class as a type: it is not re-exported from the package index, appears in no API report, and its constructor is private. The one instance is created inside the mixin and handed to `createMultiSinkLogger` as an `ITelemetryBaseLogger`, and the mixin returns a `TelemetryLoggerExt`.

This exports the mixin directly as a free function and lets the class become module private. The private constructor is no longer needed to prevent construction from outside the module, so it becomes a normal one. The two in-package call sites (`loader.ts`, `createAndLoadContainerUtils.ts`) now import `mixinDebugLogger` instead of `DebugLogger`.

No public API change, so no API report updates and no changeset.

Suggested by @jason-ha in [review feedback on #28044](https://github.com/microsoft/FluidFramework/pull/28044#discussion_r3834369353), split out here to keep that PR focused on telemetry plumbing.

## Reviewer Guidance

The review process is outlined in [the pull request guidelines](https://github.com/microsoft/FluidFramework/blob/main/docs/content/Contributing/PR-Guidelines.md#guidelines).

- The class is declared before the exported function so that `no-use-before-define` stays satisfied. Happy to flip the order if the export-first convention is preferred.
