### PR TITLE
build: tag untagged asserts for 3.0.0 release

### DIFF
--- a/packages/dds/tree/src/shared-tree-core/branchCommitCounter.ts
+++ b/packages/dds/tree/src/shared-tree-core/branchCommitCounter.ts
@@ -96,7 +96,7 @@ export class BranchCommitCounter<
 
 		assert(
 			this.cachedCommitCount >= trimmedRevisions.length,
-			"Trimmed more commits than exist in the branch",
+			0xd36 /* Trimmed more commits than exist in the branch */,
 		);
 		this.cachedCommitCount = this.cachedCommitCount - trimmedRevisions.length;
 	};

--- a/packages/dds/tree/src/shared-tree/history.ts
+++ b/packages/dds/tree/src/shared-tree/history.ts
@@ -27,7 +27,10 @@ class LazyTreeBranchCommitMetadata implements TreeBranchCommitMetadata {
 		private readonly commit: GraphCommit<SharedTreeChange>,
 		private readonly idCompressor: IIdCompressor,
 	) {
-		assert(commit.revision !== "root", "Cannot construct metadata for the root commit");
+		assert(
+			commit.revision !== "root",
+			0xd35 /* Cannot construct metadata for the root commit */,
+		);
 		this.revision = idCompressor.decompress(commit.revision);
 	}
 

--- a/packages/framework/fluid-static/src/treeRootDataObject.ts
+++ b/packages/framework/fluid-static/src/treeRootDataObject.ts
@@ -291,7 +291,10 @@ export function createTreeContainerRuntimeFactory(props: {
 	}
 
 	const minVersionForCollab = oldestSupportedClient ?? minVersionForCollaboration;
-	assert(minVersionForCollab !== undefined, "A supported client version must be defined");
+	assert(
+		minVersionForCollab !== undefined,
+		0xd37 /* A supported client version must be defined */,
+	);
 
 	const [registryEntries, sharedObjects] = parseDataObjectsFromSharedObjects(schema);
 	const registry = rootDataStoreRegistry ?? new FluidDataStoreRegistry(registryEntries);

--- a/packages/runtime/test-runtime-utils/src/assertionShortCodesMap.ts
+++ b/packages/runtime/test-runtime-utils/src/assertionShortCodesMap.ts
@@ -1978,6 +1978,8 @@ export const shortCodeMap = {
 	"0xd30": "Detach range start must not exceed end",
 	"0xd31": "Detach range must not exceed field length",
 	"0xd32": "Detach destination must be a new empty field",
-	"0xd33": "compatibilityMode must be defined",
-	"0xd34": "version mark batchId remapped to a different sequence number"
+	"0xd34": "version mark batchId remapped to a different sequence number",
+	"0xd35": "Cannot construct metadata for the root commit",
+	"0xd36": "Trimmed more commits than exist in the branch",
+	"0xd37": "A supported client version must be defined"
 };


### PR DESCRIPTION
## Purpose

Step 1 of release prep for 3.0.0: tag any untagged asserts before the release, per policy (`flub release prepare` reported untagged asserts in `@fluidframework/tree` and `@fluidframework/fluid-static`).

## Command run

```
pnpm run policy-check:asserts
```

(which runs `flub generate assertTags --all && npm run format`)

## Merge order

This PR must merge **before** the version-bump PR (`release-prep/3.0.0/4-bump-<NEXT_VERSION>`).

## Note

This is a preflight PR created ahead of the other release-blocking PRs (#27982, #28037, #28044) merging. It may need to be regenerated/updated once those land, since they could introduce additional untagged asserts.