### PR TITLE
feat(tree): implement persisted commit metadata

### DIFF
--- a/.changeset/persisted-commit-metadata.md
+++ b/.changeset/persisted-commit-metadata.md
@@ -1,0 +1,31 @@
+---
+"@fluidframework/tree": minor
+"fluid-framework": minor
+"__section": tree
+---
+Persisted commit metadata
+
+Applications can now attach an arbitrary JSON-serializable value to the commit produced by a transaction. The value is replicated to all collaborating clients and persisted in the document alongside the commit, and can be read back by revision.
+
+```typescript
+view.runTransaction(
+	() => {
+		view.root.insertAtEnd("B");
+	},
+	{ persistedMetadata: { author: "alice", reason: "checkpoint" } },
+);
+
+view.events.on("changed", (data) => {
+	if (data.isLocal) {
+		const metadata = view.getPersistedCommitMetadata(data.revision);
+	}
+});
+```
+
+The metadata shares the lifetime of the commit it is attached to: once that commit is trimmed from the trunk, its metadata goes with it. Reads therefore return `undefined` for commits that were never annotated, that predate this feature, or whose metadata has been evicted.
+
+Metadata is only written to the document when `minVersionForCollab` is at least `3.0.0`, which introduces new op and summary format versions. With an older configured value the metadata stays in memory on the client that created it and is not persisted or replicated, so a document can never contain metadata that a collaborating client would fail to preserve.
+
+Because the metadata travels on every annotated op and occupies space in the summary for as long as its commit survives, it should be kept small.
+
+`LocalChangeMetadata` (provided by the `changed` event) now also exposes the `revision` of the commit the change produced, which is what correlates a change with its persisted metadata.

--- a/packages/dds/tree/src/codec/codec.ts
+++ b/packages/dds/tree/src/codec/codec.ts
@@ -540,6 +540,17 @@ export const FluidClientVersion = {
 	 * - ModularChangeFormatVersion.v5 - written when minVersionForCollab \>= 2.80
 	 */
 	v2_80: "2.80.0",
+
+	/**
+	 * Fluid Framework Client 3.0 and newer.
+	 * @remarks
+	 * New formats introduced in 3.0:
+	 * - MessageFormatVersion.v7 - written when minVersionForCollab \>= 3.0
+	 * - EditManagerFormatVersion.v7 - written when minVersionForCollab \>= 3.0
+	 *
+	 * These formats add support for persisted commit metadata.
+	 */
+	v3_0: "3.0.0",
 } as const satisfies Record<string, OldestSupportedClientVersion>;
 
 /**

--- a/packages/dds/tree/src/core/rebase/types.ts
+++ b/packages/dds/tree/src/core/rebase/types.ts
@@ -35,6 +35,8 @@ export const SessionIdSchema = brandedStringType<SessionId>();
  *
  * The constant 'root' is reserved for the trunk base: minting a SessionSpaceCompressedId is not
  * possible on readonly clients. These clients generally don't need ids, but  must be done at tree initialization time.
+ *
+ * @alpha
  */
 export type RevisionTag = SessionSpaceCompressedId | "root";
 export type EncodedRevisionTag = Brand<OpSpaceCompressedId, "EncodedRevisionTag"> | "root";
@@ -229,6 +231,14 @@ export interface LocalChangeMetadata extends CommitMetadata {
 	getRevertible(
 		onDisposed?: (revertible: RevertibleAlpha) => void,
 	): RevertibleAlpha | undefined;
+
+	/**
+	 * The revision of the commit that this change produced.
+	 * @remarks
+	 * Use this to correlate the change with data keyed by revision, such as
+	 * persisted commit metadata.
+	 */
+	readonly revision: RevisionTag;
 
 	/**
 	 * Optional label provided by the user when commit was created.

--- a/packages/dds/tree/src/entrypoints/alpha.ts
+++ b/packages/dds/tree/src/entrypoints/alpha.ts
@@ -253,6 +253,7 @@ export {
 	RemoteChangeMetadata, 
 	RevertibleAlpha, 
 	RevertibleAlphaFactory, 
+	RevisionTag, 
 	RunTransactionParamsAlpha, 
 	SchemaFactoryAlpha, 
 	SchemaStaticsAlpha, 

--- a/packages/dds/tree/src/index.ts
+++ b/packages/dds/tree/src/index.ts
@@ -22,6 +22,7 @@ export {
 	type RevertibleFactory,
 	type RevertibleAlphaFactory,
 	type RevertibleAlpha,
+	type RevisionTag,
 } from "./core/index.js";
 
 export {

--- a/packages/dds/tree/src/shared-tree-core/editManager.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManager.ts
@@ -78,6 +78,11 @@ export class EditManager<
 > {
 	private readonly _events = createEmitter<BranchTrimmingEvents>();
 
+	/**
+	 * Events emitted by this edit manager, notably {@link BranchTrimmingEvents.ancestryTrimmed}.
+	 */
+	public readonly events: Listenable<BranchTrimmingEvents> = this._events;
+
 	private readonly sharedBranches = new Map<
 		BranchId,
 		SharedBranch<TEditor, TChangeset, TChangeProcessingContext>

--- a/packages/dds/tree/src/shared-tree-core/editManagerCodecs.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerCodecs.ts
@@ -27,6 +27,7 @@ import type {
 import { makeV1toV4andV6CodecWithVersion } from "./editManagerCodecsV1toV4.js";
 import { makeSharedBranchesCodecWithVersion } from "./editManagerCodecsVSharedBranches.js";
 import { EditManagerFormatVersion } from "./editManagerFormatCommons.js";
+import type { PersistedCommitMetadataIndex } from "./persistedCommitMetadata.js";
 
 /**
  * Codec name used to identify the {@link EditManager} codec, see {@link makeEditManagerCodecBuilder}.
@@ -48,6 +49,11 @@ interface EditManagerCodecOptions<TChangeset> extends ICodecOptions {
 		EncodedRevisionTag,
 		ChangeEncodingContext
 	>;
+	/**
+	 * The tree-wide index of persisted commit metadata, read when encoding commits and populated when decoding them.
+	 * @remarks Omitted by callers (such as tests) that do not support persisted commit metadata.
+	 */
+	persistedCommitMetadata?: PersistedCommitMetadataIndex;
 }
 
 /**
@@ -81,6 +87,7 @@ export function makeEditManagerCodecBuilder<TChangeset>(): VersionDispatchingCod
 					),
 					options.revisionTagCodec,
 					EditManagerFormatVersion.v3,
+					options.persistedCommitMetadata,
 				),
 		},
 		{
@@ -93,6 +100,7 @@ export function makeEditManagerCodecBuilder<TChangeset>(): VersionDispatchingCod
 					),
 					options.revisionTagCodec,
 					EditManagerFormatVersion.v4,
+					options.persistedCommitMetadata,
 				),
 		},
 		makeDiscontinuedCodecAndSchema(EditManagerFormatVersion.v5, "2.74.0"),
@@ -106,6 +114,20 @@ export function makeEditManagerCodecBuilder<TChangeset>(): VersionDispatchingCod
 					),
 					options.revisionTagCodec,
 					EditManagerFormatVersion.v6,
+					options.persistedCommitMetadata,
+				),
+		},
+		{
+			minVersionForCollab: FluidClientVersion.v3_0,
+			formatVersion: EditManagerFormatVersion.v7,
+			codec: (options: EditManagerCodecOptions<TChangeset>) =>
+				makeV1toV4andV6CodecWithVersion(
+					options.changeCodecs.resolve(
+						options.dependentChangeFormatVersion.lookup(EditManagerFormatVersion.v7),
+					),
+					options.revisionTagCodec,
+					EditManagerFormatVersion.v7,
+					options.persistedCommitMetadata,
 				),
 		},
 		{
@@ -120,6 +142,7 @@ export function makeEditManagerCodecBuilder<TChangeset>(): VersionDispatchingCod
 					),
 					options.revisionTagCodec,
 					EditManagerFormatVersion.vSharedBranches,
+					options.persistedCommitMetadata,
 				),
 		},
 	];

--- a/packages/dds/tree/src/shared-tree-core/editManagerCodecsCommons.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerCodecsCommons.ts
@@ -18,6 +18,7 @@ import {
 	mapIterable,
 	type IdentifierHealingConfig,
 	type JsonCompatibleReadOnly,
+	type JsonCompatibleReadOnlyObject,
 	type Mutable,
 } from "../util/index.js";
 
@@ -30,6 +31,7 @@ import type {
 	SequenceId,
 	SequencedCommit,
 } from "./editManagerFormatCommons.js";
+import type { PersistedCommitMetadataIndex } from "./persistedCommitMetadata.js";
 
 export interface EditManagerEncodingContext {
 	idCompressor: IIdCompressor;
@@ -55,6 +57,19 @@ export interface EditManagerDecodingContext {
 	readonly healing?: IdentifierHealingConfig;
 }
 
+/**
+ * How an {@link EditManager} codec should interact with the tree's {@link PersistedCommitMetadataIndex}.
+ */
+export interface PersistedCommitMetadataOptions {
+	/** The tree-wide index that metadata is read from when encoding and written to when decoding. */
+	readonly index: PersistedCommitMetadataIndex;
+	/**
+	 * Whether the codec's format version is new enough to write metadata.
+	 * @remarks Metadata is always read when present, but only written at `EditManagerFormatVersion.v7` or later.
+	 */
+	readonly writeMetadata: boolean;
+}
+
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 function encodeCommit<TChangeset, T extends Commit<TChangeset>>(
 	changeCodec: IJsonCodec<
@@ -71,8 +86,9 @@ function encodeCommit<TChangeset, T extends Commit<TChangeset>>(
 	>,
 	commit: T,
 	context: ChangeEncodingContext,
+	persistedMetadata: PersistedCommitMetadataOptions | undefined,
 ) {
-	return {
+	const encoded = {
 		...commit,
 		revision: revisionTagCodec.encode(commit.revision, {
 			originatorId: commit.sessionId,
@@ -82,6 +98,19 @@ function encodeCommit<TChangeset, T extends Commit<TChangeset>>(
 		}),
 		change: changeCodec.encode(commit.change, { ...context, revision: commit.revision }),
 	};
+
+	// Persisted commit metadata was introduced in EditManagerFormatVersion.v7 and must not be written by earlier formats.
+	const metadata =
+		persistedMetadata?.writeMetadata === true
+			? persistedMetadata.index.get(commit.revision)
+			: undefined;
+	const mutable = encoded as { persistedMetadata?: JsonCompatibleReadOnlyObject };
+	if (metadata === undefined) {
+		delete mutable.persistedMetadata;
+	} else {
+		mutable.persistedMetadata = metadata;
+	}
+	return encoded;
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
@@ -100,6 +129,7 @@ function decodeCommit<TChangeset, T extends EncodedCommit<JsonCompatibleReadOnly
 	>,
 	commit: T,
 	context: ChangeDecodingContext,
+	persistedMetadata: PersistedCommitMetadataOptions | undefined,
 ) {
 	const revision = revisionTagCodec.decode(commit.revision, {
 		originatorId: commit.sessionId,
@@ -108,11 +138,18 @@ function decodeCommit<TChangeset, T extends EncodedCommit<JsonCompatibleReadOnly
 		isSummary: context.isSummary,
 	});
 
-	return {
+	if (commit.persistedMetadata !== undefined) {
+		persistedMetadata?.index.set(revision, commit.persistedMetadata);
+	}
+
+	const decoded = {
 		...commit,
 		revision,
 		change: changeCodec.decode(commit.change, { ...context, revision }),
 	};
+	// The metadata lives in the index, not on the commit: see `PersistedCommitMetadataIndex`.
+	delete (decoded as { persistedMetadata?: JsonCompatibleReadOnlyObject }).persistedMetadata;
+	return decoded;
 }
 
 export function encodeSharedBranch<TChangeset>(
@@ -131,16 +168,23 @@ export function encodeSharedBranch<TChangeset>(
 	data: SharedBranchSummaryData<TChangeset>,
 	context: EditManagerEncodingContext,
 	originatorId: SessionId | undefined,
+	persistedMetadata: PersistedCommitMetadataOptions | undefined,
 ): EncodedSharedBranch<TChangeset> {
 	const json: Mutable<EncodedSharedBranch<TChangeset>> = {
 		trunk: data.trunk.map((commit) =>
-			encodeCommit(changeCodec, revisionTagCodec, commit, {
-				originatorId: commit.sessionId,
-				idCompressor: context.idCompressor,
-				schema: context.schema,
-				revision: undefined,
-				isSummary: context.isSummary,
-			}),
+			encodeCommit(
+				changeCodec,
+				revisionTagCodec,
+				commit,
+				{
+					originatorId: commit.sessionId,
+					idCompressor: context.idCompressor,
+					schema: context.schema,
+					revision: undefined,
+					isSummary: context.isSummary,
+				},
+				persistedMetadata,
+			),
 		),
 		peers: Array.from(data.peerLocalBranches.entries(), ([sessionId, branch]) => [
 			sessionId,
@@ -152,13 +196,19 @@ export function encodeSharedBranch<TChangeset>(
 					isSummary: context.isSummary,
 				}),
 				commits: branch.commits.map((commit) =>
-					encodeCommit(changeCodec, revisionTagCodec, commit, {
-						originatorId: commit.sessionId,
-						idCompressor: context.idCompressor,
-						schema: context.schema,
-						revision: undefined,
-						isSummary: context.isSummary,
-					}),
+					encodeCommit(
+						changeCodec,
+						revisionTagCodec,
+						commit,
+						{
+							originatorId: commit.sessionId,
+							idCompressor: context.idCompressor,
+							schema: context.schema,
+							revision: undefined,
+							isSummary: context.isSummary,
+						},
+						persistedMetadata,
+					),
 				),
 			},
 		]),
@@ -206,6 +256,7 @@ export function decodeSharedBranch<TChangeset>(
 	json: EncodedSharedBranch<TChangeset>,
 	context: EditManagerDecodingContext,
 	originatorId: SessionId | undefined,
+	persistedMetadata: PersistedCommitMetadataOptions | undefined,
 ): SharedBranchSummaryData<TChangeset> {
 	// TODO: sort out EncodedCommit vs Commit, and make this type check without type assertion.
 	const trunk = json.trunk as readonly (EncodedCommit<JsonCompatibleReadOnly> & SequenceId)[];
@@ -213,13 +264,19 @@ export function decodeSharedBranch<TChangeset>(
 		trunk: trunk.map(
 			(commit): SequencedCommit<TChangeset> =>
 				// TODO: sort out EncodedCommit vs Commit, and make this type check without `as`.
-				decodeCommit(changeCodec, revisionTagCodec, commit, {
-					originatorId: commit.sessionId,
-					idCompressor: context.idCompressor,
-					revision: undefined,
-					isSummary: context.isSummary,
-					healing: context.healing,
-				}),
+				decodeCommit(
+					changeCodec,
+					revisionTagCodec,
+					commit,
+					{
+						originatorId: commit.sessionId,
+						idCompressor: context.idCompressor,
+						revision: undefined,
+						isSummary: context.isSummary,
+						healing: context.healing,
+					},
+					persistedMetadata,
+				),
 		),
 		peerLocalBranches: new Map(
 			mapIterable(json.peers, ([sessionId, branch]) => [
@@ -244,6 +301,7 @@ export function decodeSharedBranch<TChangeset>(
 								isSummary: context.isSummary,
 								healing: context.healing,
 							},
+							persistedMetadata,
 						),
 					),
 				},

--- a/packages/dds/tree/src/shared-tree-core/editManagerCodecsV1toV4.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerCodecsV1toV4.ts
@@ -17,8 +17,11 @@ import {
 	encodeSharedBranch,
 	type EditManagerDecodingContext,
 	type EditManagerEncodingContext,
+	type PersistedCommitMetadataOptions,
 } from "./editManagerCodecsCommons.js";
+import { EditManagerFormatVersion } from "./editManagerFormatCommons.js";
 import { EncodedEditManager } from "./editManagerFormatV1toV4.js";
+import type { PersistedCommitMetadataIndex } from "./persistedCommitMetadata.js";
 
 /**
  * Create the provided version of the {@link EditManager} codec (which encodes it's {@link SummaryData}).
@@ -42,12 +45,20 @@ export function makeV1toV4andV6CodecWithVersion<TChangeset>(
 		ChangeEncodingContext
 	>,
 	version: EncodedEditManager<TChangeset>["version"],
+	persistedMetadataIndex: PersistedCommitMetadataIndex | undefined,
 ): CodecAndSchema<
 	SummaryData<TChangeset>,
 	EditManagerEncodingContext,
 	EditManagerDecodingContext
 > {
 	const schema = EncodedEditManager(changeCodec.encodedSchema ?? JsonCompatibleReadOnlySchema);
+	const persistedMetadata: PersistedCommitMetadataOptions | undefined =
+		persistedMetadataIndex === undefined
+			? undefined
+			: {
+					index: persistedMetadataIndex,
+					writeMetadata: version >= EditManagerFormatVersion.v7,
+				};
 
 	const codec: CodecAndSchema<
 		SummaryData<TChangeset>,
@@ -65,6 +76,7 @@ export function makeV1toV4andV6CodecWithVersion<TChangeset>(
 				data.main,
 				context,
 				data.originator,
+				persistedMetadata,
 			);
 			const encoded: EncodedEditManager<TChangeset> = {
 				trunk: mainBranch.trunk,
@@ -89,6 +101,7 @@ export function makeV1toV4andV6CodecWithVersion<TChangeset>(
 					},
 					context,
 					undefined, // Non "vSharedBranches" versions do not encode the summary originatorId.
+					persistedMetadata,
 				),
 			};
 		},

--- a/packages/dds/tree/src/shared-tree-core/editManagerCodecsVSharedBranches.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerCodecsVSharedBranches.ts
@@ -21,9 +21,11 @@ import {
 	encodeSharedBranch,
 	type EditManagerDecodingContext,
 	type EditManagerEncodingContext,
+	type PersistedCommitMetadataOptions,
 } from "./editManagerCodecsCommons.js";
 import type { EncodedSharedBranch } from "./editManagerFormatCommons.js";
 import { EncodedEditManager } from "./editManagerFormatVSharedBranches.js";
+import type { PersistedCommitMetadataIndex } from "./persistedCommitMetadata.js";
 
 export function makeSharedBranchesCodecWithVersion<TChangeset>(
 	changeCodec: IJsonCodec<
@@ -39,12 +41,18 @@ export function makeSharedBranchesCodecWithVersion<TChangeset>(
 		ChangeEncodingContext
 	>,
 	version: EncodedEditManager<TChangeset>["version"],
+	persistedMetadataIndex: PersistedCommitMetadataIndex | undefined,
 ): CodecAndSchema<
 	SummaryData<TChangeset>,
 	EditManagerEncodingContext,
 	EditManagerDecodingContext
 > {
 	const schema = EncodedEditManager(changeCodec.encodedSchema ?? JsonCompatibleReadOnlySchema);
+	// The shared-branches format is not yet stable, so it always carries metadata.
+	const persistedMetadata: PersistedCommitMetadataOptions | undefined =
+		persistedMetadataIndex === undefined
+			? undefined
+			: { index: persistedMetadataIndex, writeMetadata: true };
 
 	const codec: CodecAndSchema<
 		SummaryData<TChangeset>,
@@ -59,6 +67,7 @@ export function makeSharedBranchesCodecWithVersion<TChangeset>(
 				data.main,
 				context,
 				data.originator,
+				persistedMetadata,
 			);
 			assert(
 				data.originator !== undefined,
@@ -79,6 +88,7 @@ export function makeSharedBranchesCodecWithVersion<TChangeset>(
 							branch,
 							context,
 							data.originator,
+							persistedMetadata,
 						),
 					);
 				}
@@ -96,6 +106,7 @@ export function makeSharedBranchesCodecWithVersion<TChangeset>(
 				json.main,
 				context,
 				json.originator,
+				persistedMetadata,
 			);
 
 			const decoded: Mutable<SummaryData<TChangeset>> = {
@@ -112,6 +123,7 @@ export function makeSharedBranchesCodecWithVersion<TChangeset>(
 						branch,
 						context,
 						json.originator,
+						persistedMetadata,
 					);
 					assert(decodedBranch.id !== undefined, 0xc66 /* Shared branches must have an id */);
 					assert(!branches.has(decodedBranch.id), 0xc67 /* Duplicate shared branch id */);

--- a/packages/dds/tree/src/shared-tree-core/editManagerFormatCommons.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerFormatCommons.ts
@@ -13,7 +13,14 @@ import {
 	RevisionTagSchema,
 	SessionIdSchema,
 } from "../core/index.js";
-import { type Brand, brandedNumberType, strictEnum, type Values } from "../util/index.js";
+import {
+	type Brand,
+	brandedNumberType,
+	type JsonCompatibleReadOnlyObject,
+	JsonCompatibleReadOnlyObjectSchema,
+	strictEnum,
+	type Values,
+} from "../util/index.js";
 
 import type { EncodedBranchId } from "./branch.js";
 
@@ -28,6 +35,11 @@ export interface Commit<TChangeset> {
 	readonly change: TChangeset;
 	/** An identifier representing the session/user/client that made this commit */
 	readonly sessionId: SessionId;
+	/**
+	 * Application-defined metadata attached to this commit.
+	 * @remarks Only written at {@link EditManagerFormatVersion.v7} or later.
+	 */
+	readonly persistedMetadata?: JsonCompatibleReadOnlyObject;
 }
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
@@ -35,6 +47,11 @@ export type EncodedCommit<TChangeset> = {
 	readonly revision: EncodedRevisionTag;
 	readonly change: TChangeset;
 	readonly sessionId: SessionId;
+	/**
+	 * Application-defined metadata attached to this commit.
+	 * @remarks Only written at {@link EditManagerFormatVersion.v7} or later.
+	 */
+	readonly persistedMetadata?: JsonCompatibleReadOnlyObject;
 };
 
 const noAdditionalProps: ObjectOptions = { additionalProperties: false };
@@ -47,6 +64,7 @@ const CommitBase = <ChangeSchema extends TSchema>(tChange: ChangeSchema) =>
 		revision: RevisionTagSchema,
 		change: tChange,
 		sessionId: SessionIdSchema,
+		persistedMetadata: Type.Optional(JsonCompatibleReadOnlyObjectSchema),
 	});
 /**
  * @privateRemarks Commits are generally encoded from `GraphCommit`s, which often contain extra data.
@@ -164,6 +182,11 @@ export const EditManagerFormatVersion = strictEnum("editManager.FormatVersion", 
 	 */
 	v6: 6,
 	/**
+	 * Introduced and made available for writing in 3.0.0.
+	 * Adds support for persisted commit metadata.
+	 */
+	v7: 7,
+	/**
 	 * Not yet released.
 	 * Only used for testing shared branches.
 	 */
@@ -175,6 +198,7 @@ export const supportedEditManagerFormatVersions: ReadonlySet<EditManagerFormatVe
 		EditManagerFormatVersion.v3,
 		EditManagerFormatVersion.v4,
 		EditManagerFormatVersion.v6,
+		EditManagerFormatVersion.v7,
 		EditManagerFormatVersion.vSharedBranches,
 	]);
 export const editManagerFormatVersions: ReadonlySet<EditManagerFormatVersion> = new Set(

--- a/packages/dds/tree/src/shared-tree-core/editManagerFormatV1toV4.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerFormatV1toV4.ts
@@ -29,7 +29,8 @@ export interface EncodedEditManager<TChangeset> {
 		| typeof EditManagerFormatVersion.v2
 		| typeof EditManagerFormatVersion.v3
 		| typeof EditManagerFormatVersion.v4
-		| typeof EditManagerFormatVersion.v6;
+		| typeof EditManagerFormatVersion.v6
+		| typeof EditManagerFormatVersion.v7;
 }
 
 export const EncodedEditManager = <ChangeSchema extends TSchema>(tChange: ChangeSchema) =>
@@ -41,6 +42,7 @@ export const EncodedEditManager = <ChangeSchema extends TSchema>(tChange: Change
 				Type.Literal(EditManagerFormatVersion.v3),
 				Type.Literal(EditManagerFormatVersion.v4),
 				Type.Literal(EditManagerFormatVersion.v6),
+				Type.Literal(EditManagerFormatVersion.v7),
 			]),
 			trunk: Type.Array(SequencedCommit(tChange)),
 			branches: Type.Array(Type.Tuple([SessionIdSchema, SummarySessionBranch(tChange)])),

--- a/packages/dds/tree/src/shared-tree-core/index.ts
+++ b/packages/dds/tree/src/shared-tree-core/index.ts
@@ -80,3 +80,7 @@ export {
 	MessageFormatVersion,
 	supportedMessageFormatVersions,
 } from "./messageFormat.js";
+export {
+	PersistedCommitMetadataIndex,
+	type PersistedCommitMetadata,
+} from "./persistedCommitMetadata.js";

--- a/packages/dds/tree/src/shared-tree-core/messageCodecV1ToV4.ts
+++ b/packages/dds/tree/src/shared-tree-core/messageCodecV1ToV4.ts
@@ -15,12 +15,13 @@ import type {
 import {
 	type JsonCompatibleReadOnlyObject,
 	JsonCompatibleReadOnlySchema,
+	type Mutable,
 } from "../util/index.js";
 
 import type { MessageDecodingContext, MessageEncodingContext } from "./messageCodecs.js";
-import type { MessageFormatVersion } from "./messageFormat.js";
+import { MessageFormatVersion } from "./messageFormat.js";
 import { Message } from "./messageFormatV1ToV4.js";
-import type { DecodedMessage } from "./messageTypes.js";
+import type { CommitMessage, DecodedMessage } from "./messageTypes.js";
 
 export function makeV1ToV4CodecWithVersion<TChangeset>(
 	changeCodec: ChangeFamilyCodec<TChangeset>,
@@ -35,9 +36,12 @@ export function makeV1ToV4CodecWithVersion<TChangeset>(
 		| typeof MessageFormatVersion.v2
 		| typeof MessageFormatVersion.v3
 		| typeof MessageFormatVersion.v4
-		| typeof MessageFormatVersion.v6,
+		| typeof MessageFormatVersion.v6
+		| typeof MessageFormatVersion.v7,
 ): CodecAndSchema<DecodedMessage<TChangeset>, MessageEncodingContext, MessageDecodingContext> {
 	const schema = Message(changeCodec.encodedSchema ?? JsonCompatibleReadOnlySchema);
+	// Persisted commit metadata was introduced in v7 and must not be written by earlier formats.
+	const writePersistedMetadata = version >= MessageFormatVersion.v7;
 	return {
 		schema,
 		encode: (
@@ -50,7 +54,7 @@ export function makeV1ToV4CodecWithVersion<TChangeset>(
 				0xc69 /* Only commit messages to main are supported */,
 			);
 			const { commit, sessionId: originatorId } = decoded;
-			return {
+			const encoded: Mutable<Message> = {
 				revision: revisionTagCodec.encode(commit.revision, {
 					originatorId,
 					idCompressor: context.idCompressor,
@@ -67,12 +71,21 @@ export function makeV1ToV4CodecWithVersion<TChangeset>(
 				}),
 				version,
 			};
+			if (writePersistedMetadata && decoded.persistedMetadata !== undefined) {
+				encoded.persistedMetadata = decoded.persistedMetadata;
+			}
+			return encoded as Message & JsonCompatibleReadOnlyObject & Versioned;
 		},
 		decode: (
 			encoded: Message & JsonCompatibleReadOnlyObject & Versioned,
 			context: MessageDecodingContext,
 		): DecodedMessage<TChangeset> => {
-			const { revision: encodedRevision, originatorId, changeset } = encoded;
+			const {
+				revision: encodedRevision,
+				originatorId,
+				changeset,
+				persistedMetadata,
+			} = encoded;
 
 			const revision = revisionTagCodec.decode(encodedRevision, {
 				originatorId,
@@ -81,7 +94,7 @@ export function makeV1ToV4CodecWithVersion<TChangeset>(
 				isSummary: false,
 			});
 
-			return {
+			const decoded: CommitMessage<TChangeset> = {
 				branchId: "main",
 				type: "commit",
 				commit: {
@@ -95,6 +108,10 @@ export function makeV1ToV4CodecWithVersion<TChangeset>(
 				},
 				sessionId: originatorId,
 			};
+			if (persistedMetadata !== undefined) {
+				decoded.persistedMetadata = persistedMetadata;
+			}
+			return decoded;
 		},
 	};
 }

--- a/packages/dds/tree/src/shared-tree-core/messageCodecVSharedBranches.ts
+++ b/packages/dds/tree/src/shared-tree-core/messageCodecVSharedBranches.ts
@@ -14,13 +14,13 @@ import type {
 	EncodedRevisionTag,
 	RevisionTag,
 } from "../core/index.js";
-import type { JsonCompatibleReadOnlyObject } from "../util/index.js";
+import type { JsonCompatibleReadOnlyObject, Mutable } from "../util/index.js";
 
 import { decodeBranchId, encodeBranchId } from "./branchIdCodec.js";
 import type { MessageDecodingContext, MessageEncodingContext } from "./messageCodecs.js";
 import type { MessageFormatVersion } from "./messageFormat.js";
 import { Message } from "./messageFormatVSharedBranches.js";
-import type { DecodedMessage } from "./messageTypes.js";
+import type { CommitMessage, DecodedMessage } from "./messageTypes.js";
 
 export function makeSharedBranchesCodecWithVersion<TChangeset>(
 	changeCodec: ChangeFamilyCodec<TChangeset>,
@@ -51,7 +51,7 @@ export function makeSharedBranchesCodecWithVersion<TChangeset>(
 						isSummary: false,
 					};
 
-					return {
+					const encoded: Mutable<Message> = {
 						revision: revisionTagCodec.encode(message.commit.revision, {
 							originatorId: message.sessionId,
 							idCompressor: context.idCompressor,
@@ -63,6 +63,10 @@ export function makeSharedBranchesCodecWithVersion<TChangeset>(
 						branchId: encodeBranchId(context.idCompressor, message.branchId),
 						version,
 					};
+					if (message.persistedMetadata !== undefined) {
+						encoded.persistedMetadata = message.persistedMetadata;
+					}
+					return encoded as Message & JsonCompatibleReadOnlyObject & Versioned;
 				}
 				case "branch": {
 					return {
@@ -87,6 +91,7 @@ export function makeSharedBranchesCodecWithVersion<TChangeset>(
 				changeset,
 				branchId: encodedBranchId,
 				branchName: encodedBranchName,
+				persistedMetadata,
 			} = encoded;
 
 			const changeContext: ChangeEncodingContext = {
@@ -110,7 +115,7 @@ export function makeSharedBranchesCodecWithVersion<TChangeset>(
 			assert(encodedRevision !== undefined, 0xc6a /* Commit messages must have a revision */);
 			const revision = revisionTagCodec.decode(encodedRevision, changeContext);
 
-			return {
+			const decoded: CommitMessage<TChangeset> = {
 				type: "commit",
 				commit: {
 					revision,
@@ -124,6 +129,10 @@ export function makeSharedBranchesCodecWithVersion<TChangeset>(
 				branchId,
 				sessionId: originatorId,
 			};
+			if (persistedMetadata !== undefined) {
+				decoded.persistedMetadata = persistedMetadata;
+			}
+			return decoded;
 		},
 	};
 }

--- a/packages/dds/tree/src/shared-tree-core/messageCodecs.ts
+++ b/packages/dds/tree/src/shared-tree-core/messageCodecs.ts
@@ -126,6 +126,18 @@ export function makeMessageCodecBuilder<TChangeset>(): VersionDispatchingCodecBu
 				),
 		},
 		{
+			minVersionForCollab: FluidClientVersion.v3_0,
+			formatVersion: MessageFormatVersion.v7,
+			codec: (options: MessageCodecBuilderOptions<TChangeset>) =>
+				makeV1ToV4CodecWithVersion(
+					options.changeCodecs.resolve(
+						options.dependentChangeFormatVersion.lookup(MessageFormatVersion.v7),
+					),
+					options.revisionTagCodec,
+					MessageFormatVersion.v7,
+				),
+		},
+		{
 			minVersionForCollab: undefined,
 			formatVersion: MessageFormatVersion.vSharedBranches,
 			codec: (options: MessageCodecBuilderOptions<TChangeset>) =>

--- a/packages/dds/tree/src/shared-tree-core/messageFormat.ts
+++ b/packages/dds/tree/src/shared-tree-core/messageFormat.ts
@@ -53,6 +53,11 @@ export const MessageFormatVersion = strictEnum("MessageFormatVersion", {
 	 */
 	v6: 6,
 	/**
+	 * Introduced and made available for writing in 3.0.0.
+	 * Adds support for persisted commit metadata.
+	 */
+	v7: 7,
+	/**
 	 * Not yet released.
 	 * Only used for testing shared branches.
 	 */
@@ -63,5 +68,6 @@ export const supportedMessageFormatVersions: ReadonlySet<MessageFormatVersion> =
 	MessageFormatVersion.v3,
 	MessageFormatVersion.v4,
 	MessageFormatVersion.v6,
+	MessageFormatVersion.v7,
 	MessageFormatVersion.vSharedBranches,
 ]);

--- a/packages/dds/tree/src/shared-tree-core/messageFormatV1ToV4.ts
+++ b/packages/dds/tree/src/shared-tree-core/messageFormatV1ToV4.ts
@@ -8,7 +8,11 @@ import * as Type from "@sinclair/typebox";
 import type { TSchema } from "@sinclair/typebox";
 
 import { type EncodedRevisionTag, RevisionTagSchema, SessionIdSchema } from "../core/index.js";
-import type { JsonCompatibleReadOnly } from "../util/index.js";
+import {
+	type JsonCompatibleReadOnly,
+	type JsonCompatibleReadOnlyObject,
+	JsonCompatibleReadOnlyObjectSchema,
+} from "../util/index.js";
 
 import { MessageFormatVersion } from "./messageFormat.js";
 
@@ -30,6 +34,12 @@ export interface Message {
 	readonly changeset: JsonCompatibleReadOnly;
 
 	/**
+	 * Application-defined metadata attached to the commit in this message.
+	 * @remarks Only written at {@link MessageFormatVersion.v7} or later.
+	 */
+	readonly persistedMetadata?: JsonCompatibleReadOnlyObject;
+
+	/**
 	 * The version of the message. This controls how the message is encoded.
 	 *
 	 * This was not set historically and was added before making any breaking changes to the format.
@@ -40,7 +50,8 @@ export interface Message {
 		| typeof MessageFormatVersion.v2
 		| typeof MessageFormatVersion.v3
 		| typeof MessageFormatVersion.v4
-		| typeof MessageFormatVersion.v6;
+		| typeof MessageFormatVersion.v6
+		| typeof MessageFormatVersion.v7;
 }
 
 // Return type is intentionally derived.
@@ -50,6 +61,7 @@ export const Message = <ChangeSchema extends TSchema>(tChange: ChangeSchema) =>
 		revision: RevisionTagSchema,
 		originatorId: SessionIdSchema,
 		changeset: tChange,
+		persistedMetadata: Type.Optional(JsonCompatibleReadOnlyObjectSchema),
 		version: Type.Optional(
 			Type.Union([
 				Type.Literal(MessageFormatVersion.v1),
@@ -57,6 +69,7 @@ export const Message = <ChangeSchema extends TSchema>(tChange: ChangeSchema) =>
 				Type.Literal(MessageFormatVersion.v3),
 				Type.Literal(MessageFormatVersion.v4),
 				Type.Literal(MessageFormatVersion.v6),
+				Type.Literal(MessageFormatVersion.v7),
 			]),
 		),
 	});

--- a/packages/dds/tree/src/shared-tree-core/messageFormatVSharedBranches.ts
+++ b/packages/dds/tree/src/shared-tree-core/messageFormatVSharedBranches.ts
@@ -8,7 +8,11 @@ import * as Type from "@sinclair/typebox";
 import type { TSchema } from "@sinclair/typebox";
 
 import { type EncodedRevisionTag, RevisionTagSchema, SessionIdSchema } from "../core/index.js";
-import type { JsonCompatibleReadOnly } from "../util/index.js";
+import {
+	type JsonCompatibleReadOnly,
+	type JsonCompatibleReadOnlyObject,
+	JsonCompatibleReadOnlyObjectSchema,
+} from "../util/index.js";
 
 import type { EncodedBranchId } from "./branch.js";
 import { MessageFormatVersion } from "./messageFormat.js";
@@ -42,6 +46,11 @@ export interface Message {
 	readonly branchName?: string;
 
 	/**
+	 * Application-defined metadata attached to the commit in this message.
+	 */
+	readonly persistedMetadata?: JsonCompatibleReadOnlyObject;
+
+	/**
 	 * The version of the message format.
 	 */
 	readonly version: typeof MessageFormatVersion.vSharedBranches;
@@ -56,5 +65,6 @@ export const Message = <ChangeSchema extends TSchema>(tChange: ChangeSchema) =>
 		changeset: Type.Optional(tChange),
 		branchId: Type.Optional(Type.Number()),
 		branchName: Type.Optional(Type.String()),
+		persistedMetadata: Type.Optional(JsonCompatibleReadOnlyObjectSchema),
 		version: Type.Literal(MessageFormatVersion.vSharedBranches),
 	});

--- a/packages/dds/tree/src/shared-tree-core/messageTypes.ts
+++ b/packages/dds/tree/src/shared-tree-core/messageTypes.ts
@@ -6,6 +6,7 @@
 import type { SessionId } from "@fluidframework/id-compressor";
 
 import type { GraphCommit } from "../core/index.js";
+import type { JsonCompatibleReadOnlyObject } from "../util/index.js";
 
 import type { BranchId } from "./branch.js";
 
@@ -19,6 +20,13 @@ export interface CommitMessage<TChange> extends MessageBase {
 	type: "commit";
 	commit: GraphCommit<TChange>;
 	branchId: BranchId;
+	/**
+	 * Application-defined metadata attached to {@link CommitMessage.commit}.
+	 * @remarks
+	 * This is only carried on the wire; it is never stored on the {@link GraphCommit} itself
+	 * (rebasing a commit would drop it). See `PersistedCommitMetadataIndex`.
+	 */
+	persistedMetadata?: JsonCompatibleReadOnlyObject;
 }
 
 export interface BranchMessage extends MessageBase {

--- a/packages/dds/tree/src/shared-tree-core/persistedCommitMetadata.ts
+++ b/packages/dds/tree/src/shared-tree-core/persistedCommitMetadata.ts
@@ -1,0 +1,69 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import type { RevisionTag } from "../core/index.js";
+import type { JsonCompatibleReadOnlyObject } from "../util/index.js";
+
+/**
+ * Application-defined, JSON-serializable metadata attached to a commit and persisted in the document.
+ * @remarks
+ * This is distinct from `CommitMetadata`, which describes a commit's `kind` and `isLocal` flags and never leaves memory.
+ */
+export type PersistedCommitMetadata = JsonCompatibleReadOnlyObject;
+
+/**
+ * An in-memory map from {@link RevisionTag} to the {@link PersistedCommitMetadata} attached to that revision's commit.
+ *
+ * @remarks
+ * The index is deliberately keyed by revision rather than stored on the `GraphCommit` object itself:
+ * `rebaseBranch` constructs rebased commits as fresh object literals (with no spread), so any extra property
+ * on a commit is dropped the first time that commit is rebased. Revision tags, by contrast, are stable across
+ * rebase and merge, so a lookup by revision remains valid wherever a commit ends up.
+ *
+ * A single index is held by the `SharedTreeCore` and shared by every checkout of that tree, so that metadata
+ * recorded by a transaction on a fork is found when the merge of that fork submits the commit.
+ */
+export class PersistedCommitMetadataIndex {
+	readonly #metadata = new Map<RevisionTag, PersistedCommitMetadata>();
+
+	/**
+	 * Records the metadata for the given revision.
+	 */
+	public set(revision: RevisionTag, metadata: PersistedCommitMetadata): void {
+		this.#metadata.set(revision, metadata);
+	}
+
+	/**
+	 * Returns the metadata for the given revision, or `undefined` if the revision was never annotated,
+	 * predates this feature, or has been evicted.
+	 */
+	public get(revision: RevisionTag): PersistedCommitMetadata | undefined {
+		return this.#metadata.get(revision);
+	}
+
+	/**
+	 * Removes the metadata for the given revision, if any.
+	 */
+	public delete(revision: RevisionTag): void {
+		this.#metadata.delete(revision);
+	}
+
+	/**
+	 * Removes the metadata for all of the given revisions, if any.
+	 */
+	public deleteAll(revisions: readonly RevisionTag[]): void {
+		for (const revision of revisions) {
+			this.#metadata.delete(revision);
+		}
+	}
+
+	/**
+	 * The number of revisions currently tracked by this index.
+	 * @remarks Exposed for testing purposes.
+	 */
+	public get size(): number {
+		return this.#metadata.size;
+	}
+}

--- a/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
+++ b/packages/dds/tree/src/shared-tree-core/sharedTreeCore.ts
@@ -58,6 +58,7 @@ import { EditManagerSummarizer } from "./editManagerSummarizer.js";
 import { type MessageEncodingContext, makeMessageCodecBuilder } from "./messageCodecs.js";
 import type { MessageFormatVersion } from "./messageFormat.js";
 import type { DecodedMessage } from "./messageTypes.js";
+import { PersistedCommitMetadataIndex } from "./persistedCommitMetadata.js";
 import type { ResubmitMachine } from "./resubmitMachine.js";
 import {
 	minVersionToSharedTreeSummaryFormatVersion,
@@ -142,6 +143,14 @@ export class SharedTreeCore<
 
 	private readonly enrichers: Map<BranchId, EnricherState<TChange>> = new Map();
 
+	/**
+	 * The tree-wide index of persisted commit metadata, keyed by revision.
+	 * @remarks
+	 * This is shared by every checkout of this tree so that metadata recorded by a transaction on one
+	 * branch is found when a merge of that branch submits the commit.
+	 */
+	public readonly persistedCommitMetadata = new PersistedCommitMetadataIndex();
+
 	public readonly mintRevisionTag: () => RevisionTag;
 
 	private readonly schemaAndPolicy: ClonableSchemaAndPolicy;
@@ -209,12 +218,19 @@ export class SharedTreeCore<
 
 		this.registerSharedBranch("main");
 
+		// Metadata shares the lifetime of the commit it is attached to: once a commit is trimmed from the
+		// trunk, drop its metadata so that memory tracks the trunk.
+		this.editManager.events.on("ancestryTrimmed", (trimmedRevisions) => {
+			this.persistedCommitMetadata.deleteAll(trimmedRevisions);
+		});
+
 		const revisionTagCodec = new RevisionTagCodec(idCompressor);
 		const editManagerCodec = makeEditManagerCodecBuilder<TChange>().build({
 			...coreOptions,
 			changeCodecs: this.editManager.changeFamily.codecs,
 			dependentChangeFormatVersion: changeFormatVersionForEditManager,
 			revisionTagCodec,
+			persistedCommitMetadata: this.persistedCommitMetadata,
 		});
 		this.summarizables = [
 			new EditManagerSummarizer(
@@ -413,6 +429,9 @@ export class SharedTreeCore<
 				commit: enrichedCommit,
 				sessionId: this.editManager.localSessionId,
 				branchId,
+				// Read from the index (rather than off the commit) so that this works for resubmits,
+				// where the decoded op is discarded, and for commits made on a fork of another checkout.
+				persistedMetadata: this.persistedCommitMetadata.get(enrichedCommit.revision),
 			},
 			schemaAndPolicy,
 		);
@@ -490,6 +509,14 @@ export class SharedTreeCore<
 
 					branchId = message.branchId;
 					commits.push(message.commit);
+					// Record metadata for both local and remote messages so the index is populated
+					// identically on every client.
+					if (message.persistedMetadata !== undefined) {
+						this.persistedCommitMetadata.set(
+							message.commit.revision,
+							message.persistedMetadata,
+						);
+					}
 					break;
 				}
 				case "branch": {
@@ -646,6 +673,7 @@ export class SharedTreeCore<
 				assert(head.revision === revision, 0xc6b /* Can only rollback latest commit */);
 				const newHead = head.parent ?? fail(0xc6c /* must have parent */);
 				branch.removeAfter(newHead);
+				this.persistedCommitMetadata.delete(revision);
 				this.getResubmitMachine(branchId).onCommitRollback(head);
 				break;
 			}
@@ -671,7 +699,13 @@ export class SharedTreeCore<
 				const {
 					commit: { revision, change },
 					branchId,
+					persistedMetadata,
 				} = message;
+				// Restore the metadata attached before the disconnect so that it survives the
+				// pending-state round trip and is re-submitted with the commit.
+				if (persistedMetadata !== undefined) {
+					this.persistedCommitMetadata.set(revision, persistedMetadata);
+				}
 				this.editManager.getLocalBranch(branchId).apply({ change, revision });
 				break;
 			}

--- a/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
+++ b/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
@@ -12,7 +12,7 @@ import type {
 import { assert } from "@fluidframework/core-utils/internal";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
-import { anchorSlot, rootFieldKey } from "../core/index.js";
+import { anchorSlot, rootFieldKey, type RevisionTag } from "../core/index.js";
 import {
 	type NodeIdentifierManager,
 	defaultSchemaPolicy,
@@ -66,6 +66,7 @@ import {
 	breakingClass,
 	disposeSymbol,
 	type JsonCompatibleReadOnly,
+	type JsonCompatibleReadOnlyObject,
 	type WithBreakable,
 } from "../util/index.js";
 
@@ -567,6 +568,12 @@ export class SchematizingSimpleTreeView<
 		context: UntypedTreeViewAlpha,
 	): JsonCompatibleReadOnly | undefined {
 		return this.checkout.computeNetChangeIfRebasedOnto(context);
+	}
+
+	public getPersistedCommitMetadata(
+		revision: RevisionTag,
+	): JsonCompatibleReadOnlyObject | undefined {
+		return this.checkout.getPersistedCommitMetadata(revision);
 	}
 
 	// #endregion Branching

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -322,6 +322,7 @@ export class SharedTreeKernel
 			fieldBatchCodec,
 			removedRoots,
 			chunkCompressionStrategy: options.treeEncodeType,
+			persistedCommitMetadata: this.persistedCommitMetadata,
 		});
 
 		this.registerSharedBranchForEditing("main", this.checkout);
@@ -524,6 +525,7 @@ export const changeFormatVersionForEditManager = DependentFormatVersion.fromPair
 	[EditManagerFormatVersion.v4, SharedTreeChangeFormatVersion.v4],
 	[EditManagerFormatVersion.vSharedBranches, SharedTreeChangeFormatVersion.v4],
 	[EditManagerFormatVersion.v6, SharedTreeChangeFormatVersion.v5],
+	[EditManagerFormatVersion.v7, SharedTreeChangeFormatVersion.v5],
 ]);
 
 /**
@@ -540,6 +542,7 @@ export const changeFormatVersionForMessage = DependentFormatVersion.fromPairs<
 	[MessageFormatVersion.v4, SharedTreeChangeFormatVersion.v4],
 	[MessageFormatVersion.vSharedBranches, SharedTreeChangeFormatVersion.v4],
 	[MessageFormatVersion.v6, SharedTreeChangeFormatVersion.v5],
+	[MessageFormatVersion.v7, SharedTreeChangeFormatVersion.v5],
 ]);
 
 function getCodecTreeForEditManagerFormat(

--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -83,6 +83,7 @@ import {
 	type SharedTreeBranchChange,
 	type SquashingTransactionOptions,
 	type Transactor,
+	PersistedCommitMetadataIndex,
 } from "../shared-tree-core/index.js";
 import {
 	type ImplicitFieldSchema,
@@ -115,6 +116,7 @@ import {
 	hasSome,
 	throwIfBroken,
 	type JsonCompatibleReadOnly,
+	type JsonCompatibleReadOnlyObject,
 	type WithBreakable,
 } from "../util/index.js";
 
@@ -335,6 +337,7 @@ export function createTreeCheckout(
 		removedRoots?: DetachedFieldIndex;
 		chunkCompressionStrategy?: TreeCompressionStrategy;
 		codecOptions?: Partial<CodecWriteOptions>;
+		persistedCommitMetadata?: PersistedCommitMetadataIndex;
 	},
 ): TreeCheckout {
 	const schema = args?.schema ?? new TreeStoredSchemaRepository();
@@ -377,6 +380,7 @@ export function createTreeCheckout(
 		revisionTagCodec,
 		idCompressor,
 		args?.removedRoots,
+		args?.persistedCommitMetadata,
 	);
 }
 
@@ -567,6 +571,16 @@ export class TreeCheckout implements ITreeCheckout {
 	readonly #events = createEmitter<CheckoutEvents>();
 	public events: Listenable<CheckoutEvents> = this.#events;
 
+	/**
+	 * Metadata supplied to the currently running outermost transaction which has not yet been associated with a revision.
+	 */
+	#pendingPersistedMetadata: JsonCompatibleReadOnlyObject | undefined;
+
+	/**
+	 * The revision that {@link TreeCheckout.mintTransactionRevisionTag} associated the pending metadata with, if any.
+	 */
+	#pendingPersistedMetadataRevision: RevisionTag | undefined;
+
 	public constructor(
 		branch: SharedTreeBranch<
 			SharedTreeEditBuilder,
@@ -586,6 +600,13 @@ export class TreeCheckout implements ITreeCheckout {
 		private readonly revisionTagCodec: RevisionTagCodec,
 		private readonly idCompressor: IIdCompressor,
 		private readonly _removedRoots: DetachedFieldIndex = makeDetachedFieldIndex("repair"),
+		/**
+		 * The tree-wide index of persisted commit metadata.
+		 * @remarks
+		 * This is shared with every other checkout of the same tree (including forks), because a transaction run on
+		 * a fork produces a commit that is submitted by whichever branch it is later merged into.
+		 */
+		public readonly persistedCommitMetadata: PersistedCommitMetadataIndex = new PersistedCommitMetadataIndex(),
 		public readonly disposeForksAfterTransaction = true,
 	) {
 		this.#transaction = this.createTransactionStack(branch);
@@ -727,7 +748,7 @@ export class TreeCheckout implements ITreeCheckout {
 		SharedTreeChange,
 		SharedTreeChangeProcessingContext
 	> {
-		return new SquashingTransactionStack(branch, this.mintRevisionTag, () => {
+		return new SquashingTransactionStack(branch, this.mintTransactionRevisionTag, () => {
 			// When each transaction is started, make a restorable checkpoint of the current state of removed roots
 			const restoreRemovedRoots = this._removedRoots.createCheckpoint();
 			return (result, viewUpdate: SharedTreeChange | undefined) => {
@@ -738,6 +759,10 @@ export class TreeCheckout implements ITreeCheckout {
 						if (viewUpdate !== undefined) {
 							this.applyInternalChange(viewUpdate, newHead.revision);
 						}
+						if (this.transaction.size === 0) {
+							// A transaction that is rolled back produces no commit, so its metadata (if any) is discarded.
+							this.discardPendingPersistedMetadata(undefined);
+						}
 						break;
 					}
 					case InternalTransactionResult.Commit: {
@@ -747,6 +772,9 @@ export class TreeCheckout implements ITreeCheckout {
 						if (this.transaction.size === 0) {
 							// The changes in a transaction squash commit have already applied to the checkout and are known to be valid, so we can validate the squash commit automatically.
 							this.validateCommit(newHead);
+							// If the transaction body produced no commit then there is nothing for the metadata to
+							// describe, so it is discarded.
+							this.discardPendingPersistedMetadata(newHead.revision);
 						}
 						break;
 					}
@@ -756,6 +784,39 @@ export class TreeCheckout implements ITreeCheckout {
 				}
 			};
 		});
+	}
+
+	/**
+	 * Mints a revision tag for the transaction stack, associating any metadata supplied for the outermost
+	 * running transaction with the revision of the commit that transaction will produce.
+	 * @remarks
+	 * The transaction stack mints the squash commit's revision lazily, on the first edit made within the
+	 * outermost transaction. Recording the metadata here ensures that it is in the index before the squash
+	 * commit is applied to the branch (which is what triggers submission of the commit).
+	 */
+	private readonly mintTransactionRevisionTag = (): RevisionTag => {
+		const revision = this.mintRevisionTag();
+		if (this.#pendingPersistedMetadata !== undefined) {
+			this.persistedCommitMetadata.set(revision, this.#pendingPersistedMetadata);
+			this.#pendingPersistedMetadata = undefined;
+			this.#pendingPersistedMetadataRevision = revision;
+		}
+		return revision;
+	};
+
+	/**
+	 * Clears the pending metadata state for the outermost transaction that just ended, removing the index entry
+	 * unless it belongs to `committedRevision`.
+	 */
+	private discardPendingPersistedMetadata(committedRevision: RevisionTag | undefined): void {
+		if (
+			this.#pendingPersistedMetadataRevision !== undefined &&
+			this.#pendingPersistedMetadataRevision !== committedRevision
+		) {
+			this.persistedCommitMetadata.delete(this.#pendingPersistedMetadataRevision);
+		}
+		this.#pendingPersistedMetadata = undefined;
+		this.#pendingPersistedMetadataRevision = undefined;
 	}
 
 	@throwIfBroken
@@ -863,6 +924,7 @@ export class TreeCheckout implements ITreeCheckout {
 				const metadata: ChangeMetadata = {
 					kind,
 					isLocal: true,
+					revision,
 					getChange: () => {
 						assert(
 							commit.parent !== undefined,
@@ -976,6 +1038,12 @@ export class TreeCheckout implements ITreeCheckout {
 		return this.isView();
 	}
 
+	public getPersistedCommitMetadata(
+		revision: RevisionTag,
+	): JsonCompatibleReadOnlyObject | undefined {
+		return this.persistedCommitMetadata.get(revision);
+	}
+
 	public isView(): this is UntypedTreeViewAlpha {
 		return true;
 	}
@@ -1049,6 +1117,12 @@ export class TreeCheckout implements ITreeCheckout {
 			);
 		}
 		this.pushLabelFrame(params?.label);
+		if (this.transaction.size === 0) {
+			// Metadata supplied to a nested transaction is ignored: the outermost transaction is the one that
+			// produces the commit which the metadata describes.
+			this.#pendingPersistedMetadata = params?.persistedMetadata;
+			this.#pendingPersistedMetadataRevision = undefined;
+		}
 		this.transaction.start({
 			postProcessor: extractTransactionChangeProcessor(params?.postProcessor),
 		});
@@ -1326,6 +1400,9 @@ export class TreeCheckout implements ITreeCheckout {
 			this.revisionTagCodec,
 			this.idCompressor,
 			this._removedRoots.clone(),
+			// Forks share the tree's metadata index: a transaction run on a fork is submitted when that
+			// fork is merged into a branch that submits, and the lookup there is by revision.
+			this.persistedCommitMetadata,
 		);
 		this.#events.emit("fork", checkout);
 		return checkout;

--- a/packages/dds/tree/src/simple-tree/api/transactionTypes.ts
+++ b/packages/dds/tree/src/simple-tree/api/transactionTypes.ts
@@ -5,6 +5,7 @@
 
 import type { ErasedType } from "@fluidframework/core-interfaces";
 
+import type { JsonCompatibleReadOnlyObject } from "../../util/index.js";
 import type { TreeNode } from "../core/index.js";
 
 /**
@@ -218,4 +219,27 @@ export interface RunTransactionParamsAlpha extends RunTransactionParamsBeta {
 	 * reserving the behavior; a real post-processor will be provided in a future change.
 	 */
 	readonly postProcessor?: TransactionPostProcessor;
+
+	/**
+	 * Optional application-defined metadata to attach to the commit produced by this transaction.
+	 * @remarks
+	 * The metadata is replicated to all collaborating clients and persisted in the document alongside the commit,
+	 * and can be read back via `UntypedTreeViewAlpha.getPersistedCommitMetadata`.
+	 *
+	 * It shares the lifetime of the commit it is attached to: once that commit is trimmed from the trunk, the
+	 * metadata goes with it. Under the default trunk eviction policy that is the width of the collaboration window.
+	 *
+	 * The value must be JSON-serializable, since it round-trips through the persisted format. It travels on every
+	 * annotated op and occupies space in the summary for as long as its commit survives, so it should be kept small.
+	 *
+	 * If there is a nested transaction, only the outermost transaction's metadata is used.
+	 *
+	 * A transaction that produces no commit (because its body made no changes, or because it was rolled back) has no
+	 * commit to annotate, and its metadata is discarded without error.
+	 *
+	 * Metadata is only written to the document once `minVersionForCollab` is at least 3.0.0; with an older
+	 * configured value the metadata is dropped rather than persisted, so that a document never contains metadata
+	 * that a collaborating client would fail to preserve.
+	 */
+	readonly persistedMetadata?: JsonCompatibleReadOnlyObject;
 }

--- a/packages/dds/tree/src/simple-tree/api/tree.ts
+++ b/packages/dds/tree/src/simple-tree/api/tree.ts
@@ -10,6 +10,7 @@ import type {
 	CommitMetadata,
 	RevertibleAlphaFactory,
 	RevertibleFactory,
+	RevisionTag,
 } from "../../core/index.js";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars -- This is referenced by doc comments.
 import type { TreeStatus } from "../../feature-libraries/index.js";
@@ -17,7 +18,10 @@ import type {
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars, unused-imports/no-unused-imports -- This is referenced by doc comments.
 	TreeAlpha,
 } from "../../shared-tree/index.js";
-import type { JsonCompatibleReadOnly } from "../../util/index.js";
+import type {
+	JsonCompatibleReadOnly,
+	JsonCompatibleReadOnlyObject,
+} from "../../util/index.js";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars -- This is referenced by doc comments.
 import type { Unhydrated } from "../core/index.js";
 import type {
@@ -413,6 +417,21 @@ export interface UntypedTreeViewAlpha extends UntypedTreeView, TreeContextAlpha 
 	 * or `undefined` if rebasing would have no impact.
 	 */
 	computeNetChangeIfRebasedOnto(view: UntypedTreeView): JsonCompatibleReadOnly | undefined;
+
+	/**
+	 * Looks up the {@link RunTransactionParamsAlpha.persistedMetadata | persisted metadata} associated with a commit.
+	 *
+	 * @param revision - The revision of the commit to look up.
+	 * Revisions are provided to applications by the change events on this view.
+	 *
+	 * @returns The metadata that was supplied to the transaction which produced the commit, or `undefined` if the
+	 * commit was not annotated, predates this feature, or has been trimmed from the trunk.
+	 *
+	 * @remarks
+	 * Metadata shares the lifetime of the commit it is attached to: once the commit is trimmed from the trunk,
+	 * the metadata goes with it. Every read path must therefore handle `undefined`.
+	 */
+	getPersistedCommitMetadata(revision: RevisionTag): JsonCompatibleReadOnlyObject | undefined;
 }
 
 /**

--- a/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerCodecs.test.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerCodecs.test.ts
@@ -219,6 +219,7 @@ export function testCodec(): void {
 			EditManagerFormatVersion.v3,
 			EditManagerFormatVersion.v4,
 			EditManagerFormatVersion.v6,
+			EditManagerFormatVersion.v7,
 		]);
 		makeDiscontinuedEncodingTestSuite(family, [
 			EditManagerFormatVersion.v1,

--- a/packages/dds/tree/src/test/shared-tree-core/messageCodec.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/messageCodec.spec.ts
@@ -157,6 +157,7 @@ describe("message codec", () => {
 		MessageFormatVersion.v3,
 		MessageFormatVersion.v4,
 		MessageFormatVersion.v6,
+		MessageFormatVersion.v7,
 		MessageFormatVersion.vSharedBranches,
 	]);
 	makeDiscontinuedEncodingTestSuite(family, [

--- a/packages/dds/tree/src/test/shared-tree/persistedCommitMetadata.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/persistedCommitMetadata.spec.ts
@@ -1,0 +1,280 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "node:assert";
+
+import type { IChannelFactory } from "@fluidframework/datastore-definitions/internal";
+
+import { asAlpha } from "../../api.js";
+import { FluidClientVersion } from "../../codec/index.js";
+import type { RevisionTag } from "../../core/index.js";
+import { FormatValidatorBasic } from "../../external-utilities/index.js";
+import { PersistedCommitMetadataIndex } from "../../shared-tree-core/index.js";
+import {
+	TreeViewConfiguration,
+	type ITree,
+	type TreeViewAlpha,
+} from "../../simple-tree/index.js";
+import { configuredSharedTree } from "../../treeFactory.js";
+import { StringArray, TestTreeProviderLite, mintRevisionTag } from "../utils.js";
+
+/**
+ * A tree kind configured to write the format versions which carry persisted commit metadata.
+ */
+function metadataEnabledFactory(): IChannelFactory<ITree> {
+	return configuredSharedTree({
+		jsonValidator: FormatValidatorBasic,
+		minVersionForCollab: FluidClientVersion.v3_0,
+	}).getFactory();
+}
+
+const config = new TreeViewConfiguration({
+	schema: StringArray,
+	enableSchemaValidation: true,
+});
+
+/**
+ * Subscribes to `view` and records the revision of each local commit it produces.
+ */
+function trackLocalRevisions(view: TreeViewAlpha<typeof StringArray>): {
+	readonly revisions: RevisionTag[];
+	off: () => void;
+} {
+	const revisions: RevisionTag[] = [];
+	const off = view.events.on("changed", (data) => {
+		if (data.isLocal) {
+			revisions.push(data.revision);
+		}
+	});
+	return { revisions, off };
+}
+
+/**
+ * Runs `edit` inside a transaction annotated with `metadata` and returns the revision of the
+ * commit that the transaction produced, or `undefined` if it produced no commit.
+ */
+function runAnnotatedTransaction(
+	view: TreeViewAlpha<typeof StringArray>,
+	metadata: { readonly [key: string]: string } | undefined,
+	edit: () => void,
+): RevisionTag | undefined {
+	const tracker = trackLocalRevisions(view);
+	try {
+		view.runTransaction(edit, { persistedMetadata: metadata });
+	} finally {
+		tracker.off();
+	}
+	return tracker.revisions[tracker.revisions.length - 1];
+}
+
+describe("persisted commit metadata", () => {
+	describe("PersistedCommitMetadataIndex", () => {
+		it("stores, reads and removes entries by revision", () => {
+			const index = new PersistedCommitMetadataIndex();
+			const a = mintRevisionTag();
+			const b = mintRevisionTag();
+			assert.equal(index.get(a), undefined);
+			index.set(a, { x: "1" });
+			index.set(b, { x: "2" });
+			assert.deepEqual(index.get(a), { x: "1" });
+			assert.equal(index.size, 2);
+			index.delete(a);
+			assert.equal(index.get(a), undefined);
+			index.deleteAll([b]);
+			assert.equal(index.size, 0);
+		});
+	});
+
+	it("is readable on the local client immediately", () => {
+		const provider = new TestTreeProviderLite(1, metadataEnabledFactory());
+		const view = asAlpha(provider.trees[0].viewWith(config));
+		view.initialize(["A"]);
+
+		const revision = runAnnotatedTransaction(view, { note: "insert B" }, () => {
+			view.root.insertAt(1, "B");
+		});
+
+		assert(revision !== undefined);
+		assert.deepEqual(view.getPersistedCommitMetadata(revision), { note: "insert B" });
+	});
+
+	it("is undefined for un-annotated commits", () => {
+		const provider = new TestTreeProviderLite(1, metadataEnabledFactory());
+		const view = asAlpha(provider.trees[0].viewWith(config));
+		view.initialize(["A"]);
+
+		const revision = runAnnotatedTransaction(view, undefined, () => {
+			view.root.insertAt(1, "B");
+		});
+
+		assert(revision !== undefined);
+		assert.equal(view.getPersistedCommitMetadata(revision), undefined);
+	});
+
+	it("replicates to a peer", () => {
+		const provider = new TestTreeProviderLite(2, metadataEnabledFactory());
+		const view1 = asAlpha(provider.trees[0].viewWith(config));
+		view1.initialize(["A"]);
+		provider.synchronizeMessages();
+		const view2 = asAlpha(provider.trees[1].viewWith(config));
+
+		const revision = runAnnotatedTransaction(view1, { note: "from peer 1" }, () => {
+			view1.root.insertAt(1, "B");
+		});
+		provider.synchronizeMessages();
+
+		assert(revision !== undefined);
+		assert.deepEqual(view2.getPersistedCommitMetadata(revision), { note: "from peer 1" });
+	});
+
+	it("survives rebase over a concurrent remote commit", () => {
+		const provider = new TestTreeProviderLite(2, metadataEnabledFactory());
+		const view1 = asAlpha(provider.trees[0].viewWith(config));
+		view1.initialize(["A"]);
+		provider.synchronizeMessages();
+		const view2 = asAlpha(provider.trees[1].viewWith(config));
+
+		// Annotate a local commit on tree 1...
+		const revision = runAnnotatedTransaction(view1, { note: "local" }, () => {
+			view1.root.insertAt(1, "B");
+		});
+		// ...then sequence a concurrent commit from tree 2 ahead of it.
+		view2.runTransaction(() => {
+			view2.root.insertAt(0, "Z");
+		});
+		provider.synchronizeMessages();
+
+		assert(revision !== undefined);
+		// The revision tag is stable across rebase, so the metadata is still found.
+		assert.deepEqual(view1.getPersistedCommitMetadata(revision), { note: "local" });
+		assert.deepEqual(view2.getPersistedCommitMetadata(revision), { note: "local" });
+	});
+
+	it("is not written to the wire when minVersionForCollab is too old", () => {
+		const provider = new TestTreeProviderLite(
+			2,
+			configuredSharedTree({
+				jsonValidator: FormatValidatorBasic,
+				minVersionForCollab: FluidClientVersion.v2_80,
+			}).getFactory(),
+		);
+		const view1 = asAlpha(provider.trees[0].viewWith(config));
+		view1.initialize(["A"]);
+		provider.synchronizeMessages();
+		const view2 = asAlpha(provider.trees[1].viewWith(config));
+
+		const revision = runAnnotatedTransaction(view1, { note: "dropped" }, () => {
+			view1.root.insertAt(1, "B");
+		});
+		provider.synchronizeMessages();
+
+		assert(revision !== undefined);
+		// The local client still has its own in-memory record...
+		assert.deepEqual(view1.getPersistedCommitMetadata(revision), { note: "dropped" });
+		// ...but nothing was written to the wire, so the peer has none.
+		assert.equal(view2.getPersistedCommitMetadata(revision), undefined);
+	});
+
+	describe("transactions", () => {
+		it("resolve to the outermost transaction's metadata when nested", () => {
+			const provider = new TestTreeProviderLite(1, metadataEnabledFactory());
+			const view = asAlpha(provider.trees[0].viewWith(config));
+			view.initialize(["A"]);
+
+			const tracker = trackLocalRevisions(view);
+			view.runTransaction(
+				() => {
+					view.runTransaction(
+						() => {
+							view.root.insertAt(1, "B");
+						},
+						{ persistedMetadata: { note: "inner" } },
+					);
+				},
+				{ persistedMetadata: { note: "outer" } },
+			);
+			tracker.off();
+
+			const revision = tracker.revisions[tracker.revisions.length - 1];
+			assert(revision !== undefined);
+			assert.deepEqual(view.getPersistedCommitMetadata(revision), { note: "outer" });
+		});
+
+		it("discard metadata when the body makes no changes", () => {
+			const provider = new TestTreeProviderLite(1, metadataEnabledFactory());
+			const view = asAlpha(provider.trees[0].viewWith(config));
+			view.initialize(["A"]);
+
+			const tracker = trackLocalRevisions(view);
+			// No commit is produced, so there is nothing for the metadata to describe.
+			// This must not throw.
+			view.runTransaction(() => {}, { persistedMetadata: { note: "no-op" } });
+			tracker.off();
+
+			assert.equal(tracker.revisions.length, 0);
+			assert.deepEqual([...view.root], ["A"]);
+		});
+
+		it("discard metadata when explicitly rolled back", () => {
+			const provider = new TestTreeProviderLite(1, metadataEnabledFactory());
+			const view = asAlpha(provider.trees[0].viewWith(config));
+			view.initialize(["A"]);
+
+			const tracker = trackLocalRevisions(view);
+			// A rolled back transaction produces no commit. This must not throw.
+			view.runTransaction(
+				() => {
+					view.root.insertAt(1, "B");
+					return { rollback: true };
+				},
+				{ persistedMetadata: { note: "rolled back" } },
+			);
+			tracker.off();
+
+			assert.deepEqual([...view.root], ["A"]);
+			for (const revision of tracker.revisions) {
+				assert.equal(view.getPersistedCommitMetadata(revision), undefined);
+			}
+		});
+	});
+
+	describe("branches", () => {
+		it("recorded on a fork is readable after the fork is merged", () => {
+			const provider = new TestTreeProviderLite(2, metadataEnabledFactory());
+			const view1 = asAlpha(provider.trees[0].viewWith(config));
+			view1.initialize(["A"]);
+			provider.synchronizeMessages();
+			const view2 = asAlpha(provider.trees[1].viewWith(config));
+
+			const fork = view1.fork();
+			const revision = runAnnotatedTransaction(fork, { note: "on fork" }, () => {
+				fork.root.insertAt(1, "B");
+			});
+			assert(revision !== undefined);
+			assert.deepEqual(fork.getPersistedCommitMetadata(revision), { note: "on fork" });
+
+			view1.merge(fork);
+			assert.deepEqual(view1.getPersistedCommitMetadata(revision), { note: "on fork" });
+
+			provider.synchronizeMessages();
+			assert.deepEqual(view2.getPersistedCommitMetadata(revision), { note: "on fork" });
+		});
+
+		it("recorded on a fork survives disposal of that fork", () => {
+			const provider = new TestTreeProviderLite(1, metadataEnabledFactory());
+			const view1 = asAlpha(provider.trees[0].viewWith(config));
+			view1.initialize(["A"]);
+
+			const fork = view1.fork();
+			const revision = runAnnotatedTransaction(fork, { note: "on fork" }, () => {
+				fork.root.insertAt(1, "B");
+			});
+			assert(revision !== undefined);
+			view1.merge(fork, true /* disposeView */);
+
+			assert.deepEqual(view1.getPersistedCommitMetadata(revision), { note: "on fork" });
+		});
+	});
+});

--- a/packages/dds/tree/src/test/shared-tree/summary-load-snapshots/singleTree-Compressed-v3_0-1.json
+++ b/packages/dds/tree/src/test/shared-tree/summary-load-snapshots/singleTree-Compressed-v3_0-1.json
@@ -1,0 +1,66 @@
+{
+	"type": 1,
+	"tree": {
+		".metadata": {
+			"type": 2,
+			"content": "{\"version\":2}"
+		},
+		"indexes": {
+			"type": 1,
+			"tree": {
+				"EditManager": {
+					"type": 1,
+					"tree": {
+						".metadata": {
+							"type": 2,
+							"content": "{\"version\":2}"
+						},
+						"String": {
+							"type": 2,
+							"content": "{\"trunk\":[],\"branches\":[],\"version\":7}"
+						}
+					}
+				},
+				"Schema": {
+					"type": 1,
+					"tree": {
+						".metadata": {
+							"type": 2,
+							"content": "{\"version\":2}"
+						},
+						"SchemaString": {
+							"type": 2,
+							"content": "{\"version\":2,\"nodes\":{\"com.fluidframework.leaf.number\":{\"kind\":{\"leaf\":0}},\"com.fluidframework.leaf.string\":{\"kind\":{\"leaf\":1}},\"test schema.child\":{\"kind\":{\"object\":{\"count\":{\"kind\":\"Value\",\"types\":[\"com.fluidframework.leaf.number\"]}}}},\"test schema.nodes\":{\"kind\":{\"object\":{\"\":{\"kind\":\"Sequence\",\"types\":[\"test schema.child\"]}}}},\"test schema.parent\":{\"kind\":{\"object\":{\"child\":{\"kind\":\"Value\",\"types\":[\"test schema.nodes\"]},\"label\":{\"kind\":\"Value\",\"types\":[\"com.fluidframework.leaf.string\"]}}}}},\"root\":{\"kind\":\"Value\",\"types\":[\"test schema.parent\"]}}"
+						}
+					}
+				},
+				"Forest": {
+					"type": 1,
+					"tree": {
+						".metadata": {
+							"type": 2,
+							"content": "{\"version\":3}"
+						},
+						"contents": {
+							"type": 2,
+							"content": "{\"keys\":[\"rootFieldKey\"],\"fields\":{\"version\":2,\"identifiers\":[],\"shapes\":[{\"c\":{\"type\":\"test schema.parent\",\"value\":false,\"fields\":[[\"label\",1],[\"child\",2]]}},{\"c\":{\"type\":\"com.fluidframework.leaf.string\",\"value\":true}},{\"c\":{\"type\":\"test schema.nodes\",\"value\":false,\"fields\":[[\"\",3]]}},{\"a\":4},{\"c\":{\"type\":\"test schema.child\",\"value\":false,\"fields\":[[\"count\",5]]}},{\"c\":{\"type\":\"com.fluidframework.leaf.number\",\"value\":true}}],\"data\":[[0,\"foo\",[1,2]]]},\"version\":2}"
+						}
+					}
+				},
+				"DetachedFieldIndex": {
+					"type": 1,
+					"tree": {
+						".metadata": {
+							"type": 2,
+							"content": "{\"version\":2}"
+						},
+						"DetachedFieldIndexBlob": {
+							"type": 2,
+							"content": "{\"version\":2,\"data\":[],\"maxId\":4}"
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/packages/dds/tree/src/test/shared-tree/summary-load-snapshots/singleTree-Uncompressed-v3_0-1.json
+++ b/packages/dds/tree/src/test/shared-tree/summary-load-snapshots/singleTree-Uncompressed-v3_0-1.json
@@ -1,0 +1,66 @@
+{
+	"type": 1,
+	"tree": {
+		".metadata": {
+			"type": 2,
+			"content": "{\"version\":2}"
+		},
+		"indexes": {
+			"type": 1,
+			"tree": {
+				"EditManager": {
+					"type": 1,
+					"tree": {
+						".metadata": {
+							"type": 2,
+							"content": "{\"version\":2}"
+						},
+						"String": {
+							"type": 2,
+							"content": "{\"trunk\":[],\"branches\":[],\"version\":7}"
+						}
+					}
+				},
+				"Schema": {
+					"type": 1,
+					"tree": {
+						".metadata": {
+							"type": 2,
+							"content": "{\"version\":2}"
+						},
+						"SchemaString": {
+							"type": 2,
+							"content": "{\"version\":2,\"nodes\":{\"com.fluidframework.leaf.number\":{\"kind\":{\"leaf\":0}},\"com.fluidframework.leaf.string\":{\"kind\":{\"leaf\":1}},\"test schema.child\":{\"kind\":{\"object\":{\"count\":{\"kind\":\"Value\",\"types\":[\"com.fluidframework.leaf.number\"]}}}},\"test schema.nodes\":{\"kind\":{\"object\":{\"\":{\"kind\":\"Sequence\",\"types\":[\"test schema.child\"]}}}},\"test schema.parent\":{\"kind\":{\"object\":{\"child\":{\"kind\":\"Value\",\"types\":[\"test schema.nodes\"]},\"label\":{\"kind\":\"Value\",\"types\":[\"com.fluidframework.leaf.string\"]}}}}},\"root\":{\"kind\":\"Value\",\"types\":[\"test schema.parent\"]}}"
+						}
+					}
+				},
+				"Forest": {
+					"type": 1,
+					"tree": {
+						".metadata": {
+							"type": 2,
+							"content": "{\"version\":3}"
+						},
+						"contents": {
+							"type": 2,
+							"content": "{\"keys\":[\"rootFieldKey\"],\"fields\":{\"version\":2,\"identifiers\":[],\"shapes\":[{\"c\":{\"extraFields\":1}},{\"a\":0}],\"data\":[[1,[\"test schema.parent\",false,[\"child\",[\"test schema.nodes\",false,[\"\",[\"test schema.child\",false,[\"count\",[\"com.fluidframework.leaf.number\",true,1,[]]],\"test schema.child\",false,[\"count\",[\"com.fluidframework.leaf.number\",true,2,[]]]]]],\"label\",[\"com.fluidframework.leaf.string\",true,\"foo\",[]]]]]]},\"version\":2}"
+						}
+					}
+				},
+				"DetachedFieldIndex": {
+					"type": 1,
+					"tree": {
+						".metadata": {
+							"type": 2,
+							"content": "{\"version\":2}"
+						},
+						"DetachedFieldIndexBlob": {
+							"type": 2,
+							"content": "{\"version\":2,\"data\":[],\"maxId\":4}"
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/packages/dds/tree/src/test/snapshots/output/codec-tree/MinVersionForCollab.v3_0.json
+++ b/packages/dds/tree/src/test/snapshots/output/codec-tree/MinVersionForCollab.v3_0.json
@@ -1,0 +1,106 @@
+{
+  "name": "SharedTree",
+  "version": "null",
+  "children": [
+    {
+      "name": "Forest",
+      "version": 2
+    },
+    {
+      "name": "Schema",
+      "version": 2
+    },
+    {
+      "name": "DetachedFieldIndex",
+      "version": 2
+    },
+    {
+      "name": "EditManager",
+      "version": 7,
+      "children": [
+        {
+          "name": "SharedTreeChange",
+          "version": 5,
+          "children": [
+            {
+              "name": "ModularChange",
+              "version": 5,
+              "children": [
+                {
+                  "name": "FieldKind:Value",
+                  "version": 2
+                },
+                {
+                  "name": "FieldKind:Optional",
+                  "version": 2
+                },
+                {
+                  "name": "FieldKind:Sequence",
+                  "version": 3
+                },
+                {
+                  "name": "FieldKind:Forbidden",
+                  "version": 1
+                },
+                {
+                  "name": "FieldKind:Identifier",
+                  "version": 1
+                }
+              ]
+            },
+            {
+              "name": "Schema",
+              "version": 2
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Message",
+      "version": 7,
+      "children": [
+        {
+          "name": "SharedTreeChange",
+          "version": 5,
+          "children": [
+            {
+              "name": "ModularChange",
+              "version": 5,
+              "children": [
+                {
+                  "name": "FieldKind:Value",
+                  "version": 2
+                },
+                {
+                  "name": "FieldKind:Optional",
+                  "version": 2
+                },
+                {
+                  "name": "FieldKind:Sequence",
+                  "version": 3
+                },
+                {
+                  "name": "FieldKind:Forbidden",
+                  "version": 1
+                },
+                {
+                  "name": "FieldKind:Identifier",
+                  "version": 1
+                }
+              ]
+            },
+            {
+              "name": "Schema",
+              "version": 2
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "FieldBatch",
+      "version": 2
+    }
+  ]
+}

--- a/packages/dds/tree/src/test/snapshots/output/op-format/v3_0/field change.json
+++ b/packages/dds/tree/src/test/snapshots/output/op-format/v3_0/field change.json
@@ -1,0 +1,70 @@
+[
+  {
+    "revision": -2,
+    "originatorId": "00000000-0000-4000-b000-000000000000",
+    "changeset": [
+      {
+        "data": {
+          "maxId": 2,
+          "changes": [
+            {
+              "fieldKey": "rootFieldKey",
+              "fieldKind": "ModularEditBuilder.Generic",
+              "change": [
+                [
+                  0,
+                  {
+                    "fieldChanges": [
+                      {
+                        "fieldKey": "x",
+                        "fieldKind": "Value",
+                        "change": {
+                          "r": {
+                            "e": false,
+                            "d": 1,
+                            "s": 0
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
+              ]
+            }
+          ],
+          "builds": {
+            "builds": [
+              [
+                [
+                  [
+                    0,
+                    0
+                  ]
+                ]
+              ]
+            ],
+            "trees": {
+              "version": 2,
+              "identifiers": [],
+              "shapes": [
+                {
+                  "c": {
+                    "type": "com.fluidframework.leaf.number",
+                    "value": true
+                  }
+                }
+              ],
+              "data": [
+                [
+                  0,
+                  1
+                ]
+              ]
+            }
+          }
+        }
+      }
+    ],
+    "version": 7
+  }
+]

--- a/packages/dds/tree/src/test/snapshots/output/op-format/v3_0/schema change.json
+++ b/packages/dds/tree/src/test/snapshots/output/op-format/v3_0/schema change.json
@@ -1,0 +1,192 @@
+[
+  {
+    "revision": -1,
+    "originatorId": "00000000-0000-4000-b000-000000000000",
+    "changeset": [
+      {
+        "schema": {
+          "new": {
+            "version": 2,
+            "nodes": {
+              "com.fluidframework.leaf.number": {
+                "kind": {
+                  "leaf": 0
+                }
+              },
+              "snapshots.Point": {
+                "kind": {
+                  "object": {
+                    "x": {
+                      "kind": "Value",
+                      "types": [
+                        "com.fluidframework.leaf.number"
+                      ]
+                    },
+                    "y": {
+                      "kind": "Value",
+                      "types": [
+                        "com.fluidframework.leaf.number"
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "root": {
+              "kind": "Optional",
+              "types": [
+                "snapshots.Point"
+              ]
+            }
+          },
+          "old": {
+            "version": 2,
+            "nodes": {},
+            "root": {
+              "kind": "Forbidden",
+              "types": []
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "maxId": 1,
+          "changes": [
+            {
+              "fieldKey": "rootFieldKey",
+              "fieldKind": "Optional",
+              "change": {
+                "r": {
+                  "e": true,
+                  "d": 0,
+                  "s": 1
+                }
+              }
+            }
+          ],
+          "builds": {
+            "builds": [
+              [
+                [
+                  [
+                    1,
+                    0
+                  ]
+                ]
+              ]
+            ],
+            "trees": {
+              "version": 2,
+              "identifiers": [],
+              "shapes": [
+                {
+                  "c": {
+                    "type": "com.fluidframework.leaf.number",
+                    "value": true
+                  }
+                },
+                {
+                  "c": {
+                    "type": "snapshots.Point",
+                    "value": false,
+                    "fields": [
+                      [
+                        "x",
+                        0
+                      ],
+                      [
+                        "y",
+                        0
+                      ]
+                    ]
+                  }
+                }
+              ],
+              "data": [
+                [
+                  1,
+                  0,
+                  0
+                ]
+              ]
+            }
+          }
+        }
+      },
+      {
+        "schema": {
+          "new": {
+            "version": 2,
+            "nodes": {
+              "com.fluidframework.leaf.number": {
+                "kind": {
+                  "leaf": 0
+                }
+              },
+              "snapshots.Point": {
+                "kind": {
+                  "object": {
+                    "x": {
+                      "kind": "Value",
+                      "types": [
+                        "com.fluidframework.leaf.number"
+                      ]
+                    },
+                    "y": {
+                      "kind": "Value",
+                      "types": [
+                        "com.fluidframework.leaf.number"
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "root": {
+              "kind": "Value",
+              "types": [
+                "snapshots.Point"
+              ]
+            }
+          },
+          "old": {
+            "version": 2,
+            "nodes": {
+              "com.fluidframework.leaf.number": {
+                "kind": {
+                  "leaf": 0
+                }
+              },
+              "snapshots.Point": {
+                "kind": {
+                  "object": {
+                    "x": {
+                      "kind": "Value",
+                      "types": [
+                        "com.fluidframework.leaf.number"
+                      ]
+                    },
+                    "y": {
+                      "kind": "Value",
+                      "types": [
+                        "com.fluidframework.leaf.number"
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "root": {
+              "kind": "Optional",
+              "types": [
+                "snapshots.Point"
+              ]
+            }
+          }
+        }
+      }
+    ],
+    "version": 7
+  }
+]

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v3_0/attachment-tree-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v3_0/attachment-tree-final.json
@@ -1,0 +1,203 @@
+{
+  "type": "tree",
+  "entries": [
+    {
+      "type": "blob",
+      ".metadata": {
+        "type": "blob",
+        "content": {
+          "version": 2
+        },
+        "encoding": "utf-8"
+      }
+    },
+    {
+      "type": "tree",
+      "indexes": {
+        "type": "tree",
+        "entries": [
+          {
+            "type": "tree",
+            "EditManager": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "String": {
+                    "type": "blob",
+                    "content": {
+                      "trunk": [],
+                      "branches": [],
+                      "version": 7
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Schema": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "SchemaString": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "nodes": {
+                        "attachment-tree.Array<[\"com.fluidframework.leaf.string\"]>": {
+                          "kind": {
+                            "object": {
+                              "": {
+                                "kind": "Sequence",
+                                "types": [
+                                  "com.fluidframework.leaf.string"
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        "com.fluidframework.leaf.string": {
+                          "kind": {
+                            "leaf": 1
+                          }
+                        }
+                      },
+                      "root": {
+                        "kind": "Value",
+                        "types": [
+                          "attachment-tree.Array<[\"com.fluidframework.leaf.string\"]>"
+                        ]
+                      }
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Forest": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 3
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "contents": {
+                    "type": "blob",
+                    "content": {
+                      "keys": [
+                        "rootFieldKey"
+                      ],
+                      "fields": {
+                        "version": 2,
+                        "identifiers": [],
+                        "shapes": [
+                          {
+                            "c": {
+                              "type": "attachment-tree.Array<[\"com.fluidframework.leaf.string\"]>",
+                              "value": false,
+                              "fields": [
+                                [
+                                  "",
+                                  1
+                                ]
+                              ]
+                            }
+                          },
+                          {
+                            "a": 2
+                          },
+                          {
+                            "c": {
+                              "type": "com.fluidframework.leaf.string",
+                              "value": true
+                            }
+                          }
+                        ],
+                        "data": [
+                          [
+                            0,
+                            [
+                              "a",
+                              "b"
+                            ]
+                          ]
+                        ]
+                      },
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "DetachedFieldIndex": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "DetachedFieldIndexBlob": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "data": [],
+                      "maxId": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v3_0/competing-removes-index-0.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v3_0/competing-removes-index-0.json
@@ -1,0 +1,444 @@
+{
+  "type": "tree",
+  "entries": [
+    {
+      "type": "blob",
+      ".metadata": {
+        "type": "blob",
+        "content": {
+          "version": 2
+        },
+        "encoding": "utf-8"
+      }
+    },
+    {
+      "type": "tree",
+      "indexes": {
+        "type": "tree",
+        "entries": [
+          {
+            "type": "tree",
+            "EditManager": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "String": {
+                    "type": "blob",
+                    "content": {
+                      "trunk": [
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 1,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "",
+                                              "fieldKind": "Sequence",
+                                              "change": [
+                                                {
+                                                  "count": 1,
+                                                  "effect": {
+                                                    "remove": {
+                                                      "id": 0
+                                                    }
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          ],
+                          "revision": 1,
+                          "sequenceNumber": 4,
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                        },
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 1,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "",
+                                              "fieldKind": "Sequence",
+                                              "change": [
+                                                {
+                                                  "count": 1,
+                                                  "effect": {
+                                                    "remove": {
+                                                      "id": 0
+                                                    }
+                                                  },
+                                                  "cellId": [
+                                                    0,
+                                                    1
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          ],
+                          "revision": 513,
+                          "sequenceNumber": 6,
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                        },
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 1,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "",
+                                              "fieldKind": "Sequence",
+                                              "change": [
+                                                {
+                                                  "count": 1,
+                                                  "effect": {
+                                                    "remove": {
+                                                      "id": 0
+                                                    }
+                                                  },
+                                                  "cellId": [
+                                                    0,
+                                                    513
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          ],
+                          "revision": 1026,
+                          "sequenceNumber": 8,
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                        }
+                      ],
+                      "branches": [
+                        [
+                          "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          {
+                            "base": "root",
+                            "commits": [
+                              {
+                                "change": [
+                                  {
+                                    "data": {
+                                      "maxId": 1,
+                                      "changes": [
+                                        {
+                                          "fieldKey": "rootFieldKey",
+                                          "fieldKind": "ModularEditBuilder.Generic",
+                                          "change": [
+                                            [
+                                              0,
+                                              {
+                                                "fieldChanges": [
+                                                  {
+                                                    "fieldKey": "",
+                                                    "fieldKind": "Sequence",
+                                                    "change": [
+                                                      {
+                                                        "count": 1,
+                                                        "effect": {
+                                                          "remove": {
+                                                            "id": 0
+                                                          }
+                                                        }
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ],
+                                "revision": 513,
+                                "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                              }
+                            ]
+                          }
+                        ],
+                        [
+                          "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          {
+                            "base": "root",
+                            "commits": [
+                              {
+                                "change": [
+                                  {
+                                    "data": {
+                                      "maxId": 1,
+                                      "changes": [
+                                        {
+                                          "fieldKey": "rootFieldKey",
+                                          "fieldKind": "ModularEditBuilder.Generic",
+                                          "change": [
+                                            [
+                                              0,
+                                              {
+                                                "fieldChanges": [
+                                                  {
+                                                    "fieldKey": "",
+                                                    "fieldKind": "Sequence",
+                                                    "change": [
+                                                      {
+                                                        "count": 1,
+                                                        "effect": {
+                                                          "remove": {
+                                                            "id": 0
+                                                          }
+                                                        }
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ],
+                                "revision": 1026,
+                                "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                              }
+                            ]
+                          }
+                        ]
+                      ],
+                      "version": 7
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Schema": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "SchemaString": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "nodes": {
+                        "com.fluidframework.leaf.number": {
+                          "kind": {
+                            "leaf": 0
+                          }
+                        },
+                        "competing-removes.Array<[\"com.fluidframework.leaf.number\"]>": {
+                          "kind": {
+                            "object": {
+                              "": {
+                                "kind": "Sequence",
+                                "types": [
+                                  "com.fluidframework.leaf.number"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "root": {
+                        "kind": "Value",
+                        "types": [
+                          "competing-removes.Array<[\"com.fluidframework.leaf.number\"]>"
+                        ]
+                      }
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Forest": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 3
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "contents": {
+                    "type": "blob",
+                    "content": {
+                      "keys": [
+                        "rootFieldKey",
+                        "repair-3"
+                      ],
+                      "fields": {
+                        "version": 2,
+                        "identifiers": [],
+                        "shapes": [
+                          {
+                            "c": {
+                              "type": "com.fluidframework.leaf.number",
+                              "value": true
+                            }
+                          },
+                          {
+                            "c": {
+                              "type": "competing-removes.Array<[\"com.fluidframework.leaf.number\"]>",
+                              "value": false,
+                              "fields": [
+                                [
+                                  "",
+                                  2
+                                ]
+                              ]
+                            }
+                          },
+                          {
+                            "a": 0
+                          }
+                        ],
+                        "data": [
+                          [
+                            1,
+                            [
+                              1,
+                              2,
+                              3
+                            ]
+                          ],
+                          [
+                            0,
+                            0
+                          ]
+                        ]
+                      },
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "DetachedFieldIndex": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "DetachedFieldIndexBlob": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "data": [
+                        [
+                          1026,
+                          0,
+                          3
+                        ]
+                      ],
+                      "maxId": 3
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v3_0/competing-removes-index-1.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v3_0/competing-removes-index-1.json
@@ -1,0 +1,459 @@
+{
+  "type": "tree",
+  "entries": [
+    {
+      "type": "blob",
+      ".metadata": {
+        "type": "blob",
+        "content": {
+          "version": 2
+        },
+        "encoding": "utf-8"
+      }
+    },
+    {
+      "type": "tree",
+      "indexes": {
+        "type": "tree",
+        "entries": [
+          {
+            "type": "tree",
+            "EditManager": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "String": {
+                    "type": "blob",
+                    "content": {
+                      "trunk": [
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 1,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "",
+                                              "fieldKind": "Sequence",
+                                              "change": [
+                                                {
+                                                  "count": 1
+                                                },
+                                                {
+                                                  "count": 1,
+                                                  "effect": {
+                                                    "remove": {
+                                                      "id": 0
+                                                    }
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          ],
+                          "revision": 1,
+                          "sequenceNumber": 4,
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                        },
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 1,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "",
+                                              "fieldKind": "Sequence",
+                                              "change": [
+                                                {
+                                                  "count": 1
+                                                },
+                                                {
+                                                  "count": 1,
+                                                  "effect": {
+                                                    "remove": {
+                                                      "id": 0
+                                                    }
+                                                  },
+                                                  "cellId": [
+                                                    0,
+                                                    1
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          ],
+                          "revision": 513,
+                          "sequenceNumber": 6,
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                        },
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 1,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "",
+                                              "fieldKind": "Sequence",
+                                              "change": [
+                                                {
+                                                  "count": 1
+                                                },
+                                                {
+                                                  "count": 1,
+                                                  "effect": {
+                                                    "remove": {
+                                                      "id": 0
+                                                    }
+                                                  },
+                                                  "cellId": [
+                                                    0,
+                                                    513
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          ],
+                          "revision": 1026,
+                          "sequenceNumber": 8,
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                        }
+                      ],
+                      "branches": [
+                        [
+                          "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          {
+                            "base": "root",
+                            "commits": [
+                              {
+                                "change": [
+                                  {
+                                    "data": {
+                                      "maxId": 1,
+                                      "changes": [
+                                        {
+                                          "fieldKey": "rootFieldKey",
+                                          "fieldKind": "ModularEditBuilder.Generic",
+                                          "change": [
+                                            [
+                                              0,
+                                              {
+                                                "fieldChanges": [
+                                                  {
+                                                    "fieldKey": "",
+                                                    "fieldKind": "Sequence",
+                                                    "change": [
+                                                      {
+                                                        "count": 1
+                                                      },
+                                                      {
+                                                        "count": 1,
+                                                        "effect": {
+                                                          "remove": {
+                                                            "id": 0
+                                                          }
+                                                        }
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ],
+                                "revision": 513,
+                                "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                              }
+                            ]
+                          }
+                        ],
+                        [
+                          "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          {
+                            "base": "root",
+                            "commits": [
+                              {
+                                "change": [
+                                  {
+                                    "data": {
+                                      "maxId": 1,
+                                      "changes": [
+                                        {
+                                          "fieldKey": "rootFieldKey",
+                                          "fieldKind": "ModularEditBuilder.Generic",
+                                          "change": [
+                                            [
+                                              0,
+                                              {
+                                                "fieldChanges": [
+                                                  {
+                                                    "fieldKey": "",
+                                                    "fieldKind": "Sequence",
+                                                    "change": [
+                                                      {
+                                                        "count": 1
+                                                      },
+                                                      {
+                                                        "count": 1,
+                                                        "effect": {
+                                                          "remove": {
+                                                            "id": 0
+                                                          }
+                                                        }
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ],
+                                "revision": 1026,
+                                "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                              }
+                            ]
+                          }
+                        ]
+                      ],
+                      "version": 7
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Schema": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "SchemaString": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "nodes": {
+                        "com.fluidframework.leaf.number": {
+                          "kind": {
+                            "leaf": 0
+                          }
+                        },
+                        "competing-removes.Array<[\"com.fluidframework.leaf.number\"]>": {
+                          "kind": {
+                            "object": {
+                              "": {
+                                "kind": "Sequence",
+                                "types": [
+                                  "com.fluidframework.leaf.number"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "root": {
+                        "kind": "Value",
+                        "types": [
+                          "competing-removes.Array<[\"com.fluidframework.leaf.number\"]>"
+                        ]
+                      }
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Forest": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 3
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "contents": {
+                    "type": "blob",
+                    "content": {
+                      "keys": [
+                        "rootFieldKey",
+                        "repair-3"
+                      ],
+                      "fields": {
+                        "version": 2,
+                        "identifiers": [],
+                        "shapes": [
+                          {
+                            "c": {
+                              "type": "com.fluidframework.leaf.number",
+                              "value": true
+                            }
+                          },
+                          {
+                            "c": {
+                              "type": "competing-removes.Array<[\"com.fluidframework.leaf.number\"]>",
+                              "value": false,
+                              "fields": [
+                                [
+                                  "",
+                                  2
+                                ]
+                              ]
+                            }
+                          },
+                          {
+                            "a": 0
+                          }
+                        ],
+                        "data": [
+                          [
+                            1,
+                            [
+                              0,
+                              2,
+                              3
+                            ]
+                          ],
+                          [
+                            0,
+                            1
+                          ]
+                        ]
+                      },
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "DetachedFieldIndex": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "DetachedFieldIndexBlob": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "data": [
+                        [
+                          1026,
+                          0,
+                          3
+                        ]
+                      ],
+                      "maxId": 3
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v3_0/competing-removes-index-2.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v3_0/competing-removes-index-2.json
@@ -1,0 +1,459 @@
+{
+  "type": "tree",
+  "entries": [
+    {
+      "type": "blob",
+      ".metadata": {
+        "type": "blob",
+        "content": {
+          "version": 2
+        },
+        "encoding": "utf-8"
+      }
+    },
+    {
+      "type": "tree",
+      "indexes": {
+        "type": "tree",
+        "entries": [
+          {
+            "type": "tree",
+            "EditManager": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "String": {
+                    "type": "blob",
+                    "content": {
+                      "trunk": [
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 1,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "",
+                                              "fieldKind": "Sequence",
+                                              "change": [
+                                                {
+                                                  "count": 2
+                                                },
+                                                {
+                                                  "count": 1,
+                                                  "effect": {
+                                                    "remove": {
+                                                      "id": 0
+                                                    }
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          ],
+                          "revision": 1,
+                          "sequenceNumber": 4,
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                        },
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 1,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "",
+                                              "fieldKind": "Sequence",
+                                              "change": [
+                                                {
+                                                  "count": 2
+                                                },
+                                                {
+                                                  "count": 1,
+                                                  "effect": {
+                                                    "remove": {
+                                                      "id": 0
+                                                    }
+                                                  },
+                                                  "cellId": [
+                                                    0,
+                                                    1
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          ],
+                          "revision": 513,
+                          "sequenceNumber": 6,
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                        },
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 1,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "",
+                                              "fieldKind": "Sequence",
+                                              "change": [
+                                                {
+                                                  "count": 2
+                                                },
+                                                {
+                                                  "count": 1,
+                                                  "effect": {
+                                                    "remove": {
+                                                      "id": 0
+                                                    }
+                                                  },
+                                                  "cellId": [
+                                                    0,
+                                                    513
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          ],
+                          "revision": 1026,
+                          "sequenceNumber": 8,
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                        }
+                      ],
+                      "branches": [
+                        [
+                          "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          {
+                            "base": "root",
+                            "commits": [
+                              {
+                                "change": [
+                                  {
+                                    "data": {
+                                      "maxId": 1,
+                                      "changes": [
+                                        {
+                                          "fieldKey": "rootFieldKey",
+                                          "fieldKind": "ModularEditBuilder.Generic",
+                                          "change": [
+                                            [
+                                              0,
+                                              {
+                                                "fieldChanges": [
+                                                  {
+                                                    "fieldKey": "",
+                                                    "fieldKind": "Sequence",
+                                                    "change": [
+                                                      {
+                                                        "count": 2
+                                                      },
+                                                      {
+                                                        "count": 1,
+                                                        "effect": {
+                                                          "remove": {
+                                                            "id": 0
+                                                          }
+                                                        }
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ],
+                                "revision": 513,
+                                "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                              }
+                            ]
+                          }
+                        ],
+                        [
+                          "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          {
+                            "base": "root",
+                            "commits": [
+                              {
+                                "change": [
+                                  {
+                                    "data": {
+                                      "maxId": 1,
+                                      "changes": [
+                                        {
+                                          "fieldKey": "rootFieldKey",
+                                          "fieldKind": "ModularEditBuilder.Generic",
+                                          "change": [
+                                            [
+                                              0,
+                                              {
+                                                "fieldChanges": [
+                                                  {
+                                                    "fieldKey": "",
+                                                    "fieldKind": "Sequence",
+                                                    "change": [
+                                                      {
+                                                        "count": 2
+                                                      },
+                                                      {
+                                                        "count": 1,
+                                                        "effect": {
+                                                          "remove": {
+                                                            "id": 0
+                                                          }
+                                                        }
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ],
+                                "revision": 1026,
+                                "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                              }
+                            ]
+                          }
+                        ]
+                      ],
+                      "version": 7
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Schema": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "SchemaString": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "nodes": {
+                        "com.fluidframework.leaf.number": {
+                          "kind": {
+                            "leaf": 0
+                          }
+                        },
+                        "competing-removes.Array<[\"com.fluidframework.leaf.number\"]>": {
+                          "kind": {
+                            "object": {
+                              "": {
+                                "kind": "Sequence",
+                                "types": [
+                                  "com.fluidframework.leaf.number"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "root": {
+                        "kind": "Value",
+                        "types": [
+                          "competing-removes.Array<[\"com.fluidframework.leaf.number\"]>"
+                        ]
+                      }
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Forest": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 3
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "contents": {
+                    "type": "blob",
+                    "content": {
+                      "keys": [
+                        "rootFieldKey",
+                        "repair-3"
+                      ],
+                      "fields": {
+                        "version": 2,
+                        "identifiers": [],
+                        "shapes": [
+                          {
+                            "c": {
+                              "type": "com.fluidframework.leaf.number",
+                              "value": true
+                            }
+                          },
+                          {
+                            "c": {
+                              "type": "competing-removes.Array<[\"com.fluidframework.leaf.number\"]>",
+                              "value": false,
+                              "fields": [
+                                [
+                                  "",
+                                  2
+                                ]
+                              ]
+                            }
+                          },
+                          {
+                            "a": 0
+                          }
+                        ],
+                        "data": [
+                          [
+                            1,
+                            [
+                              0,
+                              1,
+                              3
+                            ]
+                          ],
+                          [
+                            0,
+                            2
+                          ]
+                        ]
+                      },
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "DetachedFieldIndex": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "DetachedFieldIndexBlob": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "data": [
+                        [
+                          1026,
+                          0,
+                          3
+                        ]
+                      ],
+                      "maxId": 3
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v3_0/competing-removes-index-3.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v3_0/competing-removes-index-3.json
@@ -1,0 +1,459 @@
+{
+  "type": "tree",
+  "entries": [
+    {
+      "type": "blob",
+      ".metadata": {
+        "type": "blob",
+        "content": {
+          "version": 2
+        },
+        "encoding": "utf-8"
+      }
+    },
+    {
+      "type": "tree",
+      "indexes": {
+        "type": "tree",
+        "entries": [
+          {
+            "type": "tree",
+            "EditManager": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "String": {
+                    "type": "blob",
+                    "content": {
+                      "trunk": [
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 1,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "",
+                                              "fieldKind": "Sequence",
+                                              "change": [
+                                                {
+                                                  "count": 3
+                                                },
+                                                {
+                                                  "count": 1,
+                                                  "effect": {
+                                                    "remove": {
+                                                      "id": 0
+                                                    }
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          ],
+                          "revision": 1,
+                          "sequenceNumber": 4,
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                        },
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 1,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "",
+                                              "fieldKind": "Sequence",
+                                              "change": [
+                                                {
+                                                  "count": 3
+                                                },
+                                                {
+                                                  "count": 1,
+                                                  "effect": {
+                                                    "remove": {
+                                                      "id": 0
+                                                    }
+                                                  },
+                                                  "cellId": [
+                                                    0,
+                                                    1
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          ],
+                          "revision": 513,
+                          "sequenceNumber": 6,
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                        },
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 1,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "",
+                                              "fieldKind": "Sequence",
+                                              "change": [
+                                                {
+                                                  "count": 3
+                                                },
+                                                {
+                                                  "count": 1,
+                                                  "effect": {
+                                                    "remove": {
+                                                      "id": 0
+                                                    }
+                                                  },
+                                                  "cellId": [
+                                                    0,
+                                                    513
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          ],
+                          "revision": 1026,
+                          "sequenceNumber": 8,
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                        }
+                      ],
+                      "branches": [
+                        [
+                          "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          {
+                            "base": "root",
+                            "commits": [
+                              {
+                                "change": [
+                                  {
+                                    "data": {
+                                      "maxId": 1,
+                                      "changes": [
+                                        {
+                                          "fieldKey": "rootFieldKey",
+                                          "fieldKind": "ModularEditBuilder.Generic",
+                                          "change": [
+                                            [
+                                              0,
+                                              {
+                                                "fieldChanges": [
+                                                  {
+                                                    "fieldKey": "",
+                                                    "fieldKind": "Sequence",
+                                                    "change": [
+                                                      {
+                                                        "count": 3
+                                                      },
+                                                      {
+                                                        "count": 1,
+                                                        "effect": {
+                                                          "remove": {
+                                                            "id": 0
+                                                          }
+                                                        }
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ],
+                                "revision": 513,
+                                "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                              }
+                            ]
+                          }
+                        ],
+                        [
+                          "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          {
+                            "base": "root",
+                            "commits": [
+                              {
+                                "change": [
+                                  {
+                                    "data": {
+                                      "maxId": 1,
+                                      "changes": [
+                                        {
+                                          "fieldKey": "rootFieldKey",
+                                          "fieldKind": "ModularEditBuilder.Generic",
+                                          "change": [
+                                            [
+                                              0,
+                                              {
+                                                "fieldChanges": [
+                                                  {
+                                                    "fieldKey": "",
+                                                    "fieldKind": "Sequence",
+                                                    "change": [
+                                                      {
+                                                        "count": 3
+                                                      },
+                                                      {
+                                                        "count": 1,
+                                                        "effect": {
+                                                          "remove": {
+                                                            "id": 0
+                                                          }
+                                                        }
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ],
+                                "revision": 1026,
+                                "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                              }
+                            ]
+                          }
+                        ]
+                      ],
+                      "version": 7
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Schema": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "SchemaString": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "nodes": {
+                        "com.fluidframework.leaf.number": {
+                          "kind": {
+                            "leaf": 0
+                          }
+                        },
+                        "competing-removes.Array<[\"com.fluidframework.leaf.number\"]>": {
+                          "kind": {
+                            "object": {
+                              "": {
+                                "kind": "Sequence",
+                                "types": [
+                                  "com.fluidframework.leaf.number"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "root": {
+                        "kind": "Value",
+                        "types": [
+                          "competing-removes.Array<[\"com.fluidframework.leaf.number\"]>"
+                        ]
+                      }
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Forest": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 3
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "contents": {
+                    "type": "blob",
+                    "content": {
+                      "keys": [
+                        "rootFieldKey",
+                        "repair-3"
+                      ],
+                      "fields": {
+                        "version": 2,
+                        "identifiers": [],
+                        "shapes": [
+                          {
+                            "c": {
+                              "type": "com.fluidframework.leaf.number",
+                              "value": true
+                            }
+                          },
+                          {
+                            "c": {
+                              "type": "competing-removes.Array<[\"com.fluidframework.leaf.number\"]>",
+                              "value": false,
+                              "fields": [
+                                [
+                                  "",
+                                  2
+                                ]
+                              ]
+                            }
+                          },
+                          {
+                            "a": 0
+                          }
+                        ],
+                        "data": [
+                          [
+                            1,
+                            [
+                              0,
+                              1,
+                              2
+                            ]
+                          ],
+                          [
+                            0,
+                            3
+                          ]
+                        ]
+                      },
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "DetachedFieldIndex": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "DetachedFieldIndexBlob": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "data": [
+                        [
+                          1026,
+                          0,
+                          3
+                        ]
+                      ],
+                      "maxId": 3
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v3_0/complete-3x3-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v3_0/complete-3x3-final.json
@@ -1,0 +1,1085 @@
+{
+  "type": "tree",
+  "entries": [
+    {
+      "type": "blob",
+      ".metadata": {
+        "type": "blob",
+        "content": {
+          "version": 2
+        },
+        "encoding": "utf-8"
+      }
+    },
+    {
+      "type": "tree",
+      "indexes": {
+        "type": "tree",
+        "entries": [
+          {
+            "type": "tree",
+            "EditManager": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "String": {
+                    "type": "blob",
+                    "content": {
+                      "trunk": [
+                        {
+                          "change": [
+                            {
+                              "schema": {
+                                "new": {
+                                  "version": 2,
+                                  "nodes": {
+                                    "com.fluidframework.leaf.string": {
+                                      "kind": {
+                                        "leaf": 1
+                                      }
+                                    },
+                                    "test trees.Recursive Map": {
+                                      "kind": {
+                                        "map": {
+                                          "kind": "Optional",
+                                          "types": [
+                                            "test trees.Recursive Map",
+                                            "test trees.String Array"
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "test trees.String Array": {
+                                      "kind": {
+                                        "object": {
+                                          "": {
+                                            "kind": "Sequence",
+                                            "types": [
+                                              "com.fluidframework.leaf.string"
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "root": {
+                                    "kind": "Optional",
+                                    "types": [
+                                      "test trees.Recursive Map",
+                                      "test trees.String Array"
+                                    ]
+                                  }
+                                },
+                                "old": {
+                                  "version": 2,
+                                  "nodes": {},
+                                  "root": {
+                                    "kind": "Forbidden",
+                                    "types": []
+                                  }
+                                }
+                              }
+                            },
+                            {
+                              "data": {
+                                "maxId": 1,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "Optional",
+                                    "change": {
+                                      "r": {
+                                        "e": true,
+                                        "d": 0,
+                                        "s": 1
+                                      }
+                                    }
+                                  }
+                                ],
+                                "builds": {
+                                  "builds": [
+                                    [
+                                      [
+                                        [
+                                          1,
+                                          0
+                                        ]
+                                      ]
+                                    ]
+                                  ],
+                                  "trees": {
+                                    "version": 2,
+                                    "identifiers": [
+                                      "FieldA",
+                                      "FieldB",
+                                      "FieldC"
+                                    ],
+                                    "shapes": [
+                                      {
+                                        "c": {
+                                          "type": "test trees.String Array",
+                                          "value": false,
+                                          "fields": [
+                                            [
+                                              "",
+                                              2
+                                            ]
+                                          ]
+                                        }
+                                      },
+                                      {
+                                        "c": {
+                                          "type": "test trees.Recursive Map",
+                                          "value": false,
+                                          "extraFields": 4
+                                        }
+                                      },
+                                      {
+                                        "a": 3
+                                      },
+                                      {
+                                        "c": {
+                                          "type": "com.fluidframework.leaf.string",
+                                          "value": true
+                                        }
+                                      },
+                                      {
+                                        "a": 5
+                                      },
+                                      {
+                                        "d": 0
+                                      }
+                                    ],
+                                    "data": [
+                                      [
+                                        1,
+                                        [
+                                          0,
+                                          [
+                                            1,
+                                            [
+                                              0,
+                                              [
+                                                1,
+                                                [
+                                                  0,
+                                                  [
+                                                    0,
+                                                    [
+                                                      "1",
+                                                      "2",
+                                                      "3"
+                                                    ]
+                                                  ],
+                                                  1,
+                                                  [
+                                                    0,
+                                                    [
+                                                      "4",
+                                                      "5",
+                                                      "6"
+                                                    ]
+                                                  ],
+                                                  2,
+                                                  [
+                                                    0,
+                                                    [
+                                                      "7",
+                                                      "8",
+                                                      "9"
+                                                    ]
+                                                  ]
+                                                ]
+                                              ],
+                                              1,
+                                              [
+                                                1,
+                                                [
+                                                  0,
+                                                  [
+                                                    0,
+                                                    [
+                                                      "10",
+                                                      "11",
+                                                      "12"
+                                                    ]
+                                                  ],
+                                                  1,
+                                                  [
+                                                    0,
+                                                    [
+                                                      "13",
+                                                      "14",
+                                                      "15"
+                                                    ]
+                                                  ],
+                                                  2,
+                                                  [
+                                                    0,
+                                                    [
+                                                      "16",
+                                                      "17",
+                                                      "18"
+                                                    ]
+                                                  ]
+                                                ]
+                                              ],
+                                              2,
+                                              [
+                                                1,
+                                                [
+                                                  0,
+                                                  [
+                                                    0,
+                                                    [
+                                                      "19",
+                                                      "20",
+                                                      "21"
+                                                    ]
+                                                  ],
+                                                  1,
+                                                  [
+                                                    0,
+                                                    [
+                                                      "22",
+                                                      "23",
+                                                      "24"
+                                                    ]
+                                                  ],
+                                                  2,
+                                                  [
+                                                    0,
+                                                    [
+                                                      "25",
+                                                      "26",
+                                                      "27"
+                                                    ]
+                                                  ]
+                                                ]
+                                              ]
+                                            ]
+                                          ],
+                                          1,
+                                          [
+                                            1,
+                                            [
+                                              0,
+                                              [
+                                                1,
+                                                [
+                                                  0,
+                                                  [
+                                                    0,
+                                                    [
+                                                      "28",
+                                                      "29",
+                                                      "30"
+                                                    ]
+                                                  ],
+                                                  1,
+                                                  [
+                                                    0,
+                                                    [
+                                                      "31",
+                                                      "32",
+                                                      "33"
+                                                    ]
+                                                  ],
+                                                  2,
+                                                  [
+                                                    0,
+                                                    [
+                                                      "34",
+                                                      "35",
+                                                      "36"
+                                                    ]
+                                                  ]
+                                                ]
+                                              ],
+                                              1,
+                                              [
+                                                1,
+                                                [
+                                                  0,
+                                                  [
+                                                    0,
+                                                    [
+                                                      "37",
+                                                      "38",
+                                                      "39"
+                                                    ]
+                                                  ],
+                                                  1,
+                                                  [
+                                                    0,
+                                                    [
+                                                      "40",
+                                                      "41",
+                                                      "42"
+                                                    ]
+                                                  ],
+                                                  2,
+                                                  [
+                                                    0,
+                                                    [
+                                                      "43",
+                                                      "44",
+                                                      "45"
+                                                    ]
+                                                  ]
+                                                ]
+                                              ],
+                                              2,
+                                              [
+                                                1,
+                                                [
+                                                  0,
+                                                  [
+                                                    0,
+                                                    [
+                                                      "46",
+                                                      "47",
+                                                      "48"
+                                                    ]
+                                                  ],
+                                                  1,
+                                                  [
+                                                    0,
+                                                    [
+                                                      "49",
+                                                      "50",
+                                                      "51"
+                                                    ]
+                                                  ],
+                                                  2,
+                                                  [
+                                                    0,
+                                                    [
+                                                      "52",
+                                                      "53",
+                                                      "54"
+                                                    ]
+                                                  ]
+                                                ]
+                                              ]
+                                            ]
+                                          ],
+                                          2,
+                                          [
+                                            1,
+                                            [
+                                              0,
+                                              [
+                                                1,
+                                                [
+                                                  0,
+                                                  [
+                                                    0,
+                                                    [
+                                                      "55",
+                                                      "56",
+                                                      "57"
+                                                    ]
+                                                  ],
+                                                  1,
+                                                  [
+                                                    0,
+                                                    [
+                                                      "58",
+                                                      "59",
+                                                      "60"
+                                                    ]
+                                                  ],
+                                                  2,
+                                                  [
+                                                    0,
+                                                    [
+                                                      "61",
+                                                      "62",
+                                                      "63"
+                                                    ]
+                                                  ]
+                                                ]
+                                              ],
+                                              1,
+                                              [
+                                                1,
+                                                [
+                                                  0,
+                                                  [
+                                                    0,
+                                                    [
+                                                      "64",
+                                                      "65",
+                                                      "66"
+                                                    ]
+                                                  ],
+                                                  1,
+                                                  [
+                                                    0,
+                                                    [
+                                                      "67",
+                                                      "68",
+                                                      "69"
+                                                    ]
+                                                  ],
+                                                  2,
+                                                  [
+                                                    0,
+                                                    [
+                                                      "70",
+                                                      "71",
+                                                      "72"
+                                                    ]
+                                                  ]
+                                                ]
+                                              ],
+                                              2,
+                                              [
+                                                1,
+                                                [
+                                                  0,
+                                                  [
+                                                    0,
+                                                    [
+                                                      "73",
+                                                      "74",
+                                                      "75"
+                                                    ]
+                                                  ],
+                                                  1,
+                                                  [
+                                                    0,
+                                                    [
+                                                      "76",
+                                                      "77",
+                                                      "78"
+                                                    ]
+                                                  ],
+                                                  2,
+                                                  [
+                                                    0,
+                                                    [
+                                                      "79",
+                                                      "80",
+                                                      "81"
+                                                    ]
+                                                  ]
+                                                ]
+                                              ]
+                                            ]
+                                          ]
+                                        ]
+                                      ]
+                                    ]
+                                  }
+                                }
+                              }
+                            },
+                            {
+                              "schema": {
+                                "new": {
+                                  "version": 2,
+                                  "nodes": {
+                                    "com.fluidframework.leaf.string": {
+                                      "kind": {
+                                        "leaf": 1
+                                      }
+                                    },
+                                    "test trees.Recursive Map": {
+                                      "kind": {
+                                        "map": {
+                                          "kind": "Optional",
+                                          "types": [
+                                            "test trees.Recursive Map",
+                                            "test trees.String Array"
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "test trees.String Array": {
+                                      "kind": {
+                                        "object": {
+                                          "": {
+                                            "kind": "Sequence",
+                                            "types": [
+                                              "com.fluidframework.leaf.string"
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "root": {
+                                    "kind": "Value",
+                                    "types": [
+                                      "test trees.Recursive Map",
+                                      "test trees.String Array"
+                                    ]
+                                  }
+                                },
+                                "old": {
+                                  "version": 2,
+                                  "nodes": {
+                                    "com.fluidframework.leaf.string": {
+                                      "kind": {
+                                        "leaf": 1
+                                      }
+                                    },
+                                    "test trees.Recursive Map": {
+                                      "kind": {
+                                        "map": {
+                                          "kind": "Optional",
+                                          "types": [
+                                            "test trees.Recursive Map",
+                                            "test trees.String Array"
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "test trees.String Array": {
+                                      "kind": {
+                                        "object": {
+                                          "": {
+                                            "kind": "Sequence",
+                                            "types": [
+                                              "com.fluidframework.leaf.string"
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "root": {
+                                    "kind": "Optional",
+                                    "types": [
+                                      "test trees.Recursive Map",
+                                      "test trees.String Array"
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          ],
+                          "revision": 0,
+                          "sequenceNumber": 2,
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                        }
+                      ],
+                      "branches": [],
+                      "version": 7
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Schema": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "SchemaString": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "nodes": {
+                        "com.fluidframework.leaf.string": {
+                          "kind": {
+                            "leaf": 1
+                          }
+                        },
+                        "test trees.Recursive Map": {
+                          "kind": {
+                            "map": {
+                              "kind": "Optional",
+                              "types": [
+                                "test trees.Recursive Map",
+                                "test trees.String Array"
+                              ]
+                            }
+                          }
+                        },
+                        "test trees.String Array": {
+                          "kind": {
+                            "object": {
+                              "": {
+                                "kind": "Sequence",
+                                "types": [
+                                  "com.fluidframework.leaf.string"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "root": {
+                        "kind": "Value",
+                        "types": [
+                          "test trees.Recursive Map",
+                          "test trees.String Array"
+                        ]
+                      }
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Forest": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 3
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "contents": {
+                    "type": "blob",
+                    "content": {
+                      "keys": [
+                        "rootFieldKey"
+                      ],
+                      "fields": {
+                        "version": 2,
+                        "identifiers": [
+                          "FieldA",
+                          "FieldB",
+                          "FieldC"
+                        ],
+                        "shapes": [
+                          {
+                            "c": {
+                              "type": "test trees.String Array",
+                              "value": false,
+                              "fields": [
+                                [
+                                  "",
+                                  2
+                                ]
+                              ]
+                            }
+                          },
+                          {
+                            "c": {
+                              "type": "test trees.Recursive Map",
+                              "value": false,
+                              "extraFields": 4
+                            }
+                          },
+                          {
+                            "a": 3
+                          },
+                          {
+                            "c": {
+                              "type": "com.fluidframework.leaf.string",
+                              "value": true
+                            }
+                          },
+                          {
+                            "a": 5
+                          },
+                          {
+                            "d": 0
+                          }
+                        ],
+                        "data": [
+                          [
+                            1,
+                            [
+                              0,
+                              [
+                                1,
+                                [
+                                  0,
+                                  [
+                                    1,
+                                    [
+                                      0,
+                                      [
+                                        0,
+                                        [
+                                          "1",
+                                          "2",
+                                          "3"
+                                        ]
+                                      ],
+                                      1,
+                                      [
+                                        0,
+                                        [
+                                          "4",
+                                          "5",
+                                          "6"
+                                        ]
+                                      ],
+                                      2,
+                                      [
+                                        0,
+                                        [
+                                          "7",
+                                          "8",
+                                          "9"
+                                        ]
+                                      ]
+                                    ]
+                                  ],
+                                  1,
+                                  [
+                                    1,
+                                    [
+                                      0,
+                                      [
+                                        0,
+                                        [
+                                          "10",
+                                          "11",
+                                          "12"
+                                        ]
+                                      ],
+                                      1,
+                                      [
+                                        0,
+                                        [
+                                          "13",
+                                          "14",
+                                          "15"
+                                        ]
+                                      ],
+                                      2,
+                                      [
+                                        0,
+                                        [
+                                          "16",
+                                          "17",
+                                          "18"
+                                        ]
+                                      ]
+                                    ]
+                                  ],
+                                  2,
+                                  [
+                                    1,
+                                    [
+                                      0,
+                                      [
+                                        0,
+                                        [
+                                          "19",
+                                          "20",
+                                          "21"
+                                        ]
+                                      ],
+                                      1,
+                                      [
+                                        0,
+                                        [
+                                          "22",
+                                          "23",
+                                          "24"
+                                        ]
+                                      ],
+                                      2,
+                                      [
+                                        0,
+                                        [
+                                          "25",
+                                          "26",
+                                          "27"
+                                        ]
+                                      ]
+                                    ]
+                                  ]
+                                ]
+                              ],
+                              1,
+                              [
+                                1,
+                                [
+                                  0,
+                                  [
+                                    1,
+                                    [
+                                      0,
+                                      [
+                                        0,
+                                        [
+                                          "28",
+                                          "29",
+                                          "30"
+                                        ]
+                                      ],
+                                      1,
+                                      [
+                                        0,
+                                        [
+                                          "31",
+                                          "32",
+                                          "33"
+                                        ]
+                                      ],
+                                      2,
+                                      [
+                                        0,
+                                        [
+                                          "34",
+                                          "35",
+                                          "36"
+                                        ]
+                                      ]
+                                    ]
+                                  ],
+                                  1,
+                                  [
+                                    1,
+                                    [
+                                      0,
+                                      [
+                                        0,
+                                        [
+                                          "37",
+                                          "38",
+                                          "39"
+                                        ]
+                                      ],
+                                      1,
+                                      [
+                                        0,
+                                        [
+                                          "40",
+                                          "41",
+                                          "42"
+                                        ]
+                                      ],
+                                      2,
+                                      [
+                                        0,
+                                        [
+                                          "43",
+                                          "44",
+                                          "45"
+                                        ]
+                                      ]
+                                    ]
+                                  ],
+                                  2,
+                                  [
+                                    1,
+                                    [
+                                      0,
+                                      [
+                                        0,
+                                        [
+                                          "46",
+                                          "47",
+                                          "48"
+                                        ]
+                                      ],
+                                      1,
+                                      [
+                                        0,
+                                        [
+                                          "49",
+                                          "50",
+                                          "51"
+                                        ]
+                                      ],
+                                      2,
+                                      [
+                                        0,
+                                        [
+                                          "52",
+                                          "53",
+                                          "54"
+                                        ]
+                                      ]
+                                    ]
+                                  ]
+                                ]
+                              ],
+                              2,
+                              [
+                                1,
+                                [
+                                  0,
+                                  [
+                                    1,
+                                    [
+                                      0,
+                                      [
+                                        0,
+                                        [
+                                          "55",
+                                          "56",
+                                          "57"
+                                        ]
+                                      ],
+                                      1,
+                                      [
+                                        0,
+                                        [
+                                          "58",
+                                          "59",
+                                          "60"
+                                        ]
+                                      ],
+                                      2,
+                                      [
+                                        0,
+                                        [
+                                          "61",
+                                          "62",
+                                          "63"
+                                        ]
+                                      ]
+                                    ]
+                                  ],
+                                  1,
+                                  [
+                                    1,
+                                    [
+                                      0,
+                                      [
+                                        0,
+                                        [
+                                          "64",
+                                          "65",
+                                          "66"
+                                        ]
+                                      ],
+                                      1,
+                                      [
+                                        0,
+                                        [
+                                          "67",
+                                          "68",
+                                          "69"
+                                        ]
+                                      ],
+                                      2,
+                                      [
+                                        0,
+                                        [
+                                          "70",
+                                          "71",
+                                          "72"
+                                        ]
+                                      ]
+                                    ]
+                                  ],
+                                  2,
+                                  [
+                                    1,
+                                    [
+                                      0,
+                                      [
+                                        0,
+                                        [
+                                          "73",
+                                          "74",
+                                          "75"
+                                        ]
+                                      ],
+                                      1,
+                                      [
+                                        0,
+                                        [
+                                          "76",
+                                          "77",
+                                          "78"
+                                        ]
+                                      ],
+                                      2,
+                                      [
+                                        0,
+                                        [
+                                          "79",
+                                          "80",
+                                          "81"
+                                        ]
+                                      ]
+                                    ]
+                                  ]
+                                ]
+                              ]
+                            ]
+                          ]
+                        ]
+                      },
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "DetachedFieldIndex": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "DetachedFieldIndexBlob": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "data": [],
+                      "maxId": 0
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v3_0/concurrent-inserts-tree2.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v3_0/concurrent-inserts-tree2.json
@@ -1,0 +1,512 @@
+{
+  "type": "tree",
+  "entries": [
+    {
+      "type": "blob",
+      ".metadata": {
+        "type": "blob",
+        "content": {
+          "version": 2
+        },
+        "encoding": "utf-8"
+      }
+    },
+    {
+      "type": "tree",
+      "indexes": {
+        "type": "tree",
+        "entries": [
+          {
+            "type": "tree",
+            "EditManager": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "String": {
+                    "type": "blob",
+                    "content": {
+                      "trunk": [
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 1,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "",
+                                              "fieldKind": "Sequence",
+                                              "change": [
+                                                {
+                                                  "count": 1,
+                                                  "effect": {
+                                                    "insert": {
+                                                      "id": 0
+                                                    }
+                                                  },
+                                                  "cellId": 0
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ],
+                                "builds": {
+                                  "builds": [
+                                    [
+                                      [
+                                        [
+                                          0,
+                                          0
+                                        ]
+                                      ]
+                                    ]
+                                  ],
+                                  "trees": {
+                                    "version": 2,
+                                    "identifiers": [],
+                                    "shapes": [
+                                      {
+                                        "c": {
+                                          "type": "com.fluidframework.leaf.string",
+                                          "value": true
+                                        }
+                                      }
+                                    ],
+                                    "data": [
+                                      [
+                                        0,
+                                        "y"
+                                      ]
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          ],
+                          "revision": 1,
+                          "sequenceNumber": 4,
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                        },
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 3,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "",
+                                              "fieldKind": "Sequence",
+                                              "change": [
+                                                {
+                                                  "count": 1,
+                                                  "effect": {
+                                                    "insert": {
+                                                      "id": 2
+                                                    }
+                                                  },
+                                                  "cellId": 2
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ],
+                                "builds": {
+                                  "builds": [
+                                    [
+                                      [
+                                        [
+                                          2,
+                                          0
+                                        ]
+                                      ]
+                                    ]
+                                  ],
+                                  "trees": {
+                                    "version": 2,
+                                    "identifiers": [],
+                                    "shapes": [
+                                      {
+                                        "c": {
+                                          "type": "com.fluidframework.leaf.string",
+                                          "value": true
+                                        }
+                                      }
+                                    ],
+                                    "data": [
+                                      [
+                                        0,
+                                        "x"
+                                      ]
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          ],
+                          "revision": 2,
+                          "sequenceNumber": 6,
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                        },
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 3,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "",
+                                              "fieldKind": "Sequence",
+                                              "change": [
+                                                {
+                                                  "count": 2
+                                                },
+                                                {
+                                                  "count": 2,
+                                                  "effect": {
+                                                    "insert": {
+                                                      "id": 0
+                                                    }
+                                                  },
+                                                  "cellId": 0
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ],
+                                "builds": {
+                                  "builds": [
+                                    [
+                                      [
+                                        [
+                                          0,
+                                          0
+                                        ]
+                                      ]
+                                    ]
+                                  ],
+                                  "trees": {
+                                    "version": 2,
+                                    "identifiers": [],
+                                    "shapes": [
+                                      {
+                                        "c": {
+                                          "type": "com.fluidframework.leaf.string",
+                                          "value": true
+                                        }
+                                      },
+                                      {
+                                        "a": 2
+                                      },
+                                      {
+                                        "d": 0
+                                      }
+                                    ],
+                                    "data": [
+                                      [
+                                        1,
+                                        [
+                                          0,
+                                          "a",
+                                          0,
+                                          "c"
+                                        ]
+                                      ]
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          ],
+                          "revision": 3,
+                          "sequenceNumber": 8,
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                        },
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 4,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "",
+                                              "fieldKind": "Sequence",
+                                              "change": [
+                                                {
+                                                  "count": 3
+                                                },
+                                                {
+                                                  "count": 1,
+                                                  "effect": {
+                                                    "insert": {
+                                                      "id": 3
+                                                    }
+                                                  },
+                                                  "cellId": 3
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ],
+                                "builds": {
+                                  "builds": [
+                                    [
+                                      [
+                                        [
+                                          3,
+                                          0
+                                        ]
+                                      ]
+                                    ]
+                                  ],
+                                  "trees": {
+                                    "version": 2,
+                                    "identifiers": [],
+                                    "shapes": [
+                                      {
+                                        "c": {
+                                          "type": "com.fluidframework.leaf.string",
+                                          "value": true
+                                        }
+                                      }
+                                    ],
+                                    "data": [
+                                      [
+                                        0,
+                                        "b"
+                                      ]
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          ],
+                          "revision": 4,
+                          "sequenceNumber": 9,
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                        }
+                      ],
+                      "branches": [],
+                      "version": 7
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Schema": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "SchemaString": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "nodes": {
+                        "com.fluidframework.leaf.string": {
+                          "kind": {
+                            "leaf": 1
+                          }
+                        },
+                        "concurrent-inserts.Array<[\"com.fluidframework.leaf.string\"]>": {
+                          "kind": {
+                            "object": {
+                              "": {
+                                "kind": "Sequence",
+                                "types": [
+                                  "com.fluidframework.leaf.string"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "root": {
+                        "kind": "Value",
+                        "types": [
+                          "concurrent-inserts.Array<[\"com.fluidframework.leaf.string\"]>"
+                        ]
+                      }
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Forest": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 3
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "contents": {
+                    "type": "blob",
+                    "content": {
+                      "keys": [
+                        "rootFieldKey"
+                      ],
+                      "fields": {
+                        "version": 2,
+                        "identifiers": [],
+                        "shapes": [
+                          {
+                            "c": {
+                              "type": "concurrent-inserts.Array<[\"com.fluidframework.leaf.string\"]>",
+                              "value": false,
+                              "fields": [
+                                [
+                                  "",
+                                  1
+                                ]
+                              ]
+                            }
+                          },
+                          {
+                            "a": 2
+                          },
+                          {
+                            "c": {
+                              "type": "com.fluidframework.leaf.string",
+                              "value": true
+                            }
+                          }
+                        ],
+                        "data": [
+                          [
+                            0,
+                            [
+                              "x",
+                              "y",
+                              "a",
+                              "b",
+                              "c"
+                            ]
+                          ]
+                        ]
+                      },
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "DetachedFieldIndex": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "DetachedFieldIndexBlob": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "data": [],
+                      "maxId": 5
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v3_0/concurrent-inserts-tree3.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v3_0/concurrent-inserts-tree3.json
@@ -1,0 +1,519 @@
+{
+  "type": "tree",
+  "entries": [
+    {
+      "type": "blob",
+      ".metadata": {
+        "type": "blob",
+        "content": {
+          "version": 2
+        },
+        "encoding": "utf-8"
+      }
+    },
+    {
+      "type": "tree",
+      "indexes": {
+        "type": "tree",
+        "entries": [
+          {
+            "type": "tree",
+            "EditManager": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "String": {
+                    "type": "blob",
+                    "content": {
+                      "trunk": [
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 4,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "",
+                                              "fieldKind": "Sequence",
+                                              "change": [
+                                                {
+                                                  "count": 3
+                                                },
+                                                {
+                                                  "count": 1,
+                                                  "effect": {
+                                                    "insert": {
+                                                      "id": 3
+                                                    }
+                                                  },
+                                                  "cellId": 3
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ],
+                                "builds": {
+                                  "builds": [
+                                    [
+                                      [
+                                        [
+                                          3,
+                                          0
+                                        ]
+                                      ]
+                                    ]
+                                  ],
+                                  "trees": {
+                                    "version": 2,
+                                    "identifiers": [],
+                                    "shapes": [
+                                      {
+                                        "c": {
+                                          "type": "com.fluidframework.leaf.string",
+                                          "value": true
+                                        }
+                                      }
+                                    ],
+                                    "data": [
+                                      [
+                                        0,
+                                        "b"
+                                      ]
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          ],
+                          "revision": 4,
+                          "sequenceNumber": 9,
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                        },
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 5,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "",
+                                              "fieldKind": "Sequence",
+                                              "change": [
+                                                {
+                                                  "count": 1,
+                                                  "effect": {
+                                                    "insert": {
+                                                      "id": 4
+                                                    }
+                                                  },
+                                                  "cellId": 4
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ],
+                                "builds": {
+                                  "builds": [
+                                    [
+                                      [
+                                        [
+                                          4,
+                                          0
+                                        ]
+                                      ]
+                                    ]
+                                  ],
+                                  "trees": {
+                                    "version": 2,
+                                    "identifiers": [],
+                                    "shapes": [
+                                      {
+                                        "c": {
+                                          "type": "com.fluidframework.leaf.string",
+                                          "value": true
+                                        }
+                                      }
+                                    ],
+                                    "data": [
+                                      [
+                                        0,
+                                        "z"
+                                      ]
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          ],
+                          "revision": 7,
+                          "sequenceNumber": 11,
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                        },
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 5,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "",
+                                              "fieldKind": "Sequence",
+                                              "change": [
+                                                {
+                                                  "count": 2
+                                                },
+                                                {
+                                                  "count": 2,
+                                                  "effect": {
+                                                    "insert": {
+                                                      "id": 0
+                                                    }
+                                                  },
+                                                  "cellId": 0
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ],
+                                "builds": {
+                                  "builds": [
+                                    [
+                                      [
+                                        [
+                                          0,
+                                          0
+                                        ]
+                                      ]
+                                    ]
+                                  ],
+                                  "trees": {
+                                    "version": 2,
+                                    "identifiers": [],
+                                    "shapes": [
+                                      {
+                                        "c": {
+                                          "type": "com.fluidframework.leaf.string",
+                                          "value": true
+                                        }
+                                      },
+                                      {
+                                        "a": 2
+                                      },
+                                      {
+                                        "d": 0
+                                      }
+                                    ],
+                                    "data": [
+                                      [
+                                        1,
+                                        [
+                                          0,
+                                          "d",
+                                          0,
+                                          "e"
+                                        ]
+                                      ]
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          ],
+                          "revision": 8,
+                          "sequenceNumber": 13,
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                        },
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 5,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "",
+                                              "fieldKind": "Sequence",
+                                              "change": [
+                                                {
+                                                  "count": 3
+                                                },
+                                                {
+                                                  "count": 1,
+                                                  "effect": {
+                                                    "insert": {
+                                                      "id": 3
+                                                    }
+                                                  },
+                                                  "cellId": 3
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ],
+                                "builds": {
+                                  "builds": [
+                                    [
+                                      [
+                                        [
+                                          3,
+                                          0
+                                        ]
+                                      ]
+                                    ]
+                                  ],
+                                  "trees": {
+                                    "version": 2,
+                                    "identifiers": [],
+                                    "shapes": [
+                                      {
+                                        "c": {
+                                          "type": "com.fluidframework.leaf.string",
+                                          "value": true
+                                        }
+                                      }
+                                    ],
+                                    "data": [
+                                      [
+                                        0,
+                                        "f"
+                                      ]
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          ],
+                          "revision": 9,
+                          "sequenceNumber": 14,
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                        }
+                      ],
+                      "branches": [],
+                      "version": 7
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Schema": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "SchemaString": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "nodes": {
+                        "com.fluidframework.leaf.string": {
+                          "kind": {
+                            "leaf": 1
+                          }
+                        },
+                        "concurrent-inserts.Array<[\"com.fluidframework.leaf.string\"]>": {
+                          "kind": {
+                            "object": {
+                              "": {
+                                "kind": "Sequence",
+                                "types": [
+                                  "com.fluidframework.leaf.string"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "root": {
+                        "kind": "Value",
+                        "types": [
+                          "concurrent-inserts.Array<[\"com.fluidframework.leaf.string\"]>"
+                        ]
+                      }
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Forest": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 3
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "contents": {
+                    "type": "blob",
+                    "content": {
+                      "keys": [
+                        "rootFieldKey"
+                      ],
+                      "fields": {
+                        "version": 2,
+                        "identifiers": [],
+                        "shapes": [
+                          {
+                            "c": {
+                              "type": "concurrent-inserts.Array<[\"com.fluidframework.leaf.string\"]>",
+                              "value": false,
+                              "fields": [
+                                [
+                                  "",
+                                  1
+                                ]
+                              ]
+                            }
+                          },
+                          {
+                            "a": 2
+                          },
+                          {
+                            "c": {
+                              "type": "com.fluidframework.leaf.string",
+                              "value": true
+                            }
+                          }
+                        ],
+                        "data": [
+                          [
+                            0,
+                            [
+                              "z",
+                              "x",
+                              "d",
+                              "f",
+                              "e",
+                              "y",
+                              "a",
+                              "b",
+                              "c"
+                            ]
+                          ]
+                        ]
+                      },
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "DetachedFieldIndex": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "DetachedFieldIndexBlob": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "data": [],
+                      "maxId": 9
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v3_0/empty-root-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v3_0/empty-root-final.json
@@ -1,0 +1,212 @@
+{
+  "type": "tree",
+  "entries": [
+    {
+      "type": "blob",
+      ".metadata": {
+        "type": "blob",
+        "content": {
+          "version": 2
+        },
+        "encoding": "utf-8"
+      }
+    },
+    {
+      "type": "tree",
+      "indexes": {
+        "type": "tree",
+        "entries": [
+          {
+            "type": "tree",
+            "EditManager": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "String": {
+                    "type": "blob",
+                    "content": {
+                      "trunk": [
+                        {
+                          "change": [
+                            {
+                              "schema": {
+                                "new": {
+                                  "version": 2,
+                                  "nodes": {
+                                    "com.fluidframework.leaf.number": {
+                                      "kind": {
+                                        "leaf": 0
+                                      }
+                                    }
+                                  },
+                                  "root": {
+                                    "kind": "Optional",
+                                    "types": [
+                                      "com.fluidframework.leaf.number"
+                                    ]
+                                  }
+                                },
+                                "old": {
+                                  "version": 2,
+                                  "nodes": {},
+                                  "root": {
+                                    "kind": "Forbidden",
+                                    "types": []
+                                  }
+                                }
+                              }
+                            },
+                            {
+                              "data": {
+                                "maxId": 0,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "Optional",
+                                    "change": {
+                                      "r": {
+                                        "e": true,
+                                        "d": 0
+                                      }
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          ],
+                          "revision": 0,
+                          "sequenceNumber": 2,
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                        }
+                      ],
+                      "branches": [],
+                      "version": 7
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Schema": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "SchemaString": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "nodes": {
+                        "com.fluidframework.leaf.number": {
+                          "kind": {
+                            "leaf": 0
+                          }
+                        }
+                      },
+                      "root": {
+                        "kind": "Optional",
+                        "types": [
+                          "com.fluidframework.leaf.number"
+                        ]
+                      }
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Forest": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 3
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "contents": {
+                    "type": "blob",
+                    "content": {
+                      "keys": [],
+                      "fields": {
+                        "version": 2,
+                        "identifiers": [],
+                        "shapes": [],
+                        "data": []
+                      },
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "DetachedFieldIndex": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "DetachedFieldIndexBlob": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "data": [],
+                      "maxId": -1
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v3_0/has-handle-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v3_0/has-handle-final.json
@@ -1,0 +1,277 @@
+{
+  "type": "tree",
+  "entries": [
+    {
+      "type": "blob",
+      ".metadata": {
+        "type": "blob",
+        "content": {
+          "version": 2
+        },
+        "encoding": "utf-8"
+      }
+    },
+    {
+      "type": "tree",
+      "indexes": {
+        "type": "tree",
+        "entries": [
+          {
+            "type": "tree",
+            "EditManager": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "String": {
+                    "type": "blob",
+                    "content": {
+                      "trunk": [
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 2,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "handleField",
+                                              "fieldKind": "Optional",
+                                              "change": {
+                                                "r": {
+                                                  "e": true,
+                                                  "d": 0,
+                                                  "s": 1
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ],
+                                "builds": {
+                                  "builds": [
+                                    [
+                                      [
+                                        [
+                                          1,
+                                          0
+                                        ]
+                                      ]
+                                    ]
+                                  ],
+                                  "trees": {
+                                    "version": 2,
+                                    "identifiers": [],
+                                    "shapes": [
+                                      {
+                                        "c": {
+                                          "type": "com.fluidframework.leaf.handle",
+                                          "value": true
+                                        }
+                                      }
+                                    ],
+                                    "data": [
+                                      [
+                                        0,
+                                        {
+                                          "type": "__fluid_handle__",
+                                          "url": "/test/tree-0"
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          ],
+                          "revision": 1,
+                          "sequenceNumber": 4,
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                        }
+                      ],
+                      "branches": [],
+                      "version": 7
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Schema": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "SchemaString": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "nodes": {
+                        "com.fluidframework.leaf.handle": {
+                          "kind": {
+                            "leaf": 3
+                          }
+                        },
+                        "has-handle.HandleObject": {
+                          "kind": {
+                            "object": {
+                              "handleField": {
+                                "kind": "Optional",
+                                "types": [
+                                  "com.fluidframework.leaf.handle"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "root": {
+                        "kind": "Value",
+                        "types": [
+                          "has-handle.HandleObject"
+                        ]
+                      }
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Forest": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 3
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "contents": {
+                    "type": "blob",
+                    "content": {
+                      "keys": [
+                        "rootFieldKey"
+                      ],
+                      "fields": {
+                        "version": 2,
+                        "identifiers": [],
+                        "shapes": [
+                          {
+                            "c": {
+                              "type": "has-handle.HandleObject",
+                              "value": false,
+                              "fields": [
+                                [
+                                  "handleField",
+                                  1
+                                ]
+                              ]
+                            }
+                          },
+                          {
+                            "a": 2
+                          },
+                          {
+                            "c": {
+                              "type": "com.fluidframework.leaf.handle",
+                              "value": true
+                            }
+                          }
+                        ],
+                        "data": [
+                          [
+                            0,
+                            [
+                              {
+                                "type": "__fluid_handle__",
+                                "url": "/test/tree-0"
+                              }
+                            ]
+                          ]
+                        ]
+                      },
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "DetachedFieldIndex": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "DetachedFieldIndexBlob": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "data": [],
+                      "maxId": 1
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v3_0/insert-and-remove-tree-0-after-insert.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v3_0/insert-and-remove-tree-0-after-insert.json
@@ -1,0 +1,275 @@
+{
+  "type": "tree",
+  "entries": [
+    {
+      "type": "blob",
+      ".metadata": {
+        "type": "blob",
+        "content": {
+          "version": 2
+        },
+        "encoding": "utf-8"
+      }
+    },
+    {
+      "type": "tree",
+      "indexes": {
+        "type": "tree",
+        "entries": [
+          {
+            "type": "tree",
+            "EditManager": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "String": {
+                    "type": "blob",
+                    "content": {
+                      "trunk": [
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 1,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "",
+                                              "fieldKind": "Sequence",
+                                              "change": [
+                                                {
+                                                  "count": 1,
+                                                  "effect": {
+                                                    "insert": {
+                                                      "id": 0
+                                                    }
+                                                  },
+                                                  "cellId": 0
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ],
+                                "builds": {
+                                  "builds": [
+                                    [
+                                      [
+                                        [
+                                          0,
+                                          0
+                                        ]
+                                      ]
+                                    ]
+                                  ],
+                                  "trees": {
+                                    "version": 2,
+                                    "identifiers": [],
+                                    "shapes": [
+                                      {
+                                        "c": {
+                                          "type": "com.fluidframework.leaf.string",
+                                          "value": true
+                                        }
+                                      }
+                                    ],
+                                    "data": [
+                                      [
+                                        0,
+                                        "42"
+                                      ]
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          ],
+                          "revision": 1,
+                          "sequenceNumber": 4,
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                        }
+                      ],
+                      "branches": [],
+                      "version": 7
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Schema": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "SchemaString": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "nodes": {
+                        "com.fluidframework.leaf.string": {
+                          "kind": {
+                            "leaf": 1
+                          }
+                        },
+                        "insert-and-remove.Array<[\"com.fluidframework.leaf.string\"]>": {
+                          "kind": {
+                            "object": {
+                              "": {
+                                "kind": "Sequence",
+                                "types": [
+                                  "com.fluidframework.leaf.string"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "root": {
+                        "kind": "Value",
+                        "types": [
+                          "insert-and-remove.Array<[\"com.fluidframework.leaf.string\"]>"
+                        ]
+                      }
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Forest": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 3
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "contents": {
+                    "type": "blob",
+                    "content": {
+                      "keys": [
+                        "rootFieldKey"
+                      ],
+                      "fields": {
+                        "version": 2,
+                        "identifiers": [],
+                        "shapes": [
+                          {
+                            "c": {
+                              "type": "insert-and-remove.Array<[\"com.fluidframework.leaf.string\"]>",
+                              "value": false,
+                              "fields": [
+                                [
+                                  "",
+                                  1
+                                ]
+                              ]
+                            }
+                          },
+                          {
+                            "a": 2
+                          },
+                          {
+                            "c": {
+                              "type": "com.fluidframework.leaf.string",
+                              "value": true
+                            }
+                          }
+                        ],
+                        "data": [
+                          [
+                            0,
+                            [
+                              "42"
+                            ]
+                          ]
+                        ]
+                      },
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "DetachedFieldIndex": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "DetachedFieldIndexBlob": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "data": [],
+                      "maxId": 1
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v3_0/insert-and-remove-tree-0-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v3_0/insert-and-remove-tree-0-final.json
@@ -1,0 +1,253 @@
+{
+  "type": "tree",
+  "entries": [
+    {
+      "type": "blob",
+      ".metadata": {
+        "type": "blob",
+        "content": {
+          "version": 2
+        },
+        "encoding": "utf-8"
+      }
+    },
+    {
+      "type": "tree",
+      "indexes": {
+        "type": "tree",
+        "entries": [
+          {
+            "type": "tree",
+            "EditManager": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "String": {
+                    "type": "blob",
+                    "content": {
+                      "trunk": [
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 3,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "",
+                                              "fieldKind": "Sequence",
+                                              "change": [
+                                                {
+                                                  "count": 1,
+                                                  "effect": {
+                                                    "remove": {
+                                                      "id": 2
+                                                    }
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          ],
+                          "revision": 2,
+                          "sequenceNumber": 6,
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                        }
+                      ],
+                      "branches": [],
+                      "version": 7
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Schema": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "SchemaString": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "nodes": {
+                        "com.fluidframework.leaf.string": {
+                          "kind": {
+                            "leaf": 1
+                          }
+                        },
+                        "insert-and-remove.Array<[\"com.fluidframework.leaf.string\"]>": {
+                          "kind": {
+                            "object": {
+                              "": {
+                                "kind": "Sequence",
+                                "types": [
+                                  "com.fluidframework.leaf.string"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "root": {
+                        "kind": "Value",
+                        "types": [
+                          "insert-and-remove.Array<[\"com.fluidframework.leaf.string\"]>"
+                        ]
+                      }
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Forest": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 3
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "contents": {
+                    "type": "blob",
+                    "content": {
+                      "keys": [
+                        "rootFieldKey",
+                        "repair-2"
+                      ],
+                      "fields": {
+                        "version": 2,
+                        "identifiers": [],
+                        "shapes": [
+                          {
+                            "c": {
+                              "type": "com.fluidframework.leaf.string",
+                              "value": true
+                            }
+                          },
+                          {
+                            "c": {
+                              "type": "insert-and-remove.Array<[\"com.fluidframework.leaf.string\"]>",
+                              "value": false,
+                              "fields": [
+                                [
+                                  "",
+                                  2
+                                ]
+                              ]
+                            }
+                          },
+                          {
+                            "a": 0
+                          }
+                        ],
+                        "data": [
+                          [
+                            1,
+                            0
+                          ],
+                          [
+                            0,
+                            "42"
+                          ]
+                        ]
+                      },
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "DetachedFieldIndex": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "DetachedFieldIndexBlob": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "data": [
+                        [
+                          2,
+                          2,
+                          2
+                        ]
+                      ],
+                      "maxId": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v3_0/insert-and-remove-tree-1-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v3_0/insert-and-remove-tree-1-final.json
@@ -1,0 +1,261 @@
+{
+  "type": "tree",
+  "entries": [
+    {
+      "type": "blob",
+      ".metadata": {
+        "type": "blob",
+        "content": {
+          "version": 2
+        },
+        "encoding": "utf-8"
+      }
+    },
+    {
+      "type": "tree",
+      "indexes": {
+        "type": "tree",
+        "entries": [
+          {
+            "type": "tree",
+            "EditManager": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "String": {
+                    "type": "blob",
+                    "content": {
+                      "trunk": [
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 3,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "",
+                                              "fieldKind": "Sequence",
+                                              "change": [
+                                                {
+                                                  "count": 1,
+                                                  "effect": {
+                                                    "remove": {
+                                                      "id": 2
+                                                    }
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          ],
+                          "revision": 2,
+                          "sequenceNumber": 6,
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                        }
+                      ],
+                      "branches": [
+                        [
+                          "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          {
+                            "base": 2,
+                            "commits": []
+                          }
+                        ]
+                      ],
+                      "version": 7
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Schema": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "SchemaString": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "nodes": {
+                        "com.fluidframework.leaf.string": {
+                          "kind": {
+                            "leaf": 1
+                          }
+                        },
+                        "insert-and-remove.Array<[\"com.fluidframework.leaf.string\"]>": {
+                          "kind": {
+                            "object": {
+                              "": {
+                                "kind": "Sequence",
+                                "types": [
+                                  "com.fluidframework.leaf.string"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "root": {
+                        "kind": "Value",
+                        "types": [
+                          "insert-and-remove.Array<[\"com.fluidframework.leaf.string\"]>"
+                        ]
+                      }
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Forest": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 3
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "contents": {
+                    "type": "blob",
+                    "content": {
+                      "keys": [
+                        "rootFieldKey",
+                        "repair-2"
+                      ],
+                      "fields": {
+                        "version": 2,
+                        "identifiers": [],
+                        "shapes": [
+                          {
+                            "c": {
+                              "type": "com.fluidframework.leaf.string",
+                              "value": true
+                            }
+                          },
+                          {
+                            "c": {
+                              "type": "insert-and-remove.Array<[\"com.fluidframework.leaf.string\"]>",
+                              "value": false,
+                              "fields": [
+                                [
+                                  "",
+                                  2
+                                ]
+                              ]
+                            }
+                          },
+                          {
+                            "a": 0
+                          }
+                        ],
+                        "data": [
+                          [
+                            1,
+                            0
+                          ],
+                          [
+                            0,
+                            "42"
+                          ]
+                        ]
+                      },
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "DetachedFieldIndex": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "DetachedFieldIndexBlob": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "data": [
+                        [
+                          2,
+                          2,
+                          2
+                        ]
+                      ],
+                      "maxId": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v3_0/move-across-fields-tree-0-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v3_0/move-across-fields-tree-0-final.json
@@ -1,0 +1,581 @@
+{
+  "type": "tree",
+  "entries": [
+    {
+      "type": "blob",
+      ".metadata": {
+        "type": "blob",
+        "content": {
+          "version": 2
+        },
+        "encoding": "utf-8"
+      }
+    },
+    {
+      "type": "tree",
+      "indexes": {
+        "type": "tree",
+        "entries": [
+          {
+            "type": "tree",
+            "EditManager": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "String": {
+                    "type": "blob",
+                    "content": {
+                      "trunk": [
+                        {
+                          "change": [
+                            {
+                              "schema": {
+                                "new": {
+                                  "version": 2,
+                                  "nodes": {
+                                    "com.fluidframework.leaf.string": {
+                                      "kind": {
+                                        "leaf": 1
+                                      }
+                                    },
+                                    "move-across-fields.Array<[\"com.fluidframework.leaf.string\"]>": {
+                                      "kind": {
+                                        "object": {
+                                          "": {
+                                            "kind": "Sequence",
+                                            "types": [
+                                              "com.fluidframework.leaf.string"
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "move-across-fields.Node": {
+                                      "kind": {
+                                        "object": {
+                                          "bar": {
+                                            "kind": "Value",
+                                            "types": [
+                                              "move-across-fields.Array<[\"com.fluidframework.leaf.string\"]>"
+                                            ]
+                                          },
+                                          "foo": {
+                                            "kind": "Value",
+                                            "types": [
+                                              "move-across-fields.Array<[\"com.fluidframework.leaf.string\"]>"
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "root": {
+                                    "kind": "Optional",
+                                    "types": [
+                                      "move-across-fields.Node"
+                                    ]
+                                  }
+                                },
+                                "old": {
+                                  "version": 2,
+                                  "nodes": {},
+                                  "root": {
+                                    "kind": "Forbidden",
+                                    "types": []
+                                  }
+                                }
+                              }
+                            },
+                            {
+                              "data": {
+                                "maxId": 1,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "Optional",
+                                    "change": {
+                                      "r": {
+                                        "e": true,
+                                        "d": 0,
+                                        "s": 1
+                                      }
+                                    }
+                                  }
+                                ],
+                                "builds": {
+                                  "builds": [
+                                    [
+                                      [
+                                        [
+                                          1,
+                                          0
+                                        ]
+                                      ]
+                                    ]
+                                  ],
+                                  "trees": {
+                                    "version": 2,
+                                    "identifiers": [],
+                                    "shapes": [
+                                      {
+                                        "c": {
+                                          "type": "move-across-fields.Array<[\"com.fluidframework.leaf.string\"]>",
+                                          "value": false,
+                                          "fields": [
+                                            [
+                                              "",
+                                              2
+                                            ]
+                                          ]
+                                        }
+                                      },
+                                      {
+                                        "c": {
+                                          "type": "move-across-fields.Node",
+                                          "value": false,
+                                          "fields": [
+                                            [
+                                              "foo",
+                                              0
+                                            ],
+                                            [
+                                              "bar",
+                                              0
+                                            ]
+                                          ]
+                                        }
+                                      },
+                                      {
+                                        "a": 3
+                                      },
+                                      {
+                                        "c": {
+                                          "type": "com.fluidframework.leaf.string",
+                                          "value": true
+                                        }
+                                      }
+                                    ],
+                                    "data": [
+                                      [
+                                        1,
+                                        [
+                                          "a",
+                                          "b",
+                                          "c"
+                                        ],
+                                        [
+                                          "d",
+                                          "e",
+                                          "f"
+                                        ]
+                                      ]
+                                    ]
+                                  }
+                                }
+                              }
+                            },
+                            {
+                              "schema": {
+                                "new": {
+                                  "version": 2,
+                                  "nodes": {
+                                    "com.fluidframework.leaf.string": {
+                                      "kind": {
+                                        "leaf": 1
+                                      }
+                                    },
+                                    "move-across-fields.Array<[\"com.fluidframework.leaf.string\"]>": {
+                                      "kind": {
+                                        "object": {
+                                          "": {
+                                            "kind": "Sequence",
+                                            "types": [
+                                              "com.fluidframework.leaf.string"
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "move-across-fields.Node": {
+                                      "kind": {
+                                        "object": {
+                                          "bar": {
+                                            "kind": "Value",
+                                            "types": [
+                                              "move-across-fields.Array<[\"com.fluidframework.leaf.string\"]>"
+                                            ]
+                                          },
+                                          "foo": {
+                                            "kind": "Value",
+                                            "types": [
+                                              "move-across-fields.Array<[\"com.fluidframework.leaf.string\"]>"
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "root": {
+                                    "kind": "Value",
+                                    "types": [
+                                      "move-across-fields.Node"
+                                    ]
+                                  }
+                                },
+                                "old": {
+                                  "version": 2,
+                                  "nodes": {
+                                    "com.fluidframework.leaf.string": {
+                                      "kind": {
+                                        "leaf": 1
+                                      }
+                                    },
+                                    "move-across-fields.Array<[\"com.fluidframework.leaf.string\"]>": {
+                                      "kind": {
+                                        "object": {
+                                          "": {
+                                            "kind": "Sequence",
+                                            "types": [
+                                              "com.fluidframework.leaf.string"
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "move-across-fields.Node": {
+                                      "kind": {
+                                        "object": {
+                                          "bar": {
+                                            "kind": "Value",
+                                            "types": [
+                                              "move-across-fields.Array<[\"com.fluidframework.leaf.string\"]>"
+                                            ]
+                                          },
+                                          "foo": {
+                                            "kind": "Value",
+                                            "types": [
+                                              "move-across-fields.Array<[\"com.fluidframework.leaf.string\"]>"
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "root": {
+                                    "kind": "Optional",
+                                    "types": [
+                                      "move-across-fields.Node"
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          ],
+                          "revision": 0,
+                          "sequenceNumber": 2,
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                        },
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 7,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "foo",
+                                              "fieldKind": "ModularEditBuilder.Generic",
+                                              "change": [
+                                                [
+                                                  0,
+                                                  {
+                                                    "fieldChanges": [
+                                                      {
+                                                        "fieldKey": "",
+                                                        "fieldKind": "Sequence",
+                                                        "change": [
+                                                          {
+                                                            "count": 1
+                                                          },
+                                                          {
+                                                            "count": 2,
+                                                            "effect": {
+                                                              "moveOut": {
+                                                                "id": 0
+                                                              }
+                                                            }
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              ]
+                                            },
+                                            {
+                                              "fieldKey": "bar",
+                                              "fieldKind": "ModularEditBuilder.Generic",
+                                              "change": [
+                                                [
+                                                  0,
+                                                  {
+                                                    "fieldChanges": [
+                                                      {
+                                                        "fieldKey": "",
+                                                        "fieldKind": "Sequence",
+                                                        "change": [
+                                                          {
+                                                            "count": 1
+                                                          },
+                                                          {
+                                                            "count": 2,
+                                                            "effect": {
+                                                              "moveIn": {
+                                                                "id": 0
+                                                              }
+                                                            },
+                                                            "cellId": 2
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          ],
+                          "revision": 1,
+                          "sequenceNumber": 4,
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                        }
+                      ],
+                      "branches": [],
+                      "version": 7
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Schema": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "SchemaString": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "nodes": {
+                        "com.fluidframework.leaf.string": {
+                          "kind": {
+                            "leaf": 1
+                          }
+                        },
+                        "move-across-fields.Array<[\"com.fluidframework.leaf.string\"]>": {
+                          "kind": {
+                            "object": {
+                              "": {
+                                "kind": "Sequence",
+                                "types": [
+                                  "com.fluidframework.leaf.string"
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        "move-across-fields.Node": {
+                          "kind": {
+                            "object": {
+                              "bar": {
+                                "kind": "Value",
+                                "types": [
+                                  "move-across-fields.Array<[\"com.fluidframework.leaf.string\"]>"
+                                ]
+                              },
+                              "foo": {
+                                "kind": "Value",
+                                "types": [
+                                  "move-across-fields.Array<[\"com.fluidframework.leaf.string\"]>"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "root": {
+                        "kind": "Value",
+                        "types": [
+                          "move-across-fields.Node"
+                        ]
+                      }
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Forest": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 3
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "contents": {
+                    "type": "blob",
+                    "content": {
+                      "keys": [
+                        "rootFieldKey"
+                      ],
+                      "fields": {
+                        "version": 2,
+                        "identifiers": [],
+                        "shapes": [
+                          {
+                            "c": {
+                              "type": "move-across-fields.Array<[\"com.fluidframework.leaf.string\"]>",
+                              "value": false,
+                              "fields": [
+                                [
+                                  "",
+                                  2
+                                ]
+                              ]
+                            }
+                          },
+                          {
+                            "c": {
+                              "type": "move-across-fields.Node",
+                              "value": false,
+                              "fields": [
+                                [
+                                  "foo",
+                                  0
+                                ],
+                                [
+                                  "bar",
+                                  0
+                                ]
+                              ]
+                            }
+                          },
+                          {
+                            "a": 3
+                          },
+                          {
+                            "c": {
+                              "type": "com.fluidframework.leaf.string",
+                              "value": true
+                            }
+                          }
+                        ],
+                        "data": [
+                          [
+                            1,
+                            [
+                              "a"
+                            ],
+                            [
+                              "d",
+                              "b",
+                              "c",
+                              "e",
+                              "f"
+                            ]
+                          ]
+                        ]
+                      },
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "DetachedFieldIndex": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "DetachedFieldIndexBlob": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "data": [],
+                      "maxId": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v3_0/nested-sequence-change-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v3_0/nested-sequence-change-final.json
@@ -1,0 +1,345 @@
+{
+  "type": "tree",
+  "entries": [
+    {
+      "type": "blob",
+      ".metadata": {
+        "type": "blob",
+        "content": {
+          "version": 2
+        },
+        "encoding": "utf-8"
+      }
+    },
+    {
+      "type": "tree",
+      "indexes": {
+        "type": "tree",
+        "entries": [
+          {
+            "type": "tree",
+            "EditManager": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "String": {
+                    "type": "blob",
+                    "content": {
+                      "trunk": [
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 5,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "",
+                                              "fieldKind": "Sequence",
+                                              "change": [
+                                                {
+                                                  "count": 1,
+                                                  "effect": {
+                                                    "insert": {
+                                                      "id": 0
+                                                    }
+                                                  },
+                                                  "cellId": 0,
+                                                  "changes": {
+                                                    "fieldChanges": [
+                                                      {
+                                                        "fieldKey": "foo",
+                                                        "fieldKind": "Optional",
+                                                        "change": {
+                                                          "r": {
+                                                            "e": true,
+                                                            "d": 2,
+                                                            "s": 3
+                                                          }
+                                                        }
+                                                      }
+                                                    ]
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ],
+                                "builds": {
+                                  "builds": [
+                                    [
+                                      [
+                                        [
+                                          0,
+                                          0
+                                        ],
+                                        [
+                                          3,
+                                          1
+                                        ]
+                                      ]
+                                    ]
+                                  ],
+                                  "trees": {
+                                    "version": 2,
+                                    "identifiers": [],
+                                    "shapes": [
+                                      {
+                                        "c": {
+                                          "type": "test trees.Recursive Map",
+                                          "value": false,
+                                          "extraFields": 3
+                                        }
+                                      },
+                                      {
+                                        "c": {
+                                          "type": "test trees.Array<[\"test trees.Recursive Map\"]>",
+                                          "value": false,
+                                          "fields": [
+                                            [
+                                              "",
+                                              2
+                                            ]
+                                          ]
+                                        }
+                                      },
+                                      {
+                                        "a": 0
+                                      },
+                                      {
+                                        "a": 1
+                                      }
+                                    ],
+                                    "data": [
+                                      [
+                                        0,
+                                        []
+                                      ],
+                                      [
+                                        1,
+                                        [
+                                          [
+                                            "bar",
+                                            [
+                                              0
+                                            ]
+                                          ]
+                                        ]
+                                      ]
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          ],
+                          "revision": 1,
+                          "sequenceNumber": 4,
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                        }
+                      ],
+                      "branches": [],
+                      "version": 7
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Schema": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "SchemaString": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "nodes": {
+                        "test trees.Array<[\"test trees.Recursive Map\"]>": {
+                          "kind": {
+                            "object": {
+                              "": {
+                                "kind": "Sequence",
+                                "types": [
+                                  "test trees.Recursive Map"
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        "test trees.Recursive Map": {
+                          "kind": {
+                            "map": {
+                              "kind": "Optional",
+                              "types": [
+                                "test trees.Array<[\"test trees.Recursive Map\"]>"
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      "root": {
+                        "kind": "Value",
+                        "types": [
+                          "test trees.Array<[\"test trees.Recursive Map\"]>"
+                        ]
+                      }
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Forest": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 3
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "contents": {
+                    "type": "blob",
+                    "content": {
+                      "keys": [
+                        "rootFieldKey"
+                      ],
+                      "fields": {
+                        "version": 2,
+                        "identifiers": [],
+                        "shapes": [
+                          {
+                            "c": {
+                              "type": "test trees.Array<[\"test trees.Recursive Map\"]>",
+                              "value": false,
+                              "fields": [
+                                [
+                                  "",
+                                  1
+                                ]
+                              ]
+                            }
+                          },
+                          {
+                            "a": 2
+                          },
+                          {
+                            "c": {
+                              "type": "test trees.Recursive Map",
+                              "value": false,
+                              "extraFields": 3
+                            }
+                          },
+                          {
+                            "a": 0
+                          }
+                        ],
+                        "data": [
+                          [
+                            0,
+                            [
+                              [
+                                "foo",
+                                [
+                                  [
+                                    [
+                                      "bar",
+                                      [
+                                        0
+                                      ]
+                                    ]
+                                  ]
+                                ]
+                              ]
+                            ]
+                          ]
+                        ]
+                      },
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "DetachedFieldIndex": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "DetachedFieldIndexBlob": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "data": [],
+                      "maxId": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v3_0/optional-field-scenarios-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v3_0/optional-field-scenarios-final.json
@@ -1,0 +1,610 @@
+{
+  "type": "tree",
+  "entries": [
+    {
+      "type": "blob",
+      ".metadata": {
+        "type": "blob",
+        "content": {
+          "version": 2
+        },
+        "encoding": "utf-8"
+      }
+    },
+    {
+      "type": "tree",
+      "indexes": {
+        "type": "tree",
+        "entries": [
+          {
+            "type": "tree",
+            "EditManager": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "String": {
+                    "type": "blob",
+                    "content": {
+                      "trunk": [
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 2,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "root 1 child",
+                                              "fieldKind": "Optional",
+                                              "change": {
+                                                "r": {
+                                                  "e": true,
+                                                  "d": 0,
+                                                  "s": 1
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ],
+                                "builds": {
+                                  "builds": [
+                                    [
+                                      [
+                                        [
+                                          1,
+                                          0
+                                        ]
+                                      ]
+                                    ]
+                                  ],
+                                  "trees": {
+                                    "version": 2,
+                                    "identifiers": [],
+                                    "shapes": [
+                                      {
+                                        "c": {
+                                          "type": "com.fluidframework.leaf.number",
+                                          "value": true
+                                        }
+                                      }
+                                    ],
+                                    "data": [
+                                      [
+                                        0,
+                                        40
+                                      ]
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          ],
+                          "revision": 513,
+                          "sequenceNumber": 6,
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                        },
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 4,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "Optional",
+                                    "change": {
+                                      "r": {
+                                        "e": false,
+                                        "d": 3,
+                                        "s": 4
+                                      }
+                                    }
+                                  }
+                                ],
+                                "builds": {
+                                  "builds": [
+                                    [
+                                      [
+                                        [
+                                          4,
+                                          0
+                                        ]
+                                      ]
+                                    ]
+                                  ],
+                                  "trees": {
+                                    "version": 2,
+                                    "identifiers": [],
+                                    "shapes": [
+                                      {
+                                        "c": {
+                                          "type": "optional-field-scenarios.Map",
+                                          "value": false,
+                                          "extraFields": 2
+                                        }
+                                      },
+                                      {
+                                        "c": {
+                                          "type": "com.fluidframework.leaf.number",
+                                          "value": true
+                                        }
+                                      },
+                                      {
+                                        "a": 3
+                                      },
+                                      {
+                                        "d": 0
+                                      }
+                                    ],
+                                    "data": [
+                                      [
+                                        0,
+                                        [
+                                          "root 2 child",
+                                          [
+                                            1,
+                                            41
+                                          ]
+                                        ]
+                                      ]
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          ],
+                          "revision": 514,
+                          "sequenceNumber": 8,
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                        },
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 7,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "Optional",
+                                    "change": {
+                                      "r": {
+                                        "e": false,
+                                        "d": 3,
+                                        "s": 4
+                                      },
+                                      "c": [
+                                        [
+                                          [
+                                            3,
+                                            514
+                                          ],
+                                          {
+                                            "fieldChanges": [
+                                              {
+                                                "fieldKey": "root 1 child",
+                                                "fieldKind": "Optional",
+                                                "change": {
+                                                  "r": {
+                                                    "e": false,
+                                                    "d": 0,
+                                                    "s": 1
+                                                  }
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        ],
+                                        [
+                                          4,
+                                          {
+                                            "fieldChanges": [
+                                              {
+                                                "fieldKey": "root 3 child",
+                                                "fieldKind": "Optional",
+                                                "change": {
+                                                  "r": {
+                                                    "e": true,
+                                                    "d": 5,
+                                                    "s": 6
+                                                  }
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      ]
+                                    }
+                                  }
+                                ],
+                                "builds": {
+                                  "builds": [
+                                    [
+                                      [
+                                        [
+                                          1,
+                                          0
+                                        ],
+                                        [
+                                          4,
+                                          1
+                                        ],
+                                        [
+                                          6,
+                                          2
+                                        ]
+                                      ]
+                                    ]
+                                  ],
+                                  "trees": {
+                                    "version": 2,
+                                    "identifiers": [],
+                                    "shapes": [
+                                      {
+                                        "c": {
+                                          "type": "com.fluidframework.leaf.number",
+                                          "value": true
+                                        }
+                                      },
+                                      {
+                                        "c": {
+                                          "type": "optional-field-scenarios.Map",
+                                          "value": false,
+                                          "extraFields": 2
+                                        }
+                                      },
+                                      {
+                                        "a": 3
+                                      },
+                                      {
+                                        "d": 0
+                                      }
+                                    ],
+                                    "data": [
+                                      [
+                                        0,
+                                        42
+                                      ],
+                                      [
+                                        1,
+                                        []
+                                      ],
+                                      [
+                                        0,
+                                        43
+                                      ]
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          ],
+                          "revision": 2,
+                          "sequenceNumber": 10,
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                        },
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 7,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "Optional",
+                                    "change": {
+                                      "c": [
+                                        [
+                                          null,
+                                          {
+                                            "fieldChanges": [
+                                              {
+                                                "fieldKey": "root 3 child",
+                                                "fieldKind": "Optional",
+                                                "change": {
+                                                  "r": {
+                                                    "e": false,
+                                                    "d": 2,
+                                                    "s": 3
+                                                  }
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      ]
+                                    }
+                                  }
+                                ],
+                                "builds": {
+                                  "builds": [
+                                    [
+                                      [
+                                        [
+                                          3,
+                                          0
+                                        ]
+                                      ]
+                                    ]
+                                  ],
+                                  "trees": {
+                                    "version": 2,
+                                    "identifiers": [],
+                                    "shapes": [
+                                      {
+                                        "c": {
+                                          "type": "com.fluidframework.leaf.number",
+                                          "value": true
+                                        }
+                                      }
+                                    ],
+                                    "data": [
+                                      [
+                                        0,
+                                        44
+                                      ]
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          ],
+                          "revision": 3,
+                          "sequenceNumber": 12,
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                        }
+                      ],
+                      "branches": [
+                        [
+                          "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          {
+                            "base": 514,
+                            "commits": []
+                          }
+                        ]
+                      ],
+                      "version": 7
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Schema": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "SchemaString": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "nodes": {
+                        "com.fluidframework.leaf.number": {
+                          "kind": {
+                            "leaf": 0
+                          }
+                        },
+                        "com.fluidframework.leaf.string": {
+                          "kind": {
+                            "leaf": 1
+                          }
+                        },
+                        "optional-field-scenarios.Map": {
+                          "kind": {
+                            "map": {
+                              "kind": "Optional",
+                              "types": [
+                                "com.fluidframework.leaf.number",
+                                "com.fluidframework.leaf.string"
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      "root": {
+                        "kind": "Optional",
+                        "types": [
+                          "optional-field-scenarios.Map"
+                        ]
+                      }
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Forest": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 3
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "contents": {
+                    "type": "blob",
+                    "content": {
+                      "keys": [
+                        "rootFieldKey",
+                        "repair-6",
+                        "repair-8",
+                        "repair-10",
+                        "repair-11"
+                      ],
+                      "fields": {
+                        "version": 2,
+                        "identifiers": [],
+                        "shapes": [
+                          {
+                            "c": {
+                              "type": "com.fluidframework.leaf.number",
+                              "value": true
+                            }
+                          },
+                          {
+                            "c": {
+                              "type": "optional-field-scenarios.Map",
+                              "value": false,
+                              "extraFields": 2
+                            }
+                          },
+                          {
+                            "a": 3
+                          },
+                          {
+                            "d": 0
+                          }
+                        ],
+                        "data": [
+                          [
+                            1,
+                            [
+                              "root 3 child",
+                              [
+                                0,
+                                44
+                              ]
+                            ]
+                          ],
+                          [
+                            0,
+                            43
+                          ],
+                          [
+                            0,
+                            40
+                          ],
+                          [
+                            1,
+                            [
+                              "root 1 child",
+                              [
+                                0,
+                                42
+                              ]
+                            ]
+                          ],
+                          [
+                            1,
+                            [
+                              "root 2 child",
+                              [
+                                0,
+                                41
+                              ]
+                            ]
+                          ]
+                        ]
+                      },
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "DetachedFieldIndex": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "DetachedFieldIndexBlob": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "data": [
+                        [
+                          2,
+                          [
+                            [
+                              0,
+                              8
+                            ],
+                            [
+                              3,
+                              11
+                            ]
+                          ]
+                        ],
+                        [
+                          3,
+                          2,
+                          6
+                        ],
+                        [
+                          514,
+                          3,
+                          10
+                        ]
+                      ],
+                      "maxId": 11
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v3_0/tree-with-identifier-field-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v3_0/tree-with-identifier-field-final.json
@@ -1,0 +1,365 @@
+{
+  "type": "tree",
+  "entries": [
+    {
+      "type": "blob",
+      ".metadata": {
+        "type": "blob",
+        "content": {
+          "version": 2
+        },
+        "encoding": "utf-8"
+      }
+    },
+    {
+      "type": "tree",
+      "indexes": {
+        "type": "tree",
+        "entries": [
+          {
+            "type": "tree",
+            "EditManager": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "String": {
+                    "type": "blob",
+                    "content": {
+                      "trunk": [
+                        {
+                          "change": [
+                            {
+                              "schema": {
+                                "new": {
+                                  "version": 2,
+                                  "nodes": {
+                                    "com.example.parent": {
+                                      "kind": {
+                                        "object": {
+                                          "identifier": {
+                                            "kind": "Identifier",
+                                            "types": [
+                                              "com.fluidframework.leaf.string"
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "com.fluidframework.leaf.string": {
+                                      "kind": {
+                                        "leaf": 1
+                                      }
+                                    }
+                                  },
+                                  "root": {
+                                    "kind": "Optional",
+                                    "types": [
+                                      "com.example.parent"
+                                    ]
+                                  }
+                                },
+                                "old": {
+                                  "version": 2,
+                                  "nodes": {},
+                                  "root": {
+                                    "kind": "Forbidden",
+                                    "types": []
+                                  }
+                                }
+                              }
+                            },
+                            {
+                              "data": {
+                                "maxId": 1,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "Optional",
+                                    "change": {
+                                      "r": {
+                                        "e": true,
+                                        "d": 0,
+                                        "s": 1
+                                      }
+                                    }
+                                  }
+                                ],
+                                "builds": {
+                                  "builds": [
+                                    [
+                                      [
+                                        [
+                                          1,
+                                          0
+                                        ]
+                                      ]
+                                    ]
+                                  ],
+                                  "trees": {
+                                    "version": 2,
+                                    "identifiers": [],
+                                    "shapes": [
+                                      {
+                                        "c": {
+                                          "type": "com.example.parent",
+                                          "value": false,
+                                          "fields": [
+                                            [
+                                              "identifier",
+                                              1
+                                            ]
+                                          ]
+                                        }
+                                      },
+                                      {
+                                        "c": {
+                                          "type": "com.fluidframework.leaf.string",
+                                          "value": 0
+                                        }
+                                      }
+                                    ],
+                                    "data": [
+                                      [
+                                        0,
+                                        0
+                                      ]
+                                    ]
+                                  }
+                                }
+                              }
+                            },
+                            {
+                              "schema": {
+                                "new": {
+                                  "version": 2,
+                                  "nodes": {
+                                    "com.example.parent": {
+                                      "kind": {
+                                        "object": {
+                                          "identifier": {
+                                            "kind": "Identifier",
+                                            "types": [
+                                              "com.fluidframework.leaf.string"
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "com.fluidframework.leaf.string": {
+                                      "kind": {
+                                        "leaf": 1
+                                      }
+                                    }
+                                  },
+                                  "root": {
+                                    "kind": "Value",
+                                    "types": [
+                                      "com.example.parent"
+                                    ]
+                                  }
+                                },
+                                "old": {
+                                  "version": 2,
+                                  "nodes": {
+                                    "com.example.parent": {
+                                      "kind": {
+                                        "object": {
+                                          "identifier": {
+                                            "kind": "Identifier",
+                                            "types": [
+                                              "com.fluidframework.leaf.string"
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "com.fluidframework.leaf.string": {
+                                      "kind": {
+                                        "leaf": 1
+                                      }
+                                    }
+                                  },
+                                  "root": {
+                                    "kind": "Optional",
+                                    "types": [
+                                      "com.example.parent"
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          ],
+                          "revision": 1,
+                          "sequenceNumber": 2,
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                        }
+                      ],
+                      "branches": [],
+                      "version": 7
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Schema": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "SchemaString": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "nodes": {
+                        "com.example.parent": {
+                          "kind": {
+                            "object": {
+                              "identifier": {
+                                "kind": "Identifier",
+                                "types": [
+                                  "com.fluidframework.leaf.string"
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        "com.fluidframework.leaf.string": {
+                          "kind": {
+                            "leaf": 1
+                          }
+                        }
+                      },
+                      "root": {
+                        "kind": "Value",
+                        "types": [
+                          "com.example.parent"
+                        ]
+                      }
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Forest": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 3
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "contents": {
+                    "type": "blob",
+                    "content": {
+                      "keys": [
+                        "rootFieldKey"
+                      ],
+                      "fields": {
+                        "version": 2,
+                        "identifiers": [],
+                        "shapes": [
+                          {
+                            "c": {
+                              "type": "com.example.parent",
+                              "value": false,
+                              "fields": [
+                                [
+                                  "identifier",
+                                  1
+                                ]
+                              ]
+                            }
+                          },
+                          {
+                            "c": {
+                              "type": "com.fluidframework.leaf.string",
+                              "value": 0
+                            }
+                          }
+                        ],
+                        "data": [
+                          [
+                            0,
+                            0
+                          ]
+                        ]
+                      },
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "DetachedFieldIndex": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "DetachedFieldIndexBlob": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "data": [],
+                      "maxId": 0
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v3_0/attachment-tree-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v3_0/attachment-tree-final.json
@@ -1,0 +1,203 @@
+{
+  "type": "tree",
+  "entries": [
+    {
+      "type": "blob",
+      ".metadata": {
+        "type": "blob",
+        "content": {
+          "version": 2
+        },
+        "encoding": "utf-8"
+      }
+    },
+    {
+      "type": "tree",
+      "indexes": {
+        "type": "tree",
+        "entries": [
+          {
+            "type": "tree",
+            "EditManager": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "String": {
+                    "type": "blob",
+                    "content": {
+                      "trunk": [],
+                      "branches": [],
+                      "version": 7
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Schema": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "SchemaString": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "nodes": {
+                        "attachment-tree.Array<[\"com.fluidframework.leaf.string\"]>": {
+                          "kind": {
+                            "object": {
+                              "": {
+                                "kind": "Sequence",
+                                "types": [
+                                  "com.fluidframework.leaf.string"
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        "com.fluidframework.leaf.string": {
+                          "kind": {
+                            "leaf": 1
+                          }
+                        }
+                      },
+                      "root": {
+                        "kind": "Value",
+                        "types": [
+                          "attachment-tree.Array<[\"com.fluidframework.leaf.string\"]>"
+                        ]
+                      }
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Forest": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 3
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "contents": {
+                    "type": "blob",
+                    "content": {
+                      "keys": [
+                        "rootFieldKey"
+                      ],
+                      "fields": {
+                        "version": 2,
+                        "identifiers": [],
+                        "shapes": [
+                          {
+                            "c": {
+                              "extraFields": 1
+                            }
+                          },
+                          {
+                            "a": 0
+                          }
+                        ],
+                        "data": [
+                          [
+                            1,
+                            [
+                              "attachment-tree.Array<[\"com.fluidframework.leaf.string\"]>",
+                              false,
+                              [
+                                "",
+                                [
+                                  "com.fluidframework.leaf.string",
+                                  true,
+                                  "a",
+                                  [],
+                                  "com.fluidframework.leaf.string",
+                                  true,
+                                  "b",
+                                  []
+                                ]
+                              ]
+                            ]
+                          ]
+                        ]
+                      },
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "DetachedFieldIndex": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "DetachedFieldIndexBlob": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "data": [],
+                      "maxId": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v3_0/competing-removes-index-0.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v3_0/competing-removes-index-0.json
@@ -1,0 +1,452 @@
+{
+  "type": "tree",
+  "entries": [
+    {
+      "type": "blob",
+      ".metadata": {
+        "type": "blob",
+        "content": {
+          "version": 2
+        },
+        "encoding": "utf-8"
+      }
+    },
+    {
+      "type": "tree",
+      "indexes": {
+        "type": "tree",
+        "entries": [
+          {
+            "type": "tree",
+            "EditManager": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "String": {
+                    "type": "blob",
+                    "content": {
+                      "trunk": [
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 1,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "",
+                                              "fieldKind": "Sequence",
+                                              "change": [
+                                                {
+                                                  "count": 1,
+                                                  "effect": {
+                                                    "remove": {
+                                                      "id": 0
+                                                    }
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          ],
+                          "revision": 1,
+                          "sequenceNumber": 4,
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                        },
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 1,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "",
+                                              "fieldKind": "Sequence",
+                                              "change": [
+                                                {
+                                                  "count": 1,
+                                                  "effect": {
+                                                    "remove": {
+                                                      "id": 0
+                                                    }
+                                                  },
+                                                  "cellId": [
+                                                    0,
+                                                    1
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          ],
+                          "revision": 513,
+                          "sequenceNumber": 6,
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                        },
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 1,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "",
+                                              "fieldKind": "Sequence",
+                                              "change": [
+                                                {
+                                                  "count": 1,
+                                                  "effect": {
+                                                    "remove": {
+                                                      "id": 0
+                                                    }
+                                                  },
+                                                  "cellId": [
+                                                    0,
+                                                    513
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          ],
+                          "revision": 1026,
+                          "sequenceNumber": 8,
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                        }
+                      ],
+                      "branches": [
+                        [
+                          "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          {
+                            "base": "root",
+                            "commits": [
+                              {
+                                "change": [
+                                  {
+                                    "data": {
+                                      "maxId": 1,
+                                      "changes": [
+                                        {
+                                          "fieldKey": "rootFieldKey",
+                                          "fieldKind": "ModularEditBuilder.Generic",
+                                          "change": [
+                                            [
+                                              0,
+                                              {
+                                                "fieldChanges": [
+                                                  {
+                                                    "fieldKey": "",
+                                                    "fieldKind": "Sequence",
+                                                    "change": [
+                                                      {
+                                                        "count": 1,
+                                                        "effect": {
+                                                          "remove": {
+                                                            "id": 0
+                                                          }
+                                                        }
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ],
+                                "revision": 513,
+                                "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                              }
+                            ]
+                          }
+                        ],
+                        [
+                          "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          {
+                            "base": "root",
+                            "commits": [
+                              {
+                                "change": [
+                                  {
+                                    "data": {
+                                      "maxId": 1,
+                                      "changes": [
+                                        {
+                                          "fieldKey": "rootFieldKey",
+                                          "fieldKind": "ModularEditBuilder.Generic",
+                                          "change": [
+                                            [
+                                              0,
+                                              {
+                                                "fieldChanges": [
+                                                  {
+                                                    "fieldKey": "",
+                                                    "fieldKind": "Sequence",
+                                                    "change": [
+                                                      {
+                                                        "count": 1,
+                                                        "effect": {
+                                                          "remove": {
+                                                            "id": 0
+                                                          }
+                                                        }
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ],
+                                "revision": 1026,
+                                "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                              }
+                            ]
+                          }
+                        ]
+                      ],
+                      "version": 7
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Schema": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "SchemaString": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "nodes": {
+                        "com.fluidframework.leaf.number": {
+                          "kind": {
+                            "leaf": 0
+                          }
+                        },
+                        "competing-removes.Array<[\"com.fluidframework.leaf.number\"]>": {
+                          "kind": {
+                            "object": {
+                              "": {
+                                "kind": "Sequence",
+                                "types": [
+                                  "com.fluidframework.leaf.number"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "root": {
+                        "kind": "Value",
+                        "types": [
+                          "competing-removes.Array<[\"com.fluidframework.leaf.number\"]>"
+                        ]
+                      }
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Forest": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 3
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "contents": {
+                    "type": "blob",
+                    "content": {
+                      "keys": [
+                        "rootFieldKey",
+                        "repair-3"
+                      ],
+                      "fields": {
+                        "version": 2,
+                        "identifiers": [],
+                        "shapes": [
+                          {
+                            "c": {
+                              "extraFields": 1
+                            }
+                          },
+                          {
+                            "a": 0
+                          }
+                        ],
+                        "data": [
+                          [
+                            1,
+                            [
+                              "competing-removes.Array<[\"com.fluidframework.leaf.number\"]>",
+                              false,
+                              [
+                                "",
+                                [
+                                  "com.fluidframework.leaf.number",
+                                  true,
+                                  1,
+                                  [],
+                                  "com.fluidframework.leaf.number",
+                                  true,
+                                  2,
+                                  [],
+                                  "com.fluidframework.leaf.number",
+                                  true,
+                                  3,
+                                  []
+                                ]
+                              ]
+                            ]
+                          ],
+                          [
+                            1,
+                            [
+                              "com.fluidframework.leaf.number",
+                              true,
+                              0,
+                              []
+                            ]
+                          ]
+                        ]
+                      },
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "DetachedFieldIndex": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "DetachedFieldIndexBlob": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "data": [
+                        [
+                          1026,
+                          0,
+                          3
+                        ]
+                      ],
+                      "maxId": 3
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v3_0/competing-removes-index-1.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v3_0/competing-removes-index-1.json
@@ -1,0 +1,467 @@
+{
+  "type": "tree",
+  "entries": [
+    {
+      "type": "blob",
+      ".metadata": {
+        "type": "blob",
+        "content": {
+          "version": 2
+        },
+        "encoding": "utf-8"
+      }
+    },
+    {
+      "type": "tree",
+      "indexes": {
+        "type": "tree",
+        "entries": [
+          {
+            "type": "tree",
+            "EditManager": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "String": {
+                    "type": "blob",
+                    "content": {
+                      "trunk": [
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 1,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "",
+                                              "fieldKind": "Sequence",
+                                              "change": [
+                                                {
+                                                  "count": 1
+                                                },
+                                                {
+                                                  "count": 1,
+                                                  "effect": {
+                                                    "remove": {
+                                                      "id": 0
+                                                    }
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          ],
+                          "revision": 1,
+                          "sequenceNumber": 4,
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                        },
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 1,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "",
+                                              "fieldKind": "Sequence",
+                                              "change": [
+                                                {
+                                                  "count": 1
+                                                },
+                                                {
+                                                  "count": 1,
+                                                  "effect": {
+                                                    "remove": {
+                                                      "id": 0
+                                                    }
+                                                  },
+                                                  "cellId": [
+                                                    0,
+                                                    1
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          ],
+                          "revision": 513,
+                          "sequenceNumber": 6,
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                        },
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 1,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "",
+                                              "fieldKind": "Sequence",
+                                              "change": [
+                                                {
+                                                  "count": 1
+                                                },
+                                                {
+                                                  "count": 1,
+                                                  "effect": {
+                                                    "remove": {
+                                                      "id": 0
+                                                    }
+                                                  },
+                                                  "cellId": [
+                                                    0,
+                                                    513
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          ],
+                          "revision": 1026,
+                          "sequenceNumber": 8,
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                        }
+                      ],
+                      "branches": [
+                        [
+                          "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          {
+                            "base": "root",
+                            "commits": [
+                              {
+                                "change": [
+                                  {
+                                    "data": {
+                                      "maxId": 1,
+                                      "changes": [
+                                        {
+                                          "fieldKey": "rootFieldKey",
+                                          "fieldKind": "ModularEditBuilder.Generic",
+                                          "change": [
+                                            [
+                                              0,
+                                              {
+                                                "fieldChanges": [
+                                                  {
+                                                    "fieldKey": "",
+                                                    "fieldKind": "Sequence",
+                                                    "change": [
+                                                      {
+                                                        "count": 1
+                                                      },
+                                                      {
+                                                        "count": 1,
+                                                        "effect": {
+                                                          "remove": {
+                                                            "id": 0
+                                                          }
+                                                        }
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ],
+                                "revision": 513,
+                                "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                              }
+                            ]
+                          }
+                        ],
+                        [
+                          "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          {
+                            "base": "root",
+                            "commits": [
+                              {
+                                "change": [
+                                  {
+                                    "data": {
+                                      "maxId": 1,
+                                      "changes": [
+                                        {
+                                          "fieldKey": "rootFieldKey",
+                                          "fieldKind": "ModularEditBuilder.Generic",
+                                          "change": [
+                                            [
+                                              0,
+                                              {
+                                                "fieldChanges": [
+                                                  {
+                                                    "fieldKey": "",
+                                                    "fieldKind": "Sequence",
+                                                    "change": [
+                                                      {
+                                                        "count": 1
+                                                      },
+                                                      {
+                                                        "count": 1,
+                                                        "effect": {
+                                                          "remove": {
+                                                            "id": 0
+                                                          }
+                                                        }
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ],
+                                "revision": 1026,
+                                "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                              }
+                            ]
+                          }
+                        ]
+                      ],
+                      "version": 7
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Schema": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "SchemaString": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "nodes": {
+                        "com.fluidframework.leaf.number": {
+                          "kind": {
+                            "leaf": 0
+                          }
+                        },
+                        "competing-removes.Array<[\"com.fluidframework.leaf.number\"]>": {
+                          "kind": {
+                            "object": {
+                              "": {
+                                "kind": "Sequence",
+                                "types": [
+                                  "com.fluidframework.leaf.number"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "root": {
+                        "kind": "Value",
+                        "types": [
+                          "competing-removes.Array<[\"com.fluidframework.leaf.number\"]>"
+                        ]
+                      }
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Forest": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 3
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "contents": {
+                    "type": "blob",
+                    "content": {
+                      "keys": [
+                        "rootFieldKey",
+                        "repair-3"
+                      ],
+                      "fields": {
+                        "version": 2,
+                        "identifiers": [],
+                        "shapes": [
+                          {
+                            "c": {
+                              "extraFields": 1
+                            }
+                          },
+                          {
+                            "a": 0
+                          }
+                        ],
+                        "data": [
+                          [
+                            1,
+                            [
+                              "competing-removes.Array<[\"com.fluidframework.leaf.number\"]>",
+                              false,
+                              [
+                                "",
+                                [
+                                  "com.fluidframework.leaf.number",
+                                  true,
+                                  0,
+                                  [],
+                                  "com.fluidframework.leaf.number",
+                                  true,
+                                  2,
+                                  [],
+                                  "com.fluidframework.leaf.number",
+                                  true,
+                                  3,
+                                  []
+                                ]
+                              ]
+                            ]
+                          ],
+                          [
+                            1,
+                            [
+                              "com.fluidframework.leaf.number",
+                              true,
+                              1,
+                              []
+                            ]
+                          ]
+                        ]
+                      },
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "DetachedFieldIndex": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "DetachedFieldIndexBlob": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "data": [
+                        [
+                          1026,
+                          0,
+                          3
+                        ]
+                      ],
+                      "maxId": 3
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v3_0/competing-removes-index-2.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v3_0/competing-removes-index-2.json
@@ -1,0 +1,467 @@
+{
+  "type": "tree",
+  "entries": [
+    {
+      "type": "blob",
+      ".metadata": {
+        "type": "blob",
+        "content": {
+          "version": 2
+        },
+        "encoding": "utf-8"
+      }
+    },
+    {
+      "type": "tree",
+      "indexes": {
+        "type": "tree",
+        "entries": [
+          {
+            "type": "tree",
+            "EditManager": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "String": {
+                    "type": "blob",
+                    "content": {
+                      "trunk": [
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 1,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "",
+                                              "fieldKind": "Sequence",
+                                              "change": [
+                                                {
+                                                  "count": 2
+                                                },
+                                                {
+                                                  "count": 1,
+                                                  "effect": {
+                                                    "remove": {
+                                                      "id": 0
+                                                    }
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          ],
+                          "revision": 1,
+                          "sequenceNumber": 4,
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                        },
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 1,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "",
+                                              "fieldKind": "Sequence",
+                                              "change": [
+                                                {
+                                                  "count": 2
+                                                },
+                                                {
+                                                  "count": 1,
+                                                  "effect": {
+                                                    "remove": {
+                                                      "id": 0
+                                                    }
+                                                  },
+                                                  "cellId": [
+                                                    0,
+                                                    1
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          ],
+                          "revision": 513,
+                          "sequenceNumber": 6,
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                        },
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 1,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "",
+                                              "fieldKind": "Sequence",
+                                              "change": [
+                                                {
+                                                  "count": 2
+                                                },
+                                                {
+                                                  "count": 1,
+                                                  "effect": {
+                                                    "remove": {
+                                                      "id": 0
+                                                    }
+                                                  },
+                                                  "cellId": [
+                                                    0,
+                                                    513
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          ],
+                          "revision": 1026,
+                          "sequenceNumber": 8,
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                        }
+                      ],
+                      "branches": [
+                        [
+                          "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          {
+                            "base": "root",
+                            "commits": [
+                              {
+                                "change": [
+                                  {
+                                    "data": {
+                                      "maxId": 1,
+                                      "changes": [
+                                        {
+                                          "fieldKey": "rootFieldKey",
+                                          "fieldKind": "ModularEditBuilder.Generic",
+                                          "change": [
+                                            [
+                                              0,
+                                              {
+                                                "fieldChanges": [
+                                                  {
+                                                    "fieldKey": "",
+                                                    "fieldKind": "Sequence",
+                                                    "change": [
+                                                      {
+                                                        "count": 2
+                                                      },
+                                                      {
+                                                        "count": 1,
+                                                        "effect": {
+                                                          "remove": {
+                                                            "id": 0
+                                                          }
+                                                        }
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ],
+                                "revision": 513,
+                                "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                              }
+                            ]
+                          }
+                        ],
+                        [
+                          "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          {
+                            "base": "root",
+                            "commits": [
+                              {
+                                "change": [
+                                  {
+                                    "data": {
+                                      "maxId": 1,
+                                      "changes": [
+                                        {
+                                          "fieldKey": "rootFieldKey",
+                                          "fieldKind": "ModularEditBuilder.Generic",
+                                          "change": [
+                                            [
+                                              0,
+                                              {
+                                                "fieldChanges": [
+                                                  {
+                                                    "fieldKey": "",
+                                                    "fieldKind": "Sequence",
+                                                    "change": [
+                                                      {
+                                                        "count": 2
+                                                      },
+                                                      {
+                                                        "count": 1,
+                                                        "effect": {
+                                                          "remove": {
+                                                            "id": 0
+                                                          }
+                                                        }
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ],
+                                "revision": 1026,
+                                "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                              }
+                            ]
+                          }
+                        ]
+                      ],
+                      "version": 7
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Schema": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "SchemaString": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "nodes": {
+                        "com.fluidframework.leaf.number": {
+                          "kind": {
+                            "leaf": 0
+                          }
+                        },
+                        "competing-removes.Array<[\"com.fluidframework.leaf.number\"]>": {
+                          "kind": {
+                            "object": {
+                              "": {
+                                "kind": "Sequence",
+                                "types": [
+                                  "com.fluidframework.leaf.number"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "root": {
+                        "kind": "Value",
+                        "types": [
+                          "competing-removes.Array<[\"com.fluidframework.leaf.number\"]>"
+                        ]
+                      }
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Forest": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 3
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "contents": {
+                    "type": "blob",
+                    "content": {
+                      "keys": [
+                        "rootFieldKey",
+                        "repair-3"
+                      ],
+                      "fields": {
+                        "version": 2,
+                        "identifiers": [],
+                        "shapes": [
+                          {
+                            "c": {
+                              "extraFields": 1
+                            }
+                          },
+                          {
+                            "a": 0
+                          }
+                        ],
+                        "data": [
+                          [
+                            1,
+                            [
+                              "competing-removes.Array<[\"com.fluidframework.leaf.number\"]>",
+                              false,
+                              [
+                                "",
+                                [
+                                  "com.fluidframework.leaf.number",
+                                  true,
+                                  0,
+                                  [],
+                                  "com.fluidframework.leaf.number",
+                                  true,
+                                  1,
+                                  [],
+                                  "com.fluidframework.leaf.number",
+                                  true,
+                                  3,
+                                  []
+                                ]
+                              ]
+                            ]
+                          ],
+                          [
+                            1,
+                            [
+                              "com.fluidframework.leaf.number",
+                              true,
+                              2,
+                              []
+                            ]
+                          ]
+                        ]
+                      },
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "DetachedFieldIndex": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "DetachedFieldIndexBlob": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "data": [
+                        [
+                          1026,
+                          0,
+                          3
+                        ]
+                      ],
+                      "maxId": 3
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v3_0/competing-removes-index-3.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v3_0/competing-removes-index-3.json
@@ -1,0 +1,467 @@
+{
+  "type": "tree",
+  "entries": [
+    {
+      "type": "blob",
+      ".metadata": {
+        "type": "blob",
+        "content": {
+          "version": 2
+        },
+        "encoding": "utf-8"
+      }
+    },
+    {
+      "type": "tree",
+      "indexes": {
+        "type": "tree",
+        "entries": [
+          {
+            "type": "tree",
+            "EditManager": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "String": {
+                    "type": "blob",
+                    "content": {
+                      "trunk": [
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 1,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "",
+                                              "fieldKind": "Sequence",
+                                              "change": [
+                                                {
+                                                  "count": 3
+                                                },
+                                                {
+                                                  "count": 1,
+                                                  "effect": {
+                                                    "remove": {
+                                                      "id": 0
+                                                    }
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          ],
+                          "revision": 1,
+                          "sequenceNumber": 4,
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                        },
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 1,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "",
+                                              "fieldKind": "Sequence",
+                                              "change": [
+                                                {
+                                                  "count": 3
+                                                },
+                                                {
+                                                  "count": 1,
+                                                  "effect": {
+                                                    "remove": {
+                                                      "id": 0
+                                                    }
+                                                  },
+                                                  "cellId": [
+                                                    0,
+                                                    1
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          ],
+                          "revision": 513,
+                          "sequenceNumber": 6,
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                        },
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 1,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "",
+                                              "fieldKind": "Sequence",
+                                              "change": [
+                                                {
+                                                  "count": 3
+                                                },
+                                                {
+                                                  "count": 1,
+                                                  "effect": {
+                                                    "remove": {
+                                                      "id": 0
+                                                    }
+                                                  },
+                                                  "cellId": [
+                                                    0,
+                                                    513
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          ],
+                          "revision": 1026,
+                          "sequenceNumber": 8,
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                        }
+                      ],
+                      "branches": [
+                        [
+                          "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          {
+                            "base": "root",
+                            "commits": [
+                              {
+                                "change": [
+                                  {
+                                    "data": {
+                                      "maxId": 1,
+                                      "changes": [
+                                        {
+                                          "fieldKey": "rootFieldKey",
+                                          "fieldKind": "ModularEditBuilder.Generic",
+                                          "change": [
+                                            [
+                                              0,
+                                              {
+                                                "fieldChanges": [
+                                                  {
+                                                    "fieldKey": "",
+                                                    "fieldKind": "Sequence",
+                                                    "change": [
+                                                      {
+                                                        "count": 3
+                                                      },
+                                                      {
+                                                        "count": 1,
+                                                        "effect": {
+                                                          "remove": {
+                                                            "id": 0
+                                                          }
+                                                        }
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ],
+                                "revision": 513,
+                                "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                              }
+                            ]
+                          }
+                        ],
+                        [
+                          "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          {
+                            "base": "root",
+                            "commits": [
+                              {
+                                "change": [
+                                  {
+                                    "data": {
+                                      "maxId": 1,
+                                      "changes": [
+                                        {
+                                          "fieldKey": "rootFieldKey",
+                                          "fieldKind": "ModularEditBuilder.Generic",
+                                          "change": [
+                                            [
+                                              0,
+                                              {
+                                                "fieldChanges": [
+                                                  {
+                                                    "fieldKey": "",
+                                                    "fieldKind": "Sequence",
+                                                    "change": [
+                                                      {
+                                                        "count": 3
+                                                      },
+                                                      {
+                                                        "count": 1,
+                                                        "effect": {
+                                                          "remove": {
+                                                            "id": 0
+                                                          }
+                                                        }
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ],
+                                "revision": 1026,
+                                "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                              }
+                            ]
+                          }
+                        ]
+                      ],
+                      "version": 7
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Schema": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "SchemaString": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "nodes": {
+                        "com.fluidframework.leaf.number": {
+                          "kind": {
+                            "leaf": 0
+                          }
+                        },
+                        "competing-removes.Array<[\"com.fluidframework.leaf.number\"]>": {
+                          "kind": {
+                            "object": {
+                              "": {
+                                "kind": "Sequence",
+                                "types": [
+                                  "com.fluidframework.leaf.number"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "root": {
+                        "kind": "Value",
+                        "types": [
+                          "competing-removes.Array<[\"com.fluidframework.leaf.number\"]>"
+                        ]
+                      }
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Forest": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 3
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "contents": {
+                    "type": "blob",
+                    "content": {
+                      "keys": [
+                        "rootFieldKey",
+                        "repair-3"
+                      ],
+                      "fields": {
+                        "version": 2,
+                        "identifiers": [],
+                        "shapes": [
+                          {
+                            "c": {
+                              "extraFields": 1
+                            }
+                          },
+                          {
+                            "a": 0
+                          }
+                        ],
+                        "data": [
+                          [
+                            1,
+                            [
+                              "competing-removes.Array<[\"com.fluidframework.leaf.number\"]>",
+                              false,
+                              [
+                                "",
+                                [
+                                  "com.fluidframework.leaf.number",
+                                  true,
+                                  0,
+                                  [],
+                                  "com.fluidframework.leaf.number",
+                                  true,
+                                  1,
+                                  [],
+                                  "com.fluidframework.leaf.number",
+                                  true,
+                                  2,
+                                  []
+                                ]
+                              ]
+                            ]
+                          ],
+                          [
+                            1,
+                            [
+                              "com.fluidframework.leaf.number",
+                              true,
+                              3,
+                              []
+                            ]
+                          ]
+                        ]
+                      },
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "DetachedFieldIndex": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "DetachedFieldIndexBlob": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "data": [
+                        [
+                          1026,
+                          0,
+                          3
+                        ]
+                      ],
+                      "maxId": 3
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v3_0/complete-3x3-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v3_0/complete-3x3-final.json
@@ -1,0 +1,1759 @@
+{
+  "type": "tree",
+  "entries": [
+    {
+      "type": "blob",
+      ".metadata": {
+        "type": "blob",
+        "content": {
+          "version": 2
+        },
+        "encoding": "utf-8"
+      }
+    },
+    {
+      "type": "tree",
+      "indexes": {
+        "type": "tree",
+        "entries": [
+          {
+            "type": "tree",
+            "EditManager": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "String": {
+                    "type": "blob",
+                    "content": {
+                      "trunk": [
+                        {
+                          "change": [
+                            {
+                              "schema": {
+                                "new": {
+                                  "version": 2,
+                                  "nodes": {
+                                    "com.fluidframework.leaf.string": {
+                                      "kind": {
+                                        "leaf": 1
+                                      }
+                                    },
+                                    "test trees.Recursive Map": {
+                                      "kind": {
+                                        "map": {
+                                          "kind": "Optional",
+                                          "types": [
+                                            "test trees.Recursive Map",
+                                            "test trees.String Array"
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "test trees.String Array": {
+                                      "kind": {
+                                        "object": {
+                                          "": {
+                                            "kind": "Sequence",
+                                            "types": [
+                                              "com.fluidframework.leaf.string"
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "root": {
+                                    "kind": "Optional",
+                                    "types": [
+                                      "test trees.Recursive Map",
+                                      "test trees.String Array"
+                                    ]
+                                  }
+                                },
+                                "old": {
+                                  "version": 2,
+                                  "nodes": {},
+                                  "root": {
+                                    "kind": "Forbidden",
+                                    "types": []
+                                  }
+                                }
+                              }
+                            },
+                            {
+                              "data": {
+                                "maxId": 1,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "Optional",
+                                    "change": {
+                                      "r": {
+                                        "e": true,
+                                        "d": 0,
+                                        "s": 1
+                                      }
+                                    }
+                                  }
+                                ],
+                                "builds": {
+                                  "builds": [
+                                    [
+                                      [
+                                        [
+                                          1,
+                                          0
+                                        ]
+                                      ]
+                                    ]
+                                  ],
+                                  "trees": {
+                                    "version": 2,
+                                    "identifiers": [],
+                                    "shapes": [
+                                      {
+                                        "c": {
+                                          "extraFields": 1
+                                        }
+                                      },
+                                      {
+                                        "a": 0
+                                      }
+                                    ],
+                                    "data": [
+                                      [
+                                        1,
+                                        [
+                                          "test trees.Recursive Map",
+                                          false,
+                                          [
+                                            "FieldA",
+                                            [
+                                              "test trees.Recursive Map",
+                                              false,
+                                              [
+                                                "FieldA",
+                                                [
+                                                  "test trees.Recursive Map",
+                                                  false,
+                                                  [
+                                                    "FieldA",
+                                                    [
+                                                      "test trees.String Array",
+                                                      false,
+                                                      [
+                                                        "",
+                                                        [
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "1",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "2",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "3",
+                                                          []
+                                                        ]
+                                                      ]
+                                                    ],
+                                                    "FieldB",
+                                                    [
+                                                      "test trees.String Array",
+                                                      false,
+                                                      [
+                                                        "",
+                                                        [
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "4",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "5",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "6",
+                                                          []
+                                                        ]
+                                                      ]
+                                                    ],
+                                                    "FieldC",
+                                                    [
+                                                      "test trees.String Array",
+                                                      false,
+                                                      [
+                                                        "",
+                                                        [
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "7",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "8",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "9",
+                                                          []
+                                                        ]
+                                                      ]
+                                                    ]
+                                                  ]
+                                                ],
+                                                "FieldB",
+                                                [
+                                                  "test trees.Recursive Map",
+                                                  false,
+                                                  [
+                                                    "FieldA",
+                                                    [
+                                                      "test trees.String Array",
+                                                      false,
+                                                      [
+                                                        "",
+                                                        [
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "10",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "11",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "12",
+                                                          []
+                                                        ]
+                                                      ]
+                                                    ],
+                                                    "FieldB",
+                                                    [
+                                                      "test trees.String Array",
+                                                      false,
+                                                      [
+                                                        "",
+                                                        [
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "13",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "14",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "15",
+                                                          []
+                                                        ]
+                                                      ]
+                                                    ],
+                                                    "FieldC",
+                                                    [
+                                                      "test trees.String Array",
+                                                      false,
+                                                      [
+                                                        "",
+                                                        [
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "16",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "17",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "18",
+                                                          []
+                                                        ]
+                                                      ]
+                                                    ]
+                                                  ]
+                                                ],
+                                                "FieldC",
+                                                [
+                                                  "test trees.Recursive Map",
+                                                  false,
+                                                  [
+                                                    "FieldA",
+                                                    [
+                                                      "test trees.String Array",
+                                                      false,
+                                                      [
+                                                        "",
+                                                        [
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "19",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "20",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "21",
+                                                          []
+                                                        ]
+                                                      ]
+                                                    ],
+                                                    "FieldB",
+                                                    [
+                                                      "test trees.String Array",
+                                                      false,
+                                                      [
+                                                        "",
+                                                        [
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "22",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "23",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "24",
+                                                          []
+                                                        ]
+                                                      ]
+                                                    ],
+                                                    "FieldC",
+                                                    [
+                                                      "test trees.String Array",
+                                                      false,
+                                                      [
+                                                        "",
+                                                        [
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "25",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "26",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "27",
+                                                          []
+                                                        ]
+                                                      ]
+                                                    ]
+                                                  ]
+                                                ]
+                                              ]
+                                            ],
+                                            "FieldB",
+                                            [
+                                              "test trees.Recursive Map",
+                                              false,
+                                              [
+                                                "FieldA",
+                                                [
+                                                  "test trees.Recursive Map",
+                                                  false,
+                                                  [
+                                                    "FieldA",
+                                                    [
+                                                      "test trees.String Array",
+                                                      false,
+                                                      [
+                                                        "",
+                                                        [
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "28",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "29",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "30",
+                                                          []
+                                                        ]
+                                                      ]
+                                                    ],
+                                                    "FieldB",
+                                                    [
+                                                      "test trees.String Array",
+                                                      false,
+                                                      [
+                                                        "",
+                                                        [
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "31",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "32",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "33",
+                                                          []
+                                                        ]
+                                                      ]
+                                                    ],
+                                                    "FieldC",
+                                                    [
+                                                      "test trees.String Array",
+                                                      false,
+                                                      [
+                                                        "",
+                                                        [
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "34",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "35",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "36",
+                                                          []
+                                                        ]
+                                                      ]
+                                                    ]
+                                                  ]
+                                                ],
+                                                "FieldB",
+                                                [
+                                                  "test trees.Recursive Map",
+                                                  false,
+                                                  [
+                                                    "FieldA",
+                                                    [
+                                                      "test trees.String Array",
+                                                      false,
+                                                      [
+                                                        "",
+                                                        [
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "37",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "38",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "39",
+                                                          []
+                                                        ]
+                                                      ]
+                                                    ],
+                                                    "FieldB",
+                                                    [
+                                                      "test trees.String Array",
+                                                      false,
+                                                      [
+                                                        "",
+                                                        [
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "40",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "41",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "42",
+                                                          []
+                                                        ]
+                                                      ]
+                                                    ],
+                                                    "FieldC",
+                                                    [
+                                                      "test trees.String Array",
+                                                      false,
+                                                      [
+                                                        "",
+                                                        [
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "43",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "44",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "45",
+                                                          []
+                                                        ]
+                                                      ]
+                                                    ]
+                                                  ]
+                                                ],
+                                                "FieldC",
+                                                [
+                                                  "test trees.Recursive Map",
+                                                  false,
+                                                  [
+                                                    "FieldA",
+                                                    [
+                                                      "test trees.String Array",
+                                                      false,
+                                                      [
+                                                        "",
+                                                        [
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "46",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "47",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "48",
+                                                          []
+                                                        ]
+                                                      ]
+                                                    ],
+                                                    "FieldB",
+                                                    [
+                                                      "test trees.String Array",
+                                                      false,
+                                                      [
+                                                        "",
+                                                        [
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "49",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "50",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "51",
+                                                          []
+                                                        ]
+                                                      ]
+                                                    ],
+                                                    "FieldC",
+                                                    [
+                                                      "test trees.String Array",
+                                                      false,
+                                                      [
+                                                        "",
+                                                        [
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "52",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "53",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "54",
+                                                          []
+                                                        ]
+                                                      ]
+                                                    ]
+                                                  ]
+                                                ]
+                                              ]
+                                            ],
+                                            "FieldC",
+                                            [
+                                              "test trees.Recursive Map",
+                                              false,
+                                              [
+                                                "FieldA",
+                                                [
+                                                  "test trees.Recursive Map",
+                                                  false,
+                                                  [
+                                                    "FieldA",
+                                                    [
+                                                      "test trees.String Array",
+                                                      false,
+                                                      [
+                                                        "",
+                                                        [
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "55",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "56",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "57",
+                                                          []
+                                                        ]
+                                                      ]
+                                                    ],
+                                                    "FieldB",
+                                                    [
+                                                      "test trees.String Array",
+                                                      false,
+                                                      [
+                                                        "",
+                                                        [
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "58",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "59",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "60",
+                                                          []
+                                                        ]
+                                                      ]
+                                                    ],
+                                                    "FieldC",
+                                                    [
+                                                      "test trees.String Array",
+                                                      false,
+                                                      [
+                                                        "",
+                                                        [
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "61",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "62",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "63",
+                                                          []
+                                                        ]
+                                                      ]
+                                                    ]
+                                                  ]
+                                                ],
+                                                "FieldB",
+                                                [
+                                                  "test trees.Recursive Map",
+                                                  false,
+                                                  [
+                                                    "FieldA",
+                                                    [
+                                                      "test trees.String Array",
+                                                      false,
+                                                      [
+                                                        "",
+                                                        [
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "64",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "65",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "66",
+                                                          []
+                                                        ]
+                                                      ]
+                                                    ],
+                                                    "FieldB",
+                                                    [
+                                                      "test trees.String Array",
+                                                      false,
+                                                      [
+                                                        "",
+                                                        [
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "67",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "68",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "69",
+                                                          []
+                                                        ]
+                                                      ]
+                                                    ],
+                                                    "FieldC",
+                                                    [
+                                                      "test trees.String Array",
+                                                      false,
+                                                      [
+                                                        "",
+                                                        [
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "70",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "71",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "72",
+                                                          []
+                                                        ]
+                                                      ]
+                                                    ]
+                                                  ]
+                                                ],
+                                                "FieldC",
+                                                [
+                                                  "test trees.Recursive Map",
+                                                  false,
+                                                  [
+                                                    "FieldA",
+                                                    [
+                                                      "test trees.String Array",
+                                                      false,
+                                                      [
+                                                        "",
+                                                        [
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "73",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "74",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "75",
+                                                          []
+                                                        ]
+                                                      ]
+                                                    ],
+                                                    "FieldB",
+                                                    [
+                                                      "test trees.String Array",
+                                                      false,
+                                                      [
+                                                        "",
+                                                        [
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "76",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "77",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "78",
+                                                          []
+                                                        ]
+                                                      ]
+                                                    ],
+                                                    "FieldC",
+                                                    [
+                                                      "test trees.String Array",
+                                                      false,
+                                                      [
+                                                        "",
+                                                        [
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "79",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "80",
+                                                          [],
+                                                          "com.fluidframework.leaf.string",
+                                                          true,
+                                                          "81",
+                                                          []
+                                                        ]
+                                                      ]
+                                                    ]
+                                                  ]
+                                                ]
+                                              ]
+                                            ]
+                                          ]
+                                        ]
+                                      ]
+                                    ]
+                                  }
+                                }
+                              }
+                            },
+                            {
+                              "schema": {
+                                "new": {
+                                  "version": 2,
+                                  "nodes": {
+                                    "com.fluidframework.leaf.string": {
+                                      "kind": {
+                                        "leaf": 1
+                                      }
+                                    },
+                                    "test trees.Recursive Map": {
+                                      "kind": {
+                                        "map": {
+                                          "kind": "Optional",
+                                          "types": [
+                                            "test trees.Recursive Map",
+                                            "test trees.String Array"
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "test trees.String Array": {
+                                      "kind": {
+                                        "object": {
+                                          "": {
+                                            "kind": "Sequence",
+                                            "types": [
+                                              "com.fluidframework.leaf.string"
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "root": {
+                                    "kind": "Value",
+                                    "types": [
+                                      "test trees.Recursive Map",
+                                      "test trees.String Array"
+                                    ]
+                                  }
+                                },
+                                "old": {
+                                  "version": 2,
+                                  "nodes": {
+                                    "com.fluidframework.leaf.string": {
+                                      "kind": {
+                                        "leaf": 1
+                                      }
+                                    },
+                                    "test trees.Recursive Map": {
+                                      "kind": {
+                                        "map": {
+                                          "kind": "Optional",
+                                          "types": [
+                                            "test trees.Recursive Map",
+                                            "test trees.String Array"
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "test trees.String Array": {
+                                      "kind": {
+                                        "object": {
+                                          "": {
+                                            "kind": "Sequence",
+                                            "types": [
+                                              "com.fluidframework.leaf.string"
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "root": {
+                                    "kind": "Optional",
+                                    "types": [
+                                      "test trees.Recursive Map",
+                                      "test trees.String Array"
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          ],
+                          "revision": 0,
+                          "sequenceNumber": 2,
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                        }
+                      ],
+                      "branches": [],
+                      "version": 7
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Schema": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "SchemaString": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "nodes": {
+                        "com.fluidframework.leaf.string": {
+                          "kind": {
+                            "leaf": 1
+                          }
+                        },
+                        "test trees.Recursive Map": {
+                          "kind": {
+                            "map": {
+                              "kind": "Optional",
+                              "types": [
+                                "test trees.Recursive Map",
+                                "test trees.String Array"
+                              ]
+                            }
+                          }
+                        },
+                        "test trees.String Array": {
+                          "kind": {
+                            "object": {
+                              "": {
+                                "kind": "Sequence",
+                                "types": [
+                                  "com.fluidframework.leaf.string"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "root": {
+                        "kind": "Value",
+                        "types": [
+                          "test trees.Recursive Map",
+                          "test trees.String Array"
+                        ]
+                      }
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Forest": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 3
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "contents": {
+                    "type": "blob",
+                    "content": {
+                      "keys": [
+                        "rootFieldKey"
+                      ],
+                      "fields": {
+                        "version": 2,
+                        "identifiers": [],
+                        "shapes": [
+                          {
+                            "c": {
+                              "extraFields": 1
+                            }
+                          },
+                          {
+                            "a": 0
+                          }
+                        ],
+                        "data": [
+                          [
+                            1,
+                            [
+                              "test trees.Recursive Map",
+                              false,
+                              [
+                                "FieldA",
+                                [
+                                  "test trees.Recursive Map",
+                                  false,
+                                  [
+                                    "FieldA",
+                                    [
+                                      "test trees.Recursive Map",
+                                      false,
+                                      [
+                                        "FieldA",
+                                        [
+                                          "test trees.String Array",
+                                          false,
+                                          [
+                                            "",
+                                            [
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "1",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "2",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "3",
+                                              []
+                                            ]
+                                          ]
+                                        ],
+                                        "FieldB",
+                                        [
+                                          "test trees.String Array",
+                                          false,
+                                          [
+                                            "",
+                                            [
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "4",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "5",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "6",
+                                              []
+                                            ]
+                                          ]
+                                        ],
+                                        "FieldC",
+                                        [
+                                          "test trees.String Array",
+                                          false,
+                                          [
+                                            "",
+                                            [
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "7",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "8",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "9",
+                                              []
+                                            ]
+                                          ]
+                                        ]
+                                      ]
+                                    ],
+                                    "FieldB",
+                                    [
+                                      "test trees.Recursive Map",
+                                      false,
+                                      [
+                                        "FieldA",
+                                        [
+                                          "test trees.String Array",
+                                          false,
+                                          [
+                                            "",
+                                            [
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "10",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "11",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "12",
+                                              []
+                                            ]
+                                          ]
+                                        ],
+                                        "FieldB",
+                                        [
+                                          "test trees.String Array",
+                                          false,
+                                          [
+                                            "",
+                                            [
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "13",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "14",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "15",
+                                              []
+                                            ]
+                                          ]
+                                        ],
+                                        "FieldC",
+                                        [
+                                          "test trees.String Array",
+                                          false,
+                                          [
+                                            "",
+                                            [
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "16",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "17",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "18",
+                                              []
+                                            ]
+                                          ]
+                                        ]
+                                      ]
+                                    ],
+                                    "FieldC",
+                                    [
+                                      "test trees.Recursive Map",
+                                      false,
+                                      [
+                                        "FieldA",
+                                        [
+                                          "test trees.String Array",
+                                          false,
+                                          [
+                                            "",
+                                            [
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "19",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "20",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "21",
+                                              []
+                                            ]
+                                          ]
+                                        ],
+                                        "FieldB",
+                                        [
+                                          "test trees.String Array",
+                                          false,
+                                          [
+                                            "",
+                                            [
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "22",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "23",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "24",
+                                              []
+                                            ]
+                                          ]
+                                        ],
+                                        "FieldC",
+                                        [
+                                          "test trees.String Array",
+                                          false,
+                                          [
+                                            "",
+                                            [
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "25",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "26",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "27",
+                                              []
+                                            ]
+                                          ]
+                                        ]
+                                      ]
+                                    ]
+                                  ]
+                                ],
+                                "FieldB",
+                                [
+                                  "test trees.Recursive Map",
+                                  false,
+                                  [
+                                    "FieldA",
+                                    [
+                                      "test trees.Recursive Map",
+                                      false,
+                                      [
+                                        "FieldA",
+                                        [
+                                          "test trees.String Array",
+                                          false,
+                                          [
+                                            "",
+                                            [
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "28",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "29",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "30",
+                                              []
+                                            ]
+                                          ]
+                                        ],
+                                        "FieldB",
+                                        [
+                                          "test trees.String Array",
+                                          false,
+                                          [
+                                            "",
+                                            [
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "31",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "32",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "33",
+                                              []
+                                            ]
+                                          ]
+                                        ],
+                                        "FieldC",
+                                        [
+                                          "test trees.String Array",
+                                          false,
+                                          [
+                                            "",
+                                            [
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "34",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "35",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "36",
+                                              []
+                                            ]
+                                          ]
+                                        ]
+                                      ]
+                                    ],
+                                    "FieldB",
+                                    [
+                                      "test trees.Recursive Map",
+                                      false,
+                                      [
+                                        "FieldA",
+                                        [
+                                          "test trees.String Array",
+                                          false,
+                                          [
+                                            "",
+                                            [
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "37",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "38",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "39",
+                                              []
+                                            ]
+                                          ]
+                                        ],
+                                        "FieldB",
+                                        [
+                                          "test trees.String Array",
+                                          false,
+                                          [
+                                            "",
+                                            [
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "40",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "41",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "42",
+                                              []
+                                            ]
+                                          ]
+                                        ],
+                                        "FieldC",
+                                        [
+                                          "test trees.String Array",
+                                          false,
+                                          [
+                                            "",
+                                            [
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "43",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "44",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "45",
+                                              []
+                                            ]
+                                          ]
+                                        ]
+                                      ]
+                                    ],
+                                    "FieldC",
+                                    [
+                                      "test trees.Recursive Map",
+                                      false,
+                                      [
+                                        "FieldA",
+                                        [
+                                          "test trees.String Array",
+                                          false,
+                                          [
+                                            "",
+                                            [
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "46",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "47",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "48",
+                                              []
+                                            ]
+                                          ]
+                                        ],
+                                        "FieldB",
+                                        [
+                                          "test trees.String Array",
+                                          false,
+                                          [
+                                            "",
+                                            [
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "49",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "50",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "51",
+                                              []
+                                            ]
+                                          ]
+                                        ],
+                                        "FieldC",
+                                        [
+                                          "test trees.String Array",
+                                          false,
+                                          [
+                                            "",
+                                            [
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "52",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "53",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "54",
+                                              []
+                                            ]
+                                          ]
+                                        ]
+                                      ]
+                                    ]
+                                  ]
+                                ],
+                                "FieldC",
+                                [
+                                  "test trees.Recursive Map",
+                                  false,
+                                  [
+                                    "FieldA",
+                                    [
+                                      "test trees.Recursive Map",
+                                      false,
+                                      [
+                                        "FieldA",
+                                        [
+                                          "test trees.String Array",
+                                          false,
+                                          [
+                                            "",
+                                            [
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "55",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "56",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "57",
+                                              []
+                                            ]
+                                          ]
+                                        ],
+                                        "FieldB",
+                                        [
+                                          "test trees.String Array",
+                                          false,
+                                          [
+                                            "",
+                                            [
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "58",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "59",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "60",
+                                              []
+                                            ]
+                                          ]
+                                        ],
+                                        "FieldC",
+                                        [
+                                          "test trees.String Array",
+                                          false,
+                                          [
+                                            "",
+                                            [
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "61",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "62",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "63",
+                                              []
+                                            ]
+                                          ]
+                                        ]
+                                      ]
+                                    ],
+                                    "FieldB",
+                                    [
+                                      "test trees.Recursive Map",
+                                      false,
+                                      [
+                                        "FieldA",
+                                        [
+                                          "test trees.String Array",
+                                          false,
+                                          [
+                                            "",
+                                            [
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "64",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "65",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "66",
+                                              []
+                                            ]
+                                          ]
+                                        ],
+                                        "FieldB",
+                                        [
+                                          "test trees.String Array",
+                                          false,
+                                          [
+                                            "",
+                                            [
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "67",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "68",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "69",
+                                              []
+                                            ]
+                                          ]
+                                        ],
+                                        "FieldC",
+                                        [
+                                          "test trees.String Array",
+                                          false,
+                                          [
+                                            "",
+                                            [
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "70",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "71",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "72",
+                                              []
+                                            ]
+                                          ]
+                                        ]
+                                      ]
+                                    ],
+                                    "FieldC",
+                                    [
+                                      "test trees.Recursive Map",
+                                      false,
+                                      [
+                                        "FieldA",
+                                        [
+                                          "test trees.String Array",
+                                          false,
+                                          [
+                                            "",
+                                            [
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "73",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "74",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "75",
+                                              []
+                                            ]
+                                          ]
+                                        ],
+                                        "FieldB",
+                                        [
+                                          "test trees.String Array",
+                                          false,
+                                          [
+                                            "",
+                                            [
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "76",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "77",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "78",
+                                              []
+                                            ]
+                                          ]
+                                        ],
+                                        "FieldC",
+                                        [
+                                          "test trees.String Array",
+                                          false,
+                                          [
+                                            "",
+                                            [
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "79",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "80",
+                                              [],
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "81",
+                                              []
+                                            ]
+                                          ]
+                                        ]
+                                      ]
+                                    ]
+                                  ]
+                                ]
+                              ]
+                            ]
+                          ]
+                        ]
+                      },
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "DetachedFieldIndex": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "DetachedFieldIndexBlob": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "data": [],
+                      "maxId": 0
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v3_0/concurrent-inserts-tree2.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v3_0/concurrent-inserts-tree2.json
@@ -1,0 +1,542 @@
+{
+  "type": "tree",
+  "entries": [
+    {
+      "type": "blob",
+      ".metadata": {
+        "type": "blob",
+        "content": {
+          "version": 2
+        },
+        "encoding": "utf-8"
+      }
+    },
+    {
+      "type": "tree",
+      "indexes": {
+        "type": "tree",
+        "entries": [
+          {
+            "type": "tree",
+            "EditManager": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "String": {
+                    "type": "blob",
+                    "content": {
+                      "trunk": [
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 1,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "",
+                                              "fieldKind": "Sequence",
+                                              "change": [
+                                                {
+                                                  "count": 1,
+                                                  "effect": {
+                                                    "insert": {
+                                                      "id": 0
+                                                    }
+                                                  },
+                                                  "cellId": 0
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ],
+                                "builds": {
+                                  "builds": [
+                                    [
+                                      [
+                                        [
+                                          0,
+                                          0
+                                        ]
+                                      ]
+                                    ]
+                                  ],
+                                  "trees": {
+                                    "version": 2,
+                                    "identifiers": [],
+                                    "shapes": [
+                                      {
+                                        "c": {
+                                          "extraFields": 1
+                                        }
+                                      },
+                                      {
+                                        "a": 0
+                                      }
+                                    ],
+                                    "data": [
+                                      [
+                                        1,
+                                        [
+                                          "com.fluidframework.leaf.string",
+                                          true,
+                                          "y",
+                                          []
+                                        ]
+                                      ]
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          ],
+                          "revision": 1,
+                          "sequenceNumber": 4,
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                        },
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 3,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "",
+                                              "fieldKind": "Sequence",
+                                              "change": [
+                                                {
+                                                  "count": 1,
+                                                  "effect": {
+                                                    "insert": {
+                                                      "id": 2
+                                                    }
+                                                  },
+                                                  "cellId": 2
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ],
+                                "builds": {
+                                  "builds": [
+                                    [
+                                      [
+                                        [
+                                          2,
+                                          0
+                                        ]
+                                      ]
+                                    ]
+                                  ],
+                                  "trees": {
+                                    "version": 2,
+                                    "identifiers": [],
+                                    "shapes": [
+                                      {
+                                        "c": {
+                                          "extraFields": 1
+                                        }
+                                      },
+                                      {
+                                        "a": 0
+                                      }
+                                    ],
+                                    "data": [
+                                      [
+                                        1,
+                                        [
+                                          "com.fluidframework.leaf.string",
+                                          true,
+                                          "x",
+                                          []
+                                        ]
+                                      ]
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          ],
+                          "revision": 2,
+                          "sequenceNumber": 6,
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                        },
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 3,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "",
+                                              "fieldKind": "Sequence",
+                                              "change": [
+                                                {
+                                                  "count": 2
+                                                },
+                                                {
+                                                  "count": 2,
+                                                  "effect": {
+                                                    "insert": {
+                                                      "id": 0
+                                                    }
+                                                  },
+                                                  "cellId": 0
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ],
+                                "builds": {
+                                  "builds": [
+                                    [
+                                      [
+                                        [
+                                          0,
+                                          0
+                                        ]
+                                      ]
+                                    ]
+                                  ],
+                                  "trees": {
+                                    "version": 2,
+                                    "identifiers": [],
+                                    "shapes": [
+                                      {
+                                        "c": {
+                                          "extraFields": 1
+                                        }
+                                      },
+                                      {
+                                        "a": 0
+                                      }
+                                    ],
+                                    "data": [
+                                      [
+                                        1,
+                                        [
+                                          "com.fluidframework.leaf.string",
+                                          true,
+                                          "a",
+                                          [],
+                                          "com.fluidframework.leaf.string",
+                                          true,
+                                          "c",
+                                          []
+                                        ]
+                                      ]
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          ],
+                          "revision": 3,
+                          "sequenceNumber": 8,
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                        },
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 4,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "",
+                                              "fieldKind": "Sequence",
+                                              "change": [
+                                                {
+                                                  "count": 3
+                                                },
+                                                {
+                                                  "count": 1,
+                                                  "effect": {
+                                                    "insert": {
+                                                      "id": 3
+                                                    }
+                                                  },
+                                                  "cellId": 3
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ],
+                                "builds": {
+                                  "builds": [
+                                    [
+                                      [
+                                        [
+                                          3,
+                                          0
+                                        ]
+                                      ]
+                                    ]
+                                  ],
+                                  "trees": {
+                                    "version": 2,
+                                    "identifiers": [],
+                                    "shapes": [
+                                      {
+                                        "c": {
+                                          "extraFields": 1
+                                        }
+                                      },
+                                      {
+                                        "a": 0
+                                      }
+                                    ],
+                                    "data": [
+                                      [
+                                        1,
+                                        [
+                                          "com.fluidframework.leaf.string",
+                                          true,
+                                          "b",
+                                          []
+                                        ]
+                                      ]
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          ],
+                          "revision": 4,
+                          "sequenceNumber": 9,
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                        }
+                      ],
+                      "branches": [],
+                      "version": 7
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Schema": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "SchemaString": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "nodes": {
+                        "com.fluidframework.leaf.string": {
+                          "kind": {
+                            "leaf": 1
+                          }
+                        },
+                        "concurrent-inserts.Array<[\"com.fluidframework.leaf.string\"]>": {
+                          "kind": {
+                            "object": {
+                              "": {
+                                "kind": "Sequence",
+                                "types": [
+                                  "com.fluidframework.leaf.string"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "root": {
+                        "kind": "Value",
+                        "types": [
+                          "concurrent-inserts.Array<[\"com.fluidframework.leaf.string\"]>"
+                        ]
+                      }
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Forest": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 3
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "contents": {
+                    "type": "blob",
+                    "content": {
+                      "keys": [
+                        "rootFieldKey"
+                      ],
+                      "fields": {
+                        "version": 2,
+                        "identifiers": [],
+                        "shapes": [
+                          {
+                            "c": {
+                              "extraFields": 1
+                            }
+                          },
+                          {
+                            "a": 0
+                          }
+                        ],
+                        "data": [
+                          [
+                            1,
+                            [
+                              "concurrent-inserts.Array<[\"com.fluidframework.leaf.string\"]>",
+                              false,
+                              [
+                                "",
+                                [
+                                  "com.fluidframework.leaf.string",
+                                  true,
+                                  "x",
+                                  [],
+                                  "com.fluidframework.leaf.string",
+                                  true,
+                                  "y",
+                                  [],
+                                  "com.fluidframework.leaf.string",
+                                  true,
+                                  "a",
+                                  [],
+                                  "com.fluidframework.leaf.string",
+                                  true,
+                                  "b",
+                                  [],
+                                  "com.fluidframework.leaf.string",
+                                  true,
+                                  "c",
+                                  []
+                                ]
+                              ]
+                            ]
+                          ]
+                        ]
+                      },
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "DetachedFieldIndex": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "DetachedFieldIndexBlob": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "data": [],
+                      "maxId": 5
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v3_0/concurrent-inserts-tree3.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v3_0/concurrent-inserts-tree3.json
@@ -1,0 +1,561 @@
+{
+  "type": "tree",
+  "entries": [
+    {
+      "type": "blob",
+      ".metadata": {
+        "type": "blob",
+        "content": {
+          "version": 2
+        },
+        "encoding": "utf-8"
+      }
+    },
+    {
+      "type": "tree",
+      "indexes": {
+        "type": "tree",
+        "entries": [
+          {
+            "type": "tree",
+            "EditManager": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "String": {
+                    "type": "blob",
+                    "content": {
+                      "trunk": [
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 4,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "",
+                                              "fieldKind": "Sequence",
+                                              "change": [
+                                                {
+                                                  "count": 3
+                                                },
+                                                {
+                                                  "count": 1,
+                                                  "effect": {
+                                                    "insert": {
+                                                      "id": 3
+                                                    }
+                                                  },
+                                                  "cellId": 3
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ],
+                                "builds": {
+                                  "builds": [
+                                    [
+                                      [
+                                        [
+                                          3,
+                                          0
+                                        ]
+                                      ]
+                                    ]
+                                  ],
+                                  "trees": {
+                                    "version": 2,
+                                    "identifiers": [],
+                                    "shapes": [
+                                      {
+                                        "c": {
+                                          "extraFields": 1
+                                        }
+                                      },
+                                      {
+                                        "a": 0
+                                      }
+                                    ],
+                                    "data": [
+                                      [
+                                        1,
+                                        [
+                                          "com.fluidframework.leaf.string",
+                                          true,
+                                          "b",
+                                          []
+                                        ]
+                                      ]
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          ],
+                          "revision": 4,
+                          "sequenceNumber": 9,
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                        },
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 5,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "",
+                                              "fieldKind": "Sequence",
+                                              "change": [
+                                                {
+                                                  "count": 1,
+                                                  "effect": {
+                                                    "insert": {
+                                                      "id": 4
+                                                    }
+                                                  },
+                                                  "cellId": 4
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ],
+                                "builds": {
+                                  "builds": [
+                                    [
+                                      [
+                                        [
+                                          4,
+                                          0
+                                        ]
+                                      ]
+                                    ]
+                                  ],
+                                  "trees": {
+                                    "version": 2,
+                                    "identifiers": [],
+                                    "shapes": [
+                                      {
+                                        "c": {
+                                          "extraFields": 1
+                                        }
+                                      },
+                                      {
+                                        "a": 0
+                                      }
+                                    ],
+                                    "data": [
+                                      [
+                                        1,
+                                        [
+                                          "com.fluidframework.leaf.string",
+                                          true,
+                                          "z",
+                                          []
+                                        ]
+                                      ]
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          ],
+                          "revision": 7,
+                          "sequenceNumber": 11,
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                        },
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 5,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "",
+                                              "fieldKind": "Sequence",
+                                              "change": [
+                                                {
+                                                  "count": 2
+                                                },
+                                                {
+                                                  "count": 2,
+                                                  "effect": {
+                                                    "insert": {
+                                                      "id": 0
+                                                    }
+                                                  },
+                                                  "cellId": 0
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ],
+                                "builds": {
+                                  "builds": [
+                                    [
+                                      [
+                                        [
+                                          0,
+                                          0
+                                        ]
+                                      ]
+                                    ]
+                                  ],
+                                  "trees": {
+                                    "version": 2,
+                                    "identifiers": [],
+                                    "shapes": [
+                                      {
+                                        "c": {
+                                          "extraFields": 1
+                                        }
+                                      },
+                                      {
+                                        "a": 0
+                                      }
+                                    ],
+                                    "data": [
+                                      [
+                                        1,
+                                        [
+                                          "com.fluidframework.leaf.string",
+                                          true,
+                                          "d",
+                                          [],
+                                          "com.fluidframework.leaf.string",
+                                          true,
+                                          "e",
+                                          []
+                                        ]
+                                      ]
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          ],
+                          "revision": 8,
+                          "sequenceNumber": 13,
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                        },
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 5,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "",
+                                              "fieldKind": "Sequence",
+                                              "change": [
+                                                {
+                                                  "count": 3
+                                                },
+                                                {
+                                                  "count": 1,
+                                                  "effect": {
+                                                    "insert": {
+                                                      "id": 3
+                                                    }
+                                                  },
+                                                  "cellId": 3
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ],
+                                "builds": {
+                                  "builds": [
+                                    [
+                                      [
+                                        [
+                                          3,
+                                          0
+                                        ]
+                                      ]
+                                    ]
+                                  ],
+                                  "trees": {
+                                    "version": 2,
+                                    "identifiers": [],
+                                    "shapes": [
+                                      {
+                                        "c": {
+                                          "extraFields": 1
+                                        }
+                                      },
+                                      {
+                                        "a": 0
+                                      }
+                                    ],
+                                    "data": [
+                                      [
+                                        1,
+                                        [
+                                          "com.fluidframework.leaf.string",
+                                          true,
+                                          "f",
+                                          []
+                                        ]
+                                      ]
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          ],
+                          "revision": 9,
+                          "sequenceNumber": 14,
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                        }
+                      ],
+                      "branches": [],
+                      "version": 7
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Schema": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "SchemaString": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "nodes": {
+                        "com.fluidframework.leaf.string": {
+                          "kind": {
+                            "leaf": 1
+                          }
+                        },
+                        "concurrent-inserts.Array<[\"com.fluidframework.leaf.string\"]>": {
+                          "kind": {
+                            "object": {
+                              "": {
+                                "kind": "Sequence",
+                                "types": [
+                                  "com.fluidframework.leaf.string"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "root": {
+                        "kind": "Value",
+                        "types": [
+                          "concurrent-inserts.Array<[\"com.fluidframework.leaf.string\"]>"
+                        ]
+                      }
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Forest": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 3
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "contents": {
+                    "type": "blob",
+                    "content": {
+                      "keys": [
+                        "rootFieldKey"
+                      ],
+                      "fields": {
+                        "version": 2,
+                        "identifiers": [],
+                        "shapes": [
+                          {
+                            "c": {
+                              "extraFields": 1
+                            }
+                          },
+                          {
+                            "a": 0
+                          }
+                        ],
+                        "data": [
+                          [
+                            1,
+                            [
+                              "concurrent-inserts.Array<[\"com.fluidframework.leaf.string\"]>",
+                              false,
+                              [
+                                "",
+                                [
+                                  "com.fluidframework.leaf.string",
+                                  true,
+                                  "z",
+                                  [],
+                                  "com.fluidframework.leaf.string",
+                                  true,
+                                  "x",
+                                  [],
+                                  "com.fluidframework.leaf.string",
+                                  true,
+                                  "d",
+                                  [],
+                                  "com.fluidframework.leaf.string",
+                                  true,
+                                  "f",
+                                  [],
+                                  "com.fluidframework.leaf.string",
+                                  true,
+                                  "e",
+                                  [],
+                                  "com.fluidframework.leaf.string",
+                                  true,
+                                  "y",
+                                  [],
+                                  "com.fluidframework.leaf.string",
+                                  true,
+                                  "a",
+                                  [],
+                                  "com.fluidframework.leaf.string",
+                                  true,
+                                  "b",
+                                  [],
+                                  "com.fluidframework.leaf.string",
+                                  true,
+                                  "c",
+                                  []
+                                ]
+                              ]
+                            ]
+                          ]
+                        ]
+                      },
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "DetachedFieldIndex": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "DetachedFieldIndexBlob": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "data": [],
+                      "maxId": 9
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v3_0/empty-root-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v3_0/empty-root-final.json
@@ -1,0 +1,221 @@
+{
+  "type": "tree",
+  "entries": [
+    {
+      "type": "blob",
+      ".metadata": {
+        "type": "blob",
+        "content": {
+          "version": 2
+        },
+        "encoding": "utf-8"
+      }
+    },
+    {
+      "type": "tree",
+      "indexes": {
+        "type": "tree",
+        "entries": [
+          {
+            "type": "tree",
+            "EditManager": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "String": {
+                    "type": "blob",
+                    "content": {
+                      "trunk": [
+                        {
+                          "change": [
+                            {
+                              "schema": {
+                                "new": {
+                                  "version": 2,
+                                  "nodes": {
+                                    "com.fluidframework.leaf.number": {
+                                      "kind": {
+                                        "leaf": 0
+                                      }
+                                    }
+                                  },
+                                  "root": {
+                                    "kind": "Optional",
+                                    "types": [
+                                      "com.fluidframework.leaf.number"
+                                    ]
+                                  }
+                                },
+                                "old": {
+                                  "version": 2,
+                                  "nodes": {},
+                                  "root": {
+                                    "kind": "Forbidden",
+                                    "types": []
+                                  }
+                                }
+                              }
+                            },
+                            {
+                              "data": {
+                                "maxId": 0,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "Optional",
+                                    "change": {
+                                      "r": {
+                                        "e": true,
+                                        "d": 0
+                                      }
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          ],
+                          "revision": 0,
+                          "sequenceNumber": 2,
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                        }
+                      ],
+                      "branches": [],
+                      "version": 7
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Schema": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "SchemaString": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "nodes": {
+                        "com.fluidframework.leaf.number": {
+                          "kind": {
+                            "leaf": 0
+                          }
+                        }
+                      },
+                      "root": {
+                        "kind": "Optional",
+                        "types": [
+                          "com.fluidframework.leaf.number"
+                        ]
+                      }
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Forest": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 3
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "contents": {
+                    "type": "blob",
+                    "content": {
+                      "keys": [],
+                      "fields": {
+                        "version": 2,
+                        "identifiers": [],
+                        "shapes": [
+                          {
+                            "c": {
+                              "extraFields": 1
+                            }
+                          },
+                          {
+                            "a": 0
+                          }
+                        ],
+                        "data": []
+                      },
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "DetachedFieldIndex": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "DetachedFieldIndexBlob": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "data": [],
+                      "maxId": -1
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v3_0/has-handle-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v3_0/has-handle-final.json
@@ -1,0 +1,281 @@
+{
+  "type": "tree",
+  "entries": [
+    {
+      "type": "blob",
+      ".metadata": {
+        "type": "blob",
+        "content": {
+          "version": 2
+        },
+        "encoding": "utf-8"
+      }
+    },
+    {
+      "type": "tree",
+      "indexes": {
+        "type": "tree",
+        "entries": [
+          {
+            "type": "tree",
+            "EditManager": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "String": {
+                    "type": "blob",
+                    "content": {
+                      "trunk": [
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 2,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "handleField",
+                                              "fieldKind": "Optional",
+                                              "change": {
+                                                "r": {
+                                                  "e": true,
+                                                  "d": 0,
+                                                  "s": 1
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ],
+                                "builds": {
+                                  "builds": [
+                                    [
+                                      [
+                                        [
+                                          1,
+                                          0
+                                        ]
+                                      ]
+                                    ]
+                                  ],
+                                  "trees": {
+                                    "version": 2,
+                                    "identifiers": [],
+                                    "shapes": [
+                                      {
+                                        "c": {
+                                          "extraFields": 1
+                                        }
+                                      },
+                                      {
+                                        "a": 0
+                                      }
+                                    ],
+                                    "data": [
+                                      [
+                                        1,
+                                        [
+                                          "com.fluidframework.leaf.handle",
+                                          true,
+                                          {
+                                            "type": "__fluid_handle__",
+                                            "url": "/test/tree-0"
+                                          },
+                                          []
+                                        ]
+                                      ]
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          ],
+                          "revision": 1,
+                          "sequenceNumber": 4,
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                        }
+                      ],
+                      "branches": [],
+                      "version": 7
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Schema": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "SchemaString": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "nodes": {
+                        "com.fluidframework.leaf.handle": {
+                          "kind": {
+                            "leaf": 3
+                          }
+                        },
+                        "has-handle.HandleObject": {
+                          "kind": {
+                            "object": {
+                              "handleField": {
+                                "kind": "Optional",
+                                "types": [
+                                  "com.fluidframework.leaf.handle"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "root": {
+                        "kind": "Value",
+                        "types": [
+                          "has-handle.HandleObject"
+                        ]
+                      }
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Forest": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 3
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "contents": {
+                    "type": "blob",
+                    "content": {
+                      "keys": [
+                        "rootFieldKey"
+                      ],
+                      "fields": {
+                        "version": 2,
+                        "identifiers": [],
+                        "shapes": [
+                          {
+                            "c": {
+                              "extraFields": 1
+                            }
+                          },
+                          {
+                            "a": 0
+                          }
+                        ],
+                        "data": [
+                          [
+                            1,
+                            [
+                              "has-handle.HandleObject",
+                              false,
+                              [
+                                "handleField",
+                                [
+                                  "com.fluidframework.leaf.handle",
+                                  true,
+                                  {
+                                    "type": "__fluid_handle__",
+                                    "url": "/test/tree-0"
+                                  },
+                                  []
+                                ]
+                              ]
+                            ]
+                          ]
+                        ]
+                      },
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "DetachedFieldIndex": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "DetachedFieldIndexBlob": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "data": [],
+                      "maxId": 1
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v3_0/insert-and-remove-tree-0-after-insert.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v3_0/insert-and-remove-tree-0-after-insert.json
@@ -1,0 +1,279 @@
+{
+  "type": "tree",
+  "entries": [
+    {
+      "type": "blob",
+      ".metadata": {
+        "type": "blob",
+        "content": {
+          "version": 2
+        },
+        "encoding": "utf-8"
+      }
+    },
+    {
+      "type": "tree",
+      "indexes": {
+        "type": "tree",
+        "entries": [
+          {
+            "type": "tree",
+            "EditManager": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "String": {
+                    "type": "blob",
+                    "content": {
+                      "trunk": [
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 1,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "",
+                                              "fieldKind": "Sequence",
+                                              "change": [
+                                                {
+                                                  "count": 1,
+                                                  "effect": {
+                                                    "insert": {
+                                                      "id": 0
+                                                    }
+                                                  },
+                                                  "cellId": 0
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ],
+                                "builds": {
+                                  "builds": [
+                                    [
+                                      [
+                                        [
+                                          0,
+                                          0
+                                        ]
+                                      ]
+                                    ]
+                                  ],
+                                  "trees": {
+                                    "version": 2,
+                                    "identifiers": [],
+                                    "shapes": [
+                                      {
+                                        "c": {
+                                          "extraFields": 1
+                                        }
+                                      },
+                                      {
+                                        "a": 0
+                                      }
+                                    ],
+                                    "data": [
+                                      [
+                                        1,
+                                        [
+                                          "com.fluidframework.leaf.string",
+                                          true,
+                                          "42",
+                                          []
+                                        ]
+                                      ]
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          ],
+                          "revision": 1,
+                          "sequenceNumber": 4,
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                        }
+                      ],
+                      "branches": [],
+                      "version": 7
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Schema": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "SchemaString": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "nodes": {
+                        "com.fluidframework.leaf.string": {
+                          "kind": {
+                            "leaf": 1
+                          }
+                        },
+                        "insert-and-remove.Array<[\"com.fluidframework.leaf.string\"]>": {
+                          "kind": {
+                            "object": {
+                              "": {
+                                "kind": "Sequence",
+                                "types": [
+                                  "com.fluidframework.leaf.string"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "root": {
+                        "kind": "Value",
+                        "types": [
+                          "insert-and-remove.Array<[\"com.fluidframework.leaf.string\"]>"
+                        ]
+                      }
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Forest": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 3
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "contents": {
+                    "type": "blob",
+                    "content": {
+                      "keys": [
+                        "rootFieldKey"
+                      ],
+                      "fields": {
+                        "version": 2,
+                        "identifiers": [],
+                        "shapes": [
+                          {
+                            "c": {
+                              "extraFields": 1
+                            }
+                          },
+                          {
+                            "a": 0
+                          }
+                        ],
+                        "data": [
+                          [
+                            1,
+                            [
+                              "insert-and-remove.Array<[\"com.fluidframework.leaf.string\"]>",
+                              false,
+                              [
+                                "",
+                                [
+                                  "com.fluidframework.leaf.string",
+                                  true,
+                                  "42",
+                                  []
+                                ]
+                              ]
+                            ]
+                          ]
+                        ]
+                      },
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "DetachedFieldIndex": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "DetachedFieldIndexBlob": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "data": [],
+                      "maxId": 1
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v3_0/insert-and-remove-tree-0-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v3_0/insert-and-remove-tree-0-final.json
@@ -1,0 +1,249 @@
+{
+  "type": "tree",
+  "entries": [
+    {
+      "type": "blob",
+      ".metadata": {
+        "type": "blob",
+        "content": {
+          "version": 2
+        },
+        "encoding": "utf-8"
+      }
+    },
+    {
+      "type": "tree",
+      "indexes": {
+        "type": "tree",
+        "entries": [
+          {
+            "type": "tree",
+            "EditManager": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "String": {
+                    "type": "blob",
+                    "content": {
+                      "trunk": [
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 3,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "",
+                                              "fieldKind": "Sequence",
+                                              "change": [
+                                                {
+                                                  "count": 1,
+                                                  "effect": {
+                                                    "remove": {
+                                                      "id": 2
+                                                    }
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          ],
+                          "revision": 2,
+                          "sequenceNumber": 6,
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                        }
+                      ],
+                      "branches": [],
+                      "version": 7
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Schema": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "SchemaString": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "nodes": {
+                        "com.fluidframework.leaf.string": {
+                          "kind": {
+                            "leaf": 1
+                          }
+                        },
+                        "insert-and-remove.Array<[\"com.fluidframework.leaf.string\"]>": {
+                          "kind": {
+                            "object": {
+                              "": {
+                                "kind": "Sequence",
+                                "types": [
+                                  "com.fluidframework.leaf.string"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "root": {
+                        "kind": "Value",
+                        "types": [
+                          "insert-and-remove.Array<[\"com.fluidframework.leaf.string\"]>"
+                        ]
+                      }
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Forest": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 3
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "contents": {
+                    "type": "blob",
+                    "content": {
+                      "keys": [
+                        "rootFieldKey",
+                        "repair-2"
+                      ],
+                      "fields": {
+                        "version": 2,
+                        "identifiers": [],
+                        "shapes": [
+                          {
+                            "c": {
+                              "extraFields": 1
+                            }
+                          },
+                          {
+                            "a": 0
+                          }
+                        ],
+                        "data": [
+                          [
+                            1,
+                            [
+                              "insert-and-remove.Array<[\"com.fluidframework.leaf.string\"]>",
+                              false,
+                              []
+                            ]
+                          ],
+                          [
+                            1,
+                            [
+                              "com.fluidframework.leaf.string",
+                              true,
+                              "42",
+                              []
+                            ]
+                          ]
+                        ]
+                      },
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "DetachedFieldIndex": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "DetachedFieldIndexBlob": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "data": [
+                        [
+                          2,
+                          2,
+                          2
+                        ]
+                      ],
+                      "maxId": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v3_0/insert-and-remove-tree-1-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v3_0/insert-and-remove-tree-1-final.json
@@ -1,0 +1,257 @@
+{
+  "type": "tree",
+  "entries": [
+    {
+      "type": "blob",
+      ".metadata": {
+        "type": "blob",
+        "content": {
+          "version": 2
+        },
+        "encoding": "utf-8"
+      }
+    },
+    {
+      "type": "tree",
+      "indexes": {
+        "type": "tree",
+        "entries": [
+          {
+            "type": "tree",
+            "EditManager": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "String": {
+                    "type": "blob",
+                    "content": {
+                      "trunk": [
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 3,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "",
+                                              "fieldKind": "Sequence",
+                                              "change": [
+                                                {
+                                                  "count": 1,
+                                                  "effect": {
+                                                    "remove": {
+                                                      "id": 2
+                                                    }
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          ],
+                          "revision": 2,
+                          "sequenceNumber": 6,
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                        }
+                      ],
+                      "branches": [
+                        [
+                          "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          {
+                            "base": 2,
+                            "commits": []
+                          }
+                        ]
+                      ],
+                      "version": 7
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Schema": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "SchemaString": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "nodes": {
+                        "com.fluidframework.leaf.string": {
+                          "kind": {
+                            "leaf": 1
+                          }
+                        },
+                        "insert-and-remove.Array<[\"com.fluidframework.leaf.string\"]>": {
+                          "kind": {
+                            "object": {
+                              "": {
+                                "kind": "Sequence",
+                                "types": [
+                                  "com.fluidframework.leaf.string"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "root": {
+                        "kind": "Value",
+                        "types": [
+                          "insert-and-remove.Array<[\"com.fluidframework.leaf.string\"]>"
+                        ]
+                      }
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Forest": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 3
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "contents": {
+                    "type": "blob",
+                    "content": {
+                      "keys": [
+                        "rootFieldKey",
+                        "repair-2"
+                      ],
+                      "fields": {
+                        "version": 2,
+                        "identifiers": [],
+                        "shapes": [
+                          {
+                            "c": {
+                              "extraFields": 1
+                            }
+                          },
+                          {
+                            "a": 0
+                          }
+                        ],
+                        "data": [
+                          [
+                            1,
+                            [
+                              "insert-and-remove.Array<[\"com.fluidframework.leaf.string\"]>",
+                              false,
+                              []
+                            ]
+                          ],
+                          [
+                            1,
+                            [
+                              "com.fluidframework.leaf.string",
+                              true,
+                              "42",
+                              []
+                            ]
+                          ]
+                        ]
+                      },
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "DetachedFieldIndex": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "DetachedFieldIndexBlob": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "data": [
+                        [
+                          2,
+                          2,
+                          2
+                        ]
+                      ],
+                      "maxId": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v3_0/move-across-fields-tree-0-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v3_0/move-across-fields-tree-0-final.json
@@ -1,0 +1,603 @@
+{
+  "type": "tree",
+  "entries": [
+    {
+      "type": "blob",
+      ".metadata": {
+        "type": "blob",
+        "content": {
+          "version": 2
+        },
+        "encoding": "utf-8"
+      }
+    },
+    {
+      "type": "tree",
+      "indexes": {
+        "type": "tree",
+        "entries": [
+          {
+            "type": "tree",
+            "EditManager": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "String": {
+                    "type": "blob",
+                    "content": {
+                      "trunk": [
+                        {
+                          "change": [
+                            {
+                              "schema": {
+                                "new": {
+                                  "version": 2,
+                                  "nodes": {
+                                    "com.fluidframework.leaf.string": {
+                                      "kind": {
+                                        "leaf": 1
+                                      }
+                                    },
+                                    "move-across-fields.Array<[\"com.fluidframework.leaf.string\"]>": {
+                                      "kind": {
+                                        "object": {
+                                          "": {
+                                            "kind": "Sequence",
+                                            "types": [
+                                              "com.fluidframework.leaf.string"
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "move-across-fields.Node": {
+                                      "kind": {
+                                        "object": {
+                                          "bar": {
+                                            "kind": "Value",
+                                            "types": [
+                                              "move-across-fields.Array<[\"com.fluidframework.leaf.string\"]>"
+                                            ]
+                                          },
+                                          "foo": {
+                                            "kind": "Value",
+                                            "types": [
+                                              "move-across-fields.Array<[\"com.fluidframework.leaf.string\"]>"
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "root": {
+                                    "kind": "Optional",
+                                    "types": [
+                                      "move-across-fields.Node"
+                                    ]
+                                  }
+                                },
+                                "old": {
+                                  "version": 2,
+                                  "nodes": {},
+                                  "root": {
+                                    "kind": "Forbidden",
+                                    "types": []
+                                  }
+                                }
+                              }
+                            },
+                            {
+                              "data": {
+                                "maxId": 1,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "Optional",
+                                    "change": {
+                                      "r": {
+                                        "e": true,
+                                        "d": 0,
+                                        "s": 1
+                                      }
+                                    }
+                                  }
+                                ],
+                                "builds": {
+                                  "builds": [
+                                    [
+                                      [
+                                        [
+                                          1,
+                                          0
+                                        ]
+                                      ]
+                                    ]
+                                  ],
+                                  "trees": {
+                                    "version": 2,
+                                    "identifiers": [],
+                                    "shapes": [
+                                      {
+                                        "c": {
+                                          "extraFields": 1
+                                        }
+                                      },
+                                      {
+                                        "a": 0
+                                      }
+                                    ],
+                                    "data": [
+                                      [
+                                        1,
+                                        [
+                                          "move-across-fields.Node",
+                                          false,
+                                          [
+                                            "foo",
+                                            [
+                                              "move-across-fields.Array<[\"com.fluidframework.leaf.string\"]>",
+                                              false,
+                                              [
+                                                "",
+                                                [
+                                                  "com.fluidframework.leaf.string",
+                                                  true,
+                                                  "a",
+                                                  [],
+                                                  "com.fluidframework.leaf.string",
+                                                  true,
+                                                  "b",
+                                                  [],
+                                                  "com.fluidframework.leaf.string",
+                                                  true,
+                                                  "c",
+                                                  []
+                                                ]
+                                              ]
+                                            ],
+                                            "bar",
+                                            [
+                                              "move-across-fields.Array<[\"com.fluidframework.leaf.string\"]>",
+                                              false,
+                                              [
+                                                "",
+                                                [
+                                                  "com.fluidframework.leaf.string",
+                                                  true,
+                                                  "d",
+                                                  [],
+                                                  "com.fluidframework.leaf.string",
+                                                  true,
+                                                  "e",
+                                                  [],
+                                                  "com.fluidframework.leaf.string",
+                                                  true,
+                                                  "f",
+                                                  []
+                                                ]
+                                              ]
+                                            ]
+                                          ]
+                                        ]
+                                      ]
+                                    ]
+                                  }
+                                }
+                              }
+                            },
+                            {
+                              "schema": {
+                                "new": {
+                                  "version": 2,
+                                  "nodes": {
+                                    "com.fluidframework.leaf.string": {
+                                      "kind": {
+                                        "leaf": 1
+                                      }
+                                    },
+                                    "move-across-fields.Array<[\"com.fluidframework.leaf.string\"]>": {
+                                      "kind": {
+                                        "object": {
+                                          "": {
+                                            "kind": "Sequence",
+                                            "types": [
+                                              "com.fluidframework.leaf.string"
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "move-across-fields.Node": {
+                                      "kind": {
+                                        "object": {
+                                          "bar": {
+                                            "kind": "Value",
+                                            "types": [
+                                              "move-across-fields.Array<[\"com.fluidframework.leaf.string\"]>"
+                                            ]
+                                          },
+                                          "foo": {
+                                            "kind": "Value",
+                                            "types": [
+                                              "move-across-fields.Array<[\"com.fluidframework.leaf.string\"]>"
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "root": {
+                                    "kind": "Value",
+                                    "types": [
+                                      "move-across-fields.Node"
+                                    ]
+                                  }
+                                },
+                                "old": {
+                                  "version": 2,
+                                  "nodes": {
+                                    "com.fluidframework.leaf.string": {
+                                      "kind": {
+                                        "leaf": 1
+                                      }
+                                    },
+                                    "move-across-fields.Array<[\"com.fluidframework.leaf.string\"]>": {
+                                      "kind": {
+                                        "object": {
+                                          "": {
+                                            "kind": "Sequence",
+                                            "types": [
+                                              "com.fluidframework.leaf.string"
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "move-across-fields.Node": {
+                                      "kind": {
+                                        "object": {
+                                          "bar": {
+                                            "kind": "Value",
+                                            "types": [
+                                              "move-across-fields.Array<[\"com.fluidframework.leaf.string\"]>"
+                                            ]
+                                          },
+                                          "foo": {
+                                            "kind": "Value",
+                                            "types": [
+                                              "move-across-fields.Array<[\"com.fluidframework.leaf.string\"]>"
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "root": {
+                                    "kind": "Optional",
+                                    "types": [
+                                      "move-across-fields.Node"
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          ],
+                          "revision": 0,
+                          "sequenceNumber": 2,
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                        },
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 7,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "foo",
+                                              "fieldKind": "ModularEditBuilder.Generic",
+                                              "change": [
+                                                [
+                                                  0,
+                                                  {
+                                                    "fieldChanges": [
+                                                      {
+                                                        "fieldKey": "",
+                                                        "fieldKind": "Sequence",
+                                                        "change": [
+                                                          {
+                                                            "count": 1
+                                                          },
+                                                          {
+                                                            "count": 2,
+                                                            "effect": {
+                                                              "moveOut": {
+                                                                "id": 0
+                                                              }
+                                                            }
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              ]
+                                            },
+                                            {
+                                              "fieldKey": "bar",
+                                              "fieldKind": "ModularEditBuilder.Generic",
+                                              "change": [
+                                                [
+                                                  0,
+                                                  {
+                                                    "fieldChanges": [
+                                                      {
+                                                        "fieldKey": "",
+                                                        "fieldKind": "Sequence",
+                                                        "change": [
+                                                          {
+                                                            "count": 1
+                                                          },
+                                                          {
+                                                            "count": 2,
+                                                            "effect": {
+                                                              "moveIn": {
+                                                                "id": 0
+                                                              }
+                                                            },
+                                                            "cellId": 2
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          ],
+                          "revision": 1,
+                          "sequenceNumber": 4,
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                        }
+                      ],
+                      "branches": [],
+                      "version": 7
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Schema": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "SchemaString": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "nodes": {
+                        "com.fluidframework.leaf.string": {
+                          "kind": {
+                            "leaf": 1
+                          }
+                        },
+                        "move-across-fields.Array<[\"com.fluidframework.leaf.string\"]>": {
+                          "kind": {
+                            "object": {
+                              "": {
+                                "kind": "Sequence",
+                                "types": [
+                                  "com.fluidframework.leaf.string"
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        "move-across-fields.Node": {
+                          "kind": {
+                            "object": {
+                              "bar": {
+                                "kind": "Value",
+                                "types": [
+                                  "move-across-fields.Array<[\"com.fluidframework.leaf.string\"]>"
+                                ]
+                              },
+                              "foo": {
+                                "kind": "Value",
+                                "types": [
+                                  "move-across-fields.Array<[\"com.fluidframework.leaf.string\"]>"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "root": {
+                        "kind": "Value",
+                        "types": [
+                          "move-across-fields.Node"
+                        ]
+                      }
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Forest": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 3
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "contents": {
+                    "type": "blob",
+                    "content": {
+                      "keys": [
+                        "rootFieldKey"
+                      ],
+                      "fields": {
+                        "version": 2,
+                        "identifiers": [],
+                        "shapes": [
+                          {
+                            "c": {
+                              "extraFields": 1
+                            }
+                          },
+                          {
+                            "a": 0
+                          }
+                        ],
+                        "data": [
+                          [
+                            1,
+                            [
+                              "move-across-fields.Node",
+                              false,
+                              [
+                                "foo",
+                                [
+                                  "move-across-fields.Array<[\"com.fluidframework.leaf.string\"]>",
+                                  false,
+                                  [
+                                    "",
+                                    [
+                                      "com.fluidframework.leaf.string",
+                                      true,
+                                      "a",
+                                      []
+                                    ]
+                                  ]
+                                ],
+                                "bar",
+                                [
+                                  "move-across-fields.Array<[\"com.fluidframework.leaf.string\"]>",
+                                  false,
+                                  [
+                                    "",
+                                    [
+                                      "com.fluidframework.leaf.string",
+                                      true,
+                                      "d",
+                                      [],
+                                      "com.fluidframework.leaf.string",
+                                      true,
+                                      "b",
+                                      [],
+                                      "com.fluidframework.leaf.string",
+                                      true,
+                                      "c",
+                                      [],
+                                      "com.fluidframework.leaf.string",
+                                      true,
+                                      "e",
+                                      [],
+                                      "com.fluidframework.leaf.string",
+                                      true,
+                                      "f",
+                                      []
+                                    ]
+                                  ]
+                                ]
+                              ]
+                            ]
+                          ]
+                        ]
+                      },
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "DetachedFieldIndex": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "DetachedFieldIndexBlob": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "data": [],
+                      "maxId": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v3_0/nested-sequence-change-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v3_0/nested-sequence-change-final.json
@@ -1,0 +1,344 @@
+{
+  "type": "tree",
+  "entries": [
+    {
+      "type": "blob",
+      ".metadata": {
+        "type": "blob",
+        "content": {
+          "version": 2
+        },
+        "encoding": "utf-8"
+      }
+    },
+    {
+      "type": "tree",
+      "indexes": {
+        "type": "tree",
+        "entries": [
+          {
+            "type": "tree",
+            "EditManager": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "String": {
+                    "type": "blob",
+                    "content": {
+                      "trunk": [
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 5,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "",
+                                              "fieldKind": "Sequence",
+                                              "change": [
+                                                {
+                                                  "count": 1,
+                                                  "effect": {
+                                                    "insert": {
+                                                      "id": 0
+                                                    }
+                                                  },
+                                                  "cellId": 0,
+                                                  "changes": {
+                                                    "fieldChanges": [
+                                                      {
+                                                        "fieldKey": "foo",
+                                                        "fieldKind": "Optional",
+                                                        "change": {
+                                                          "r": {
+                                                            "e": true,
+                                                            "d": 2,
+                                                            "s": 3
+                                                          }
+                                                        }
+                                                      }
+                                                    ]
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ],
+                                "builds": {
+                                  "builds": [
+                                    [
+                                      [
+                                        [
+                                          0,
+                                          0
+                                        ],
+                                        [
+                                          3,
+                                          1
+                                        ]
+                                      ]
+                                    ]
+                                  ],
+                                  "trees": {
+                                    "version": 2,
+                                    "identifiers": [],
+                                    "shapes": [
+                                      {
+                                        "c": {
+                                          "extraFields": 1
+                                        }
+                                      },
+                                      {
+                                        "a": 0
+                                      }
+                                    ],
+                                    "data": [
+                                      [
+                                        1,
+                                        [
+                                          "test trees.Recursive Map",
+                                          false,
+                                          []
+                                        ]
+                                      ],
+                                      [
+                                        1,
+                                        [
+                                          "test trees.Array<[\"test trees.Recursive Map\"]>",
+                                          false,
+                                          [
+                                            "",
+                                            [
+                                              "test trees.Recursive Map",
+                                              false,
+                                              [
+                                                "bar",
+                                                [
+                                                  "test trees.Array<[\"test trees.Recursive Map\"]>",
+                                                  false,
+                                                  []
+                                                ]
+                                              ]
+                                            ]
+                                          ]
+                                        ]
+                                      ]
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          ],
+                          "revision": 1,
+                          "sequenceNumber": 4,
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                        }
+                      ],
+                      "branches": [],
+                      "version": 7
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Schema": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "SchemaString": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "nodes": {
+                        "test trees.Array<[\"test trees.Recursive Map\"]>": {
+                          "kind": {
+                            "object": {
+                              "": {
+                                "kind": "Sequence",
+                                "types": [
+                                  "test trees.Recursive Map"
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        "test trees.Recursive Map": {
+                          "kind": {
+                            "map": {
+                              "kind": "Optional",
+                              "types": [
+                                "test trees.Array<[\"test trees.Recursive Map\"]>"
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      "root": {
+                        "kind": "Value",
+                        "types": [
+                          "test trees.Array<[\"test trees.Recursive Map\"]>"
+                        ]
+                      }
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Forest": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 3
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "contents": {
+                    "type": "blob",
+                    "content": {
+                      "keys": [
+                        "rootFieldKey"
+                      ],
+                      "fields": {
+                        "version": 2,
+                        "identifiers": [],
+                        "shapes": [
+                          {
+                            "c": {
+                              "extraFields": 1
+                            }
+                          },
+                          {
+                            "a": 0
+                          }
+                        ],
+                        "data": [
+                          [
+                            1,
+                            [
+                              "test trees.Array<[\"test trees.Recursive Map\"]>",
+                              false,
+                              [
+                                "",
+                                [
+                                  "test trees.Recursive Map",
+                                  false,
+                                  [
+                                    "foo",
+                                    [
+                                      "test trees.Array<[\"test trees.Recursive Map\"]>",
+                                      false,
+                                      [
+                                        "",
+                                        [
+                                          "test trees.Recursive Map",
+                                          false,
+                                          [
+                                            "bar",
+                                            [
+                                              "test trees.Array<[\"test trees.Recursive Map\"]>",
+                                              false,
+                                              []
+                                            ]
+                                          ]
+                                        ]
+                                      ]
+                                    ]
+                                  ]
+                                ]
+                              ]
+                            ]
+                          ]
+                        ]
+                      },
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "DetachedFieldIndex": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "DetachedFieldIndexBlob": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "data": [],
+                      "maxId": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v3_0/optional-field-scenarios-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v3_0/optional-field-scenarios-final.json
@@ -1,0 +1,639 @@
+{
+  "type": "tree",
+  "entries": [
+    {
+      "type": "blob",
+      ".metadata": {
+        "type": "blob",
+        "content": {
+          "version": 2
+        },
+        "encoding": "utf-8"
+      }
+    },
+    {
+      "type": "tree",
+      "indexes": {
+        "type": "tree",
+        "entries": [
+          {
+            "type": "tree",
+            "EditManager": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "String": {
+                    "type": "blob",
+                    "content": {
+                      "trunk": [
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 2,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "ModularEditBuilder.Generic",
+                                    "change": [
+                                      [
+                                        0,
+                                        {
+                                          "fieldChanges": [
+                                            {
+                                              "fieldKey": "root 1 child",
+                                              "fieldKind": "Optional",
+                                              "change": {
+                                                "r": {
+                                                  "e": true,
+                                                  "d": 0,
+                                                  "s": 1
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    ]
+                                  }
+                                ],
+                                "builds": {
+                                  "builds": [
+                                    [
+                                      [
+                                        [
+                                          1,
+                                          0
+                                        ]
+                                      ]
+                                    ]
+                                  ],
+                                  "trees": {
+                                    "version": 2,
+                                    "identifiers": [],
+                                    "shapes": [
+                                      {
+                                        "c": {
+                                          "extraFields": 1
+                                        }
+                                      },
+                                      {
+                                        "a": 0
+                                      }
+                                    ],
+                                    "data": [
+                                      [
+                                        1,
+                                        [
+                                          "com.fluidframework.leaf.number",
+                                          true,
+                                          40,
+                                          []
+                                        ]
+                                      ]
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          ],
+                          "revision": 513,
+                          "sequenceNumber": 6,
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                        },
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 4,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "Optional",
+                                    "change": {
+                                      "r": {
+                                        "e": false,
+                                        "d": 3,
+                                        "s": 4
+                                      }
+                                    }
+                                  }
+                                ],
+                                "builds": {
+                                  "builds": [
+                                    [
+                                      [
+                                        [
+                                          4,
+                                          0
+                                        ]
+                                      ]
+                                    ]
+                                  ],
+                                  "trees": {
+                                    "version": 2,
+                                    "identifiers": [],
+                                    "shapes": [
+                                      {
+                                        "c": {
+                                          "extraFields": 1
+                                        }
+                                      },
+                                      {
+                                        "a": 0
+                                      }
+                                    ],
+                                    "data": [
+                                      [
+                                        1,
+                                        [
+                                          "optional-field-scenarios.Map",
+                                          false,
+                                          [
+                                            "root 2 child",
+                                            [
+                                              "com.fluidframework.leaf.number",
+                                              true,
+                                              41,
+                                              []
+                                            ]
+                                          ]
+                                        ]
+                                      ]
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          ],
+                          "revision": 514,
+                          "sequenceNumber": 8,
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                        },
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 7,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "Optional",
+                                    "change": {
+                                      "r": {
+                                        "e": false,
+                                        "d": 3,
+                                        "s": 4
+                                      },
+                                      "c": [
+                                        [
+                                          [
+                                            3,
+                                            514
+                                          ],
+                                          {
+                                            "fieldChanges": [
+                                              {
+                                                "fieldKey": "root 1 child",
+                                                "fieldKind": "Optional",
+                                                "change": {
+                                                  "r": {
+                                                    "e": false,
+                                                    "d": 0,
+                                                    "s": 1
+                                                  }
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        ],
+                                        [
+                                          4,
+                                          {
+                                            "fieldChanges": [
+                                              {
+                                                "fieldKey": "root 3 child",
+                                                "fieldKind": "Optional",
+                                                "change": {
+                                                  "r": {
+                                                    "e": true,
+                                                    "d": 5,
+                                                    "s": 6
+                                                  }
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      ]
+                                    }
+                                  }
+                                ],
+                                "builds": {
+                                  "builds": [
+                                    [
+                                      [
+                                        [
+                                          1,
+                                          0
+                                        ],
+                                        [
+                                          4,
+                                          1
+                                        ],
+                                        [
+                                          6,
+                                          2
+                                        ]
+                                      ]
+                                    ]
+                                  ],
+                                  "trees": {
+                                    "version": 2,
+                                    "identifiers": [],
+                                    "shapes": [
+                                      {
+                                        "c": {
+                                          "extraFields": 1
+                                        }
+                                      },
+                                      {
+                                        "a": 0
+                                      }
+                                    ],
+                                    "data": [
+                                      [
+                                        1,
+                                        [
+                                          "com.fluidframework.leaf.number",
+                                          true,
+                                          42,
+                                          []
+                                        ]
+                                      ],
+                                      [
+                                        1,
+                                        [
+                                          "optional-field-scenarios.Map",
+                                          false,
+                                          []
+                                        ]
+                                      ],
+                                      [
+                                        1,
+                                        [
+                                          "com.fluidframework.leaf.number",
+                                          true,
+                                          43,
+                                          []
+                                        ]
+                                      ]
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          ],
+                          "revision": 2,
+                          "sequenceNumber": 10,
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                        },
+                        {
+                          "change": [
+                            {
+                              "data": {
+                                "maxId": 7,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "Optional",
+                                    "change": {
+                                      "c": [
+                                        [
+                                          null,
+                                          {
+                                            "fieldChanges": [
+                                              {
+                                                "fieldKey": "root 3 child",
+                                                "fieldKind": "Optional",
+                                                "change": {
+                                                  "r": {
+                                                    "e": false,
+                                                    "d": 2,
+                                                    "s": 3
+                                                  }
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      ]
+                                    }
+                                  }
+                                ],
+                                "builds": {
+                                  "builds": [
+                                    [
+                                      [
+                                        [
+                                          3,
+                                          0
+                                        ]
+                                      ]
+                                    ]
+                                  ],
+                                  "trees": {
+                                    "version": 2,
+                                    "identifiers": [],
+                                    "shapes": [
+                                      {
+                                        "c": {
+                                          "extraFields": 1
+                                        }
+                                      },
+                                      {
+                                        "a": 0
+                                      }
+                                    ],
+                                    "data": [
+                                      [
+                                        1,
+                                        [
+                                          "com.fluidframework.leaf.number",
+                                          true,
+                                          44,
+                                          []
+                                        ]
+                                      ]
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          ],
+                          "revision": 3,
+                          "sequenceNumber": 12,
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                        }
+                      ],
+                      "branches": [
+                        [
+                          "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          {
+                            "base": 514,
+                            "commits": []
+                          }
+                        ]
+                      ],
+                      "version": 7
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Schema": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "SchemaString": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "nodes": {
+                        "com.fluidframework.leaf.number": {
+                          "kind": {
+                            "leaf": 0
+                          }
+                        },
+                        "com.fluidframework.leaf.string": {
+                          "kind": {
+                            "leaf": 1
+                          }
+                        },
+                        "optional-field-scenarios.Map": {
+                          "kind": {
+                            "map": {
+                              "kind": "Optional",
+                              "types": [
+                                "com.fluidframework.leaf.number",
+                                "com.fluidframework.leaf.string"
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      "root": {
+                        "kind": "Optional",
+                        "types": [
+                          "optional-field-scenarios.Map"
+                        ]
+                      }
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Forest": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 3
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "contents": {
+                    "type": "blob",
+                    "content": {
+                      "keys": [
+                        "rootFieldKey",
+                        "repair-6",
+                        "repair-8",
+                        "repair-10",
+                        "repair-11"
+                      ],
+                      "fields": {
+                        "version": 2,
+                        "identifiers": [],
+                        "shapes": [
+                          {
+                            "c": {
+                              "extraFields": 1
+                            }
+                          },
+                          {
+                            "a": 0
+                          }
+                        ],
+                        "data": [
+                          [
+                            1,
+                            [
+                              "optional-field-scenarios.Map",
+                              false,
+                              [
+                                "root 3 child",
+                                [
+                                  "com.fluidframework.leaf.number",
+                                  true,
+                                  44,
+                                  []
+                                ]
+                              ]
+                            ]
+                          ],
+                          [
+                            1,
+                            [
+                              "com.fluidframework.leaf.number",
+                              true,
+                              43,
+                              []
+                            ]
+                          ],
+                          [
+                            1,
+                            [
+                              "com.fluidframework.leaf.number",
+                              true,
+                              40,
+                              []
+                            ]
+                          ],
+                          [
+                            1,
+                            [
+                              "optional-field-scenarios.Map",
+                              false,
+                              [
+                                "root 1 child",
+                                [
+                                  "com.fluidframework.leaf.number",
+                                  true,
+                                  42,
+                                  []
+                                ]
+                              ]
+                            ]
+                          ],
+                          [
+                            1,
+                            [
+                              "optional-field-scenarios.Map",
+                              false,
+                              [
+                                "root 2 child",
+                                [
+                                  "com.fluidframework.leaf.number",
+                                  true,
+                                  41,
+                                  []
+                                ]
+                              ]
+                            ]
+                          ]
+                        ]
+                      },
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "DetachedFieldIndex": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "DetachedFieldIndexBlob": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "data": [
+                        [
+                          2,
+                          [
+                            [
+                              0,
+                              8
+                            ],
+                            [
+                              3,
+                              11
+                            ]
+                          ]
+                        ],
+                        [
+                          3,
+                          2,
+                          6
+                        ],
+                        [
+                          514,
+                          3,
+                          10
+                        ]
+                      ],
+                      "maxId": 11
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v3_0/tree-with-identifier-field-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v3_0/tree-with-identifier-field-final.json
@@ -1,0 +1,369 @@
+{
+  "type": "tree",
+  "entries": [
+    {
+      "type": "blob",
+      ".metadata": {
+        "type": "blob",
+        "content": {
+          "version": 2
+        },
+        "encoding": "utf-8"
+      }
+    },
+    {
+      "type": "tree",
+      "indexes": {
+        "type": "tree",
+        "entries": [
+          {
+            "type": "tree",
+            "EditManager": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "String": {
+                    "type": "blob",
+                    "content": {
+                      "trunk": [
+                        {
+                          "change": [
+                            {
+                              "schema": {
+                                "new": {
+                                  "version": 2,
+                                  "nodes": {
+                                    "com.example.parent": {
+                                      "kind": {
+                                        "object": {
+                                          "identifier": {
+                                            "kind": "Identifier",
+                                            "types": [
+                                              "com.fluidframework.leaf.string"
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "com.fluidframework.leaf.string": {
+                                      "kind": {
+                                        "leaf": 1
+                                      }
+                                    }
+                                  },
+                                  "root": {
+                                    "kind": "Optional",
+                                    "types": [
+                                      "com.example.parent"
+                                    ]
+                                  }
+                                },
+                                "old": {
+                                  "version": 2,
+                                  "nodes": {},
+                                  "root": {
+                                    "kind": "Forbidden",
+                                    "types": []
+                                  }
+                                }
+                              }
+                            },
+                            {
+                              "data": {
+                                "maxId": 1,
+                                "changes": [
+                                  {
+                                    "fieldKey": "rootFieldKey",
+                                    "fieldKind": "Optional",
+                                    "change": {
+                                      "r": {
+                                        "e": true,
+                                        "d": 0,
+                                        "s": 1
+                                      }
+                                    }
+                                  }
+                                ],
+                                "builds": {
+                                  "builds": [
+                                    [
+                                      [
+                                        [
+                                          1,
+                                          0
+                                        ]
+                                      ]
+                                    ]
+                                  ],
+                                  "trees": {
+                                    "version": 2,
+                                    "identifiers": [],
+                                    "shapes": [
+                                      {
+                                        "c": {
+                                          "extraFields": 1
+                                        }
+                                      },
+                                      {
+                                        "a": 0
+                                      }
+                                    ],
+                                    "data": [
+                                      [
+                                        1,
+                                        [
+                                          "com.example.parent",
+                                          false,
+                                          [
+                                            "identifier",
+                                            [
+                                              "com.fluidframework.leaf.string",
+                                              true,
+                                              "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                                              []
+                                            ]
+                                          ]
+                                        ]
+                                      ]
+                                    ]
+                                  }
+                                }
+                              }
+                            },
+                            {
+                              "schema": {
+                                "new": {
+                                  "version": 2,
+                                  "nodes": {
+                                    "com.example.parent": {
+                                      "kind": {
+                                        "object": {
+                                          "identifier": {
+                                            "kind": "Identifier",
+                                            "types": [
+                                              "com.fluidframework.leaf.string"
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "com.fluidframework.leaf.string": {
+                                      "kind": {
+                                        "leaf": 1
+                                      }
+                                    }
+                                  },
+                                  "root": {
+                                    "kind": "Value",
+                                    "types": [
+                                      "com.example.parent"
+                                    ]
+                                  }
+                                },
+                                "old": {
+                                  "version": 2,
+                                  "nodes": {
+                                    "com.example.parent": {
+                                      "kind": {
+                                        "object": {
+                                          "identifier": {
+                                            "kind": "Identifier",
+                                            "types": [
+                                              "com.fluidframework.leaf.string"
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "com.fluidframework.leaf.string": {
+                                      "kind": {
+                                        "leaf": 1
+                                      }
+                                    }
+                                  },
+                                  "root": {
+                                    "kind": "Optional",
+                                    "types": [
+                                      "com.example.parent"
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          ],
+                          "revision": 1,
+                          "sequenceNumber": 2,
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                        }
+                      ],
+                      "branches": [],
+                      "version": 7
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Schema": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "SchemaString": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "nodes": {
+                        "com.example.parent": {
+                          "kind": {
+                            "object": {
+                              "identifier": {
+                                "kind": "Identifier",
+                                "types": [
+                                  "com.fluidframework.leaf.string"
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        "com.fluidframework.leaf.string": {
+                          "kind": {
+                            "leaf": 1
+                          }
+                        }
+                      },
+                      "root": {
+                        "kind": "Value",
+                        "types": [
+                          "com.example.parent"
+                        ]
+                      }
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "Forest": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 3
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "contents": {
+                    "type": "blob",
+                    "content": {
+                      "keys": [
+                        "rootFieldKey"
+                      ],
+                      "fields": {
+                        "version": 2,
+                        "identifiers": [],
+                        "shapes": [
+                          {
+                            "c": {
+                              "extraFields": 1
+                            }
+                          },
+                          {
+                            "a": 0
+                          }
+                        ],
+                        "data": [
+                          [
+                            1,
+                            [
+                              "com.example.parent",
+                              false,
+                              [
+                                "identifier",
+                                [
+                                  "com.fluidframework.leaf.string",
+                                  true,
+                                  "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                                  []
+                                ]
+                              ]
+                            ]
+                          ]
+                        ]
+                      },
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "tree",
+            "DetachedFieldIndex": {
+              "type": "tree",
+              "entries": [
+                {
+                  "type": "blob",
+                  ".metadata": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2
+                    },
+                    "encoding": "utf-8"
+                  }
+                },
+                {
+                  "type": "blob",
+                  "DetachedFieldIndexBlob": {
+                    "type": "blob",
+                    "content": {
+                      "version": 2,
+                      "data": [],
+                      "maxId": 0
+                    },
+                    "encoding": "utf-8"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/dds/tree/src/test/utils.ts
+++ b/packages/dds/tree/src/test/utils.ts
@@ -1585,6 +1585,11 @@ export class MockTreeCheckout implements ITreeCheckout {
 	public computeNetChangeIfRebasedOnto(branch: unknown): never {
 		throw new Error("Method 'getRebaseChanges' not implemented in MockTreeCheckout.");
 	}
+	public getPersistedCommitMetadata(): never {
+		throw new Error(
+			"Method 'getPersistedCommitMetadata' not implemented in MockTreeCheckout.",
+		);
+	}
 	public isMissingEditsFrom(branch: unknown): never {
 		throw new Error("Method 'isMissingEditsFrom' not implemented in MockTreeCheckout.");
 	}

--- a/packages/dds/tree/src/util/index.ts
+++ b/packages/dds/tree/src/util/index.ts
@@ -78,6 +78,7 @@ export {
 	type JsonCompatibleReadOnly,
 	type JsonCompatibleReadOnlyObject,
 	JsonCompatibleReadOnlySchema,
+	JsonCompatibleReadOnlyObjectSchema,
 	makeArray,
 	mapIterable,
 	filterIterable,

--- a/packages/dds/tree/src/util/utils.ts
+++ b/packages/dds/tree/src/util/utils.ts
@@ -361,6 +361,17 @@ export const JsonCompatibleReadOnlySchema =
 	Type.Any() as unknown as TUnsafe<JsonCompatibleReadOnly>;
 
 /**
+ * Schema for {@link JsonCompatibleReadOnlyObject}.
+ * @remarks
+ * Like {@link JsonCompatibleReadOnlySchema} this does not deeply validate the contents,
+ * but it does require that the value be a (non-array, non-null) object.
+ */
+export const JsonCompatibleReadOnlyObjectSchema = Type.Object(
+	{},
+	{ additionalProperties: true },
+) as unknown as TUnsafe<JsonCompatibleReadOnlyObject>;
+
+/**
  * Returns if a particular json compatible value is an object.
  * Does not include `null` or arrays.
  */


### PR DESCRIPTION
Implements persisted commit metadata for SharedTree per the design in [PR #28047](https://github.com/microsoft/FluidFramework/pull/28047): applications can attach a JSON-serializable value to the commit produced by a transaction, have it replicated to peers and persisted inline on commits in the `EditManager` summary, and read it back by revision. The metadata shares the lifetime of its commit, so it is dropped automatically when the commit is trimmed from the trunk — no separate GC policy.

## What changed

- **Format + codecs (`shared-tree-core`)**: adds `MessageFormatVersion.v7` and `EditManagerFormatVersion.v7`, both gated behind a new `FluidClientVersion.v3_0`, plus an optional `persistedMetadata` field on both message formats, on `CommitBase`/`Commit`/`EncodedCommit`, and on `CommitMessage`. `encodeCommit`/`decodeCommit` and both message codecs carry the field, writing it only at v7 or later.
- **Lifecycle**: a `PersistedCommitMetadataIndex` keyed by `RevisionTag` lives on `SharedTreeCore` and is shared by every checkout (including forks), so metadata recorded by a transaction on a fork is found when a merge submits the commit. It is populated/read across `submitCommit`, `processMessagesCore`, `applyStashedOp` and `rollback` (resubmit works because `submitCommit` reads the index, not the decoded op), and pruned on `ancestryTrimmed`. It is deliberately *not* stored on `GraphCommit`, because `rebaseBranch` rebuilds commits as fresh object literals and would silently drop it.
- **Alpha API**: `RunTransactionParamsAlpha.persistedMetadata`, `UntypedTreeViewAlpha.getPersistedCommitMetadata(revision)`, `RevisionTag` exported as `@alpha`, and `LocalChangeMetadata.revision` so a `changed` event can be correlated to its metadata. Metadata from nested transactions resolves to the outermost transaction; a transaction that produces no commit (empty body or rollback) discards its metadata without throwing.

## Validation

**No validation could be run in this environment, and none is claimed.** The sandbox has no package registry access and no `node_modules`, so the toolchain could not be obtained:

| Command | Result |
| --- | --- |
| `npx tsc --project ./tsconfig.json --noEmit` (in `packages/dds/tree`) | fails — no `node_modules`; install blocked |
| `npm install -g typescript --offline` | `npm error code ENOTCACHED` (configured registry is an ADO feed returning 401; nothing cached) |
| `Invoke-WebRequest https://registry.npmjs.org/typescript` | `ERR_SSL_SSL/TLS_ALERT_HANDSHAKE_FAILURE` |
| `corepack pnpm --version` | fails downloading from `registry.npmjs.org` (same TLS failure) |

Consequently **the branch has not been compiled, no test has been executed, and API reports were not regenerated.** Before merging, a reviewer must run, from `packages/dds/tree`:

```
pnpm build && pnpm test:mocha:esm
pnpm build:api-reports          # expected diffs listed below
pnpm test:snapshots:regen       # to confirm the hand-derived snapshots below
```

### Required follow-up: API reports

`api-report/*.api.md` are generated artifacts and per `.claude/CLAUDE.md` must never be hand-edited, so they are **not** included here and CI will flag them as stale. Regenerating should add exactly: `FluidClientVersion.v3_0`, `RunTransactionParamsAlpha.persistedMetadata`, `UntypedTreeViewAlpha.getPersistedCommitMetadata`, `RevisionTag`, and `LocalChangeMetadata.revision` (and the corresponding re-exports in `fluid-framework`).

### Snapshots

New snapshot files for the `v3_0` client version were derived mechanically rather than generated, and should be verified with `test:snapshots:regen`. Every one is byte-identical to its `v2_80` counterpart except for the single EditManager/Message format version field changing from `6` to `7` — which is exactly the delta observed between the existing `v2_74` and `v2_80` snapshot sets (`4` → `6`). Existing snapshots are untouched, because the codec tree records the *write* version and older `minVersionForCollab` values still write v6.

## Scope

**Scope: 72 changed files, one concern.** 39 of those are the mechanically derived `v3_0` snapshot files described above, and 1 is a changeset — 32 files carry real change.

The feature cannot be split. Landing the op codecs without the lifecycle wiring registers a format version with no producer; landing the summary persistence without the index leaves `encodeCommit` with nothing to read; landing the public API without either produces an alpha API that silently does nothing. Any intermediate slice would either be dead code or would advertise durability the document does not yet have.

### Review map

Read in this order:

1. `shared-tree-core/persistedCommitMetadata.ts` — the index and the rationale for keying by revision.
2. `shared-tree-core/sharedTreeCore.ts` — all lifecycle wiring (submit / process / stash / rollback / trim).
3. `shared-tree-core/editManagerFormatCommons.ts`, `messageFormat*.ts`, `messageTypes.ts` — the format additions.
4. `shared-tree-core/editManagerCodecsCommons.ts`, `messageCodec*.ts`, `*Codecs*.ts`, `codec/codec.ts`, `shared-tree/sharedTree.ts` — codec plumbing and v7/`v3_0` registration.
5. `shared-tree/treeCheckout.ts` — where a transaction's metadata is recorded. Note the non-obvious part: the transaction stack mints the squash commit's revision lazily on the first edit, and `SharedTreeCore` submits from the branch's `beforeChange` during apply, so the recording hook is the revision minter (`mintTransactionRevisionTag`) rather than a branch event. `discardPendingPersistedMetadata` cleans up the abort / no-commit cases.
6. `simple-tree/api/tree.ts`, `simple-tree/api/transactionTypes.ts`, `core/rebase/types.ts`, `index.ts`, `entrypoints/alpha.ts` — the alpha surface.
7. `test/shared-tree/persistedCommitMetadata.spec.ts` and the two version-list additions in existing codec tests — everything else is generated/mechanical.

Alternatives considered: putting the metadata on `GraphCommit` (loses data on the first rebase — see above), and a separately persisted index blob (needs its own GC policy and can drift from the trunk). A feature-flagged partial landing was rejected because the flag would be `minVersionForCollab` itself, which is already the gate this design uses.

### Test coverage

`test/shared-tree/persistedCommitMetadata.spec.ts` covers: local readback; `undefined` for un-annotated commits; peer replication; survival across rebase behind a concurrent remote commit; metadata dropped from the wire when `minVersionForCollab` is too old; nested transactions resolving to the outermost; no-change and rolled-back transactions discarding metadata without throwing; and fork → merge → peer, including after the fork is disposed. The spec's summary round-trip, trailing-op, `retainHistory`, trimming, disconnect/resubmit and stashed-op scenarios are **not** yet covered by direct tests; the code paths are implemented but those cases need the async `TestTreeProvider` harness and should be added once the suite can actually be executed.

Authored with [Minions](https://icy-water-0224cc51e.2.azurestaticapps.net/minions).
