### PR TITLE
Enable Whole Summary Upload in Self-Hosted End-to-End Tests

### DIFF
--- a/tools/selfhost/azure/README.md
+++ b/tools/selfhost/azure/README.md
@@ -424,6 +424,16 @@ provisioning:
 This rebuilds and redeploys the application only. It does not touch Cosmos, Redis, Event Hubs,
 Key Vault or Front Door.
 
+## Low-IO write
+
+gitrest's `git__enableLowIoWrite` setting in `azure/backends.yaml` controls low-IO summary
+writes. When enabled, clients must use `driverPolicies.enableWholeSummaryUpload` to read
+summaries.
+
+For end-to-end tests, set `lowIoWriteEnabled` in the test parameters file to the same value.
+The test script configures `driverPolicies.enableWholeSummaryUpload` to match the low-IO write
+configuration.
+
 ## Removing the deployment
 
 Everything lives in one resource group, so deleting it removes all of it:

--- a/tools/selfhost/azure/end-to-end-tests/README.md
+++ b/tools/selfhost/azure/end-to-end-tests/README.md
@@ -39,3 +39,10 @@ runs the suite with `--driver=r11s --r11sEndpointName=custom`.
 
 The driver configuration contains the remote service URLs and the tenant secret
 only in process memory. It is not written to the parameters file.
+
+## Low-IO write
+
+Set `lowIoWriteEnabled` in the test parameters file to match the deployed gitrest
+`enableLowIoWrite` setting. The script applies this value to
+`driverPolicies.enableWholeSummaryUpload`. This policy must be enabled to read summaries from a
+deployment that uses low-IO write.

--- a/tools/selfhost/azure/end-to-end-tests/end-to-end-tests.parameters.example.json
+++ b/tools/selfhost/azure/end-to-end-tests/end-to-end-tests.parameters.example.json
@@ -1,7 +1,12 @@
 {
 	"subscriptionId": "00000000-0000-0000-0000-000000000000",
 	"resourceGroup": "my-fluid-rg",
-	"aksName": "my-fluid-aks",
-	"frontDoorProfileName": "my-fluid-afd",
-	"tenantId": "fluid"
+	"aks": {
+		"name": "my-fluid-aks"
+	},
+	"frontDoor": {
+		"profileName": "my-fluid-afd"
+	},
+	"tenantId": "fluid",
+	"lowIoWriteEnabled": false
 }

--- a/tools/selfhost/azure/end-to-end-tests/end-to-end-tests.parameters.example.json
+++ b/tools/selfhost/azure/end-to-end-tests/end-to-end-tests.parameters.example.json
@@ -8,5 +8,5 @@
 		"profileName": "my-fluid-afd"
 	},
 	"tenantId": "fluid",
-	"lowIoWriteEnabled": false
+	"lowIoWriteEnabled": true
 }

--- a/tools/selfhost/azure/end-to-end-tests/lib.sh
+++ b/tools/selfhost/azure/end-to-end-tests/lib.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Supporting functions for end-to-end-tests.sh parameter loading, tool checks, 
+# Supporting functions for end-to-end-tests.sh parameter loading, tool checks,
 # Azure authentication and endpoint discovery, and custom routerlicious driver configuration.
 
 E2E_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -31,6 +31,7 @@ load_parameters() {
   AKS="$(jqr '.aks.name')"
   AFD="$(jqr '.frontDoor.profileName')"
   TENANT_ID="$(jqr '.tenantId')"; TENANT_ID="${TENANT_ID:-fluid}"
+  LOW_IO_WRITE="$(jqr '.lowIoWriteEnabled')"
 
   if [ -z "$RG" ]; then
     echo "ERROR: 'resourceGroup' is required in $PARAMETERS_FILE." >&2
@@ -42,6 +43,10 @@ load_parameters() {
   fi
   if [ -z "$AFD" ]; then
     echo "ERROR: 'frontDoor.profileName' is required in $PARAMETERS_FILE." >&2
+    exit 1
+  fi
+  if [ "$LOW_IO_WRITE" != "true" ] && [ "$LOW_IO_WRITE" != "false" ]; then
+    echo "ERROR: 'lowIoWriteEnabled' is required in $PARAMETERS_FILE and must be a boolean (true or false)." >&2
     exit 1
   fi
 }
@@ -98,6 +103,7 @@ configure_test_environment() {
 # Export the custom driver configuration built from the discovered endpoints and tenant secret.
 export_custom_driver_config() {
   export fluid__test__driver__custom
+  # enableWholeSummaryUpload is required to read summaries when low-IO write is enabled in gitrest
   fluid__test__driver__custom="$(jq -n \
     --arg tenantId "$TENANT_ID" \
     --arg tenantSecret "$TENANT_SECRET" \
@@ -105,5 +111,6 @@ export_custom_driver_config() {
     --arg ordererUrl "https://$ALFRED_HOST" \
     --arg deltaStorageUrl "https://$HISTORIAN_HOST" \
     --arg deltaStreamUrl "https://$NEXUS_HOST" \
-    '{tenantId: $tenantId, tenantSecret: $tenantSecret, host: $host, ordererUrl: $ordererUrl, deltaStorageUrl: $deltaStorageUrl, deltaStreamUrl: $deltaStreamUrl}')"
+    --argjson enableWholeSummaryUpload "$LOW_IO_WRITE" \
+    '{tenantId: $tenantId, tenantSecret: $tenantSecret, host: $host, ordererUrl: $ordererUrl, deltaStorageUrl: $deltaStorageUrl, deltaStreamUrl: $deltaStreamUrl, driverPolicies: {enableWholeSummaryUpload: $enableWholeSummaryUpload}}')"
 }


### PR DESCRIPTION
## Description
When Low-IO write is enabled in gitrest, whole summary uploads must also be enabled.
The self-host end-to-end test script will read the `lowIoWriteEnabled` parameter from the configuration file, and update `driverPolicies.enableWholeSummaryUpload`.

## Reviewer Guidance
This has been tested with a self-hosted fluid deployment with low IO write enabled. End-to-end tests that failed previously were able to successfully read summaries once `enableWholeSummaryUpload` was updated.
