### PR TITLE
chore(examples): remove stale browser bundle metadata

### DIFF
--- a/examples/benchmarks/bubblebench/common/package.json
+++ b/examples/benchmarks/bubblebench/common/package.json
@@ -59,16 +59,6 @@
 		"rimraf": "^6.1.3",
 		"typescript": "~6.0.3"
 	},
-	"fluid": {
-		"browser": {
-			"umd": {
-				"files": [
-					"dist/main.bundle.js"
-				],
-				"library": "main"
-			}
-		}
-	},
 	"typeValidation": {
 		"disabled": true
 	}

--- a/examples/data-objects/multiview/constellation-model/package.json
+++ b/examples/data-objects/multiview/constellation-model/package.json
@@ -51,16 +51,6 @@
 		"rimraf": "^6.1.3",
 		"typescript": "~6.0.3"
 	},
-	"fluid": {
-		"browser": {
-			"umd": {
-				"files": [
-					"dist/main.bundle.js"
-				],
-				"library": "main"
-			}
-		}
-	},
 	"typeValidation": {
 		"disabled": true
 	}

--- a/examples/data-objects/multiview/constellation-view/package.json
+++ b/examples/data-objects/multiview/constellation-view/package.json
@@ -52,16 +52,6 @@
 		"rimraf": "^6.1.3",
 		"typescript": "~6.0.3"
 	},
-	"fluid": {
-		"browser": {
-			"umd": {
-				"files": [
-					"dist/main.bundle.js"
-				],
-				"library": "main"
-			}
-		}
-	},
 	"typeValidation": {
 		"disabled": true
 	}

--- a/examples/data-objects/multiview/coordinate-model/package.json
+++ b/examples/data-objects/multiview/coordinate-model/package.json
@@ -49,16 +49,6 @@
 		"rimraf": "^6.1.3",
 		"typescript": "~6.0.3"
 	},
-	"fluid": {
-		"browser": {
-			"umd": {
-				"files": [
-					"dist/main.bundle.js"
-				],
-				"library": "main"
-			}
-		}
-	},
 	"typeValidation": {
 		"disabled": true
 	}

--- a/examples/data-objects/multiview/interface/package.json
+++ b/examples/data-objects/multiview/interface/package.json
@@ -48,16 +48,6 @@
 		"rimraf": "^6.1.3",
 		"typescript": "~6.0.3"
 	},
-	"fluid": {
-		"browser": {
-			"umd": {
-				"files": [
-					"dist/main.bundle.js"
-				],
-				"library": "main"
-			}
-		}
-	},
 	"typeValidation": {
 		"disabled": true
 	}

--- a/examples/data-objects/multiview/plot-coordinate-view/package.json
+++ b/examples/data-objects/multiview/plot-coordinate-view/package.json
@@ -51,16 +51,6 @@
 		"rimraf": "^6.1.3",
 		"typescript": "~6.0.3"
 	},
-	"fluid": {
-		"browser": {
-			"umd": {
-				"files": [
-					"dist/main.bundle.js"
-				],
-				"library": "main"
-			}
-		}
-	},
 	"typeValidation": {
 		"disabled": true
 	}

--- a/examples/data-objects/multiview/slider-coordinate-view/package.json
+++ b/examples/data-objects/multiview/slider-coordinate-view/package.json
@@ -51,16 +51,6 @@
 		"rimraf": "^6.1.3",
 		"typescript": "~6.0.3"
 	},
-	"fluid": {
-		"browser": {
-			"umd": {
-				"files": [
-					"dist/main.bundle.js"
-				],
-				"library": "main"
-			}
-		}
-	},
 	"typeValidation": {
 		"disabled": true
 	}

--- a/examples/data-objects/multiview/triangle-view/package.json
+++ b/examples/data-objects/multiview/triangle-view/package.json
@@ -51,16 +51,6 @@
 		"rimraf": "^6.1.3",
 		"typescript": "~6.0.3"
 	},
-	"fluid": {
-		"browser": {
-			"umd": {
-				"files": [
-					"dist/main.bundle.js"
-				],
-				"library": "main"
-			}
-		}
-	},
 	"typeValidation": {
 		"disabled": true
 	}

--- a/examples/data-objects/table-document/package.json
+++ b/examples/data-objects/table-document/package.json
@@ -111,16 +111,6 @@
 		"rimraf": "^6.1.3",
 		"typescript": "~6.0.3"
 	},
-	"fluid": {
-		"browser": {
-			"umd": {
-				"files": [
-					"dist/main.bundle.js"
-				],
-				"library": "main"
-			}
-		}
-	},
 	"typeValidation": {
 		"disabled": true
 	}


### PR DESCRIPTION
Remove fluid.browser.umd declarations from library-only example packages that do not run webpack or produce the referenced main.bundle.js artifact. Runnable accumulator packages continue to declare their own browser bundles.