### PR TITLE
Authenticate Docker Hub image imports

### DIFF
--- a/tools/selfhost/azure/README.md
+++ b/tools/selfhost/azure/README.md
@@ -293,6 +293,21 @@ There are two ways. They create identical resources in the identical order.
 ./azure/deploy.sh <release-id>
 ```
 
+The release includes digest-pinned Docker Official Images. ACR imports those from Docker Hub,
+whose anonymous pull quota can be exhausted by Azure's shared import egress. If the import returns
+HTTP 429, authenticate it with a Docker Hub username and access token (not your password):
+
+```bash
+export DOCKERHUB_USERNAME=<docker-hub-username>
+read -rsp "Docker Hub access token: " DOCKERHUB_TOKEN
+export DOCKERHUB_TOKEN
+echo
+./azure/deploy.sh <release-id>
+```
+
+These values are read only from the process environment; do not put the token in
+`deploy.parameters.json`.
+
 To use a parameters file somewhere else:
 
 ```bash

--- a/tools/selfhost/azure/deploy.sh
+++ b/tools/selfhost/azure/deploy.sh
@@ -381,6 +381,17 @@ else
   REDIS_ZONES="$(jq -r '.redis.zones[]?' "$PARAMS_FILE" | tr '\n' ' ')"
 fi
 STORAGE="$(jqr '.storage.accountName')"
+
+# ACR imports Docker Official Images through Docker Hub. Authentication is optional, but avoids
+# Docker Hub's anonymous pull quota, which can be exhausted by Azure's shared import egress.
+DOCKERHUB_USERNAME="${DOCKERHUB_USERNAME:-}"
+DOCKERHUB_TOKEN="${DOCKERHUB_TOKEN:-}"
+if [[ ( -n "$DOCKERHUB_USERNAME" && -z "$DOCKERHUB_TOKEN" ) ||
+      ( -z "$DOCKERHUB_USERNAME" && -n "$DOCKERHUB_TOKEN" ) ]]; then
+  echo "ERROR: set both DOCKERHUB_USERNAME and DOCKERHUB_TOKEN, or leave both unset." >&2
+  exit 1
+fi
+
 # Standard_ZRS (Zone-Redundant Storage) by default -- falls back to Standard_LRS if create
 # fails (not all regions support ZRS, see phase8_storage). Cannot be changed on an existing
 # account (`az storage account update --help`: SKU can't be updated to/from Standard_ZRS).
@@ -803,7 +814,8 @@ create_private_endpoint() {
 phase1_images() {
   banner "Phase 1: Import release images"
   az acr login -n "$ACR"
-  local name repository digest src repo ref target_tag target_repo base without_tag
+  local name repository digest src repo target_tag target_repo source_repo first
+  local dependency_auth_args=()
 
   while IFS=$'\t' read -r name repository digest; do
     [[ -n "$name" && -n "$repository" && -n "$digest" ]] || continue
@@ -834,11 +846,22 @@ phase1_images() {
 
     src="$source_repo@$digest"
     target_tag="${tag:-$RELEASE_ID}"
+    dependency_auth_args=()
+    if [[ "$source_repo" == docker.io/* && -n "$DOCKERHUB_USERNAME" ]]; then
+      dependency_auth_args=(--username "$DOCKERHUB_USERNAME" --password "$DOCKERHUB_TOKEN")
+    fi
 
     if az acr repository show --name "$ACR" --image "$target_repo:$target_tag" >/dev/null 2>&1; then
       log "$target_repo:$target_tag already in ACR, skipping import"
     else
-      az acr import --name "$ACR" --source "$src" --image "$target_repo:$target_tag" --force
+      if ! az acr import --name "$ACR" --source "$src" --image "$target_repo:$target_tag" \
+        "${dependency_auth_args[@]}" --force; then
+        if [[ "$source_repo" == docker.io/* && -z "$DOCKERHUB_USERNAME" ]]; then
+          echo "ERROR: Docker Hub rejected the anonymous ACR import." >&2
+          echo "Set DOCKERHUB_USERNAME and DOCKERHUB_TOKEN to a Docker Hub username and access token, then rerun." >&2
+        fi
+        exit 1
+      fi
     fi
   done < <(jq -r '.dependencyImages[]? | select(.status == "pinned") | [.name, (.tag // ""), .digest] | @tsv' "$IMAGES_FILE")
 

--- a/tools/selfhost/azure/test/deploy-eventhubs.test.sh
+++ b/tools/selfhost/azure/test/deploy-eventhubs.test.sh
@@ -37,6 +37,17 @@ cat > "$BIN/az" <<'STUB'
 #!/usr/bin/env bash
 echo "az $*" >> "$CALLS"
 case "$*" in
+  *"acr repository show"*)
+    requested=""
+    while [[ $# -gt 0 ]]; do
+      if [[ "$1" == "--image" ]]; then requested="$2"; break; fi
+      shift
+    done
+    while IFS= read -r line; do
+      [[ "$line" == "az acr import "* && "$line" == *"--image $requested"* ]] && exit 0
+    done < "$CALLS"
+    exit 1 ;;
+  *"acr import"*)                                                        exit 0 ;;
   *"eventhubs namespace show"*"--query zoneRedundant"*)       echo "true"; exit 0 ;;
   *"eventhubs namespace show"*"--query sku.tier"*)            echo "${MOCK_TIER:-Standard}"; exit 0 ;;
   *"eventhubs namespace show"*"--query kafkaEnabled"*)        echo "true"; exit 0 ;;
@@ -77,7 +88,18 @@ REL_DIR="$RELEASE_ROOT/$REL_ID"
 mkdir -p "$REL_DIR/deployment/azure"
 cp "$AZURE_DIR"/*.yaml "$REL_DIR/deployment/azure/" 2>/dev/null || true
 printf '{"sourceRepo":"https://github.com/microsoft/FluidFramework","resolvedCommitSha":"0123456789abcdef0123456789abcdef01234567"}\n' > "$REL_DIR/source.json"
-printf '{"builtImages":[{"name":"routerlicious","status":"pinned","tag":"mock-tag"}]}\n' > "$REL_DIR/images.json"
+cat > "$REL_DIR/images.json" <<'JSON'
+{
+  "builtImages": [
+    {"name":"routerlicious","repository":"mockbuild.azurecr.io/routerlicious","digest":"sha256:111","status":"pinned","tag":"mock-tag"},
+    {"name":"historian","repository":"mockbuild.azurecr.io/historian","digest":"sha256:222","status":"pinned","tag":"mock-tag"},
+    {"name":"gitrest","repository":"mockbuild.azurecr.io/gitrest","digest":"sha256:333","status":"pinned","tag":"mock-tag"}
+  ],
+  "dependencyImages": [
+    {"name":"nginx","tag":"1.31.3","digest":"sha256:444","status":"pinned"}
+  ]
+}
+JSON
 
 PARAMS="$WORK/params.json"
 # fluidRepoDir is mandatory since the release-pipeline merge; git is stubbed, so a directory with
@@ -168,6 +190,39 @@ d="$(read_vars "$MIN" EVENTHUBS_SKU EVENTHUBS_CAPACITY EVENTHUBS_PARTITIONS EVEN
    && "$d" == *"EVENTHUBS_AUTO_INFLATE=true"* && "$d" == *"EVENTHUBS_MAX_TU=10"* ]] \
   && ok "baseline defaults apply when optional keys are omitted" \
   || no "baseline defaults apply when optional keys are omitted" "$d"
+
+# ---------------------------------------------------------------------------
+group "1b. Docker Hub authenticated ACR import"
+# ---------------------------------------------------------------------------
+: > "$CALLS"
+out="$(
+  export DOCKERHUB_USERNAME=mock-user DOCKERHUB_TOKEN=mock-token
+  run_phase 'phase1_images'
+)"; rc=$?
+assert_eq "phase1_images exits 0 with Docker Hub credentials" "$rc" "0"
+if [[ $rc -ne 0 ]]; then
+  printf '%s\n' "$out" | tail -10 | sed 's/^/         /'
+fi
+expected_import="--source docker.io/library/nginx@sha256:444 --image nginx:1.31.3 --username mock-user --password mock-token"
+if grep -qF -- "$expected_import" "$CALLS"; then
+  ok "Docker Hub credentials are passed to dependency import"
+else
+  no "Docker Hub credentials are passed to dependency import" "$(tail -30 "$CALLS")"
+fi
+if grep -F "mockbuild.azurecr.io" "$CALLS" | grep -q -- "--username"; then
+  no "Docker Hub credentials are not sent to Azure registry imports"
+else
+  ok "Docker Hub credentials are not sent to Azure registry imports"
+fi
+
+(
+  export DOCKERHUB_USERNAME=mock-user
+  unset DOCKERHUB_TOKEN
+  run_phase ':'
+) >/dev/null 2>&1
+rc=$?
+[[ $rc -ne 0 ]] && ok "partial Docker Hub credentials are rejected" \
+                || no "partial Docker Hub credentials are rejected" "expected non-zero exit"
 
 # ---------------------------------------------------------------------------
 group "2. Mock deploy: phase3_eventhubs on a fresh subscription"


### PR DESCRIPTION
## Summary
- allow ACR dependency-image imports to authenticate to Docker Hub with environment-provided username and access token
- reject incomplete credential configuration and provide an actionable message for anonymous pull-rate failures
- avoid sending Docker Hub credentials to Azure registry imports
- document secure operator setup without placing tokens in deployment parameters

## Validation
- 67 Azure deployment and Helm-render checks passed
- focused coverage verifies credential forwarding, registry isolation, and partial-credential rejection
- shell syntax and diff validation passed