### PR TITLE
fix: Expect ODSP container close telemetry after injected storage error

### DIFF
--- a/packages/test/test-end-to-end-tests/src/test/error.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/error.spec.ts
@@ -126,6 +126,12 @@ describeCompat("Errors Types", "NoCompat", (getTestObjectProvider, apis) => {
 			(await cache?.get?.(cacheFileEntry)) !== undefined,
 			"create container should have cached the snapshot",
 		);
+		provider.tracker?.registerExpectedEvent({
+			eventName: "fluid:telemetry:Container:ContainerClose",
+			error: "Injected error",
+			errorType: ContainerErrorTypes.genericError,
+			category: "error",
+		});
 		try {
 			const mockFactory = wrapObjectAndOverride<IDocumentServiceFactory>(
 				provider.documentServiceFactory,


### PR DESCRIPTION
[How contribute to this repo](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).

[Guidelines for Pull Requests](../docs/content/Contributing/PR-Guidelines.md#guidelines).

## Description

The ODSP Non-compat test `Clear odsp driver cache on critical load error` intentionally injects a storage connection failure. Although the test body passes, the resulting `ContainerClose` error telemetry was treated as unexpected by the shared `afterEach` hook, causing every execution to fail.

Register the exact expected `ContainerClose` event before injecting the error. This keeps telemetry validation scoped to the test and avoids suppressing genuine container-close errors suite-wide.

## Reviewer Guidance

The review process is outlined in [the pull request guidelines](../docs/content/Contributing/PR-Guidelines.md#guidelines).

Confirm that the expected event properties remain aligned with the telemetry emitted for the injected generic error.