### PR TITLE
(client-utils): make layer compat policy window names explicit

### DIFF
--- a/packages/common/client-utils/package.json
+++ b/packages/common/client-utils/package.json
@@ -274,6 +274,9 @@
 			},
 			"Variable_IsoBuffer": {
 				"backCompat": false
+			},
+			"Variable_LayerCompatibilityPolicyWindowMonths": {
+				"backCompat": false
 			}
 		},
 		"entrypoint": ""

--- a/packages/common/client-utils/src/layerCompat.ts
+++ b/packages/common/client-utils/src/layerCompat.ts
@@ -23,29 +23,29 @@ export type FluidLayer = "loader" | "driver" | "runtime" | "dataStore";
  */
 export const LayerCompatibilityPolicyWindowMonths = {
 	/**
-	 * Driver is compatible with Loader versions up to 12 months (or generations) older.
+	 * A newer Driver is compatible with Loader versions up to 12 months (or generations) older.
 	 */
-	DriverLoader: 12,
+	NewDriverOldLoader: 12,
 	/**
-	 * Loader is compatible with Driver versions up to 12 months (or generations) older.
+	 * A newer Loader is compatible with Driver versions up to 12 months (or generations) older.
 	 */
-	LoaderDriver: 12,
+	NewLoaderOldDriver: 12,
 	/**
-	 * Runtime is compatible with Loader versions up to 12 months (or generations) older.
+	 * A newer Runtime is compatible with Loader versions up to 12 months (or generations) older.
 	 */
-	RuntimeLoader: 12,
+	NewRuntimeOldLoader: 12,
 	/**
-	 * Loader is compatible with Runtime versions up to 3 months (or generations) older.
+	 * A newer Loader is compatible with Runtime versions up to 3 months (or generations) older.
 	 */
-	LoaderRuntime: 3,
+	NewLoaderOldRuntime: 3,
 	/**
-	 * Runtime is compatible with DataStore versions up to 3 months (or generations) older.
+	 * A newer Runtime is compatible with DataStore versions up to 3 months (or generations) older.
 	 */
-	RuntimeDataStore: 3,
+	NewRuntimeOldDataStore: 3,
 	/**
-	 * DataStore is compatible with Runtime versions up to 3 months (or generations) older.
+	 * A newer DataStore is compatible with Runtime versions up to 3 months (or generations) older.
 	 */
-	DataStoreRuntime: 3,
+	NewDataStoreOldRuntime: 3,
 } as const;
 
 /**

--- a/packages/common/client-utils/src/test/types/validateClientUtilsPrevious.generated.ts
+++ b/packages/common/client-utils/src/test/types/validateClientUtilsPrevious.generated.ts
@@ -415,6 +415,7 @@ declare type current_as_old_for_Variable_IsoBuffer = requireAssignableTo<TypeOnl
  * typeValidation.broken:
  * "Variable_LayerCompatibilityPolicyWindowMonths": {"backCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type current_as_old_for_Variable_LayerCompatibilityPolicyWindowMonths = requireAssignableTo<TypeOnly<typeof current.LayerCompatibilityPolicyWindowMonths>, TypeOnly<typeof old.LayerCompatibilityPolicyWindowMonths>>
 
 /*

--- a/packages/drivers/local-driver/src/localLayerCompatState.ts
+++ b/packages/drivers/local-driver/src/localLayerCompatState.ts
@@ -40,13 +40,13 @@ export const localDriverCompatDetailsForLoader: ILayerCompatDetails = {
 export const localDriverCompatRequirementsForLoader: ILayerCompatSupportRequirements = {
 	/**
 	 * Minimum generation that Loader must be at to be compatible with this Driver. This is calculated based on the
-	 * LayerCompatibilityPolicyWindowMonths.DriverLoader value which defines how many months old can the Loader layer
-	 * be compared to the Driver layer for them to still be considered compatible.
+	 * LayerCompatibilityPolicyWindowMonths.NewDriverOldLoader value which defines how many months old can the Loader
+	 * layer be compared to the Driver layer for them to still be considered compatible.
 	 * The minimum valid generation value is 0.
 	 */
 	minSupportedGeneration: Math.max(
 		0,
-		generation - LayerCompatibilityPolicyWindowMonths.DriverLoader,
+		generation - LayerCompatibilityPolicyWindowMonths.NewDriverOldLoader,
 	),
 	/**
 	 * The features that the Loader must support to be compatible with this Driver.

--- a/packages/drivers/odsp-driver/src/odspLayerCompatState.ts
+++ b/packages/drivers/odsp-driver/src/odspLayerCompatState.ts
@@ -40,13 +40,13 @@ export const odspDriverCompatDetailsForLoader: ILayerCompatDetails = {
 export const odspDriverCompatRequirementsForLoader: ILayerCompatSupportRequirements = {
 	/**
 	 * Minimum generation that Loader must be at to be compatible with this Driver. This is calculated based on the
-	 * LayerCompatibilityPolicyWindowMonths.DriverLoader value which defines how many months old can the Loader layer
-	 * be compared to the Driver layer for them to still be considered compatible.
+	 * LayerCompatibilityPolicyWindowMonths.NewDriverOldLoader value which defines how many months old can the Loader
+	 * layer be compared to the Driver layer for them to still be considered compatible.
 	 * The minimum valid generation value is 0.
 	 */
 	minSupportedGeneration: Math.max(
 		0,
-		generation - LayerCompatibilityPolicyWindowMonths.DriverLoader,
+		generation - LayerCompatibilityPolicyWindowMonths.NewDriverOldLoader,
 	),
 	/**
 	 * The features that the Loader must support to be compatible with this Driver.

--- a/packages/drivers/routerlicious-driver/src/r11sLayerCompatState.ts
+++ b/packages/drivers/routerlicious-driver/src/r11sLayerCompatState.ts
@@ -40,13 +40,13 @@ export const r11sDriverCompatDetailsForLoader: ILayerCompatDetails = {
 export const r11sDriverCompatRequirementsForLoader: ILayerCompatSupportRequirements = {
 	/**
 	 * Minimum generation that Loader must be at to be compatible with this Driver. This is calculated based on the
-	 * LayerCompatibilityPolicyWindowMonths.DriverLoader value which defines how many months old can the Loader layer
-	 * be compared to the Driver layer for them to still be considered compatible.
+	 * LayerCompatibilityPolicyWindowMonths.NewDriverOldLoader value which defines how many months old can the Loader
+	 * layer be compared to the Driver layer for them to still be considered compatible.
 	 * The minimum valid generation value is 0.
 	 */
 	minSupportedGeneration: Math.max(
 		0,
-		generation - LayerCompatibilityPolicyWindowMonths.DriverLoader,
+		generation - LayerCompatibilityPolicyWindowMonths.NewDriverOldLoader,
 	),
 	/**
 	 * The features that the Loader must support to be compatible with this Driver.

--- a/packages/loader/container-loader/src/loaderLayerCompatState.ts
+++ b/packages/loader/container-loader/src/loaderLayerCompatState.ts
@@ -64,13 +64,14 @@ export const loaderCompatDetailsForDriver: ILayerCompatDetails = {
 export const runtimeSupportRequirementsForLoader: ILayerCompatSupportRequirements = {
 	/**
 	 * Minimum generation that Runtime must be at to be compatible with this Loader. This is calculated
-	 * based on the LayerCompatibilityPolicyWindowMonths.LoaderRuntime value which defines how many months old can
-	 * the Runtime layer be compared to the Loader layer for them to still be considered compatible.
+	 * based on the LayerCompatibilityPolicyWindowMonths.NewLoaderOldRuntime value which defines how many months
+	 * old can the Runtime layer be compared to the Loader layer for them to still be considered compatible.
 	 * The minimum valid generation value is 0.
 	 */
 	minSupportedGeneration: Math.max(
 		0,
-		loaderCoreCompatDetails.generation - LayerCompatibilityPolicyWindowMonths.LoaderRuntime,
+		loaderCoreCompatDetails.generation -
+			LayerCompatibilityPolicyWindowMonths.NewLoaderOldRuntime,
 	),
 	/**
 	 * The features that the Runtime must support to be compatible with Loader.
@@ -85,13 +86,14 @@ export const runtimeSupportRequirementsForLoader: ILayerCompatSupportRequirement
 export const driverSupportRequirementsForLoader: ILayerCompatSupportRequirements = {
 	/**
 	 * Minimum generation that Driver must be at to be compatible with this Loader. This is calculated
-	 * based on the LayerCompatibilityPolicyWindowMonths.LoaderDriver value which defines how many months old can
-	 * the Driver layer be compared to the Loader layer for them to still be considered compatible.
+	 * based on the LayerCompatibilityPolicyWindowMonths.NewLoaderOldDriver value which defines how many months
+	 * old can the Driver layer be compared to the Loader layer for them to still be considered compatible.
 	 * The minimum valid generation value is 0.
 	 */
 	minSupportedGeneration: Math.max(
 		0,
-		loaderCoreCompatDetails.generation - LayerCompatibilityPolicyWindowMonths.LoaderDriver,
+		loaderCoreCompatDetails.generation -
+			LayerCompatibilityPolicyWindowMonths.NewLoaderOldDriver,
 	),
 	/**
 	 * The features that the Driver must support to be compatible with Loader.

--- a/packages/runtime/container-runtime/src/runtimeLayerCompatState.ts
+++ b/packages/runtime/container-runtime/src/runtimeLayerCompatState.ts
@@ -61,13 +61,14 @@ export const runtimeCompatDetailsForLoader: ILayerCompatDetails = {
 export const loaderSupportRequirementsForRuntime: ILayerCompatSupportRequirements = {
 	/**
 	 * Minimum generation that Loader must be at to be compatible with this Runtime. This is calculated
-	 * based on the LayerCompatibilityPolicyWindowMonths.RuntimeLoader value which defines how many months old can
-	 * the Loader layer be compared to the Runtime layer for them to still be considered compatible.
+	 * based on the LayerCompatibilityPolicyWindowMonths.NewRuntimeOldLoader value which defines how many months
+	 * old can the Loader layer be compared to the Runtime layer for them to still be considered compatible.
 	 * The minimum valid generation value is 0.
 	 */
 	minSupportedGeneration: Math.max(
 		0,
-		runtimeCoreCompatDetails.generation - LayerCompatibilityPolicyWindowMonths.RuntimeLoader,
+		runtimeCoreCompatDetails.generation -
+			LayerCompatibilityPolicyWindowMonths.NewRuntimeOldLoader,
 	),
 	/**
 	 * The features that the Loader must support to be compatible with Runtime.
@@ -94,14 +95,14 @@ export const runtimeCompatDetailsForDataStore: ILayerCompatDetails = {
 export const dataStoreSupportRequirementsForRuntime: ILayerCompatSupportRequirements = {
 	/**
 	 * Minimum generation that DataStore must be at to be compatible with this Runtime. This is calculated
-	 * based on the LayerCompatibilityPolicyWindowMonths.RuntimeDataStore value which defines how many months old can
-	 * the DataStore layer be compared to the Runtime layer for them to still be considered compatible.
+	 * based on the LayerCompatibilityPolicyWindowMonths.NewRuntimeOldDataStore value which defines how many months
+	 * old can the DataStore layer be compared to the Runtime layer for them to still be considered compatible.
 	 * The minimum valid generation value is 0.
 	 */
 	minSupportedGeneration: Math.max(
 		0,
 		runtimeCoreCompatDetails.generation -
-			LayerCompatibilityPolicyWindowMonths.RuntimeDataStore,
+			LayerCompatibilityPolicyWindowMonths.NewRuntimeOldDataStore,
 	),
 	/**
 	 * The features that the DataStore must support to be compatible with Runtime.

--- a/packages/runtime/datastore/src/dataStoreLayerCompatState.ts
+++ b/packages/runtime/datastore/src/dataStoreLayerCompatState.ts
@@ -50,14 +50,14 @@ export const dataStoreCompatDetailsForRuntime: ILayerCompatDetails = {
 export const runtimeSupportRequirementsForDataStore: ILayerCompatSupportRequirements = {
 	/**
 	 * Minimum generation that Runtime must be at to be compatible with this DataStore. This is calculated
-	 * based on the LayerCompatibilityPolicyWindowMonths.DataStoreRuntime value which defines how many months old can
-	 * the Runtime layer be compared to the DataStore layer for them to still be considered compatible.
+	 * based on the LayerCompatibilityPolicyWindowMonths.NewDataStoreOldRuntime value which defines how many months
+	 * old can the Runtime layer be compared to the DataStore layer for them to still be considered compatible.
 	 * The minimum valid generation value is 0.
 	 */
 	minSupportedGeneration: Math.max(
 		0,
 		dataStoreCoreCompatDetails.generation -
-			LayerCompatibilityPolicyWindowMonths.DataStoreRuntime,
+			LayerCompatibilityPolicyWindowMonths.NewDataStoreOldRuntime,
 	),
 	/**
 	 * The features that the Runtime must support to be compatible with DataStore.


### PR DESCRIPTION
## Description

`LayerCompatibilityPolicyWindowMonths` defines the support window for each layer boundary, but its members were named by adjacent-layer pair alone — `DriverLoader`, `LoaderDriver`, `RuntimeLoader`, `LoaderRuntime`, and so on. Which layer is the newer one and which is the older one was conveyed only by word order, and `DriverLoader` / `LoaderDriver` differ solely in that ordering. At a call site like `generation - LayerCompatibilityPolicyWindowMonths.DriverLoader`, the intended direction is easy to misread.

Each member now names both sides explicitly:

| Before | After | Window |
| --- | --- | --- |
| `DriverLoader` | `NewDriverOldLoader` | 12 months |
| `LoaderDriver` | `NewLoaderOldDriver` | 12 months |
| `RuntimeLoader` | `NewRuntimeOldLoader` | 12 months |
| `LoaderRuntime` | `NewLoaderOldRuntime` | 3 months |
| `RuntimeDataStore` | `NewRuntimeOldDataStore` | 3 months |
| `DataStoreRuntime` | `NewDataStoreOldRuntime` | 3 months |

The values are unchanged, so every call site resolves to the same number and there is no behavior change. All 16 references are updated across the Loader, Runtime and DataStore layer-compat state files, plus the three Driver ones added by #27516 (`local-driver`, `odsp-driver`, `routerlicious-driver`), along with the doc comments that name the constant.

`Variable_LayerCompatibilityPolicyWindowMonths` is added to `typeValidation.broken` in `@fluid-internal/client-utils` because the exported shape of the object changed. `LayerCompatibilityPolicyWindowMonths` is `@internal` and appears in no API report, so there is no customer-facing API change and no changeset.

Follow-up to review feedback on https://github.com/microsoft/FluidFramework/pull/27516#discussion_r3438899004.

## Reviewer Guidance

The review process is outlined in [the pull request guidelines](https://github.com/microsoft/FluidFramework/blob/main/docs/content/Contributing/PR-Guidelines.md#guidelines).

This is a pure rename — no values, logic, or documentation changed. The one judgment call worth a look is casing: `NewDriverOldLoader` (PascalCase) keeps continuity with the previous `DriverLoader` style, though some const-object "enums" in the repo (e.g. `FluidErrorTypes`) use camelCase instead.
