### PR TITLE
ci: Share package publish-order generation

### DIFF
--- a/scripts/generate-package-publish-order.sh
+++ b/scripts/generate-package-publish-order.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -eux -o pipefail
+
+# Generates canonical package-name lists in dependency order for each publishing destination.
+# Packing is intentionally handled elsewhere because Docker service builds must pack from their built image.
+
+echo RELEASE_GROUP="$RELEASE_GROUP"
+echo STAGING_PATH="$STAGING_PATH"
+
+mkdir -p "$STAGING_PATH/pack"
+
+flub list "$RELEASE_GROUP" --no-private --feed public --outFile "$STAGING_PATH/pack/packagePublishOrder-public.txt"
+flub list "$RELEASE_GROUP" --no-private --feed internal-build --outFile "$STAGING_PATH/pack/packagePublishOrder-internal-build.txt"
+flub list "$RELEASE_GROUP" --no-private --feed internal-dev --outFile "$STAGING_PATH/pack/packagePublishOrder-internal-dev.txt"
+flub list "$RELEASE_GROUP" --no-private --feed internal-test --outFile "$STAGING_PATH/pack/packagePublishOrder-internal-test.txt"

--- a/scripts/pack-packages.sh
+++ b/scripts/pack-packages.sh
@@ -38,11 +38,5 @@ else
   mv -t $STAGING_PATH/pack/tarballs/ ./*.tgz
 fi
 
-# This saves a list of the packages in the working directory in topological order to a temporary file.
-# Packages will be published in this order to avoid dependency issues.
-# These files are consumed by the dedicated publish pipelines, which publish the packed tarballs produced
-# alongside them.
-flub list $RELEASE_GROUP --no-private --feed public --outFile $STAGING_PATH/pack/packagePublishOrder-public.txt
-flub list $RELEASE_GROUP --no-private --feed internal-build --outFile $STAGING_PATH/pack/packagePublishOrder-internal-build.txt
-flub list $RELEASE_GROUP --no-private --feed internal-dev --outFile $STAGING_PATH/pack/packagePublishOrder-internal-dev.txt
-flub list $RELEASE_GROUP --no-private --feed internal-test --outFile $STAGING_PATH/pack/packagePublishOrder-internal-test.txt
+SCRIPT_DIRECTORY="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+bash "$SCRIPT_DIRECTORY/generate-package-publish-order.sh"

--- a/tools/pipelines/templates/build-docker-service.yml
+++ b/tools/pipelines/templates/build-docker-service.yml
@@ -480,23 +480,18 @@ extends:
                 volumes:
                   $(hostPathToPackArtifact)/tarballs:/usr/src/pack
 
-            # Generating package lists manually because using scripts/pack-packages.sh (like build-npm-package.yml does)
-            # inside the Docker container is proving problematic.
-            # See https://github.com/microsoft/FluidFramework/pull/18445 for details.
+            # Package metadata can be read from the host checkout, but packing must remain in the built
+            # container above because its generated output is not present on the host.
+            # See https://github.com/microsoft/FluidFramework/pull/22072 for the regression this avoids.
             - task: Bash@3
               displayName: Generate package lists
               env:
                 RELEASE_GROUP: ${{ parameters.tagName }}
                 STAGING_PATH: $(Build.ArtifactStagingDirectory)
               inputs:
-                targetType: 'inline'
+                targetType: filePath
                 workingDirectory: $(Pipeline.Workspace)/${{ parameters.buildDirectory }}
-                script: |
-                  set -eu -o pipefail
-                  flub list --no-private $RELEASE_GROUP --tarball --feed public --outFile $STAGING_PATH/pack/packagePublishOrder-public.txt
-                  flub list --no-private $RELEASE_GROUP --tarball --feed internal-build --outFile $STAGING_PATH/pack/packagePublishOrder-internal-build.txt
-                  flub list --no-private $RELEASE_GROUP --tarball --feed internal-dev --outFile $STAGING_PATH/pack/packagePublishOrder-internal-dev.txt
-                  flub list --no-private $RELEASE_GROUP --tarball --feed internal-test --outFile $STAGING_PATH/pack/packagePublishOrder-internal-test.txt
+                filePath: $(Pipeline.Workspace)/$(FluidFrameworkDirectory)/scripts/generate-package-publish-order.sh
 
             - template: /tools/pipelines/templates/include-generate-publish-metadata.yml@self
               parameters:


### PR DESCRIPTION
## Description

Extracts package publish-order generation into a shared script used by both standard npm package builds and Docker service builds. The generated order files now consistently contain canonical npm package names, matching the current publishing pipeline's expected format.

Docker service packages continue to be packed inside the built container. This preserves the generated `lib`/`dist` content and avoids repeating the regression from PR #22072, where running the complete host-side packing script produced tarballs without built output.
