### PR TITLE
build(client-devtools-view): workaround @fluentui misauthoring

### DIFF
--- a/packages/tools/devtools/devtools-view/jest.setup.cjs
+++ b/packages/tools/devtools/devtools-view/jest.setup.cjs
@@ -4,5 +4,11 @@
  */
 
 // This file is used to mock the canvas element for jest tests.
+// Jest does not inject `jest` into the global scope in ESM mode, so we do it manually.
+// Alternatively, every test using `jest.*` could import `import { jest } from "@jest/globals";`
+// Unfortunately, there is no compile time detection of the missing import because some
+// Jest globals are injected at runtime providing the convenience of not importing
+// `{ describe, it }` in all tests but that brings along all of the types and hides
+// that others like `jest.fn` are not available without the import or this injection.
 globalThis.jest = jest;
 HTMLCanvasElement.prototype.getContext = jest.fn();

--- a/packages/tools/devtools/devtools-view/jest.setup.cjs
+++ b/packages/tools/devtools/devtools-view/jest.setup.cjs
@@ -4,4 +4,5 @@
  */
 
 // This file is used to mock the canvas element for jest tests.
+globalThis.jest = jest;
 HTMLCanvasElement.prototype.getContext = jest.fn();

--- a/packages/tools/devtools/devtools-view/package.json
+++ b/packages/tools/devtools/devtools-view/package.json
@@ -53,7 +53,7 @@
 		"rebuild": "npm run clean && npm run build",
 		"test": "npm run test:jest",
 		"test:coverage": "npm run test:jest:coverage",
-		"test:jest": "pnpm test:jest:cjs && echo skip per fluentui issue 30778 - pnpm test:jest:esm",
+		"test:jest": "pnpm test:jest:esm",
 		"test:jest:cjs": "jest --ci --roots ./dist",
 		"test:jest:coverage": "jest --coverage --ci",
 		"test:jest:esm": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --roots ./lib",

--- a/packages/tools/devtools/devtools-view/src/DevtoolsView.tsx
+++ b/packages/tools/devtools/devtools-view/src/DevtoolsView.tsx
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { FluentProvider, makeStyles, shorthands, tokens } from "@fluentui/react-components";
 import type { ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
 import {
 	CloseContainer,
@@ -20,6 +19,7 @@ import {
 import { createChildLogger } from "@fluidframework/telemetry-utils/internal";
 import { type ReactElement, useCallback, useEffect, useMemo, useState } from "react";
 
+import { FluentReactComponents } from "./FluentUi.cjs";
 import { useMessageRelay } from "./MessageRelayContext.js";
 import {
 	ConsoleVerboseLogger,
@@ -39,6 +39,8 @@ import {
 	TelemetryView,
 	Waiting,
 } from "./components/index.js";
+
+const { FluentProvider, makeStyles, shorthands, tokens } = FluentReactComponents;
 
 const loggingContext = "INLINE(DevtoolsView)";
 

--- a/packages/tools/devtools/devtools-view/src/FluentUi.cts
+++ b/packages/tools/devtools/devtools-view/src/FluentUi.cts
@@ -1,0 +1,19 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/* eslint-disable @typescript-eslint/no-require-imports -- This module is the CommonJS boundary for misauthored @fluentui packages. */
+
+// @fluentui packages are misauthored to declare ESM support ("module" field in package.json).
+// Import them via CJS to avoid importing ESM modules that don't have "type": "module"
+// or .mjs extension.
+// See @fluentui issue 30778 -- https://github.com/microsoft/fluentui/issues/30778 (closed)
+// and overall issue 23508 -- https://github.com/microsoft/fluentui/issues/23508
+
+// eslint-disable-next-line no-restricted-imports -- provides MessageBar, MessageBarType, initializeIcons
+import FluentReact = require("@fluentui/react");
+import FluentReactComponents = require("@fluentui/react-components");
+import FluentReactIcons = require("@fluentui/react-icons");
+
+export { FluentReact, FluentReactComponents, FluentReactIcons };

--- a/packages/tools/devtools/devtools-view/src/FluentUi.cts
+++ b/packages/tools/devtools/devtools-view/src/FluentUi.cts
@@ -10,6 +10,8 @@
 // or .mjs extension.
 // See @fluentui issue 30778 -- https://github.com/microsoft/fluentui/issues/30778 (closed)
 // and overall issue 23508 -- https://github.com/microsoft/fluentui/issues/23508
+//
+// Note that type-only imports are immune to this issue. But workaround is required for runtime imports.
 
 // eslint-disable-next-line no-restricted-imports -- provides MessageBar, MessageBarType, initializeIcons
 import FluentReact = require("@fluentui/react");

--- a/packages/tools/devtools/devtools-view/src/ThemeHelper.ts
+++ b/packages/tools/devtools/devtools-view/src/ThemeHelper.ts
@@ -3,13 +3,12 @@
  * Licensed under the MIT License.
  */
 
-import {
-	type Theme,
-	teamsHighContrastTheme,
-	webDarkTheme,
-	webLightTheme,
-} from "@fluentui/react-components";
+import type { Theme } from "@fluentui/react-components";
 import { createContext, type Dispatch, type SetStateAction, useContext } from "react";
+
+import { FluentReactComponents } from "./FluentUi.cjs";
+
+const { teamsHighContrastTheme, webDarkTheme, webLightTheme } = FluentReactComponents;
 
 teamsHighContrastTheme.colorSubtleBackgroundHover = "#1aebff";
 teamsHighContrastTheme.colorBrandBackground2 = "#1aebff";

--- a/packages/tools/devtools/devtools-view/src/components/AudienceHistoryTable.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/AudienceHistoryTable.tsx
@@ -3,29 +3,24 @@
  * Licensed under the MIT License.
  */
 
-import {
-	Table,
-	TableBody,
-	TableCell,
-	TableHeader,
-	TableRow,
-	makeStyles,
-	tokens,
-} from "@fluentui/react-components";
-import {
-	ArrowExitRegular,
-	ArrowJoinRegular,
-	Clock12Regular,
-	DoorArrowLeftRegular,
-	Person12Regular,
-} from "@fluentui/react-icons";
 import type { ReactElement } from "react";
 
+import { FluentReactComponents, FluentReactIcons } from "../FluentUi.cjs";
 import { ThemeOption, useThemeContext } from "../ThemeHelper.js";
 
 import type { TransformedAudienceHistoryData } from "./AudienceView.js";
 import { clientIdTooltipText } from "./TooltipTexts.js";
 import { LabelCellLayout } from "./utility-components/index.js";
+
+const { Table, TableBody, TableCell, TableHeader, TableRow, makeStyles, tokens } =
+	FluentReactComponents;
+const {
+	ArrowExitRegular,
+	ArrowJoinRegular,
+	Clock12Regular,
+	DoorArrowLeftRegular,
+	Person12Regular,
+} = FluentReactIcons;
 
 const audienceStyles = makeStyles({
 	joined: {

--- a/packages/tools/devtools/devtools-view/src/components/AudienceStateTable.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/AudienceStateTable.tsx
@@ -3,18 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import {
-	Table,
-	TableBody,
-	TableCell,
-	TableHeader,
-	TableRow,
-	makeStyles,
-	tokens,
-} from "@fluentui/react-components";
-import { EditRegular, Person12Regular, Search12Regular } from "@fluentui/react-icons";
 import { type ReactElement, useContext } from "react";
 
+import { FluentReactComponents, FluentReactIcons } from "../FluentUi.cjs";
 import { ThemeContext, ThemeOption } from "../ThemeHelper.js";
 
 import type { TransformedAudienceStateData } from "./AudienceView.js";
@@ -25,6 +16,10 @@ import {
 	userIdTooltipText,
 } from "./TooltipTexts.js";
 import { LabelCellLayout } from "./utility-components/index.js";
+
+const { Table, TableBody, TableCell, TableHeader, TableRow, makeStyles, tokens } =
+	FluentReactComponents;
+const { EditRegular, Person12Regular, Search12Regular } = FluentReactIcons;
 
 const audienceStateStyle = makeStyles({
 	currentUser: {

--- a/packages/tools/devtools/devtools-view/src/components/AudienceView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/AudienceView.tsx
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { Divider } from "@fluentui/react-components";
 import {
 	AudienceSummary,
 	GetAudienceSummary,
@@ -15,11 +14,14 @@ import {
 import type { IClient } from "@fluidframework/driver-definitions";
 import { type ReactElement, useEffect, useState } from "react";
 
+import { FluentReactComponents } from "../FluentUi.cjs";
 import { useMessageRelay } from "../MessageRelayContext.js";
 
 import { AudienceHistoryTable } from "./AudienceHistoryTable.js";
 import { AudienceStateTable } from "./AudienceStateTable.js";
 import { Waiting } from "./Waiting.js";
+
+const { Divider } = FluentReactComponents;
 
 // TODOs:
 // - Special annotation for the member elected as the summarizer

--- a/packages/tools/devtools/devtools-view/src/components/ContainerDevtoolsView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/ContainerDevtoolsView.tsx
@@ -3,16 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import {
-	Divider,
-	type SelectTabData,
-	type SelectTabEvent,
-	Tab,
-	TabList,
-	type TabValue,
-	makeStyles,
-	shorthands,
-} from "@fluentui/react-components";
+import type { SelectTabData, SelectTabEvent, TabValue } from "@fluentui/react-components";
 import {
 	type ContainerDevtoolsFeatureFlags,
 	ContainerDevtoolsFeatures,
@@ -25,6 +16,7 @@ import {
 import { type ReactElement, useEffect, useState } from "react";
 
 import { ContainerFeatureFlagContext } from "../ContainerFeatureFlagHelper.js";
+import { FluentReactComponents } from "../FluentUi.cjs";
 import { useMessageRelay } from "../MessageRelayContext.js";
 import { useLogger } from "../TelemetryUtils.js";
 
@@ -33,6 +25,8 @@ import { ContainerHistoryView } from "./ContainerHistoryView.js";
 import { ContainerSummaryView } from "./ContainerSummaryView.js";
 import { DataObjectsView } from "./DataObjectsView.js";
 import { Waiting } from "./Waiting.js";
+
+const { Divider, Tab, TabList, makeStyles, shorthands } = FluentReactComponents;
 
 // TODOs:
 // - Allow consumers to specify additional tabs / views for list of inner app view options.

--- a/packages/tools/devtools/devtools-view/src/components/ContainerHistoryLog.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/ContainerHistoryLog.tsx
@@ -3,16 +3,17 @@
  * Licensed under the MIT License.
  */
 
-import {
-	Table,
-	TableBody,
-	TableCell,
-	TableHeader,
-	TableHeaderCell,
-	TableRow,
-	tokens,
-} from "@fluentui/react-components";
-import {
+import type { ConnectionStateChangeLogEntry } from "@fluidframework/devtools-core/internal";
+import { type ReactElement, useContext } from "react";
+
+import { FluentReactComponents, FluentReactIcons } from "../FluentUi.cjs";
+import { ThemeContext, ThemeOption } from "../ThemeHelper.js";
+
+import { LabelCellLayout } from "./utility-components/index.js";
+
+const { Table, TableBody, TableCell, TableHeader, TableHeaderCell, TableRow, tokens } =
+	FluentReactComponents;
+const {
 	AlertBadgeRegular,
 	Attach20Regular,
 	Clock12Regular,
@@ -21,13 +22,7 @@ import {
 	PlugConnected20Regular,
 	PlugDisconnected20Regular,
 	Warning20Regular,
-} from "@fluentui/react-icons";
-import type { ConnectionStateChangeLogEntry } from "@fluidframework/devtools-core/internal";
-import { type ReactElement, useContext } from "react";
-
-import { ThemeContext, ThemeOption } from "../ThemeHelper.js";
-
-import { LabelCellLayout } from "./utility-components/index.js";
+} = FluentReactIcons;
 
 /**
  * Returns the text color based on the current color theme of the devtools.

--- a/packages/tools/devtools/devtools-view/src/components/ContainerHistoryView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/ContainerHistoryView.tsx
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { Divider } from "@fluentui/react-components";
 import {
 	type ConnectionStateChangeLogEntry,
 	ContainerStateHistory,
@@ -15,10 +14,13 @@ import {
 } from "@fluidframework/devtools-core/internal";
 import { type ReactElement, useEffect, useState } from "react";
 
+import { FluentReactComponents } from "../FluentUi.cjs";
 import { useMessageRelay } from "../MessageRelayContext.js";
 
 import { ContainerHistoryLog } from "./ContainerHistoryLog.js";
 import { Waiting } from "./Waiting.js";
+
+const { Divider } = FluentReactComponents;
 
 /**
  * {@link ContainerHistoryView} input props.

--- a/packages/tools/devtools/devtools-view/src/components/ContainerSummaryView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/ContainerSummaryView.tsx
@@ -3,28 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import {
-	Badge,
-	Button,
-	InfoLabel,
-	Table,
-	TableBody,
-	TableCell,
-	TableCellLayout,
-	type TableColumnDefinition,
-	type TableColumnSizingOptions,
-	TableRow,
-	createTableColumn,
-	makeStyles,
-	shorthands,
-	useTableColumnSizing_unstable,
-	useTableFeatures,
+import type {
+	TableColumnDefinition,
+	TableColumnSizingOptions,
 } from "@fluentui/react-components";
-import {
-	Delete20Regular,
-	PlugConnected20Regular,
-	PlugDisconnected20Regular,
-} from "@fluentui/react-icons";
 import { AttachState } from "@fluidframework/container-definitions";
 import { ConnectionState } from "@fluidframework/container-loader";
 import {
@@ -43,6 +25,7 @@ import {
 import { type ReactElement, useEffect, useState } from "react";
 
 import { useContainerFeaturesContext } from "../ContainerFeatureFlagHelper.js";
+import { FluentReactComponents, FluentReactIcons } from "../FluentUi.cjs";
 import { useMessageRelay } from "../MessageRelayContext.js";
 import { useLogger } from "../TelemetryUtils.js";
 import { connectionStateToString } from "../Utilities.js";
@@ -53,6 +36,24 @@ import {
 	userIdTooltipText,
 } from "./TooltipTexts.js";
 import { Waiting } from "./Waiting.js";
+
+const {
+	Badge,
+	Button,
+	InfoLabel,
+	Table,
+	TableBody,
+	TableCell,
+	TableCellLayout,
+	TableRow,
+	createTableColumn,
+	makeStyles,
+	shorthands,
+	useTableColumnSizing_unstable,
+	useTableFeatures,
+} = FluentReactComponents;
+const { Delete20Regular, PlugConnected20Regular, PlugDisconnected20Regular } =
+	FluentReactIcons;
 
 /**
  * {@link ContainerSummaryView} input props.

--- a/packages/tools/devtools/devtools-view/src/components/DataObjectsView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/DataObjectsView.tsx
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { Tree as FluentTree } from "@fluentui/react-components";
 import {
 	GetRootDataVisualizations,
 	type HasContainerKey,
@@ -15,10 +14,13 @@ import {
 } from "@fluidframework/devtools-core/internal";
 import { type ReactElement, useEffect, useState } from "react";
 
+import { FluentReactComponents } from "../FluentUi.cjs";
 import { useMessageRelay } from "../MessageRelayContext.js";
 
 import { Waiting } from "./Waiting.js";
 import { TreeDataView } from "./data-visualization/index.js";
+
+const { Tree: FluentTree } = FluentReactComponents;
 
 const loggingContext = "INLINE(VIEW)";
 

--- a/packages/tools/devtools/devtools-view/src/components/Menu.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/Menu.tsx
@@ -3,28 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import {
-	Button,
-	makeStyles,
-	mergeClasses,
-	shorthands,
-	tokens,
-	Tooltip,
-} from "@fluentui/react-components";
-import {
-	QuestionCircle16Regular,
-	ArrowSync16Regular,
-	CatchUp16Regular,
-	Run16Regular,
-	LockClosed16Regular,
-	PlugConnected16Regular,
-	PlugDisconnected16Regular,
-	Delete16Regular,
-	Dismiss24Regular,
-	Attach16Regular,
-	DocumentDataLink16Regular,
-	DocumentDismiss16Regular,
-} from "@fluentui/react-icons";
 import { ConnectionState } from "@fluidframework/container-loader";
 import type {
 	HasContainerKey,
@@ -48,11 +26,29 @@ import {
 	useState,
 } from "react";
 
+import { FluentReactComponents, FluentReactIcons } from "../FluentUi.cjs";
 import { useMessageRelay } from "../MessageRelayContext.js";
 import { useLogger } from "../TelemetryUtils.js";
 
 import { Waiting } from "./Waiting.js";
 import { ScreenReaderAnnouncement } from "./utility-components/index.js";
+
+const { Button, makeStyles, mergeClasses, shorthands, tokens, Tooltip } =
+	FluentReactComponents;
+const {
+	QuestionCircle16Regular,
+	ArrowSync16Regular,
+	CatchUp16Regular,
+	Run16Regular,
+	LockClosed16Regular,
+	PlugConnected16Regular,
+	PlugDisconnected16Regular,
+	Delete16Regular,
+	Dismiss24Regular,
+	Attach16Regular,
+	DocumentDataLink16Regular,
+	DocumentDismiss16Regular,
+} = FluentReactIcons;
 
 const useMenuStyles = makeStyles({
 	root: {

--- a/packages/tools/devtools/devtools-view/src/components/NoDevtoolsErrorBar.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/NoDevtoolsErrorBar.tsx
@@ -6,10 +6,12 @@
 // The `MessageBar` component was removed in FluentUI React v9 with no replacement offered.
 // In the future, we will want to re-write this component to use something else, but for now this import is required.
 // When these imports are removed, the `@fluentui/react` dependency should be removed from this package.
-// eslint-disable-next-line no-restricted-imports
-import { MessageBar, MessageBarType, initializeIcons } from "@fluentui/react";
-import { Button, Link, Tooltip, makeStyles } from "@fluentui/react-components";
 import type { ReactElement } from "react";
+
+import { FluentReact, FluentReactComponents } from "../FluentUi.cjs";
+
+const { MessageBar, MessageBarType, initializeIcons } = FluentReact;
+const { Button, Link, Tooltip, makeStyles } = FluentReactComponents;
 
 // NoDevtoolsErrorBar uses legacy @fluentui/react, which requires explicit icon initialization.
 initializeIcons();

--- a/packages/tools/devtools/devtools-view/src/components/OpLatencyView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/OpLatencyView.tsx
@@ -4,14 +4,6 @@
  */
 
 import {
-	Body1,
-	Body1Strong,
-	Button,
-	Link,
-	Subtitle1,
-	makeStyles,
-} from "@fluentui/react-components";
-import {
 	DevtoolsFeatures,
 	GetDevtoolsFeatures,
 	type ISourcedDevtoolsMessage,
@@ -22,9 +14,12 @@ import {
 } from "@fluidframework/devtools-core/internal";
 import { type ReactElement, useEffect, useState } from "react";
 
+import { FluentReactComponents } from "../FluentUi.cjs";
 import { useMessageRelay } from "../MessageRelayContext.js";
 
 import { DynamicComposedChart, type GraphDataSet } from "./graphs/index.js";
+
+const { Body1, Body1Strong, Button, Link, Subtitle1, makeStyles } = FluentReactComponents;
 
 const useStyles = makeStyles({
 	flexColumn: {

--- a/packages/tools/devtools/devtools-view/src/components/SettingsView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/SettingsView.tsx
@@ -3,7 +3,13 @@
  * Licensed under the MIT License.
  */
 
-import {
+import type { ReactElement } from "react";
+
+import { FluentReactComponents } from "../FluentUi.cjs";
+import { useTelemetryOptIn } from "../TelemetryUtils.js";
+import { ThemeOption, useThemeContext } from "../ThemeHelper.js";
+
+const {
 	Dropdown,
 	Link,
 	Option,
@@ -12,11 +18,7 @@ import {
 	teamsHighContrastTheme,
 	webDarkTheme,
 	webLightTheme,
-} from "@fluentui/react-components";
-import type { ReactElement } from "react";
-
-import { useTelemetryOptIn } from "../TelemetryUtils.js";
-import { ThemeOption, useThemeContext } from "../ThemeHelper.js";
+} = FluentReactComponents;
 
 const useStyles = makeStyles({
 	root: {

--- a/packages/tools/devtools/devtools-view/src/components/TelemetryConsentModal.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/TelemetryConsentModal.tsx
@@ -3,10 +3,12 @@
  * Licensed under the MIT License.
  */
 
-import { Button, Checkbox, makeStyles, shorthands, tokens } from "@fluentui/react-components";
 import type { ReactElement } from "react";
 
+import { FluentReactComponents } from "../FluentUi.cjs";
 import { useTelemetryOptIn } from "../TelemetryUtils.js";
+
+const { Button, Checkbox, makeStyles, shorthands, tokens } = FluentReactComponents;
 
 const useStyles = makeStyles({
 	root: {

--- a/packages/tools/devtools/devtools-view/src/components/TelemetryView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/TelemetryView.tsx
@@ -3,25 +3,10 @@
  * Licensed under the MIT License.
  */
 
-import {
-	Button,
-	Combobox,
-	type ComboboxProps,
-	CounterBadge,
-	DataGrid,
-	DataGridBody,
-	DataGridCell,
-	DataGridHeader,
-	DataGridHeaderCell,
-	DataGridRow,
-	Dropdown,
-	type DropdownProps,
-	Option,
-	type TableColumnDefinition,
-	createTableColumn,
-	makeStyles,
-	shorthands,
-	tokens,
+import type {
+	ComboboxProps,
+	DropdownProps,
+	TableColumnDefinition,
 } from "@fluentui/react-components";
 import {
 	DevtoolsDisposed,
@@ -42,6 +27,7 @@ import {
 	useState,
 } from "react";
 
+import { FluentReactComponents } from "../FluentUi.cjs";
 import { useMessageRelay } from "../MessageRelayContext.js";
 import { useLogger } from "../TelemetryUtils.js";
 import { ThemeOption, useThemeContext } from "../ThemeHelper.js";
@@ -49,6 +35,24 @@ import { ThemeOption, useThemeContext } from "../ThemeHelper.js";
 import { SplitPane } from "./SplitPane.cjs";
 import { Waiting } from "./Waiting.js";
 import { ScreenReaderAnnouncement } from "./utility-components/index.js";
+
+const {
+	Button,
+	Combobox,
+	CounterBadge,
+	DataGrid,
+	DataGridBody,
+	DataGridCell,
+	DataGridHeader,
+	DataGridHeaderCell,
+	DataGridRow,
+	Dropdown,
+	Option,
+	createTableColumn,
+	makeStyles,
+	shorthands,
+	tokens,
+} = FluentReactComponents;
 
 /**
  * Set the default displayed size to 100.

--- a/packages/tools/devtools/devtools-view/src/components/TooltipTexts.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/TooltipTexts.tsx
@@ -3,7 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import { Link } from "@fluentui/react-components";
+import { FluentReactComponents } from "../FluentUi.cjs";
+
+const { Link } = FluentReactComponents;
 
 /**
  * Description of "Client ID" for use in tooltips.

--- a/packages/tools/devtools/devtools-view/src/components/Waiting.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/Waiting.tsx
@@ -3,8 +3,11 @@
  * Licensed under the MIT License.
  */
 
-import { Spinner } from "@fluentui/react-components";
 import type { ReactElement } from "react";
+
+import { FluentReactComponents } from "../FluentUi.cjs";
+
+const { Spinner } = FluentReactComponents;
 
 /**
  * Default label displayed by {@link Waiting} when no {@link WaitingProps.label} is specified.

--- a/packages/tools/devtools/devtools-view/src/components/data-visualization/FluidHandleView.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/data-visualization/FluidHandleView.tsx
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-import { Spinner } from "@fluentui/react-components";
 import {
 	CloseDataVisualization,
 	DataVisualization,
@@ -17,12 +16,15 @@ import {
 } from "@fluidframework/devtools-core/internal";
 import { type ReactElement, useEffect, useState } from "react";
 
+import { FluentReactComponents } from "../../FluentUi.cjs";
 import { useMessageRelay } from "../../MessageRelayContext.js";
 
 import type { HasLabel } from "./CommonInterfaces.js";
 import { TreeDataView } from "./TreeDataView.js";
 import { TreeHeader } from "./TreeHeader.js";
 import { TreeItem } from "./TreeItem.js";
+
+const { Spinner } = FluentReactComponents;
 
 const loggingContext = "EXTENSION(HandleView)";
 

--- a/packages/tools/devtools/devtools-view/src/components/data-visualization/TreeHeader.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/data-visualization/TreeHeader.tsx
@@ -3,15 +3,17 @@
  * Licensed under the MIT License.
  */
 
-import { Tooltip, makeStyles, tokens } from "@fluentui/react-components";
-import { Info20Regular } from "@fluentui/react-icons";
 import type { VisualChildNode } from "@fluidframework/devtools-core/internal";
 import { type ReactElement, useContext } from "react";
 
+import { FluentReactComponents, FluentReactIcons } from "../../FluentUi.cjs";
 import { ThemeContext, ThemeOption } from "../../ThemeHelper.js";
 
 import type { HasLabel } from "./CommonInterfaces.js";
 import { ToolTipContentsView } from "./ToolTipContentsView.js";
+
+const { Tooltip, makeStyles, tokens } = FluentReactComponents;
+const { Info20Regular } = FluentReactIcons;
 
 /**
  * Input props to {@link TreeHeader}

--- a/packages/tools/devtools/devtools-view/src/components/data-visualization/TreeItem.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/data-visualization/TreeItem.tsx
@@ -3,12 +3,15 @@
  * Licensed under the MIT License.
  */
 
-import {
-	Tree as FluentTree,
-	TreeItem as FluentTreeItem,
-	TreeItemLayout as FluentTreeItemLayout,
-} from "@fluentui/react-components";
 import { Children, type PropsWithChildren, type ReactElement } from "react";
+
+import { FluentReactComponents } from "../../FluentUi.cjs";
+
+const {
+	Tree: FluentTree,
+	TreeItem: FluentTreeItem,
+	TreeItemLayout: FluentTreeItemLayout,
+} = FluentReactComponents;
 
 /**
  * Input to {@link TreeItem}

--- a/packages/tools/devtools/devtools-view/src/components/utility-components/LabelCellLayout.tsx
+++ b/packages/tools/devtools/devtools-view/src/components/utility-components/LabelCellLayout.tsx
@@ -3,8 +3,11 @@
  * Licensed under the MIT License.
  */
 
-import { InfoLabel, Label, TableCellLayout } from "@fluentui/react-components";
 import type { PropsWithChildren, ReactElement } from "react";
+
+import { FluentReactComponents } from "../../FluentUi.cjs";
+
+const { InfoLabel, Label, TableCellLayout } = FluentReactComponents;
 
 /**
  * {@link LabelCellLayout} input props.

--- a/packages/tools/devtools/devtools-view/src/test/utils/axeUtils.ts
+++ b/packages/tools/devtools/devtools-view/src/test/utils/axeUtils.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import * as axe from "axe-core";
+import axe from "axe-core";
 
 /**
  * Represents an accessibility violation found by axe


### PR DESCRIPTION
Route Fluent UI runtime imports through a CommonJS wrapper so their misauthored module entrypoints are not loaded by Jest's ESM runtime. Update Jest and axe interop for ESM, and make the ESM suite the default test target.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>