### PR TITLE
feat(tree): custom snapshot filenames

### DIFF
--- a/.changeset/nine-beans-drop.md
+++ b/.changeset/nine-beans-drop.md
@@ -5,7 +5,7 @@
 ---
 Schema compatibility snapshots support custom filename prefixes and suffixes
 
-`snapshotSchemaCompatibility` now accepts `snapshotFileNameFormat`, which can add a prefix and suffix around the version in generated snapshot filenames. The same format is used to discover historical snapshots, allowing multiple schema snapshot sets or unrelated JSON files to share a directory.
+[`snapshotSchemaCompatibility`](https://fluidframework.com/docs/api/tree#snapshotschemacompatibility-function) now accepts `snapshotFileNameFormat`, which can add a prefix and suffix around the version in generated snapshot filenames. The same format is used to discover historical snapshots, allowing multiple schema snapshot sets or unrelated JSON files to share a directory.
 
 ```typescript
 snapshotSchemaCompatibility({

--- a/.changeset/nine-beans-drop.md
+++ b/.changeset/nine-beans-drop.md
@@ -1,0 +1,18 @@
+---
+"@fluidframework/tree": minor
+"fluid-framework": minor
+"__section": tree
+---
+Schema compatibility snapshots support custom filename prefixes and suffixes
+
+`snapshotSchemaCompatibility` now accepts `snapshotFileNameFormat`, which can add a prefix and suffix around the version in generated snapshot filenames. The same format is used to discover historical snapshots, allowing multiple schema snapshot sets or unrelated JSON files to share a directory.
+
+```typescript
+snapshotSchemaCompatibility({
+	// Existing options...
+	snapshotFileNameFormat: {
+		prefix: "point-schema-",
+		suffix: "-snapshot",
+	},
+});
+```

--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -1493,6 +1493,10 @@ export interface SnapshotSchemaCompatibilityOptions {
     readonly rejectVersionsWithNoSchemaChange?: true;
     readonly schema: TreeViewConfiguration;
     readonly snapshotDirectory: string;
+    readonly snapshotFileNameFormat?: {
+        readonly prefix?: string;
+        readonly suffix?: string;
+    };
     readonly snapshotUnchangedVersions?: true;
     readonly version: string;
     readonly versionComparer?: (a: string, b: string) => number;

--- a/packages/dds/tree/api-report/tree.beta.api.md
+++ b/packages/dds/tree/api-report/tree.beta.api.md
@@ -673,6 +673,10 @@ export interface SnapshotSchemaCompatibilityOptions {
     readonly rejectVersionsWithNoSchemaChange?: true;
     readonly schema: TreeViewConfiguration;
     readonly snapshotDirectory: string;
+    readonly snapshotFileNameFormat?: {
+        readonly prefix?: string;
+        readonly suffix?: string;
+    };
     readonly snapshotUnchangedVersions?: true;
     readonly version: string;
     readonly versionComparer?: (a: string, b: string) => number;

--- a/packages/dds/tree/api-report/tree.legacy.beta.api.md
+++ b/packages/dds/tree/api-report/tree.legacy.beta.api.md
@@ -685,6 +685,10 @@ export interface SnapshotSchemaCompatibilityOptions {
     readonly rejectVersionsWithNoSchemaChange?: true;
     readonly schema: TreeViewConfiguration;
     readonly snapshotDirectory: string;
+    readonly snapshotFileNameFormat?: {
+        readonly prefix?: string;
+        readonly suffix?: string;
+    };
     readonly snapshotUnchangedVersions?: true;
     readonly version: string;
     readonly versionComparer?: (a: string, b: string) => number;

--- a/packages/dds/tree/src/simple-tree/api/snapshotCompatibilityChecker.ts
+++ b/packages/dds/tree/src/simple-tree/api/snapshotCompatibilityChecker.ts
@@ -264,6 +264,26 @@ export interface SnapshotSchemaCompatibilityOptions {
 	readonly snapshotDirectory: string;
 
 	/**
+	 * Customizes the names of schema snapshot files.
+	 * @remarks
+	 * Snapshot files are named by surrounding the version with the provided strings, followed by the ".json" extension.
+	 * For example, `{ prefix: "schema-", suffix: "-snapshot" }` produces `schema-1.0.0-snapshot.json` for version `1.0.0`.
+	 *
+	 * Only JSON files matching this format are treated as schema snapshots.
+	 */
+	readonly snapshotFileNameFormat?: {
+		/**
+		 * Text to include before the version.
+		 */
+		readonly prefix?: string;
+
+		/**
+		 * Text to include after the version and before the ".json" extension.
+		 */
+		readonly suffix?: string;
+	};
+
+	/**
 	 * How the `snapshotDirectory` is accessed.
 	 */
 	readonly fileSystem: SnapshotFileSystem;
@@ -492,6 +512,7 @@ export function snapshotSchemaCompatibility(
 	const checker = new SnapshotCompatibilityChecker(
 		options.snapshotDirectory,
 		options.fileSystem,
+		options.snapshotFileNameFormat,
 	);
 	const {
 		version: currentVersion,
@@ -743,12 +764,19 @@ export class SnapshotCompatibilityChecker {
 		 * How the `snapshotDirectory` is accessed.
 		 */
 		private readonly fileSystemMethods: SnapshotFileSystem,
+		/**
+		 * Text surrounding the version in snapshot file names.
+		 */
+		private readonly snapshotFileNameFormat: {
+			readonly prefix?: string;
+			readonly suffix?: string;
+		} = {},
 	) {}
 
 	public writeSchemaSnapshot(snapshotName: string, snapshot: JsonCompatibleReadOnly): void {
 		const fullPath = this.fileSystemMethods.join(
 			this.snapshotDirectory,
-			`${snapshotName}.json`,
+			this.getSnapshotFileName(snapshotName),
 		);
 		this.ensureSnapshotDirectoryExists();
 		this.fileSystemMethods.writeFileSync(fullPath, JSON.stringify(snapshot, undefined, "\t"), {
@@ -764,7 +792,7 @@ export class SnapshotCompatibilityChecker {
 	public readSchemaSnapshotRaw(snapshotName: string): JsonCompatibleReadOnly {
 		const fullPath = this.fileSystemMethods.join(
 			this.snapshotDirectory,
-			`${snapshotName}.json`,
+			this.getSnapshotFileName(snapshotName),
 		);
 		const snapshot = JSON.parse(
 			this.fileSystemMethods.readFileSync(fullPath, "utf8"),
@@ -782,8 +810,8 @@ export class SnapshotCompatibilityChecker {
 		const files = this.fileSystemMethods.readdirSync(this.snapshotDirectory);
 		const versions: string[] = [];
 		for (const file of files) {
-			if (file.endsWith(".json")) {
-				const snapshotName = file.slice(0, ".json".length * -1);
+			const snapshotName = this.getSnapshotName(file);
+			if (snapshotName !== undefined) {
 				versions.push(snapshotName);
 			}
 		}
@@ -799,6 +827,32 @@ export class SnapshotCompatibilityChecker {
 
 	public ensureSnapshotDirectoryExists(): void {
 		this.fileSystemMethods.mkdirSync(this.snapshotDirectory, { recursive: true });
+	}
+
+	private getSnapshotFileName(snapshotName: string): string {
+		const { prefix = "", suffix = "" } = this.snapshotFileNameFormat;
+		return `${prefix}${snapshotName}${suffix}.json`;
+	}
+
+	private getSnapshotName(fileName: string): string | undefined {
+		const extension = ".json";
+		if (!fileName.endsWith(extension)) {
+			return undefined;
+		}
+
+		const { prefix = "", suffix = "" } = this.snapshotFileNameFormat;
+		const fileNameWithoutExtension = fileName.slice(0, -extension.length);
+		if (
+			!fileNameWithoutExtension.startsWith(prefix) ||
+			!fileNameWithoutExtension.endsWith(suffix)
+		) {
+			return undefined;
+		}
+
+		return fileNameWithoutExtension.slice(
+			prefix.length,
+			fileNameWithoutExtension.length - suffix.length,
+		);
 	}
 }
 

--- a/packages/dds/tree/src/simple-tree/api/snapshotCompatibilityChecker.ts
+++ b/packages/dds/tree/src/simple-tree/api/snapshotCompatibilityChecker.ts
@@ -277,11 +277,15 @@ export interface SnapshotSchemaCompatibilityOptions {
 	readonly snapshotFileNameFormat?: {
 		/**
 		 * Text to include before the version.
+		 *
+		 * @defaultValue `""`
 		 */
 		readonly prefix?: string;
 
 		/**
 		 * Text to include after the version and before the ".json" extension.
+		 *
+		 * @defaultValue `""`
 		 */
 		readonly suffix?: string;
 	};

--- a/packages/dds/tree/src/simple-tree/api/snapshotCompatibilityChecker.ts
+++ b/packages/dds/tree/src/simple-tree/api/snapshotCompatibilityChecker.ts
@@ -256,7 +256,9 @@ export interface SnapshotSchemaCompatibilityOptions {
 	 * and not erased when regenerating snapshots.
 	 *
 	 * This directory will be created if it does not already exist.
-	 * All ".json" files in this directory will be treated as schema snapshots.
+	 * By default, all ".json" files in this directory will be treated as schema snapshots.
+	 * When {@link SnapshotSchemaCompatibilityOptions.snapshotFileNameFormat} is provided,
+	 * only JSON files matching that format will be treated as schema snapshots.
 	 * It is recommended to use a dedicated directory for each {@link snapshotSchemaCompatibility} powered test.
 	 *
 	 * This can use any path syntax supported by the provided {@link SnapshotSchemaCompatibilityOptions.fileSystem}.
@@ -270,6 +272,7 @@ export interface SnapshotSchemaCompatibilityOptions {
 	 * For example, `{ prefix: "schema-", suffix: "-snapshot" }` produces `schema-1.0.0-snapshot.json` for version `1.0.0`.
 	 *
 	 * Only JSON files matching this format are treated as schema snapshots.
+	 * The prefix and suffix must not contain path separators ("/" or "\").
 	 */
 	readonly snapshotFileNameFormat?: {
 		/**
@@ -771,7 +774,19 @@ export class SnapshotCompatibilityChecker {
 			readonly prefix?: string;
 			readonly suffix?: string;
 		} = {},
-	) {}
+	) {
+		const { prefix = "", suffix = "" } = snapshotFileNameFormat;
+		for (const [property, value] of [
+			["prefix", prefix],
+			["suffix", suffix],
+		] as const) {
+			if (value.includes("/") || value.includes("\\")) {
+				throw new UsageError(
+					`Invalid snapshotFileNameFormat.${property}: ${JSON.stringify(value)}. Must not contain path separators ("/" or "\\").`,
+				);
+			}
+		}
+	}
 
 	public writeSchemaSnapshot(snapshotName: string, snapshot: JsonCompatibleReadOnly): void {
 		const fullPath = this.fileSystemMethods.join(

--- a/packages/dds/tree/src/simple-tree/api/snapshotCompatibilityChecker.ts
+++ b/packages/dds/tree/src/simple-tree/api/snapshotCompatibilityChecker.ts
@@ -272,7 +272,7 @@ export interface SnapshotSchemaCompatibilityOptions {
 	 * For example, `{ prefix: "schema-", suffix: "-snapshot" }` produces `schema-1.0.0-snapshot.json` for version `1.0.0`.
 	 *
 	 * Only JSON files matching this format are treated as schema snapshots.
-	 * The prefix and suffix must not contain path separators ("/" or "\").
+	 * The prefix and suffix must not contain ASCII control characters or characters that are invalid in cross-platform file names.
 	 */
 	readonly snapshotFileNameFormat?: {
 		/**
@@ -776,13 +776,15 @@ export class SnapshotCompatibilityChecker {
 		} = {},
 	) {
 		const { prefix = "", suffix = "" } = snapshotFileNameFormat;
+		// eslint-disable-next-line no-control-regex -- The control character range is intentionally invalid for cross-platform file names.
+		const invalidFileNameCharacters = /[\u0000-\u001F<>:"/\\|?*]/u;
 		for (const [property, value] of [
 			["prefix", prefix],
 			["suffix", suffix],
 		] as const) {
-			if (value.includes("/") || value.includes("\\")) {
+			if (invalidFileNameCharacters.test(value)) {
 				throw new UsageError(
-					`Invalid snapshotFileNameFormat.${property}: ${JSON.stringify(value)}. Must not contain path separators ("/" or "\\").`,
+					`Invalid snapshotFileNameFormat.${property}: ${JSON.stringify(value)}. Must not contain ASCII control characters or any of <>:"/\\|?*.`,
 				);
 			}
 		}
@@ -844,11 +846,17 @@ export class SnapshotCompatibilityChecker {
 		this.fileSystemMethods.mkdirSync(this.snapshotDirectory, { recursive: true });
 	}
 
+	/**
+	 * Builds the file name used to read or write a snapshot with a known snapshot name.
+	 */
 	private getSnapshotFileName(snapshotName: string): string {
 		const { prefix = "", suffix = "" } = this.snapshotFileNameFormat;
 		return `${prefix}${snapshotName}${suffix}.json`;
 	}
 
+	/**
+	 * Extracts the snapshot name from a matching file found while scanning the snapshot directory.
+	 */
 	private getSnapshotName(fileName: string): string | undefined {
 		const extension = ".json";
 		if (!fileName.endsWith(extension)) {

--- a/packages/dds/tree/src/test/simple-tree/api/snapshotCompatibilityChecker.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/snapshotCompatibilityChecker.spec.ts
@@ -766,15 +766,22 @@ Snapshots exist for versions: [
 			);
 		});
 
-		it("rejects path separators in custom snapshot file name format", () => {
+		it("rejects invalid characters in custom snapshot file name format", () => {
 			const [fileSystem] = inMemorySnapshotFileSystem();
 			const schema = new TreeViewConfiguration({ schema: [] });
 
 			for (const [property, value] of [
 				["prefix", "schema/"],
 				["prefix", "schema\\"],
-				["suffix", "/snapshot"],
-				["suffix", "\\snapshot"],
+				["prefix", "schema\0"],
+				["prefix", "schema\u0001"],
+				["suffix", "<snapshot"],
+				["suffix", ">snapshot"],
+				["suffix", ":snapshot"],
+				["suffix", '"snapshot'],
+				["suffix", "|snapshot"],
+				["suffix", "?snapshot"],
+				["suffix", "*snapshot"],
 			] as const) {
 				assert.throws(
 					() =>
@@ -788,7 +795,7 @@ Snapshots exist for versions: [
 							snapshotFileNameFormat: { [property]: value },
 						}),
 					validateUsageError(
-						`Invalid snapshotFileNameFormat.${property}: ${JSON.stringify(value)}. Must not contain path separators ("/" or "\\").`,
+						`Invalid snapshotFileNameFormat.${property}: ${JSON.stringify(value)}. Must not contain ASCII control characters or any of <>:"/\\|?*.`,
 					),
 				);
 			}

--- a/packages/dds/tree/src/test/simple-tree/api/snapshotCompatibilityChecker.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/snapshotCompatibilityChecker.spec.ts
@@ -766,6 +766,34 @@ Snapshots exist for versions: [
 			);
 		});
 
+		it("rejects path separators in custom snapshot file name format", () => {
+			const [fileSystem] = inMemorySnapshotFileSystem();
+			const schema = new TreeViewConfiguration({ schema: [] });
+
+			for (const [property, value] of [
+				["prefix", "schema/"],
+				["prefix", "schema\\"],
+				["suffix", "/snapshot"],
+				["suffix", "\\snapshot"],
+			] as const) {
+				assert.throws(
+					() =>
+						snapshotSchemaCompatibility({
+							version: "1.0.0",
+							schema,
+							fileSystem,
+							minVersionForCollaboration: "1.0.0",
+							mode: "update",
+							snapshotDirectory: "dir",
+							snapshotFileNameFormat: { [property]: value },
+						}),
+					validateUsageError(
+						`Invalid snapshotFileNameFormat.${property}: ${JSON.stringify(value)}. Must not contain path separators ("/" or "\\").`,
+					),
+				);
+			}
+		});
+
 		it("snapshotUnchangedVersions", () => {
 			const snapshotDirectory = "dir";
 			const [fileSystem] = inMemorySnapshotFileSystem();

--- a/packages/dds/tree/src/test/simple-tree/api/snapshotCompatibilityChecker.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/snapshotCompatibilityChecker.spec.ts
@@ -723,6 +723,49 @@ Snapshots exist for versions: [
 			assert.deepEqual([...snapshots.keys()], ["1.json", "2.json", "3.json"]);
 		});
 
+		it("custom snapshot file name format", () => {
+			const snapshotDirectory = "dir";
+			const [fileSystem, snapshots] = inMemorySnapshotFileSystem();
+			const snapshotFileNameFormat = {
+				prefix: "point-schema-",
+				suffix: "-snapshot",
+			};
+			const schema = new TreeViewConfiguration({ schema: [] });
+
+			snapshotSchemaCompatibility({
+				version: "1.0.0",
+				schema,
+				fileSystem,
+				minVersionForCollaboration: "1.0.0",
+				mode: "update",
+				snapshotDirectory,
+				snapshotFileNameFormat,
+				snapshotUnchangedVersions: true,
+			});
+
+			snapshots.set("unrelated.json", "{}");
+
+			snapshotSchemaCompatibility({
+				version: "2.0.0",
+				schema,
+				fileSystem,
+				minVersionForCollaboration: "1.0.0",
+				mode: "update",
+				snapshotDirectory,
+				snapshotFileNameFormat,
+				snapshotUnchangedVersions: true,
+			});
+
+			assert.deepEqual(
+				[...snapshots.keys()],
+				[
+					"point-schema-1.0.0-snapshot.json",
+					"unrelated.json",
+					"point-schema-2.0.0-snapshot.json",
+				],
+			);
+		});
+
 		it("snapshotUnchangedVersions", () => {
 			const snapshotDirectory = "dir";
 			const [fileSystem] = inMemorySnapshotFileSystem();

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -2095,6 +2095,10 @@ export interface SnapshotSchemaCompatibilityOptions {
     readonly rejectVersionsWithNoSchemaChange?: true;
     readonly schema: TreeViewConfiguration;
     readonly snapshotDirectory: string;
+    readonly snapshotFileNameFormat?: {
+        readonly prefix?: string;
+        readonly suffix?: string;
+    };
     readonly snapshotUnchangedVersions?: true;
     readonly version: string;
     readonly versionComparer?: (a: string, b: string) => number;

--- a/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
@@ -1169,6 +1169,10 @@ export interface SnapshotSchemaCompatibilityOptions {
     readonly rejectVersionsWithNoSchemaChange?: true;
     readonly schema: TreeViewConfiguration;
     readonly snapshotDirectory: string;
+    readonly snapshotFileNameFormat?: {
+        readonly prefix?: string;
+        readonly suffix?: string;
+    };
     readonly snapshotUnchangedVersions?: true;
     readonly version: string;
     readonly versionComparer?: (a: string, b: string) => number;

--- a/packages/framework/fluid-framework/api-report/fluid-framework.legacy.beta.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.legacy.beta.api.md
@@ -1539,6 +1539,10 @@ export interface SnapshotSchemaCompatibilityOptions {
     readonly rejectVersionsWithNoSchemaChange?: true;
     readonly schema: TreeViewConfiguration;
     readonly snapshotDirectory: string;
+    readonly snapshotFileNameFormat?: {
+        readonly prefix?: string;
+        readonly suffix?: string;
+    };
     readonly snapshotUnchangedVersions?: true;
     readonly version: string;
     readonly versionComparer?: (a: string, b: string) => number;


### PR DESCRIPTION
## Description

Adds a snapshotFileNameFormat option to snapshotSchemaCompatibility so callers can add a prefix and suffix around snapshot versions.