### PR TITLE
test(routerlicious-driver): mock socket client for ESM

### DIFF
--- a/packages/drivers/routerlicious-driver/.mocharc.cjs
+++ b/packages/drivers/routerlicious-driver/.mocharc.cjs
@@ -8,4 +8,7 @@
 const getFluidTestMochaConfig = require("@fluid-internal/mocha-test-setup/mocharc-common");
 
 const config = getFluidTestMochaConfig(__dirname);
+const outputDirectory = process.env.FLUID_TEST_MODULE_SYSTEM === "CJS" ? "dist" : "lib";
+config.require.push(`${__dirname}/${outputDirectory}/test/socketModuleMock.js`);
+config["node-option"].push("experimental-test-module-mocks");
 module.exports = config;

--- a/packages/drivers/routerlicious-driver/package.json
+++ b/packages/drivers/routerlicious-driver/package.json
@@ -83,7 +83,7 @@
 		"lint:fix": "fluid-build . --task eslint:fix --task format",
 		"test": "npm run test:mocha",
 		"test:coverage": "c8 npm test",
-		"test:mocha": "npm run test:mocha:cjs && echo \"ADO #7404 - ESM modules cannot be stubbed - npm run test:mocha:esm\"",
+		"test:mocha": "npm run test:mocha:esm",
 		"test:mocha:cjs": "cross-env FLUID_TEST_MODULE_SYSTEM=CJS mocha",
 		"test:mocha:esm": "mocha",
 		"test:mocha:verbose": "cross-env FLUID_TEST_VERBOSE=1 npm run test:mocha",

--- a/packages/drivers/routerlicious-driver/src/test/r11sSocketTests.spec.ts
+++ b/packages/drivers/routerlicious-driver/src/test/r11sSocketTests.spec.ts
@@ -12,7 +12,7 @@ import {
 	type IAnyDriverError,
 } from "@fluidframework/driver-definitions/internal";
 import { isFluidError } from "@fluidframework/telemetry-utils/internal";
-import { stub, spy } from "sinon";
+import { spy } from "sinon";
 import type { Socket } from "socket.io-client";
 
 import { R11sServiceClusterDrainingErrorCode } from "../contracts.js";
@@ -20,8 +20,8 @@ import { DefaultTokenProvider } from "../defaultTokenProvider.js";
 import { DocumentService } from "../documentService.js";
 import { RouterliciousDocumentServiceFactory } from "../documentServiceFactory.js";
 import { RouterliciousErrorTypes } from "../errorUtils.js";
-import * as socketModule from "../socketModule.js";
 
+import { resetSocketFactory, setSocketFactory } from "./socketModuleMock.js";
 // eslint-disable-next-line import-x/no-internal-modules
 import { ClientSocketMock } from "./socketTestUtils.ts/socketMock.js";
 
@@ -35,14 +35,13 @@ async function mockSocket<T>(
 	_response: ClientSocketMock,
 	callback: () => Promise<T>,
 ): Promise<T> {
-	const getSocketCreationStub = stub(socketModule, "SocketIOClientStatic");
 	// Cast needed because ClientSocketMock doesn't implement the full Socket interface,
 	// but provides the minimal functionality needed for our tests
-	getSocketCreationStub.returns(_response as unknown as Socket);
+	setSocketFactory(() => _response as unknown as Socket);
 	try {
 		return await callback();
 	} finally {
-		getSocketCreationStub.restore();
+		resetSocketFactory();
 	}
 }
 

--- a/packages/drivers/routerlicious-driver/src/test/socketModuleMock.ts
+++ b/packages/drivers/routerlicious-driver/src/test/socketModuleMock.ts
@@ -1,0 +1,39 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { createRequire } from "node:module";
+import path from "node:path";
+import { mock } from "node:test";
+import { pathToFileURL } from "node:url";
+
+import type { io } from "socket.io-client";
+
+let socketFactory: typeof io | undefined;
+
+export function setSocketFactory(factory: typeof io): void {
+	socketFactory = factory;
+}
+
+export function resetSocketFactory(): void {
+	socketFactory = undefined;
+}
+
+const socketIoClientSpecifier =
+	process.env.FLUID_TEST_MODULE_SYSTEM === "CJS"
+		? pathToFileURL(
+				createRequire(path.join(process.cwd(), "package.json")).resolve("socket.io-client"),
+			)
+		: "socket.io-client";
+
+mock.module(socketIoClientSpecifier, {
+	namedExports: {
+		io: (...args: Parameters<typeof io>) => {
+			if (socketFactory === undefined) {
+				throw new Error("A socket factory must be configured before creating a socket.");
+			}
+			return socketFactory(...args);
+		},
+	},
+});


### PR DESCRIPTION
Use Node's experimental module mocking to replace socket.io-client before Routerlicious modules load and thus keep socket.io-client unloaded at runtime.

This replaces `sinon.stub` whose functionality is blocked by ESM.

For CommonJS testing, resolve the entrypoint explicitly for proper mocking.

And now run the ESM Mocha suite by default.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>