### PR TITLE
chore(examples): remove redundant Bubblebench excludes

### DIFF
--- a/examples/benchmarks/bubblebench/baseline/tsconfig.json
+++ b/examples/benchmarks/bubblebench/baseline/tsconfig.json
@@ -1,6 +1,5 @@
 {
 	"extends": "../../../../common/build/build-common/tsconfig.node20.json",
-	"exclude": ["dist", "lib", "node_modules"],
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",

--- a/examples/benchmarks/bubblebench/common/tsconfig.json
+++ b/examples/benchmarks/bubblebench/common/tsconfig.json
@@ -1,6 +1,5 @@
 {
 	"extends": "../../../../common/build/build-common/tsconfig.node20.json",
-	"exclude": ["dist", "lib", "node_modules"],
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",

--- a/examples/benchmarks/bubblebench/experimental-tree/tsconfig.json
+++ b/examples/benchmarks/bubblebench/experimental-tree/tsconfig.json
@@ -1,6 +1,5 @@
 {
 	"extends": "../../../../common/build/build-common/tsconfig.node20.json",
-	"exclude": ["dist", "node_modules"],
 	"compilerOptions": {
 		"lib": ["ESNext", "DOM"],
 		"rootDir": "./src",

--- a/examples/benchmarks/bubblebench/ot/tsconfig.json
+++ b/examples/benchmarks/bubblebench/ot/tsconfig.json
@@ -1,6 +1,5 @@
 {
 	"extends": "../../../../common/build/build-common/tsconfig.node20.json",
-	"exclude": ["dist", "node_modules"],
 	"compilerOptions": {
 		"lib": ["ESNext", "DOM"],
 		"rootDir": "./src",

--- a/examples/benchmarks/bubblebench/shared-tree/tsconfig.json
+++ b/examples/benchmarks/bubblebench/shared-tree/tsconfig.json
@@ -1,6 +1,5 @@
 {
 	"extends": "../../../../common/build/build-common/tsconfig.node20.json",
-	"exclude": ["dist", "node_modules"],
 	"compilerOptions": {
 		"lib": ["ESNext", "DOM"],
 		"rootDir": "./src",


### PR DESCRIPTION
Each Bubblebench TypeScript project explicitly includes only src/**/*, so excluding generated output and node_modules has no effect on root-file discovery. Imported dependencies are followed regardless of exclude settings.