### PR TITLE
build(client): update to module=node20

### DIFF
--- a/azure/packages/azure-local-service/tsconfig.eslint.json
+++ b/azure/packages/azure-local-service/tsconfig.eslint.json
@@ -1,7 +1,7 @@
 {
 	// This file is only used by ESLint to check the index.js file.
 	// Because the common config uses TypeScript, we need to provide a tsconfig file to them.
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["index.js"],
 	"compilerOptions": {
 		"allowJs": true,

--- a/azure/packages/azure-service-utils/src/test/tsconfig.json
+++ b/azure/packages/azure-service-utils/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/azure/packages/azure-service-utils/tsconfig.json
+++ b/azure/packages/azure-service-utils/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/common/build/build-common/tsconfig.node20.json
+++ b/common/build/build-common/tsconfig.node20.json
@@ -1,0 +1,6 @@
+{
+	"extends": "./tsconfig.base.json",
+	"compilerOptions": {
+		"module": "node20",
+	},
+}

--- a/common/build/build-common/tsconfig.test.json
+++ b/common/build/build-common/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+	"compilerOptions": {
+		"composite": false,
+		"customConditions": ["allow-ff-test-exports"],
+		"types": ["node"],
+		"declaration": false,
+		"declarationMap": false,
+		"skipLibCheck": true,
+	},
+}

--- a/common/build/build-common/tsconfig.test.node16.json
+++ b/common/build/build-common/tsconfig.test.node16.json
@@ -1,11 +1,3 @@
 {
-	"extends": ["./tsconfig.base.json", "./tsconfig.node16.json"],
-	"compilerOptions": {
-		"composite": false,
-		"customConditions": ["allow-ff-test-exports"],
-		"types": ["node"],
-		"declaration": false,
-		"declarationMap": false,
-		"skipLibCheck": true,
-	},
+	"extends": ["./tsconfig.node16.json", "./tsconfig.test.json"],
 }

--- a/examples/apps/blobs/tsconfig.json
+++ b/examples/apps/blobs/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",

--- a/examples/apps/claims-example/tsconfig.json
+++ b/examples/apps/claims-example/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",

--- a/examples/apps/collaborative-textarea/tsconfig.json
+++ b/examples/apps/collaborative-textarea/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"compilerOptions": {
 		"outDir": "./lib",
 		"rootDir": "./src",

--- a/examples/apps/collaborative-textarea/tsconfig.test.json
+++ b/examples/apps/collaborative-textarea/tsconfig.test.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": [
+		"../../../common/build/build-common/tsconfig.node20.json",
+		"../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"noEmit": true,
 		"types": ["react", "react-dom", "node"],

--- a/examples/apps/contact-collection/tsconfig.json
+++ b/examples/apps/contact-collection/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",

--- a/examples/apps/diceroller/tsconfig.json
+++ b/examples/apps/diceroller/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",

--- a/examples/apps/presence-tracker/tsconfig.json
+++ b/examples/apps/presence-tracker/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",

--- a/examples/apps/staging/tsconfig.json
+++ b/examples/apps/staging/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",

--- a/examples/apps/task-selection/tsconfig.json
+++ b/examples/apps/task-selection/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",

--- a/examples/apps/tree-cli-app/src/test/tsconfig.json
+++ b/examples/apps/tree-cli-app/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/examples/apps/tree-cli-app/tsconfig.json
+++ b/examples/apps/tree-cli-app/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/examples/apps/tree-comparison/tsconfig.json
+++ b/examples/apps/tree-comparison/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",

--- a/examples/benchmarks/bubblebench/baseline/tsconfig.json
+++ b/examples/benchmarks/bubblebench/baseline/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../../common/build/build-common/tsconfig.node20.json",
 	"exclude": ["dist", "lib", "node_modules"],
 	"compilerOptions": {
 		"rootDir": "./src",

--- a/examples/benchmarks/bubblebench/common/tsconfig.json
+++ b/examples/benchmarks/bubblebench/common/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../../common/build/build-common/tsconfig.node20.json",
 	"exclude": ["dist", "lib", "node_modules"],
 	"compilerOptions": {
 		"rootDir": "./src",

--- a/examples/benchmarks/bubblebench/experimental-tree/tsconfig.json
+++ b/examples/benchmarks/bubblebench/experimental-tree/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../../common/build/build-common/tsconfig.node20.json",
 	"exclude": ["dist", "node_modules"],
 	"compilerOptions": {
 		"lib": ["ESNext", "DOM"],

--- a/examples/benchmarks/bubblebench/ot/tsconfig.json
+++ b/examples/benchmarks/bubblebench/ot/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../../common/build/build-common/tsconfig.node20.json",
 	"exclude": ["dist", "node_modules"],
 	"compilerOptions": {
 		"lib": ["ESNext", "DOM"],

--- a/examples/benchmarks/bubblebench/shared-tree/tsconfig.json
+++ b/examples/benchmarks/bubblebench/shared-tree/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../../common/build/build-common/tsconfig.node20.json",
 	"exclude": ["dist", "node_modules"],
 	"compilerOptions": {
 		"lib": ["ESNext", "DOM"],

--- a/examples/benchmarks/tablebench/src/test/tsconfig.json
+++ b/examples/benchmarks/tablebench/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/examples/benchmarks/tablebench/tsconfig.json
+++ b/examples/benchmarks/tablebench/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {
 		"rootDir": "./src",

--- a/examples/client-logger/app-insights-logger/jest.config.cjs
+++ b/examples/client-logger/app-insights-logger/jest.config.cjs
@@ -4,10 +4,15 @@
  */
 
 module.exports = {
-	preset: "ts-jest",
+	preset: "ts-jest/presets/default-esm",
 	roots: ["<rootDir>/src"],
 	transform: {
-		"^.+\\.tsx?$": "ts-jest",
+		"^.+\\.tsx?$": [
+			"ts-jest",
+			{
+				useESM: true,
+			},
+		],
 	},
 	testRegex: "(/__tests__/.*|(\\.|/)(test|spec))\\.(ts|tsx)?$",
 	testPathIgnorePatterns: ["/node_modules/", "dist"],

--- a/examples/client-logger/app-insights-logger/tsconfig.json
+++ b/examples/client-logger/app-insights-logger/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"compilerOptions": {
+		"isolatedModules": true,
 		"rootDir": "src",
 		"outDir": "./lib",
 		"types": ["jest"],

--- a/examples/client-logger/app-insights-logger/tsconfig.json
+++ b/examples/client-logger/app-insights-logger/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"compilerOptions": {
 		"rootDir": "src",
 		"outDir": "./lib",

--- a/examples/data-objects/canvas/tsconfig.json
+++ b/examples/data-objects/canvas/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",

--- a/examples/data-objects/clicker/tsconfig.json
+++ b/examples/data-objects/clicker/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"compilerOptions": {
 		"outDir": "./lib",
 		"rootDir": "./src",

--- a/examples/data-objects/codemirror/tsconfig.json
+++ b/examples/data-objects/codemirror/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",

--- a/examples/data-objects/inventory-app/src/test/tsconfig.json
+++ b/examples/data-objects/inventory-app/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/examples/data-objects/inventory-app/tsconfig.json
+++ b/examples/data-objects/inventory-app/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",

--- a/examples/data-objects/monaco/tsconfig.json
+++ b/examples/data-objects/monaco/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"compilerOptions": {
 		"outDir": "./lib",
 		"types": ["react"],

--- a/examples/data-objects/multiview/constellation-model/tsconfig.json
+++ b/examples/data-objects/multiview/constellation-model/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../../common/build/build-common/tsconfig.node20.json",
 	"compilerOptions": {
 		"outDir": "./lib",
 		"rootDir": "./src",

--- a/examples/data-objects/multiview/constellation-view/tsconfig.json
+++ b/examples/data-objects/multiview/constellation-view/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../../common/build/build-common/tsconfig.node20.json",
 	"compilerOptions": {
 		"outDir": "./lib",
 		"rootDir": "./src",

--- a/examples/data-objects/multiview/container/tsconfig.json
+++ b/examples/data-objects/multiview/container/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../../common/build/build-common/tsconfig.node20.json",
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",

--- a/examples/data-objects/multiview/coordinate-model/tsconfig.json
+++ b/examples/data-objects/multiview/coordinate-model/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../../common/build/build-common/tsconfig.node20.json",
 	"compilerOptions": {
 		"outDir": "./lib",
 		"rootDir": "./src",

--- a/examples/data-objects/multiview/interface/tsconfig.json
+++ b/examples/data-objects/multiview/interface/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../../common/build/build-common/tsconfig.node20.json",
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",

--- a/examples/data-objects/multiview/plot-coordinate-view/tsconfig.json
+++ b/examples/data-objects/multiview/plot-coordinate-view/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../../common/build/build-common/tsconfig.node20.json",
 	"compilerOptions": {
 		"outDir": "./lib",
 		"rootDir": "./src",

--- a/examples/data-objects/multiview/slider-coordinate-view/tsconfig.json
+++ b/examples/data-objects/multiview/slider-coordinate-view/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../../common/build/build-common/tsconfig.node20.json",
 	"compilerOptions": {
 		"outDir": "./lib",
 		"rootDir": "./src",

--- a/examples/data-objects/multiview/triangle-view/tsconfig.json
+++ b/examples/data-objects/multiview/triangle-view/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../../common/build/build-common/tsconfig.node20.json",
 	"compilerOptions": {
 		"outDir": "./lib",
 		"rootDir": "./src", // "rootDir" is a TypeScript compiler option that specifies the root directory of input files

--- a/examples/data-objects/prosemirror/tsconfig.json
+++ b/examples/data-objects/prosemirror/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",

--- a/examples/data-objects/smde/tsconfig.json
+++ b/examples/data-objects/smde/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"compilerOptions": {
 		"outDir": "./lib",
 		"types": ["react"],

--- a/examples/data-objects/table-document/src/test/tsconfig.json
+++ b/examples/data-objects/table-document/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/examples/data-objects/table-document/tsconfig.json
+++ b/examples/data-objects/table-document/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {
 		"strictNullChecks": false,

--- a/examples/data-objects/table-tree/tsconfig.json
+++ b/examples/data-objects/table-tree/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",

--- a/examples/data-objects/text-editor/src/test/tsconfig.json
+++ b/examples/data-objects/text-editor/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/examples/data-objects/text-editor/tsconfig.json
+++ b/examples/data-objects/text-editor/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",

--- a/examples/data-objects/todo/tsconfig.json
+++ b/examples/data-objects/todo/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",

--- a/examples/data-objects/webflow/src/test/tsconfig.json
+++ b/examples/data-objects/webflow/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/examples/data-objects/webflow/tsconfig.json
+++ b/examples/data-objects/webflow/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {
 		"strictNullChecks": false,

--- a/examples/external-data/src/test/tsconfig.json
+++ b/examples/external-data/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/examples/external-data/test/tsconfig.json
+++ b/examples/external-data/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../common/build/build-common/tsconfig.node20.json",
+		"../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"noEmit": true,
 		"rootDir": "./",

--- a/examples/external-data/tsconfig.json
+++ b/examples/external-data/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../common/build/build-common/tsconfig.node20.json",
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",

--- a/examples/service-clients/azure-client/external-controller/tsconfig.json
+++ b/examples/service-clients/azure-client/external-controller/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../../common/build/build-common/tsconfig.node20.json",
 	"exclude": ["lib", "node_modules"],
 	"compilerOptions": {
 		"rootDir": "./src",

--- a/examples/service-clients/azure-client/todo-list/tsconfig.json
+++ b/examples/service-clients/azure-client/todo-list/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../../common/build/build-common/tsconfig.node20.json",
 	"exclude": ["lib", "node_modules"],
 	"compilerOptions": {
 		"rootDir": "./src",

--- a/examples/service-clients/odsp-client/shared-tree-demo/tsconfig.json
+++ b/examples/service-clients/odsp-client/shared-tree-demo/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../../common/build/build-common/tsconfig.node20.json",
 	"compilerOptions": {
 		"outDir": "./lib",
 		"types": ["react", "react-dom"],

--- a/examples/utils/bundle-size-tests/src/test/tsconfig.json
+++ b/examples/utils/bundle-size-tests/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/examples/utils/bundle-size-tests/tsconfig.json
+++ b/examples/utils/bundle-size-tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"compilerOptions": {
 		"outDir": "./lib",
 		"exactOptionalPropertyTypes": false,

--- a/examples/utils/example-driver/tsconfig.json
+++ b/examples/utils/example-driver/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"compilerOptions": {
 		"rootDir": "./src",

--- a/examples/utils/example-utils/tsconfig.json
+++ b/examples/utils/example-utils/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"compilerOptions": {
 		"rootDir": "./src",

--- a/examples/utils/example-webpack-integration/tsconfig.json
+++ b/examples/utils/example-webpack-integration/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"compilerOptions": {
 		"rootDir": "./src",

--- a/examples/utils/import-testing/eslint.config.mts
+++ b/examples/utils/import-testing/eslint.config.mts
@@ -20,6 +20,7 @@ const config: Linter.Config[] = [
 				project: [
 					"./tsconfig.json",
 					"./tsconfig.crossPackage.node16.json",
+					"./tsconfig.crossPackage.node20.json",
 					"./src/test/tsconfig.json",
 				],
 			},

--- a/examples/utils/import-testing/package.json
+++ b/examples/utils/import-testing/package.json
@@ -17,6 +17,10 @@
 			"import": "./lib/crossPackage/node16/schemaDefinitions.js",
 			"require": "./dist/crossPackage/node16/schemaDefinitions.js"
 		},
+		"./crossPackageSchema/node20": {
+			"import": "./lib/crossPackage/node20/schemaDefinitions.js",
+			"require": "./dist/crossPackage/node20/schemaDefinitions.js"
+		},
 		"./crossPackageSchema/bundler": {
 			"import": "./lib/crossPackage/bundler/schemaDefinitions.js"
 		},
@@ -28,12 +32,14 @@
 		"build": "fluid-build . --task build",
 		"build:cjs": "concurrently \"npm:build:cjs:*\"",
 		"build:cjs:crossPackage:node16": "fluid-tsc commonjs --project ./tsconfig.crossPackage.node16.cjs.json && npm run place:cjs:package-stub",
+		"build:cjs:crossPackage:node20": "fluid-tsc commonjs --project ./tsconfig.crossPackage.node20.cjs.json && npm run place:cjs:package-stub",
 		"build:cjs:main": "fluid-tsc commonjs --project ./tsconfig.cjs.json && npm run place:cjs:package-stub",
 		"build:commonjs": "fluid-build . --task commonjs",
 		"build:compile": "fluid-build . --task compile",
 		"build:esm": "concurrently \"npm:build:esm:*\"",
 		"build:esm:crossPackage:bundler": "tsc --project ./tsconfig.crossPackage.bundler.json",
 		"build:esm:crossPackage:node16": "tsc --project ./tsconfig.crossPackage.node16.json",
+		"build:esm:crossPackage:node20": "tsc --project ./tsconfig.crossPackage.node20.json",
 		"build:esm:crossPackage:nodenext": "tsc --project ./tsconfig.crossPackage.nodenext.json",
 		"build:esm:main": "tsc --project ./tsconfig.json",
 		"build:test": "concurrently npm:build:test:esm npm:build:test:cjs",
@@ -86,6 +92,9 @@
 			"build:cjs:crossPackage:node16": [
 				"^build:package:cjs"
 			],
+			"build:cjs:crossPackage:node20": [
+				"^build:package:cjs"
+			],
 			"build:cjs:main": [
 				"^build:package:cjs"
 			],
@@ -93,6 +102,9 @@
 				"^build:package:esm"
 			],
 			"build:esm:crossPackage:node16": [
+				"^build:package:esm"
+			],
+			"build:esm:crossPackage:node20": [
 				"^build:package:esm"
 			],
 			"build:esm:crossPackage:nodenext": [
@@ -103,11 +115,13 @@
 			],
 			"build:test:cjs": [
 				"build:cjs:crossPackage:node16",
+				"build:cjs:crossPackage:node20",
 				"build:cjs:main"
 			],
 			"build:test:esm": [
 				"build:esm:crossPackage:bundler",
 				"build:esm:crossPackage:node16",
+				"build:esm:crossPackage:node20",
 				"build:esm:crossPackage:nodenext",
 				"build:esm:main"
 			]

--- a/examples/utils/import-testing/src/cjs/package.json
+++ b/examples/utils/import-testing/src/cjs/package.json
@@ -1,6 +1,7 @@
 {
 	"type": "commonjs",
 	"exports": {
-		"./crossPackageSchema/node16": "./crossPackage/node16/schemaDefinitions.js"
+		"./crossPackageSchema/node16": "./crossPackage/node16/schemaDefinitions.js",
+		"./crossPackageSchema/node20": "./crossPackage/node20/schemaDefinitions.js"
 	}
 }

--- a/examples/utils/import-testing/src/test/crossPackage/node20Importer.ts
+++ b/examples/utils/import-testing/src/test/crossPackage/node20Importer.ts
@@ -1,0 +1,29 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/*
+Compile-time test for cross-package schema consumption where schemaDefinitions.d.ts
+was generated under Node16 module resolution.
+
+Each tree export tier has its own JS entrypoint, so TypeScript correctly
+resolves import paths in .d.ts files. These imports should compile without error.
+*/
+import { TreeViewConfiguration } from "@fluidframework/tree";
+
+/* eslint-disable import-x/no-internal-modules -- Compile-time test imports its generated package subpath. */
+import {
+	AppState,
+	Container,
+	Dimensions,
+	Position,
+} from "@fluid-example/import-testing/crossPackageSchema/node20";
+/* eslint-enable import-x/no-internal-modules */
+
+const _config = new TreeViewConfiguration({ schema: AppState });
+const _container = new Container({
+	id: "test",
+	position: new Position({ x: 0, y: 0 }),
+	dimensions: new Dimensions({ width: 100, height: 100 }),
+});

--- a/examples/utils/import-testing/src/test/crossPackage/node20Importer.ts
+++ b/examples/utils/import-testing/src/test/crossPackage/node20Importer.ts
@@ -5,7 +5,7 @@
 
 /*
 Compile-time test for cross-package schema consumption where schemaDefinitions.d.ts
-was generated under Node16 module resolution.
+was generated under Node20 module resolution.
 
 Each tree export tier has its own JS entrypoint, so TypeScript correctly
 resolves import paths in .d.ts files. These imports should compile without error.

--- a/examples/utils/import-testing/src/test/tsconfig.cjs.json
+++ b/examples/utils/import-testing/src/test/tsconfig.cjs.json
@@ -16,5 +16,8 @@
 		{
 			"path": "../../tsconfig.crossPackage.node16.cjs.json",
 		},
+		{
+			"path": "../../tsconfig.crossPackage.node20.cjs.json",
+		},
 	],
 }

--- a/examples/utils/import-testing/src/test/tsconfig.json
+++ b/examples/utils/import-testing/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",
@@ -25,6 +28,9 @@
 		},
 		{
 			"path": "../../tsconfig.crossPackage.node16.json",
+		},
+		{
+			"path": "../../tsconfig.crossPackage.node20.json",
 		},
 		{
 			"path": "../../tsconfig.crossPackage.bundler.json",

--- a/examples/utils/import-testing/tsconfig.crossPackage.node16.json
+++ b/examples/utils/import-testing/tsconfig.crossPackage.node16.json
@@ -2,5 +2,7 @@
 	"extends": "./tsconfig.crossPackage.base.json",
 	"compilerOptions": {
 		"outDir": "./lib/crossPackage/node16",
+		"module": "node16",
+		"moduleResolution": "node16",
 	},
 }

--- a/examples/utils/import-testing/tsconfig.crossPackage.node20.cjs.json
+++ b/examples/utils/import-testing/tsconfig.crossPackage.node20.cjs.json
@@ -1,0 +1,8 @@
+{
+	// This config must be used in a "type": "commonjs" environment. (Use fluid-tsc commonjs.)
+	"extends": "./tsconfig.crossPackage.base.json",
+	"compilerOptions": {
+		"outDir": "./dist/crossPackage/node20",
+		"module": "node20",
+	},
+}

--- a/examples/utils/import-testing/tsconfig.crossPackage.node20.json
+++ b/examples/utils/import-testing/tsconfig.crossPackage.node20.json
@@ -1,0 +1,7 @@
+{
+	"extends": "./tsconfig.crossPackage.base.json",
+	"compilerOptions": {
+		"outDir": "./lib/crossPackage/node20",
+		"module": "node20",
+	},
+}

--- a/examples/utils/import-testing/tsconfig.json
+++ b/examples/utils/import-testing/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*", "src/crossPackage/**/*"],
 	"compilerOptions": {

--- a/examples/utils/migration-tools/tsconfig.json
+++ b/examples/utils/migration-tools/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"compilerOptions": {
 		"rootDir": "./src",

--- a/examples/utils/webpack-fluid-loader/src/test/tsconfig.json
+++ b/examples/utils/webpack-fluid-loader/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/examples/utils/webpack-fluid-loader/tsconfig.json
+++ b/examples/utils/webpack-fluid-loader/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/examples/version-migration/live-schema-upgrade/tsconfig.json
+++ b/examples/version-migration/live-schema-upgrade/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",

--- a/examples/version-migration/same-container/tsconfig.json
+++ b/examples/version-migration/same-container/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",

--- a/examples/version-migration/separate-container/tsconfig.json
+++ b/examples/version-migration/separate-container/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",

--- a/examples/version-migration/tree-shim/tsconfig.json
+++ b/examples/version-migration/tree-shim/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",

--- a/examples/view-integration/container-views/tsconfig.json
+++ b/examples/view-integration/container-views/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",

--- a/examples/view-integration/external-views/tsconfig.json
+++ b/examples/view-integration/external-views/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",

--- a/examples/view-integration/view-framework-sampler/tsconfig.json
+++ b/examples/view-integration/view-framework-sampler/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",

--- a/experimental/PropertyDDS/packages/property-changeset/src/test/tsconfig.json
+++ b/experimental/PropertyDDS/packages/property-changeset/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		// PropertyDDS relies on legacy class field semantics, which TypeScript enables by
 		// default at target ES2022+. Keep them by disabling useDefineForClassFields.

--- a/experimental/PropertyDDS/packages/property-changeset/tsconfig.json
+++ b/experimental/PropertyDDS/packages/property-changeset/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../../common/build/build-common/tsconfig.node20.json",
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {
 		// PropertyDDS relies on legacy class field semantics, which TypeScript enables by

--- a/experimental/PropertyDDS/packages/property-common/src/test/tsconfig.json
+++ b/experimental/PropertyDDS/packages/property-common/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		// PropertyDDS relies on legacy class field semantics, which TypeScript enables by
 		// default at target ES2022+. Keep them by disabling useDefineForClassFields.

--- a/experimental/PropertyDDS/packages/property-common/tsconfig.json
+++ b/experimental/PropertyDDS/packages/property-common/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/experimental/PropertyDDS/packages/property-dds/src/test/tsconfig.json
+++ b/experimental/PropertyDDS/packages/property-dds/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		// PropertyDDS relies on legacy class field semantics, which TypeScript enables by
 		// default at target ES2022+. Keep them by disabling useDefineForClassFields.

--- a/experimental/PropertyDDS/packages/property-dds/tsconfig.json
+++ b/experimental/PropertyDDS/packages/property-dds/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../../common/build/build-common/tsconfig.node20.json",
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {
 		// PropertyDDS relies on legacy class field semantics, which TypeScript enables by

--- a/experimental/PropertyDDS/packages/property-properties/src/test/tsconfig.json
+++ b/experimental/PropertyDDS/packages/property-properties/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"include": ["./**/*"],
 	"compilerOptions": {
 		// PropertyDDS relies on legacy class field semantics, which TypeScript enables by

--- a/experimental/PropertyDDS/packages/property-properties/tsconfig.json
+++ b/experimental/PropertyDDS/packages/property-properties/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/experimental/dds/ot/ot/src/test/tsconfig.json
+++ b/experimental/dds/ot/ot/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/experimental/dds/ot/ot/tsconfig.json
+++ b/experimental/dds/ot/ot/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../../common/build/build-common/tsconfig.node20.json",
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {
 		"rootDir": "./src",

--- a/experimental/dds/ot/sharejs/json1/src/test/tsconfig.json
+++ b/experimental/dds/ot/sharejs/json1/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/experimental/dds/ot/sharejs/json1/tsconfig.json
+++ b/experimental/dds/ot/sharejs/json1/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../../../common/build/build-common/tsconfig.node20.json",
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {
 		"rootDir": "./src",

--- a/experimental/dds/sequence-deprecated/src/test/tsconfig.json
+++ b/experimental/dds/sequence-deprecated/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/experimental/dds/sequence-deprecated/tsconfig.json
+++ b/experimental/dds/sequence-deprecated/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/experimental/dds/tree/tsconfig.json
+++ b/experimental/dds/tree/tsconfig.json
@@ -1,15 +1,15 @@
 {
 	// This config must be used in a "type": "commonjs" environment. (Use `fluid-tsc commonjs`.)
-	"extends": "../../../common/build/build-common/ts-common-config.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"exclude": ["dist", "node_modules"],
 	"compilerOptions": {
 		"composite": true,
 		"noUnusedLocals": false,
 		"outDir": "./dist",
-		"module": "Node16",
-		"moduleResolution": "Node16",
 		"rootDir": "./src",
 		"types": ["mocha"],
+		"exactOptionalPropertyTypes": false,
+		"noUncheckedIndexedAccess": false,
 	},
 	"include": ["src/**/*"],
 }

--- a/experimental/framework/data-objects/tsconfig.json
+++ b/experimental/framework/data-objects/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"exclude": ["dist", "node_modules"],
 	"compilerOptions": {
 		"rootDir": "./src",

--- a/experimental/framework/last-edited/tsconfig.json
+++ b/experimental/framework/last-edited/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"exclude": ["dist", "node_modules"],
 	"compilerOptions": {
 		"rootDir": "./src",

--- a/packages/common/client-utils/src/test/mocha/tsconfig.json
+++ b/packages/common/client-utils/src/test/mocha/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../../lib/test/mocha",

--- a/packages/common/client-utils/src/test/playwright/tsconfig.json
+++ b/packages/common/client-utils/src/test/playwright/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../../lib/test/playwright",

--- a/packages/common/client-utils/src/test/types/tsconfig.json
+++ b/packages/common/client-utils/src/test/types/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../../lib/test/types",

--- a/packages/common/client-utils/tsconfig.json
+++ b/packages/common/client-utils/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",

--- a/packages/common/container-definitions/src/test/tsconfig.json
+++ b/packages/common/container-definitions/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"include": ["./**/*"],
 	"compilerOptions": {
 		"rootDir": "./",

--- a/packages/common/container-definitions/tsconfig.json
+++ b/packages/common/container-definitions/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/common/core-interfaces/src/test/tsconfig.json
+++ b/packages/common/core-interfaces/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/common/core-interfaces/tsconfig.json
+++ b/packages/common/core-interfaces/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/common/core-utils/src/test/tsconfig.json
+++ b/packages/common/core-utils/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/common/core-utils/tsconfig.json
+++ b/packages/common/core-utils/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/common/driver-definitions/src/test/tsconfig.json
+++ b/packages/common/driver-definitions/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"include": ["./**/*"],
 	"compilerOptions": {
 		"noImplicitAny": true,

--- a/packages/common/driver-definitions/tsconfig.json
+++ b/packages/common/driver-definitions/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/dds/cell/src/test/tsconfig.json
+++ b/packages/dds/cell/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/dds/cell/tsconfig.json
+++ b/packages/dds/cell/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/dds/claims/src/test/tsconfig.json
+++ b/packages/dds/claims/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/dds/claims/tsconfig.json
+++ b/packages/dds/claims/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/dds/counter/src/test/tsconfig.json
+++ b/packages/dds/counter/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/dds/counter/tsconfig.json
+++ b/packages/dds/counter/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/dds/ink/src/test/tsconfig.json
+++ b/packages/dds/ink/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/dds/ink/tsconfig.json
+++ b/packages/dds/ink/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/dds/legacy-dds/src/test/tsconfig.json
+++ b/packages/dds/legacy-dds/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/dds/legacy-dds/tsconfig.json
+++ b/packages/dds/legacy-dds/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/dds/map/src/test/tsconfig.json
+++ b/packages/dds/map/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/dds/map/tsconfig.json
+++ b/packages/dds/map/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/dds/matrix/src/test/tsconfig.json
+++ b/packages/dds/matrix/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/dds/matrix/tsconfig.json
+++ b/packages/dds/matrix/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/dds/merge-tree/src/test/tsconfig.json
+++ b/packages/dds/merge-tree/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/dds/merge-tree/tsconfig.json
+++ b/packages/dds/merge-tree/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/dds/ordered-collection/src/test/tsconfig.json
+++ b/packages/dds/ordered-collection/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/dds/ordered-collection/tsconfig.json
+++ b/packages/dds/ordered-collection/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/dds/pact-map/src/test/tsconfig.json
+++ b/packages/dds/pact-map/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/dds/pact-map/tsconfig.json
+++ b/packages/dds/pact-map/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/dds/register-collection/src/test/tsconfig.json
+++ b/packages/dds/register-collection/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/dds/register-collection/tsconfig.json
+++ b/packages/dds/register-collection/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/dds/sequence/src/test/tsconfig.json
+++ b/packages/dds/sequence/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/dds/sequence/tsconfig.json
+++ b/packages/dds/sequence/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/dds/shared-object-base/src/test/tsconfig.json
+++ b/packages/dds/shared-object-base/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/dds/shared-object-base/tsconfig.json
+++ b/packages/dds/shared-object-base/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/dds/shared-summary-block/src/test/tsconfig.json
+++ b/packages/dds/shared-summary-block/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/dds/shared-summary-block/tsconfig.json
+++ b/packages/dds/shared-summary-block/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/dds/task-manager/src/test/tsconfig.json
+++ b/packages/dds/task-manager/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/dds/task-manager/tsconfig.json
+++ b/packages/dds/task-manager/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/dds/test-dds-utils/src/test/tsconfig.json
+++ b/packages/dds/test-dds-utils/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/dds/test-dds-utils/tsconfig.json
+++ b/packages/dds/test-dds-utils/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/dds/tree/src/test/tsconfig.json
+++ b/packages/dds/tree/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"noImplicitAny": true,
 		"noUnusedLocals": false,

--- a/packages/dds/tree/tsconfig.json
+++ b/packages/dds/tree/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/drivers/debugger/src/test/tsconfig.json
+++ b/packages/drivers/debugger/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"include": ["./**/*"],
 	"compilerOptions": {
 		"noImplicitAny": true,

--- a/packages/drivers/debugger/tsconfig.json
+++ b/packages/drivers/debugger/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/drivers/driver-base/src/test/tsconfig.json
+++ b/packages/drivers/driver-base/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/drivers/driver-base/tsconfig.json
+++ b/packages/drivers/driver-base/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/drivers/driver-web-cache/src/test/tsconfig.json
+++ b/packages/drivers/driver-web-cache/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/drivers/driver-web-cache/tsconfig.json
+++ b/packages/drivers/driver-web-cache/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/drivers/file-driver/src/test/tsconfig.json
+++ b/packages/drivers/file-driver/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"include": ["./**/*"],
 	"compilerOptions": {
 		"noImplicitAny": true,

--- a/packages/drivers/file-driver/tsconfig.json
+++ b/packages/drivers/file-driver/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/drivers/local-driver/src/test/tsconfig.json
+++ b/packages/drivers/local-driver/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/drivers/local-driver/tsconfig.json
+++ b/packages/drivers/local-driver/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/drivers/odsp-driver-definitions/src/test/tsconfig.json
+++ b/packages/drivers/odsp-driver-definitions/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/drivers/odsp-driver-definitions/tsconfig.json
+++ b/packages/drivers/odsp-driver-definitions/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/drivers/odsp-driver/src/test/tsconfig.json
+++ b/packages/drivers/odsp-driver/src/test/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": ["../../../../../common/build/build-common/tsconfig.node20.json", "../../../../../common/build/build-common/tsconfig.test.json"],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/drivers/odsp-driver/tsconfig.json
+++ b/packages/drivers/odsp-driver/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/drivers/odsp-urlResolver/src/test/tsconfig.json
+++ b/packages/drivers/odsp-urlResolver/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/drivers/odsp-urlResolver/tsconfig.json
+++ b/packages/drivers/odsp-urlResolver/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/drivers/replay-driver/src/test/tsconfig.json
+++ b/packages/drivers/replay-driver/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"include": ["./**/*"],
 	"compilerOptions": {
 		"noImplicitAny": true,

--- a/packages/drivers/replay-driver/tsconfig.json
+++ b/packages/drivers/replay-driver/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/drivers/routerlicious-driver/src/test/tsconfig.json
+++ b/packages/drivers/routerlicious-driver/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/drivers/routerlicious-driver/tsconfig.json
+++ b/packages/drivers/routerlicious-driver/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/drivers/routerlicious-urlResolver/src/test/tsconfig.json
+++ b/packages/drivers/routerlicious-urlResolver/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/drivers/routerlicious-urlResolver/tsconfig.json
+++ b/packages/drivers/routerlicious-urlResolver/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/drivers/tinylicious-driver/src/test/tsconfig.json
+++ b/packages/drivers/tinylicious-driver/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/drivers/tinylicious-driver/tsconfig.json
+++ b/packages/drivers/tinylicious-driver/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/framework/agent-scheduler/src/test/tsconfig.json
+++ b/packages/framework/agent-scheduler/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/framework/agent-scheduler/tsconfig.json
+++ b/packages/framework/agent-scheduler/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/framework/aqueduct/src/test/tsconfig.json
+++ b/packages/framework/aqueduct/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/framework/aqueduct/tsconfig.json
+++ b/packages/framework/aqueduct/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/framework/attributor/src/test/tsconfig.json
+++ b/packages/framework/attributor/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/framework/attributor/tsconfig.json
+++ b/packages/framework/attributor/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/framework/client-logger/app-insights-logger/src/test/tsconfig.json
+++ b/packages/framework/client-logger/app-insights-logger/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"include": ["./**/*"],
 	"compilerOptions": {
 		"noImplicitAny": true,

--- a/packages/framework/client-logger/app-insights-logger/tsconfig.json
+++ b/packages/framework/client-logger/app-insights-logger/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/framework/client-logger/fluid-telemetry/src/test/tsconfig.json
+++ b/packages/framework/client-logger/fluid-telemetry/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"include": ["./**/*"],
 	"compilerOptions": {
 		"noImplicitAny": true,

--- a/packages/framework/client-logger/fluid-telemetry/tsconfig.json
+++ b/packages/framework/client-logger/fluid-telemetry/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/framework/dds-interceptions/src/test/tsconfig.json
+++ b/packages/framework/dds-interceptions/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/framework/dds-interceptions/tsconfig.json
+++ b/packages/framework/dds-interceptions/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/framework/fluid-framework/src/test/tsconfig.json
+++ b/packages/framework/fluid-framework/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/framework/fluid-framework/tsconfig.json
+++ b/packages/framework/fluid-framework/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/framework/fluid-static/src/test/tsconfig.json
+++ b/packages/framework/fluid-static/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"noUnusedLocals": false,
 		"rootDir": "./",

--- a/packages/framework/fluid-static/tsconfig.json
+++ b/packages/framework/fluid-static/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",

--- a/packages/framework/oldest-client-observer/tsconfig.json
+++ b/packages/framework/oldest-client-observer/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/framework/presence-definitions/src/test/tsconfig.json
+++ b/packages/framework/presence-definitions/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/framework/presence-definitions/tsconfig.json
+++ b/packages/framework/presence-definitions/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/framework/presence-runtime/tsconfig.esm.json
+++ b/packages/framework/presence-runtime/tsconfig.esm.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["**/test/**/*"],
 	"compilerOptions": {

--- a/packages/framework/presence-runtime/tsconfig.json
+++ b/packages/framework/presence-runtime/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": [],
 	"references": [
 		{

--- a/packages/framework/presence-runtime/tsconfig.test.esm.json
+++ b/packages/framework/presence-runtime/tsconfig.test.esm.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../common/build/build-common/tsconfig.node20.json",
+		"../../../common/build/build-common/tsconfig.test.json",
+	],
 	"include": ["./src/**/test/**/*"],
 	"compilerOptions": {
 		"rootDir": "./src",

--- a/packages/framework/presence/tsconfig.json
+++ b/packages/framework/presence/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/framework/quill-react/src/test/tsconfig.json
+++ b/packages/framework/quill-react/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/framework/quill-react/tsconfig.json
+++ b/packages/framework/quill-react/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/framework/react/src/test/tsconfig.json
+++ b/packages/framework/react/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/framework/react/tsconfig.json
+++ b/packages/framework/react/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/framework/request-handler/src/test/tsconfig.json
+++ b/packages/framework/request-handler/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/framework/request-handler/tsconfig.json
+++ b/packages/framework/request-handler/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/framework/synthesize/src/test/tsconfig.json
+++ b/packages/framework/synthesize/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/framework/synthesize/tsconfig.json
+++ b/packages/framework/synthesize/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/framework/tree-agent-langchain/src/test/tsconfig.json
+++ b/packages/framework/tree-agent-langchain/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/framework/tree-agent-langchain/tsconfig.json
+++ b/packages/framework/tree-agent-langchain/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/framework/tree-agent-ses/src/test/tsconfig.json
+++ b/packages/framework/tree-agent-ses/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/framework/tree-agent-ses/tsconfig.json
+++ b/packages/framework/tree-agent-ses/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/framework/tree-agent/src/test/tsconfig.json
+++ b/packages/framework/tree-agent/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/framework/tree-agent/tsconfig.json
+++ b/packages/framework/tree-agent/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/framework/type-factory/src/test/tsconfig.json
+++ b/packages/framework/type-factory/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/framework/type-factory/tsconfig.json
+++ b/packages/framework/type-factory/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/framework/undo-redo/src/test/tsconfig.json
+++ b/packages/framework/undo-redo/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/framework/undo-redo/tsconfig.json
+++ b/packages/framework/undo-redo/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/loader/container-loader/src/test/tsconfig.json
+++ b/packages/loader/container-loader/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/loader/container-loader/tsconfig.json
+++ b/packages/loader/container-loader/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/loader/driver-utils/src/test/tsconfig.json
+++ b/packages/loader/driver-utils/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/loader/driver-utils/tsconfig.json
+++ b/packages/loader/driver-utils/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/loader/test-loader-utils/tsconfig.json
+++ b/packages/loader/test-loader-utils/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["dist", "node_modules"],
 	"compilerOptions": {

--- a/packages/runtime/container-runtime-definitions/src/test/tsconfig.json
+++ b/packages/runtime/container-runtime-definitions/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"include": ["./**/*"],
 	"compilerOptions": {
 		"rootDir": "./",

--- a/packages/runtime/container-runtime-definitions/tsconfig.json
+++ b/packages/runtime/container-runtime-definitions/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/runtime/container-runtime/src/test/tsconfig.json
+++ b/packages/runtime/container-runtime/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/runtime/container-runtime/tsconfig.json
+++ b/packages/runtime/container-runtime/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/runtime/datastore-definitions/src/test/tsconfig.json
+++ b/packages/runtime/datastore-definitions/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/runtime/datastore-definitions/tsconfig.json
+++ b/packages/runtime/datastore-definitions/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/runtime/datastore/src/test/tsconfig.json
+++ b/packages/runtime/datastore/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/runtime/datastore/tsconfig.json
+++ b/packages/runtime/datastore/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/runtime/id-compressor/src/test/tsconfig.json
+++ b/packages/runtime/id-compressor/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/runtime/id-compressor/tsconfig.json
+++ b/packages/runtime/id-compressor/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",

--- a/packages/runtime/runtime-definitions/src/test/tsconfig.json
+++ b/packages/runtime/runtime-definitions/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/runtime/runtime-definitions/tsconfig.json
+++ b/packages/runtime/runtime-definitions/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/runtime/runtime-utils/src/test/tsconfig.json
+++ b/packages/runtime/runtime-utils/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/runtime/runtime-utils/tsconfig.json
+++ b/packages/runtime/runtime-utils/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/runtime/test-runtime-utils/src/test/tsconfig.json
+++ b/packages/runtime/test-runtime-utils/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/runtime/test-runtime-utils/tsconfig.json
+++ b/packages/runtime/test-runtime-utils/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/service-clients/azure-client/src/test/tsconfig.json
+++ b/packages/service-clients/azure-client/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/service-clients/azure-client/tsconfig.json
+++ b/packages/service-clients/azure-client/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/tsconfig.json
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	// This deviates from the standard test tsconfig pattern to accommodate `gen-version`, which emits
 	// `src/packageVersion.ts` one directory above the test sources. We widen `rootDir` (and adjust
 	// `outDir` to match) and explicitly include the generated file so it compiles alongside the tests.

--- a/packages/service-clients/end-to-end-tests/odsp-client/src/test/tsconfig.json
+++ b/packages/service-clients/end-to-end-tests/odsp-client/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	// This deviates from the standard test tsconfig pattern to accommodate `gen-version`, which emits
 	// `src/packageVersion.ts` one directory above the test sources. We widen `rootDir` (and adjust
 	// `outDir` to match) and explicitly include the generated file so it compiles alongside the tests.

--- a/packages/service-clients/odsp-client/src/test/tsconfig.json
+++ b/packages/service-clients/odsp-client/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/service-clients/odsp-client/tsconfig.json
+++ b/packages/service-clients/odsp-client/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/service-clients/tinylicious-client/src/test/tsconfig.json
+++ b/packages/service-clients/tinylicious-client/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/service-clients/tinylicious-client/tsconfig.json
+++ b/packages/service-clients/tinylicious-client/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/test/functional-tests/tsconfig.json
+++ b/packages/test/functional-tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"compilerOptions": {
 		"rootDir": "./src",

--- a/packages/test/local-server-stress-tests/src/test/tsconfig.json
+++ b/packages/test/local-server-stress-tests/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/test/local-server-tests/src/test/tsconfig.json
+++ b/packages/test/local-server-tests/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/test/mocha-test-setup/tsconfig.json
+++ b/packages/test/mocha-test-setup/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["dist", "node_modules"],
 	"compilerOptions": {

--- a/packages/test/snapshots/src/test/tsconfig.json
+++ b/packages/test/snapshots/src/test/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": ["../../../../../common/build/build-common/tsconfig.node20.json", "../../../../../common/build/build-common/tsconfig.test.json"],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/test/snapshots/tsconfig.json
+++ b/packages/test/snapshots/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/test/stochastic-test-utils/src/test/tsconfig.json
+++ b/packages/test/stochastic-test-utils/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/test/stochastic-test-utils/tsconfig.json
+++ b/packages/test/stochastic-test-utils/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/test/test-driver-definitions/tsconfig.json
+++ b/packages/test/test-driver-definitions/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"compilerOptions": {
 		"rootDir": "./src",

--- a/packages/test/test-drivers/tsconfig.json
+++ b/packages/test/test-drivers/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/test/test-end-to-end-tests/src/test/tsconfig.json
+++ b/packages/test/test-end-to-end-tests/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "../",
 		"outDir": "../../lib",

--- a/packages/test/test-pairwise-generator/src/test/tsconfig.json
+++ b/packages/test/test-pairwise-generator/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"include": ["./**/*"],
 	"compilerOptions": {
 		"noImplicitAny": true,

--- a/packages/test/test-pairwise-generator/tsconfig.json
+++ b/packages/test/test-pairwise-generator/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/test/test-service-load/src/test/tsconfig.json
+++ b/packages/test/test-service-load/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/test/test-service-load/tsconfig.json
+++ b/packages/test/test-service-load/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"exclude": ["src/test/**/*"],
 	"include": ["src/**/*"],
 	"compilerOptions": {

--- a/packages/test/test-utils/src/test/tsconfig.json
+++ b/packages/test/test-utils/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/test/test-utils/tsconfig.json
+++ b/packages/test/test-utils/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {
 		"rootDir": "./src",

--- a/packages/test/test-version-utils/src/test/tsconfig.json
+++ b/packages/test/test-version-utils/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/test/test-version-utils/tsconfig.json
+++ b/packages/test/test-version-utils/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {
 		"rootDir": "./src",

--- a/packages/tools/devtools/devtools-browser-extension/e2e-tests/tsconfig.json
+++ b/packages/tools/devtools/devtools-browser-extension/e2e-tests/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		// This config is type-check only — Playwright transpiles the e2e tests at runtime
 		// and webpack builds the test app under ./app/.

--- a/packages/tools/devtools/devtools-browser-extension/tsconfig.json
+++ b/packages/tools/devtools/devtools-browser-extension/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../../common/build/build-common/tsconfig.node20.json",
 	"compilerOptions": {
 		"rootDir": "src",
 		"outDir": "./lib/tsc",

--- a/packages/tools/devtools/devtools-core/src/test/tsconfig.json
+++ b/packages/tools/devtools/devtools-core/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"include": ["./**/*"],
 	"compilerOptions": {
 		"rootDir": "./",

--- a/packages/tools/devtools/devtools-core/tsconfig.json
+++ b/packages/tools/devtools/devtools-core/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/tools/devtools/devtools-test-app/tsconfig.json
+++ b/packages/tools/devtools/devtools-test-app/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../../common/build/build-common/tsconfig.node20.json",
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",

--- a/packages/tools/devtools/devtools-view/src/test/tsconfig.jest.json
+++ b/packages/tools/devtools/devtools-view/src/test/tsconfig.jest.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"include": ["./**/*"],
 	"compilerOptions": {
 		"rootDir": "./",

--- a/packages/tools/devtools/devtools-view/tsconfig.json
+++ b/packages/tools/devtools/devtools-view/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/tools/devtools/devtools/src/test/tsconfig.json
+++ b/packages/tools/devtools/devtools/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"include": ["./**/*"],
 	"compilerOptions": {
 		"noImplicitAny": true,

--- a/packages/tools/devtools/devtools/tsconfig.json
+++ b/packages/tools/devtools/devtools/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/tools/fetch-tool/tsconfig.json
+++ b/packages/tools/fetch-tool/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*.ts"],
 	"exclude": ["dist", "node_modules"],
 	"compilerOptions": {

--- a/packages/tools/fluid-runner/src/test/tsconfig.json
+++ b/packages/tools/fluid-runner/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"include": ["./**/*"],
 	"exclude": ["./**/*.cjs.*"],
 	"compilerOptions": {

--- a/packages/tools/fluid-runner/tsconfig.bin.lint.json
+++ b/packages/tools/fluid-runner/tsconfig.bin.lint.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["bin/*"],
 	"compilerOptions": {
 		"allowJs": true,

--- a/packages/tools/fluid-runner/tsconfig.json
+++ b/packages/tools/fluid-runner/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/tools/replay-tool/tsconfig.json
+++ b/packages/tools/replay-tool/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["dist", "node_modules"],
 	"compilerOptions": {

--- a/packages/utils/odsp-doclib-utils/src/test/tsconfig.json
+++ b/packages/utils/odsp-doclib-utils/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/utils/odsp-doclib-utils/tsconfig.json
+++ b/packages/utils/odsp-doclib-utils/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {

--- a/packages/utils/telemetry-utils/src/test/tsconfig.json
+++ b/packages/utils/telemetry-utils/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/utils/telemetry-utils/tsconfig.json
+++ b/packages/utils/telemetry-utils/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {
 		"rootDir": "./src",

--- a/packages/utils/tool-utils/src/test/tsconfig.json
+++ b/packages/utils/tool-utils/src/test/tsconfig.json
@@ -1,5 +1,8 @@
 {
-	"extends": "../../../../../common/build/build-common/tsconfig.test.node16.json",
+	"extends": [
+		"../../../../../common/build/build-common/tsconfig.node20.json",
+		"../../../../../common/build/build-common/tsconfig.test.json",
+	],
 	"compilerOptions": {
 		"rootDir": "./",
 		"outDir": "../../lib/test",

--- a/packages/utils/tool-utils/tsconfig.json
+++ b/packages/utils/tool-utils/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../../common/build/build-common/tsconfig.node16.json",
+	"extends": "../../../common/build/build-common/tsconfig.node20.json",
 	"include": ["src/**/*"],
 	"exclude": ["src/test/**/*"],
 	"compilerOptions": {


### PR DESCRIPTION
to enable require-esm support.

- Add node20 base config
- Separate test base config from test.node16 config
   - Tests select module config and test config independently
- Add node20 import resolution testing to `import-testing`

[AB#81440](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/81440)