### PR TITLE
feat(telemetry-utils): Add SchemaArtifact telemetry tag for DDS schema metadata

### DIFF
--- a/packages/dds/tree/src/feature-libraries/schemaChecker.ts
+++ b/packages/dds/tree/src/feature-libraries/schemaChecker.ts
@@ -12,13 +12,7 @@ import type {
 	ITelemetryBaseProperties,
 	TelemetryBaseEventPropertyType,
 } from "@fluidframework/core-interfaces";
-import {
-	tagCodeArtifacts,
-	tagData,
-	tagSchemaArtifacts,
-	TelemetryDataTag,
-	UsageError,
-} from "@fluidframework/telemetry-utils/internal";
+import { tagSchemaArtifacts, UsageError } from "@fluidframework/telemetry-utils/internal";
 
 import {
 	type TreeFieldStoredSchema,
@@ -64,10 +58,8 @@ export function throwOutOfSchema(details: SchemaValidationErrorDetails): never {
 	throw new UsageError(
 		appendDebugMessage(message, () => getSchemaValidationDebugMessage(details)),
 		{
-			...tagCodeArtifacts({
+			...tagSchemaArtifacts({
 				schemaValidationError: SchemaValidationError[details.error],
-			}),
-			...tagData(TelemetryDataTag.UserData, {
 				schemaValidationPath: JSON.stringify(details.path),
 			}),
 			...details.telemetryProperties,
@@ -213,8 +205,8 @@ export function isNodeInSchema<T extends NotUndefined>(
 			const unexpectedFields = [...mapIterable(node.fields, ([key]) => key)].sort();
 			return onError(
 				schemaValidationError(SchemaValidationError.LeafNode_FieldsNotAllowed, {
-					...tagSchemaArtifacts({ nodeType: node.type }),
-					...tagData(TelemetryDataTag.UserData, {
+					...tagSchemaArtifacts({
+						nodeType: node.type,
 						unexpectedFields: JSON.stringify(unexpectedFields),
 					}),
 				}),
@@ -263,8 +255,8 @@ export function isNodeInSchema<T extends NotUndefined>(
 			if (uncheckedFieldsFromNode.size > 0) {
 				return onError(
 					schemaValidationError(SchemaValidationError.ObjectNode_FieldNotInSchema, {
-						...tagSchemaArtifacts({ nodeType: node.type }),
-						...tagData(TelemetryDataTag.UserData, {
+						...tagSchemaArtifacts({
+							nodeType: node.type,
 							unexpectedFields: JSON.stringify([...uncheckedFieldsFromNode].sort()),
 						}),
 					}),

--- a/packages/dds/tree/src/feature-libraries/schemaChecker.ts
+++ b/packages/dds/tree/src/feature-libraries/schemaChecker.ts
@@ -15,6 +15,7 @@ import type {
 import {
 	tagCodeArtifacts,
 	tagData,
+	tagSchemaArtifacts,
 	TelemetryDataTag,
 	UsageError,
 } from "@fluidframework/telemetry-utils/internal";
@@ -200,7 +201,7 @@ export function isNodeInSchema<T extends NotUndefined>(
 		return onError(
 			schemaValidationError(
 				SchemaValidationError.Node_MissingSchema,
-				tagCodeArtifacts({ nodeType: node.type }),
+				tagSchemaArtifacts({ nodeType: node.type }),
 			),
 		);
 	}
@@ -212,7 +213,7 @@ export function isNodeInSchema<T extends NotUndefined>(
 			const unexpectedFields = [...mapIterable(node.fields, ([key]) => key)].sort();
 			return onError(
 				schemaValidationError(SchemaValidationError.LeafNode_FieldsNotAllowed, {
-					...tagCodeArtifacts({ nodeType: node.type }),
+					...tagSchemaArtifacts({ nodeType: node.type }),
 					...tagData(TelemetryDataTag.UserData, {
 						unexpectedFields: JSON.stringify(unexpectedFields),
 					}),
@@ -222,7 +223,7 @@ export function isNodeInSchema<T extends NotUndefined>(
 		if (!allowsValue(schema.leafValue, node.value)) {
 			return onError(
 				schemaValidationError(SchemaValidationError.LeafNode_InvalidValue, {
-					...tagCodeArtifacts({
+					...tagSchemaArtifacts({
 						nodeType: node.type,
 						expectedValueType: ValueSchema[schema.leafValue],
 					}),
@@ -234,7 +235,7 @@ export function isNodeInSchema<T extends NotUndefined>(
 		if (node.value !== undefined) {
 			return onError(
 				schemaValidationError(SchemaValidationError.NonLeafNode_ValueNotAllowed, {
-					...tagCodeArtifacts({ nodeType: node.type }),
+					...tagSchemaArtifacts({ nodeType: node.type }),
 					actualValueType: getValueType(node.value),
 				}),
 			);
@@ -262,7 +263,7 @@ export function isNodeInSchema<T extends NotUndefined>(
 			if (uncheckedFieldsFromNode.size > 0) {
 				return onError(
 					schemaValidationError(SchemaValidationError.ObjectNode_FieldNotInSchema, {
-						...tagCodeArtifacts({ nodeType: node.type }),
+						...tagSchemaArtifacts({ nodeType: node.type }),
 						...tagData(TelemetryDataTag.UserData, {
 							unexpectedFields: JSON.stringify([...uncheckedFieldsFromNode].sort()),
 						}),
@@ -308,7 +309,7 @@ export function isFieldInSchema<T extends NotUndefined>(
 		return onError(
 			schemaValidationError(
 				SchemaValidationError.Field_KindNotInSchemaPolicy,
-				tagCodeArtifacts({ fieldKind: schema.kind }),
+				tagSchemaArtifacts({ fieldKind: schema.kind }),
 			),
 		);
 	}
@@ -319,7 +320,7 @@ export function isFieldInSchema<T extends NotUndefined>(
 		if (multiplicityCheck !== undefined) {
 			return onError(
 				schemaValidationError(multiplicityCheck, {
-					...tagCodeArtifacts({ fieldKind: schema.kind }),
+					...tagSchemaArtifacts({ fieldKind: schema.kind }),
 					childCount: childNodes.length,
 				}),
 			);
@@ -337,7 +338,7 @@ export function isFieldInSchema<T extends NotUndefined>(
 			)(
 				schemaValidationError(
 					SchemaValidationError.Field_NodeTypeNotAllowed,
-					tagCodeArtifacts({
+					tagSchemaArtifacts({
 						nodeType: node.type,
 						allowedTypes: JSON.stringify(allowedTypes),
 					}),

--- a/packages/dds/tree/src/simple-tree/core/treeNodeValid.ts
+++ b/packages/dds/tree/src/simple-tree/core/treeNodeValid.ts
@@ -4,7 +4,7 @@
  */
 
 import { assert, fail } from "@fluidframework/core-utils/internal";
-import { UsageError } from "@fluidframework/telemetry-utils/internal";
+import { tagSchemaArtifacts, UsageError } from "@fluidframework/telemetry-utils/internal";
 
 import { type FlexTreeNode, isFlexTreeNode } from "../../feature-libraries/index.js";
 
@@ -135,6 +135,7 @@ export abstract class TreeNodeValid<TInput> extends TreeNode {
 			}) which derived from the same SchemaFactory generated class (${JSON.stringify(
 				this.identifier,
 			)}). This is invalid.`,
+			tagSchemaArtifacts({ schemaIdentifier: this.identifier }),
 		);
 	}
 
@@ -237,6 +238,7 @@ export function schemaAsTreeNodeValid(
 			`Schema for ${JSON.stringify(
 				schema.identifier,
 			)} does not extend a SchemaFactory generated class. This is invalid.`,
+			tagSchemaArtifacts({ schemaIdentifier: schema.identifier }),
 		);
 	}
 

--- a/packages/dds/tree/src/test/feature-libraries/schemaChecker.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/schemaChecker.spec.ts
@@ -541,11 +541,11 @@ describe("schema validation", () => {
 				path: [0],
 				telemetryProperties: {
 					allowedTypes: {
-						tag: TelemetryDataTag.CodeArtifact,
+						tag: TelemetryDataTag.SchemaArtifact,
 						value: '["myNumberNode"]',
 					},
 					nodeType: {
-						tag: TelemetryDataTag.CodeArtifact,
+						tag: TelemetryDataTag.SchemaArtifact,
 						value: 'my"StringNode',
 					},
 				},
@@ -576,11 +576,11 @@ describe("schema validation", () => {
 				telemetryProperties: {
 					actualValueType: "string",
 					expectedValueType: {
-						tag: TelemetryDataTag.CodeArtifact,
+						tag: TelemetryDataTag.SchemaArtifact,
 						value: "Number",
 					},
 					nodeType: {
-						tag: TelemetryDataTag.CodeArtifact,
+						tag: TelemetryDataTag.SchemaArtifact,
 						value: "number",
 					},
 				},
@@ -614,11 +614,11 @@ describe("schema validation", () => {
 				);
 				const telemetryProperties = error.getTelemetryProperties();
 				assert.deepEqual(telemetryProperties.schemaValidationError, {
-					tag: TelemetryDataTag.CodeArtifact,
+					tag: TelemetryDataTag.SchemaArtifact,
 					value: "LeafNode_InvalidValue",
 				});
 				assert.deepEqual(telemetryProperties.schemaValidationPath, {
-					tag: TelemetryDataTag.UserData,
+					tag: TelemetryDataTag.SchemaArtifact,
 					value: '["child",0]',
 				});
 				assert.deepEqual(telemetryProperties.nodeType, {

--- a/packages/utils/telemetry-utils/src/internal.ts
+++ b/packages/utils/telemetry-utils/src/internal.ts
@@ -69,6 +69,7 @@ export {
 	TaggedLoggerAdapter,
 	tagData,
 	tagCodeArtifacts,
+	tagSchemaArtifacts,
 	TelemetryDataTag,
 	toITelemetryLoggerExt,
 } from "./logger.js";

--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -89,6 +89,7 @@ export enum TelemetryDataTag {
 	/**
 	 * Data containing identifiers or other metadata from a DDS's schema (e.g. SharedTree schema
 	 * identifiers) that may have been dynamically defined by application code.
+	 * @remarks
 	 * Note: only log schema artifacts that do not contain user data, or that have been sanitized to remove user data.
 	 */
 	SchemaArtifact = "SchemaArtifact",
@@ -1136,7 +1137,7 @@ export const tagCodeArtifacts = <
  * ```typescript
  * {
  * 	// ...Other properties being added to a telemetry event
- * 	...tagSchemaArtifacts({ foo: 1, bar: 2 }),
+ * 	...tagSchemaArtifacts({ nodeType: node.type }),
  * 	// ...
  * }
  * ```

--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -1136,7 +1136,7 @@ export const tagCodeArtifacts = <
  * ```typescript
  * {
  * 	// ...Other properties being added to a telemetry event
- * 	...tagSchemaArtifacts("someTag", {foo: 1, bar: 2}),
+ * 	...tagSchemaArtifacts({ foo: 1, bar: 2 }),
  * 	// ...
  * }
  * ```

--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -84,6 +84,10 @@ export function extractTelemetryLoggerExt<
 export enum TelemetryDataTag {
 	/**
 	 * Data containing terms or IDs from code packages that may have been dynamically loaded
+	 *
+	 * @remarks
+	 * For identifiers or other metadata derived from a DDS's schema (e.g. SharedTree schema
+	 * identifiers), use {@link TelemetryDataTag.SchemaArtifact} instead.
 	 */
 	CodeArtifact = "CodeArtifact",
 	/**
@@ -1088,6 +1092,9 @@ export const tagData = <
  * @remarks
  * It supports properties of type {@link @fluidframework/core-interfaces#TelemetryBaseEventPropertyType},
  * as well as callbacks that return that type.
+ *
+ * Note: for identifiers or other metadata derived from a DDS's schema (e.g. SharedTree schema
+ * identifiers), use {@link tagSchemaArtifacts} instead.
  *
  * @example Sample usage
  * ```typescript

--- a/packages/utils/telemetry-utils/src/logger.ts
+++ b/packages/utils/telemetry-utils/src/logger.ts
@@ -87,6 +87,12 @@ export enum TelemetryDataTag {
 	 */
 	CodeArtifact = "CodeArtifact",
 	/**
+	 * Data containing identifiers or other metadata from a DDS's schema (e.g. SharedTree schema
+	 * identifiers) that may have been dynamically defined by application code.
+	 * Note: only log schema artifacts that do not contain user data, or that have been sanitized to remove user data.
+	 */
+	SchemaArtifact = "SchemaArtifact",
+	/**
 	 * Personal data of a variety of classifications that pertains to the user
 	 */
 	UserData = "UserData",
@@ -384,9 +390,10 @@ export class TaggedLoggerAdapter implements ITelemetryBaseLogger {
 					break;
 				}
 				case "PackageData": // For back-compat
-				case TelemetryDataTag.CodeArtifact: {
-					// For Microsoft applications, CodeArtifact is safe for now
-					// (we don't load 3P code in 1P apps)
+				case TelemetryDataTag.CodeArtifact:
+				case TelemetryDataTag.SchemaArtifact: {
+					// For Microsoft applications, CodeArtifact and SchemaArtifact are safe for now
+					// (we don't load 3P code or schema in 1P apps)
 					newEvent[key] = value;
 					break;
 				}
@@ -1115,3 +1122,47 @@ export const tagCodeArtifacts = <
 					})
 		| (T[P] extends undefined ? undefined : never);
 } => tagData<TelemetryDataTag.CodeArtifact, T>(TelemetryDataTag.CodeArtifact, values);
+
+/**
+ * Tags all provided `values` as {@link TelemetryDataTag.SchemaArtifact}.
+ *
+ * @param values - The values to be tagged.
+ *
+ * @remarks
+ * It supports properties of type {@link @fluidframework/core-interfaces#TelemetryBaseEventPropertyType},
+ * as well as callbacks that return that type.
+ *
+ * @example Sample usage
+ * ```typescript
+ * {
+ * 	// ...Other properties being added to a telemetry event
+ * 	...tagSchemaArtifacts("someTag", {foo: 1, bar: 2}),
+ * 	// ...
+ * }
+ * ```
+ * This will result in `foo` and `bar` added to the event with their values tagged as {@link TelemetryDataTag.SchemaArtifact}.
+ *
+ * @see {@link tagData}
+ *
+ * @internal
+ */
+export const tagSchemaArtifacts = <
+	T extends Record<
+		string,
+		TelemetryBaseEventPropertyType | (() => TelemetryBaseEventPropertyType)
+	>,
+>(
+	values: T,
+): {
+	[P in keyof T]:
+		| (T[P] extends () => TelemetryBaseEventPropertyType
+				? () => {
+						value: ReturnType<T[P]>;
+						tag: TelemetryDataTag.SchemaArtifact;
+					}
+				: {
+						value: Exclude<T[P], undefined>;
+						tag: TelemetryDataTag.SchemaArtifact;
+					})
+		| (T[P] extends undefined ? undefined : never);
+} => tagData<TelemetryDataTag.SchemaArtifact, T>(TelemetryDataTag.SchemaArtifact, values);

--- a/packages/utils/telemetry-utils/src/test/errorLogging.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/errorLogging.spec.ts
@@ -181,6 +181,23 @@ describe("Error Logging", () => {
 			);
 			events.pop();
 		});
+		it("TaggedLoggerAdapter - tagged SchemaArtifact are preserved", () => {
+			const event = {
+				category: "cat",
+				eventName: "event",
+				schemaDataObject: {
+					tag: TelemetryDataTag.SchemaArtifact,
+					value: "someSchemaData",
+				},
+			};
+			adaptedLogger.send(event, LogLevel.essential);
+			assert.strictEqual(
+				events[0].schemaDataObject,
+				"someSchemaData",
+				"someSchemaData should be preserved",
+			);
+			events.pop();
+		});
 		it("TaggedLoggerAdapter - tagged [unrecognized tag] are removed", () => {
 			const event = {
 				category: "cat",
@@ -203,6 +220,7 @@ describe("Error Logging", () => {
 		it("Ensure backwards compatibility", () => {
 			// The values of the enum should never change (even if the keys are renamed)
 			assert(TelemetryDataTag.CodeArtifact === ("CodeArtifact" as TelemetryDataTag));
+			assert(TelemetryDataTag.SchemaArtifact === ("SchemaArtifact" as TelemetryDataTag));
 			assert(TelemetryDataTag.UserData === ("UserData" as TelemetryDataTag));
 		});
 	});

--- a/packages/utils/telemetry-utils/src/test/utils.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/utils.spec.ts
@@ -13,7 +13,7 @@ import type {
 import { LogLevel } from "@fluidframework/core-interfaces";
 
 import { mixinMonitoringContext } from "../config.js";
-import { TelemetryDataTag, tagCodeArtifacts, tagData } from "../logger.js";
+import { TelemetryDataTag, tagCodeArtifacts, tagData, tagSchemaArtifacts } from "../logger.js";
 import type {
 	ITelemetryGenericEventExt,
 	TelemetryLoggerExt,
@@ -565,6 +565,42 @@ describe("tagCodeArtifacts", () => {
 			booleanValue,
 			expectedBooleanValue,
 			"boolean getter not tagged as expected",
+		);
+	});
+});
+
+describe("tagSchemaArtifacts", () => {
+	it("tagSchemaArtifacts with undefined", () => {
+		const taggedData = tagSchemaArtifacts({ node: undefined });
+		const expected: Partial<typeof taggedData> = {};
+		assert.deepStrictEqual(taggedData, expected, "undefined not tagged as expected");
+	});
+
+	it("tagSchemaArtifacts with TelemetryBaseEventPropertyType properties", () => {
+		const taggedData = tagSchemaArtifacts({
+			string: "foo",
+			number: 0,
+			boolean: true,
+			none: undefined,
+		});
+		const expected: Partial<typeof taggedData> = {
+			string: {
+				value: "foo",
+				tag: TelemetryDataTag.SchemaArtifact,
+			},
+			number: {
+				value: 0,
+				tag: TelemetryDataTag.SchemaArtifact,
+			},
+			boolean: {
+				value: true,
+				tag: TelemetryDataTag.SchemaArtifact,
+			},
+		};
+		assert.deepStrictEqual(
+			taggedData,
+			expected,
+			"TelemetryBaseEventPropertyType not tagged as expected",
 		);
 	});
 });

--- a/packages/utils/telemetry-utils/src/test/utils.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/utils.spec.ts
@@ -603,4 +603,101 @@ describe("tagSchemaArtifacts", () => {
 			"TelemetryBaseEventPropertyType not tagged as expected",
 		);
 	});
+
+	it("tagSchemaArtifacts with TelemetryBaseEventPropertyType getters", () => {
+		const taggedData = tagSchemaArtifacts({
+			string: () => "foo",
+			number: () => 0,
+			boolean: () => true,
+		});
+		const stringValue = taggedData.string();
+		const numberValue = taggedData.number();
+		const booleanValue = taggedData.boolean();
+
+		assert.deepStrictEqual(
+			stringValue,
+			{
+				tag: TelemetryDataTag.SchemaArtifact,
+				value: "foo",
+			},
+			"string getter not tagged as expected",
+		);
+		assert.deepStrictEqual(
+			numberValue,
+			{
+				tag: TelemetryDataTag.SchemaArtifact,
+				value: 0,
+			},
+			"number getter not tagged as expected",
+		);
+		assert.deepStrictEqual(
+			booleanValue,
+			{
+				tag: TelemetryDataTag.SchemaArtifact,
+				value: true,
+			},
+			"boolean getter not tagged as expected",
+		);
+	});
+
+	it("tagSchemaArtifacts with both TelemetryBaseEventPropertyType properties and getters", () => {
+		const expectedStringValue = {
+			tag: TelemetryDataTag.SchemaArtifact,
+			value: "foo",
+		};
+		const expectedNumberValue = {
+			tag: TelemetryDataTag.SchemaArtifact,
+			value: 0,
+		};
+		const expectedBooleanValue = {
+			tag: TelemetryDataTag.SchemaArtifact,
+			value: true,
+		};
+
+		const taggedData = tagSchemaArtifacts({
+			string: "foo",
+			number: 0,
+			boolean: true,
+			stringGetter: () => "foo",
+			numberGetter: () => 0,
+			booleanGetter: () => true,
+		});
+
+		// Validate basic properties are tagged.
+		assert.deepStrictEqual(
+			taggedData.string,
+			expectedStringValue,
+			"string property not tagged as expected",
+		);
+		assert.deepStrictEqual(
+			taggedData.number,
+			expectedNumberValue,
+			"number property not tagged as expected",
+		);
+		assert.deepStrictEqual(
+			taggedData.boolean,
+			expectedBooleanValue,
+			"boolean property not tagged as expected",
+		);
+
+		// Validate getters are tagged.
+		const stringValue = taggedData.stringGetter();
+		const numberValue = taggedData.numberGetter();
+		const booleanValue = taggedData.booleanGetter();
+		assert.deepStrictEqual(
+			stringValue,
+			expectedStringValue,
+			"string getter not tagged as expected",
+		);
+		assert.deepStrictEqual(
+			numberValue,
+			expectedNumberValue,
+			"number getter not tagged as expected",
+		);
+		assert.deepStrictEqual(
+			booleanValue,
+			expectedBooleanValue,
+			"boolean getter not tagged as expected",
+		);
+	});
 });


### PR DESCRIPTION
## Description

Adds a new `TelemetryDataTag.SchemaArtifact` and corresponding `tagSchemaArtifacts()` helper in `@fluidframework/telemetry-utils`, following the same pattern as `TelemetryDataTag.CodeArtifact`/`tagCodeArtifacts()`. Like `CodeArtifact`, `SchemaArtifact` is treated as safe to pass through in 1P telemetry pipelines (we don't load 3P schema), since these values (e.g. SharedTree node type identifiers, field kinds) are application/code-defined rather than user content.

Updated a few representative call sites in `@fluidframework/tree` to use the new tag instead of `CodeArtifact` for schema-specific metadata:
- `feature-libraries/schemaChecker.ts`: `nodeType`, `fieldKind`, and `allowedTypes` in schema validation errors.
- `simple-tree/core/treeNodeValid.ts`: `schemaIdentifier` in `UsageError`s for schema class mismatches.

Also adds unit test coverage for the new tag/helper and its pass-through behavior in `TaggedLoggerAdapter`.

[AB#81372](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/81372)

## Reviewer Guidance

The review process is outlined in [the pull request guidelines](../docs/content/Contributing/PR-Guidelines.md#guidelines).