### PR TITLE
fix(selfhost): harden deployment and prevent Redis retention regressions

### DIFF
--- a/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
+++ b/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml
@@ -227,7 +227,7 @@ data:
             }
         },
         "usage": {
-            "clientConnectivityCountingEnabled": "{{ .Values.usage.clientConnectivityCountingEnabled }}",
+            "clientConnectivityCountingEnabled": {{ .Values.usage.clientConnectivityCountingEnabled }},
             "signalUsageCountingEnabled": {{ .Values.usage.signalUsageCountingEnabled }},
             "httpUsageCountingEnabled": {{ .Values.usage.httpUsageCountingEnabled }}
         },

--- a/tools/selfhost/ARCHITECTURE.md
+++ b/tools/selfhost/ARCHITECTURE.md
@@ -579,11 +579,12 @@ fallback only if a customer's own quota increase is denied or insufficient.
 
 ### 7.8 ACR credential hardening
 
-The AKS kubelet identity holds `AcrPull` on the ACR (`azure/deploy.sh`'s `phase2_acr_harden`);
-there is no long-lived admin-password secret, and the ACR admin account is disabled. An earlier
-state (`az acr create --admin-enabled true`, with the admin username/password stored as a
-Kubernetes `regsecret`) predates this and is no longer how a fresh deployment provisions ACR
-access.
+The AKS kubelet identity holds `AcrPull` on the deploy ACR
+(`azure/deploy.sh`'s `phase2_acr_harden`), and build operators authenticate to the build ACR
+through `az acr login`. Both registries are created with their admin accounts disabled and
+reconcile an existing registry back to that state. There is no long-lived admin-password secret.
+An earlier state, with an admin username/password stored as a Kubernetes `regsecret`, predates
+this and is no longer how a fresh deployment provisions ACR access.
 
 ### 7.9 AKS application-tier scaling
 

--- a/tools/selfhost/azure/README.md
+++ b/tools/selfhost/azure/README.md
@@ -1177,10 +1177,17 @@ az cosmosdb mongodb collection create -a "$COSMOS" -g "$RG" -d admin -n reservat
 Step 2 — Store the connection string in Key Vault
 
 ```bash
-COSMOS_CONN=$(az cosmosdb keys list -n "$COSMOS" -g "$RG" --type connection-strings \
-  --query "connectionStrings[0].connectionString" -o tsv)
-az keyvault secret set --vault-name "$KV" --name cosmos-connection-string --value "$COSMOS_CONN"
-unset COSMOS_CONN
+(
+  COSMOS_CONN=$(az cosmosdb keys list -n "$COSMOS" -g "$RG" --type connection-strings \
+    --query "connectionStrings[0].connectionString" -o tsv)
+  COSMOS_SECRET_FILE="$(mktemp)"
+  trap 'rm -f "$COSMOS_SECRET_FILE"' EXIT
+  chmod 600 "$COSMOS_SECRET_FILE"
+  printf '%s' "$COSMOS_CONN" > "$COSMOS_SECRET_FILE"
+  unset COSMOS_CONN
+  az keyvault secret set --vault-name "$KV" --name cosmos-connection-string \
+    --file "$COSMOS_SECRET_FILE" --encoding utf-8
+)
 ```
 
 Expected: `az keyvault secret set` returns JSON with a non-empty `id` (the secret's versioned URI).

--- a/tools/selfhost/azure/README.md
+++ b/tools/selfhost/azure/README.md
@@ -305,10 +305,11 @@ Redis, and waiting for Front Door DNS to propagate all take real time. Progress 
 goes and written to:
 
 ```
-${TMPDIR:-/tmp}/selfhost-fluid-<aks-name>/deploy-<timestamp>.log
+${TMPDIR:-/tmp}/selfhost-fluid-<aks-name>.<random-suffix>/deploy-<timestamp>.log
 ```
 
-When it finishes it prints your three public endpoints.
+The exact private temporary directory is printed near the start of each run. When deployment
+finishes it prints your three public endpoints.
 
 **If it fails partway, just run it again.** Every phase checks whether its resource already
 exists before creating it, so re-running skips completed work and resumes where it stopped.
@@ -573,7 +574,7 @@ Create the registry before attempting to log in or push images:
 
 ```bash
 az group create -n "$RG" -l "$RG_LOC"
-az acr create -g "$RG" -n "$ACR" -l "$ACR_LOC" --sku Standard --admin-enabled true
+az acr create -g "$RG" -n "$ACR" -l "$ACR_LOC" --sku Standard --admin-enabled false
 ```
 
 **VERIFY:** `az acr show -g "$RG" -n "$ACR" --query provisioningState -o tsv` prints
@@ -718,8 +719,8 @@ Render deployment copies outside the Git checkout so live values are not committ
 
 ```bash
 REDIS_HOSTNAME=$(az redisenterprise show --name "$REDIS" --resource-group "$RG" --query hostName -o tsv)
-DEPLOY_DIR="${TMPDIR:-/tmp}/selfhost-fluid-$AKS"
-mkdir -p "$DEPLOY_DIR"
+DEPLOY_DIR="$(mktemp -d "${TMPDIR:-/tmp}/selfhost-fluid-${AKS}.XXXXXX")"
+chmod 700 "$DEPLOY_DIR"
 sed -e "s|<ACR>|$ACR|g" -e "s|<IMAGE_TAG>|$IMAGE_TAG|g" \
     -e "s|<RG>|$RG|g" -e "s|<STORAGE>|$STORAGE|g" \
     -e "s|<REDIS_HOSTNAME>|$REDIS_HOSTNAME|g" \
@@ -825,7 +826,7 @@ for deploy in fluid-alfred fluid-nexus fluid-riddler; do
     }},
     {"op": "add", "path": "/spec/template/spec/initContainers", "value": [{
       "name": "load-secrets",
-      "image": "busybox",
+      "image": "$ACR.azurecr.io/busybox@$BUSYBOX_DIGEST",
       "command": ["sh", "-c",
         "TENANT_KEY=$(cat /mnt/secrets/tenant-key) && echo \"export TENANT_KEY=$TENANT_KEY\" > /config/secrets.env"
       ],
@@ -865,7 +866,7 @@ for deploy in fluid-scribe fluid-scriptorium; do
     }},
     {"op": "add", "path": "/spec/template/spec/initContainers", "value": [{
       "name": "load-secrets",
-      "image": "busybox",
+      "image": "$ACR.azurecr.io/busybox@$BUSYBOX_DIGEST",
       "command": ["sh", "-c",
         "COSMOS_CONN=$(cat /mnt/secrets/cosmos-connection-string) && echo \"export mongodb__operationsDbEndpoint=$COSMOS_CONN\" > /config/secrets.env"
       ],

--- a/tools/selfhost/azure/README.md
+++ b/tools/selfhost/azure/README.md
@@ -760,7 +760,8 @@ Store CSI driver** rather than rendered into ConfigMaps or Helm metadata.
 >
 > The upstream chart writes both into its ConfigMap as literals rather than Helm values, so a
 > values file has nothing to override. `phase5_helm` rewrites those two lines in the chart
-> template to read from `auth:`, once per checkout; that is the only reason the patch exists.
+> template to read from `auth:` and emits the legacy root-level value still read by Historian,
+> once per checkout; that is the only reason the patch exists.
 
 **Check:** after Phase 5,
 
@@ -772,6 +773,10 @@ kubectl get cm fluid-routerlicious -o jsonpath='{.data.config\.json}' \
 reports `'enableTokenExpiration': True`. To confirm enforcement, sign a token with **no `exp`
 claim** and call alfred with it — expect `403 Invalid token expiry`. An already-expired token is
 not a valid check: those are rejected either way.
+
+The same phase ensures `usage.clientConnectivityCountingEnabled` is a JSON boolean. An older
+chart rendered the disabled value as the truthy string `"false"`, causing Nexus to append every
+disconnect to the non-expiring `clientConnectivityUsage` Redis list.
 
 > **Superseded:** the SecretProviderClass now authenticates via **AAD Workload Identity** (one
 > shared managed identity + a Kubernetes ServiceAccount, `azure/secretproviderclass.yaml`'s

--- a/tools/selfhost/azure/deploy.sh
+++ b/tools/selfhost/azure/deploy.sh
@@ -163,6 +163,7 @@ ensure_role_assignment() {
 }
 
 TEMP_ROLE_ASSIGNMENT_IDS=()
+SENSITIVE_TEMP_FILES=()
 KV_PUBLIC_ACCESS_RESTORE=""
 
 restore_keyvault_public_access() {
@@ -175,7 +176,7 @@ restore_keyvault_public_access() {
 
 cleanup_temporary_role_assignments() {
   local id
-  for id in "${TEMP_ROLE_ASSIGNMENT_IDS[@]}"; do
+  for id in "${TEMP_ROLE_ASSIGNMENT_IDS[@]+"${TEMP_ROLE_ASSIGNMENT_IDS[@]}"}"; do
     [[ -n "$id" ]] || continue
     log "Removing temporary Key Vault role assignment"
     az rest --method delete \
@@ -183,7 +184,15 @@ cleanup_temporary_role_assignments() {
   done
 }
 
+cleanup_sensitive_temp_files() {
+  local file
+  for file in "${SENSITIVE_TEMP_FILES[@]+"${SENSITIVE_TEMP_FILES[@]}"}"; do
+    [[ -n "$file" ]] && rm -f "$file"
+  done
+}
+
 cleanup_deployment_state() {
+  cleanup_sensitive_temp_files || true
   restore_keyvault_public_access || true
   cleanup_temporary_role_assignments
 }
@@ -206,30 +215,36 @@ current_principal_object_id() {
 # Azure RBAC role assignments can take a couple minutes to propagate after creation. Retry on
 # Forbidden instead of failing the whole deployment over a timing race.
 keyvault_secret_set_with_retry() {
-  local vault="$1" name="$2" value="$3" attempt err
+  local vault="$1" name="$2" value="$3" attempt err value_file
   err="$(mktemp "$DEPLOY_DIR/kv-secret-set.XXXXXX")"
+  value_file="$(mktemp "$DEPLOY_DIR/kv-secret-value.XXXXXX")"
+  SENSITIVE_TEMP_FILES+=("$value_file")
+  chmod 600 "$value_file"
+  printf '%s' "$value" > "$value_file"
+  unset value
   for attempt in 1 2 3 4 5 6; do
-    if az keyvault secret set --vault-name "$vault" --name "$name" --value "$value" >/dev/null 2>"$err"; then
-      rm -f "$err"
+    if az keyvault secret set --vault-name "$vault" --name "$name" \
+      --file "$value_file" --encoding utf-8 >/dev/null 2>"$err"; then
+      rm -f "$err" "$value_file"
       return 0
     fi
     # A network-locked-down vault (public network access disabled) also contains the
     # substring "Forbidden" but retrying can never fix it -- fail immediately with a clear
     # pointer instead of burning ~90s on retries that cannot succeed.
     if grep -q "Public network access is disabled" "$err" 2>/dev/null; then
-      cat "$err" >&2; rm -f "$err"
+      cat "$err" >&2; rm -f "$err" "$value_file"
       echo "ERROR: Key Vault $vault still has public network access disabled." >&2
       echo "phase8_keyvault should have enabled it temporarily for this workstation write; confirm the update was not blocked by Azure Policy." >&2
       return 1
     fi
     if ! grep -q "Forbidden\|ForbiddenByRbac" "$err" 2>/dev/null; then
-      cat "$err" >&2; rm -f "$err"
+      cat "$err" >&2; rm -f "$err" "$value_file"
       return 1
     fi
     log "Key Vault secret '$name' set forbidden (likely RBAC propagation delay), retrying in 15s (attempt $attempt/6)"
     sleep 15
   done
-  rm -f "$err"
+  rm -f "$err" "$value_file"
   echo "ERROR: could not set Key Vault secret '$name' after retries -- RBAC role may not have propagated" >&2
   return 1
 }

--- a/tools/selfhost/azure/deploy.sh
+++ b/tools/selfhost/azure/deploy.sh
@@ -130,6 +130,9 @@ FLUID_REF="$(jq -r '.resolvedCommitSha // empty' "$SOURCE_FILE")"
 
 IMAGE_TAG="$(jq -r '.builtImages[]? | select(.status == "pinned") | .tag // empty' "$IMAGES_FILE" | head -n 1)"
 IMAGE_TAG="${IMAGE_TAG:-$RELEASE_ID}"
+BUSYBOX_DIGEST="$(jq -r '.dependencyImages[]? | select(.name == "busybox" and .status == "pinned") | .digest // empty' "$IMAGES_FILE" | head -n 1)"
+[[ "$BUSYBOX_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]] \
+  || { echo "ERROR: images.json must contain a pinned busybox dependency image digest" >&2; exit 1; }
 
 log()    { printf '[%s] %s\n' "$(date -u +%H:%M:%S)" "$*"; }
 banner() { printf '\n=== %s ===\n' "$*"; }
@@ -317,6 +320,7 @@ elif [[ "$FLUID_REPO_DIR" == "~" ]]; then
   FLUID_REPO_DIR="$HOME"
 fi
 ACR="$(jqr '.deployAcr.name')"
+BUSYBOX_IMAGE="$ACR.azurecr.io/busybox@$BUSYBOX_DIGEST"
 AKS="$(jqr '.aks.name')"
 AKS_LOC="$(jqr '.aks.location')"; AKS_LOC="${AKS_LOC:-$RG_LOC}"
 AKS_K8S_VERSION="$(jqr '.aks.kubernetesVersion')"; AKS_K8S_VERSION="${AKS_K8S_VERSION:-1.35}"
@@ -515,12 +519,10 @@ done
 kubectl() { command kubectl --context "$AKS" "$@"; }
 helm() { command helm --kube-context "$AKS" "$@"; }
 
-DEPLOY_DIR="${TMPDIR:-/tmp}/selfhost-fluid-$AKS"
-mkdir -p "$DEPLOY_DIR"
-# Front Door hostnames, discovered in phase12 and consumed by phase5_helm. Persisted so a re-run
-# renders the chart values with the real hostnames from the start rather than briefly
-# advertising in-cluster names.
-AFD_HOSTS_FILE="$DEPLOY_DIR/afd-hosts.env"
+TEMP_BASE="${TMPDIR:-/tmp}"
+[[ -d "$TEMP_BASE" ]] || { echo "ERROR: temporary directory does not exist: $TEMP_BASE" >&2; exit 1; }
+DEPLOY_DIR="$(mktemp -d "$TEMP_BASE/selfhost-fluid-${AKS}.XXXXXX")"
+chmod 700 "$DEPLOY_DIR"
 LOG_FILE="$DEPLOY_DIR/deploy-$(date -u +%Y%m%dT%H%M%SZ).log"
 exec > >(tee -a "$LOG_FILE") 2>&1
 log "Logging to $LOG_FILE"
@@ -590,10 +592,15 @@ phase0_rg_acr() {
     # No --zone-redundancy flag needed: ACR zone redundancy is on by default for every tier
     # (Basic/Standard/Premium) in a region with Availability Zone support, and cannot be
     # disabled there -- the flag is legacy/backward-compat only now (aka.ms/acr/az).
-    az acr create -g "$RG" -n "$ACR" -l "$RG_LOC" --sku Standard --admin-enabled true
+    az acr create -g "$RG" -n "$ACR" -l "$RG_LOC" --sku Standard --admin-enabled false
   fi
   [[ "$(az acr show -g "$RG" -n "$ACR" --query provisioningState -o tsv)" == "Succeeded" ]] \
     || { echo "ERROR: ACR $ACR did not provision successfully" >&2; exit 1; }
+  if [[ "$(az acr show -g "$RG" -n "$ACR" --query adminUserEnabled -o tsv)" == "true" ]]; then
+    az acr update -g "$RG" -n "$ACR" --admin-enabled false
+  fi
+  [[ "$(az acr show -g "$RG" -n "$ACR" --query adminUserEnabled -o tsv)" == "false" ]] \
+    || { echo "ERROR: ACR $ACR admin account is still enabled" >&2; exit 1; }
   log "Phase 0 VERIFY passed"
 }
 
@@ -854,8 +861,8 @@ phase1_images() {
     src="$source_repo@$digest"
     target_tag="${tag:-$RELEASE_ID}"
 
-    if az acr repository show --name "$ACR" --image "$target_repo:$target_tag" >/dev/null 2>&1; then
-      log "$target_repo:$target_tag already in ACR, skipping import"
+    if az acr repository show --name "$ACR" --image "$target_repo@$digest" >/dev/null 2>&1; then
+      log "$target_repo@$digest already in ACR, skipping import"
     else
       az acr import --name "$ACR" --source "$src" --image "$target_repo:$target_tag" --force
     fi
@@ -1640,19 +1647,25 @@ phase5_helm() {
          exit 1; }
 
   # Front Door hostnames do not exist yet the first time this phase runs, so fall back to the
-  # in-cluster URLs. publish_frontdoor_hostnames writes the real hostnames to $AFD_HOSTS_FILE
-  # and re-runs this phase, which is why the substitution is here rather than in a follow-up `helm upgrade`:
+  # in-cluster URLs. Once phase12 creates them, query Azure directly rather than persisting and
+  # shell-executing deployment state from a temporary file. publish_frontdoor_hostnames re-runs
+  # this phase, which is why the substitution is here rather than in a follow-up `helm upgrade`:
   # a bare upgrade re-renders the chart's Deployments and strips the container `command`
   # overrides applied below, which is what injects the Cosmos connection string. Losing them
   # sends every stateful service into CrashLoopBackOff with `MongoParseError: Invalid scheme`.
   local ext_alfred="http://fluid-alfred" ext_nexus="ws://fluid-nexus" ext_historian="http://historian"
-  if [[ -f "$AFD_HOSTS_FILE" ]]; then
-    # shellcheck source=/dev/null
-    source "$AFD_HOSTS_FILE"
-    ext_alfred="https://$AFD_ALFRED_HOST"
-    ext_nexus="wss://$AFD_NEXUS_HOST"
-    ext_historian="https://$AFD_HISTORIAN_HOST"
-    log "Rendering chart values with Front Door hostnames ($AFD_ALFRED_HOST)"
+  local afd_alfred_host afd_nexus_host afd_historian_host
+  afd_alfred_host="$(az afd endpoint show -g "$RG" --profile-name "$AFD" \
+    --endpoint-name "alfred-${AFD}" --query hostName -o tsv 2>/dev/null || true)"
+  afd_nexus_host="$(az afd endpoint show -g "$RG" --profile-name "$AFD" \
+    --endpoint-name "nexus-${AFD}" --query hostName -o tsv 2>/dev/null || true)"
+  afd_historian_host="$(az afd endpoint show -g "$RG" --profile-name "$AFD" \
+    --endpoint-name "historian-${AFD}" --query hostName -o tsv 2>/dev/null || true)"
+  if [[ -n "$afd_alfred_host" && -n "$afd_nexus_host" && -n "$afd_historian_host" ]]; then
+    ext_alfred="https://$afd_alfred_host"
+    ext_nexus="wss://$afd_nexus_host"
+    ext_historian="https://$afd_historian_host"
+    log "Rendering chart values with Front Door hostnames ($afd_alfred_host)"
   fi
 
   # nexus's socketIo.gracefulShutdownDrainTimeMs (fluid-configmap.yaml) is 45s, but the
@@ -1761,7 +1774,7 @@ phase5_helm() {
   # file (its ENTRYPOINT is just tini plus a bare `node ...` command).
   patch_secrets_and_command() {
     local deploy="$1" real_cmd="$2" extra_env_json="${3:-[]}"
-    local init_script run_script
+    local init_script run_script busybox_image="$BUSYBOX_IMAGE"
     # shellcheck disable=SC2016
     # Values are wrapped in literal double-quotes (printf 'export NAME="%s"') because Cosmos
     # Mongo connection strings contain '&', which an unquoted `sh` source would treat as a
@@ -1862,7 +1875,7 @@ phase5_helm() {
       log "$deploy already has CSI secrets volumes/init-container, skipping that part"
     else
       local setup_patch_file="$DEPLOY_DIR/patch-$deploy-setup.json"
-      jq -n --arg initScript "$init_script" '[
+      jq -n --arg initScript "$init_script" --arg busyboxImage "$busybox_image" '[
         {"op": "add", "path": "/spec/template/spec/volumes/-", "value": {
           "name": "fluid-secrets",
           "csi": {"driver": "secrets-store.csi.k8s.io", "readOnly": true,
@@ -1870,7 +1883,7 @@ phase5_helm() {
         }},
         {"op": "add", "path": "/spec/template/spec/volumes/-", "value": {"name": "fluid-secrets-env", "emptyDir": {}}},
         {"op": "add", "path": "/spec/template/spec/initContainers", "value": [{
-          "name": "load-secrets", "image": "busybox",
+          "name": "load-secrets", "image": $busyboxImage,
           "command": ["sh", "-c", $initScript],
           "volumeMounts": [
             {"name": "fluid-secrets", "mountPath": "/mnt/secrets", "readOnly": true},
@@ -1881,16 +1894,18 @@ phase5_helm() {
       kubectl patch deployment "$deploy" --type=json --patch-file="$setup_patch_file"
     fi
 
-    # The init container's script is only written once, in the "add" branch above -- it is not
-    # re-synced if `init_script`'s content changes later. Re-check and reapply on every run so
-    # existing deployments pick up script fixes too.
-    local current_init_cmd
+    # The init container's image and script are only written once in the "add" branch above.
+    # Re-check and reapply both on every run so existing deployments move from the former
+    # mutable Docker Hub image to this release's ACR-hosted digest and pick up script fixes.
+    local current_init_cmd current_init_image
     current_init_cmd="$(kubectl get deployment "$deploy" -o jsonpath='{.spec.template.spec.initContainers[0].command[2]}' 2>/dev/null)"
-    if [[ "$current_init_cmd" == "$init_script" ]]; then
-      log "$deploy init-container script already up to date, skipping"
+    current_init_image="$(kubectl get deployment "$deploy" -o jsonpath='{.spec.template.spec.initContainers[0].image}' 2>/dev/null)"
+    if [[ "$current_init_cmd" == "$init_script" && "$current_init_image" == "$busybox_image" ]]; then
+      log "$deploy init-container image and script already up to date, skipping"
     else
       local init_patch_file="$DEPLOY_DIR/patch-$deploy-init.json"
-      jq -n --arg initScript "$init_script" '[
+      jq -n --arg initScript "$init_script" --arg busyboxImage "$busybox_image" '[
+        {"op": "replace", "path": "/spec/template/spec/initContainers/0/image", "value": $busyboxImage},
         {"op": "replace", "path": "/spec/template/spec/initContainers/0/command", "value": ["sh", "-c", $initScript]}
       ]' > "$init_patch_file"
       kubectl patch deployment "$deploy" --type=json --patch-file="$init_patch_file"
@@ -2048,11 +2063,6 @@ publish_frontdoor_hostnames() {
   fi
 
   log "Publishing Front Door hostnames into the chart's discovery values"
-  cat > "$AFD_HOSTS_FILE" <<EOF
-AFD_ALFRED_HOST=$afd_alfred
-AFD_NEXUS_HOST=$afd_nexus
-AFD_HISTORIAN_HOST=$afd_historian
-EOF
   phase5_helm
   kubectl rollout status deploy/fluid-alfred --timeout=300s >/dev/null 2>&1 || true
   advertised="$(kubectl get configmap fluid-routerlicious -o jsonpath='{.data.config\.json}' 2>/dev/null \

--- a/tools/selfhost/azure/deploy.sh
+++ b/tools/selfhost/azure/deploy.sh
@@ -206,29 +206,30 @@ current_principal_object_id() {
 # Azure RBAC role assignments can take a couple minutes to propagate after creation. Retry on
 # Forbidden instead of failing the whole deployment over a timing race.
 keyvault_secret_set_with_retry() {
-  local vault="$1" name="$2" value="$3" attempt
+  local vault="$1" name="$2" value="$3" attempt err
+  err="$(mktemp "$DEPLOY_DIR/kv-secret-set.XXXXXX")"
   for attempt in 1 2 3 4 5 6; do
-    if az keyvault secret set --vault-name "$vault" --name "$name" --value "$value" >/dev/null 2>/tmp/kv_secret_set_err.$$; then
-      rm -f /tmp/kv_secret_set_err.$$
+    if az keyvault secret set --vault-name "$vault" --name "$name" --value "$value" >/dev/null 2>"$err"; then
+      rm -f "$err"
       return 0
     fi
     # A network-locked-down vault (public network access disabled) also contains the
     # substring "Forbidden" but retrying can never fix it -- fail immediately with a clear
     # pointer instead of burning ~90s on retries that cannot succeed.
-    if grep -q "Public network access is disabled" /tmp/kv_secret_set_err.$$ 2>/dev/null; then
-      cat /tmp/kv_secret_set_err.$$ >&2; rm -f /tmp/kv_secret_set_err.$$
+    if grep -q "Public network access is disabled" "$err" 2>/dev/null; then
+      cat "$err" >&2; rm -f "$err"
       echo "ERROR: Key Vault $vault still has public network access disabled." >&2
       echo "phase8_keyvault should have enabled it temporarily for this workstation write; confirm the update was not blocked by Azure Policy." >&2
       return 1
     fi
-    if ! grep -q "Forbidden\|ForbiddenByRbac" /tmp/kv_secret_set_err.$$ 2>/dev/null; then
-      cat /tmp/kv_secret_set_err.$$ >&2; rm -f /tmp/kv_secret_set_err.$$
+    if ! grep -q "Forbidden\|ForbiddenByRbac" "$err" 2>/dev/null; then
+      cat "$err" >&2; rm -f "$err"
       return 1
     fi
     log "Key Vault secret '$name' set forbidden (likely RBAC propagation delay), retrying in 15s (attempt $attempt/6)"
     sleep 15
   done
-  rm -f /tmp/kv_secret_set_err.$$
+  rm -f "$err"
   echo "ERROR: could not set Key Vault secret '$name' after retries -- RBAC role may not have propagated" >&2
   return 1
 }
@@ -238,20 +239,21 @@ keyvault_secret_set_with_retry() {
 # a new one fail immediately with (OperationNotAllowed), not queue behind it. Observed addon
 # operations taking 1-3 minutes to clear; retry budget below is sized with margin over that.
 aks_enable_addon_with_retry() {
-  local rg="$1" aks="$2" addon="$3" attempt
+  local rg="$1" aks="$2" addon="$3" attempt err
+  err="$(mktemp "$DEPLOY_DIR/aks-addon.XXXXXX")"
   for attempt in $(seq 1 10); do
-    if az aks enable-addons -g "$rg" -n "$aks" --addons "$addon" 2>/tmp/aks_addon_err.$$; then
-      rm -f /tmp/aks_addon_err.$$
+    if az aks enable-addons -g "$rg" -n "$aks" --addons "$addon" 2>"$err"; then
+      rm -f "$err"
       return 0
     fi
-    if ! grep -q "OperationNotAllowed" /tmp/aks_addon_err.$$ 2>/dev/null; then
-      cat /tmp/aks_addon_err.$$ >&2; rm -f /tmp/aks_addon_err.$$
+    if ! grep -q "OperationNotAllowed" "$err" 2>/dev/null; then
+      cat "$err" >&2; rm -f "$err"
       return 1
     fi
     log "AKS cluster $aks has another operation in progress, retrying '$addon' addon enable in 30s (attempt $attempt/10)"
     sleep 30
   done
-  cat /tmp/aks_addon_err.$$ >&2; rm -f /tmp/aks_addon_err.$$
+  cat "$err" >&2; rm -f "$err"
   echo "ERROR: could not enable '$addon' addon on $aks after retries -- another operation may be stuck (check with 'az aks operation show-latest -g $rg -n $aks')" >&2
   return 1
 }
@@ -1175,16 +1177,18 @@ phase8_cosmos() {
     # means that check was skipped or the region's support changed since. Fail loudly rather
     # than silently downgrading to non-zone-redundant behind the customer's back: the customer
     # sets cosmos.zoneRedundant to False themselves if their region can't support it.
+    local cosmos_create_err
+    cosmos_create_err="$(mktemp "$DEPLOY_DIR/cosmos-create.XXXXXX")"
     if ! az cosmosdb create -n "$COSMOS" -g "$RG" --kind MongoDB --capabilities EnableMongo \
       --server-version "$COSMOS_SERVER_VERSION" \
       --locations regionName="$RG_LOC" failoverPriority=0 isZoneRedundant="$COSMOS_ZONE_REDUNDANT" \
-      2>/tmp/cosmos_create_err.$$; then
-      cat /tmp/cosmos_create_err.$$ >&2
-      rm -f /tmp/cosmos_create_err.$$
+      2>"$cosmos_create_err"; then
+      cat "$cosmos_create_err" >&2
+      rm -f "$cosmos_create_err"
       echo "ERROR: Cosmos DB create with isZoneRedundant=$COSMOS_ZONE_REDUNDANT failed -- if $RG_LOC doesn't support Availability Zones, set cosmos.zoneRedundant to False in your parameters file (re-run azure/preflight-check.sh to confirm) and retry" >&2
       exit 1
     fi
-    rm -f /tmp/cosmos_create_err.$$
+    rm -f "$cosmos_create_err"
   fi
   local cosmos_conn cosmos_id
   cosmos_conn="$(az cosmosdb keys list -n "$COSMOS" -g "$RG" --type connection-strings \
@@ -1239,7 +1243,8 @@ phase8_cosmos() {
 # RU/s values are a starting point informed by a real reference deployment plus source-verified
 # usage patterns, not load-test-derived final values (design doc Section 9 "pending load test").
 phase8_cosmos_throughput() {
-  local coll max shard
+  local coll max shard throughput_err
+  throughput_err="$(mktemp "$DEPLOY_DIR/cosmos-throughput.XXXXXX")"
   # $1=name $2=max RU/s (autoscale) $3=shard key
   # documents/checkpoints/scribeDeltas sharded on documentId: matches deltas' existing sharding,
   # and lets documents scale past the ~10000 RU/s ceiling an unsharded ("fixed to unlimited
@@ -1275,11 +1280,11 @@ phase8_cosmos_throughput() {
       if [[ -z "$(az cosmosdb mongodb collection throughput show -a "$COSMOS" -g "$RG" -d admin -n "$coll" --query resource.autoscaleSettings.maxThroughput -o tsv 2>/dev/null)" ]]; then
         az cosmosdb mongodb collection throughput migrate -a "$COSMOS" -g "$RG" -d admin -n "$coll" --throughput-type autoscale -o none
       fi
-      if ! az cosmosdb mongodb collection throughput update -a "$COSMOS" -g "$RG" -d admin -n "$coll" --max-throughput "$max" -o none 2>/tmp/cosmos_thr_err.$$; then
-        if grep -q "fixed to unlimited" /tmp/cosmos_thr_err.$$; then
+      if ! az cosmosdb mongodb collection throughput update -a "$COSMOS" -g "$RG" -d admin -n "$coll" --max-throughput "$max" -o none 2>"$throughput_err"; then
+        if grep -q "fixed to unlimited" "$throughput_err"; then
           log "WARNING: $coll is a legacy 'fixed' container (capped, no autoscale) -- fixing requires manually dropping and recreating it (az cosmosdb mongodb collection delete, then create --shard $shard --max-throughput $max); not done automatically since it discards existing data"
         else
-          cat /tmp/cosmos_thr_err.$$ >&2
+          cat "$throughput_err" >&2
         fi
       fi
     else
@@ -1290,7 +1295,7 @@ phase8_cosmos_throughput() {
       fi
     fi
   done
-  rm -f /tmp/cosmos_thr_err.$$
+  rm -f "$throughput_err"
   # Clean up the one genuinely unused collection (partitions) if a prior run created it.
   if az cosmosdb mongodb collection show -a "$COSMOS" -g "$RG" -d admin -n partitions >/dev/null 2>&1; then
     az cosmosdb mongodb collection delete -a "$COSMOS" -g "$RG" -d admin -n partitions --yes
@@ -1412,14 +1417,16 @@ phase8_storage() {
     # not an ARM/RBAC error.
     # STORAGE_SKU (Standard_ZRS by default) is not available in every region -- fall back to
     # Standard_LRS on failure the same way phase8_redis/phase8_cosmos fall back.
+    local storage_create_err
+    storage_create_err="$(mktemp "$DEPLOY_DIR/storage-create.XXXXXX")"
     if ! az storage account create -g "$RG" -n "$STORAGE" -l "$RG_LOC" --sku "$STORAGE_SKU" --kind StorageV2 \
-      --allow-shared-key-access true 2>/tmp/storage_create_err.$$; then
+      --allow-shared-key-access true 2>"$storage_create_err"; then
       log "WARNING: Storage account create with SKU $STORAGE_SKU failed -- falling back to Standard_LRS (not zone-redundant)"
-      cat /tmp/storage_create_err.$$ >&2
+      cat "$storage_create_err" >&2
       az storage account create -g "$RG" -n "$STORAGE" -l "$RG_LOC" --sku Standard_LRS --kind StorageV2 \
         --allow-shared-key-access true
     fi
-    rm -f /tmp/storage_create_err.$$
+    rm -f "$storage_create_err"
     # azure/backends.yaml's PVC does NOT bind to this named share -- the azurefile-gitrest
     # StorageClass dynamically provisions its own separate share instead. This "gitrest-data"
     # share exists for parity/documentation only; its quota is unused.

--- a/tools/selfhost/azure/deploy.sh
+++ b/tools/selfhost/azure/deploy.sh
@@ -54,6 +54,7 @@ set -euo pipefail
 # manifests + logs (never commit rendered files with live values).
 # ---------------------------------------------------------------------------
 SELFHOST_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+. "$SELFHOST_ROOT/release/lib.sh"
 
 usage() {
   cat >&2 <<'EOF'
@@ -592,6 +593,7 @@ if [[ "$(git -C "$FLUID_ROOT" rev-parse HEAD 2>/dev/null || true)" != "$FLUID_RE
   fi
   git -C "$FLUID_ROOT" checkout --detach "$FLUID_REF"
 fi
+validate_selfhost_source_compatibility "$FLUID_ROOT"
 
 # ===========================================================================
 # Phase 0 — Resource group + ACR
@@ -809,11 +811,17 @@ phase0_network_allow_frontdoor() {
 create_private_endpoint() {
   local resource_id="$1" group_id="$2" short_name="$3" zone_name="$4"
   local pe_name="pe-$short_name" zone_link_name="link-$short_name"
+  local vnet_id existing_zone_link
 
   if ! az network private-dns zone show -g "$RG" -n "$zone_name" >/dev/null 2>&1; then
     az network private-dns zone create -g "$RG" -n "$zone_name"
   fi
-  if ! az network private-dns link vnet show -g "$RG" -n "$zone_link_name" -z "$zone_name" >/dev/null 2>&1; then
+  vnet_id="$(az network vnet show -g "$RG" -n "$VNET" --query id -o tsv)"
+  existing_zone_link="$(az network private-dns link vnet list -g "$RG" -z "$zone_name" \
+    --query "[?virtualNetwork.id=='$vnet_id'] | [0].name" -o tsv)"
+  if [[ -n "$existing_zone_link" ]]; then
+    log "Private DNS zone $zone_name is already linked to $VNET as $existing_zone_link, reusing it"
+  else
     az network private-dns link vnet create -g "$RG" -n "$zone_link_name" -z "$zone_name" \
       -v "$VNET" -e false
   fi
@@ -1652,6 +1660,8 @@ phase5_helm() {
   # upstream chart writes them into its ConfigMap as literals rather than Helm values, so a
   # values file has nothing to override. Rewrite the two literals to read from `auth:` once per
   # checkout; after this, changing those settings is just editing the values file and re-running.
+  # Historian still reads the legacy root-level maxTokenLifetimeSec, while Routerlicious reads
+  # auth:maxTokenLifetimeSec, so emit both paths from the same value.
   local cm_tmpl="$FLUID_ROOT/server/routerlicious/kubernetes/routerlicious/templates/fluid-configmap.yaml"
   awk '
     $0 == "            \"maxTokenLifetimeSec\": 3600," {
@@ -1663,9 +1673,33 @@ phase5_helm() {
     { print }
   ' "$cm_tmpl" > "$cm_tmpl.tmp"
   mv "$cm_tmpl.tmp" "$cm_tmpl"
+  if ! grep -qF '        "maxTokenLifetimeSec": {{ .Values.auth.maxTokenLifetimeSec }},' "$cm_tmpl"; then
+    awk '
+      $0 == "        \"auth\": {" {
+        print "        \"maxTokenLifetimeSec\": {{ .Values.auth.maxTokenLifetimeSec }},"
+      }
+      { print }
+    ' "$cm_tmpl" > "$cm_tmpl.tmp"
+    mv "$cm_tmpl.tmp" "$cm_tmpl"
+  fi
   grep -qF '.Values.auth.maxTokenLifetimeSec' "$cm_tmpl" \
     && grep -qF '.Values.auth.enableTokenExpiration' "$cm_tmpl" \
+    && grep -qF '        "maxTokenLifetimeSec": {{ .Values.auth.maxTokenLifetimeSec }},' "$cm_tmpl" \
     || { echo "ERROR: could not point the auth block in $cm_tmpl at .Values.auth -- upstream changed it." >&2
+         exit 1; }
+
+  # The upstream template quotes this one boolean (unlike the other two usage flags), rendering
+  # false as the truthy string "false". Nexus then records every disconnect in the non-expiring
+  # clientConnectivityUsage Redis list. Keep it a JSON boolean so the disabled default is honored.
+  awk '
+    $0 == "            \"clientConnectivityCountingEnabled\": \"{{ .Values.usage.clientConnectivityCountingEnabled }}\"," {
+      print "            \"clientConnectivityCountingEnabled\": {{ .Values.usage.clientConnectivityCountingEnabled }},"; next
+    }
+    { print }
+  ' "$cm_tmpl" > "$cm_tmpl.tmp"
+  mv "$cm_tmpl.tmp" "$cm_tmpl"
+  grep -qF '"clientConnectivityCountingEnabled": {{ .Values.usage.clientConnectivityCountingEnabled }},' "$cm_tmpl" \
+    || { echo "ERROR: could not render clientConnectivityCountingEnabled as a boolean in $cm_tmpl -- upstream changed it." >&2
          exit 1; }
 
   # Front Door hostnames do not exist yet the first time this phase runs, so fall back to the

--- a/tools/selfhost/azure/preflight-check.sh
+++ b/tools/selfhost/azure/preflight-check.sh
@@ -9,6 +9,9 @@ set -uo pipefail   # deliberately NOT -e: a single failed check must not abort t
 
 SELFHOST_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PARAMS_FILE="${1:-$SELFHOST_ROOT/azure/deploy.parameters.json}"
+PREFLIGHT_TEMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/selfhost-preflight.XXXXXX")"
+chmod 700 "$PREFLIGHT_TEMP_DIR"
+trap 'rm -rf "$PREFLIGHT_TEMP_DIR"' EXIT
 
 if [[ ! -f "$PARAMS_FILE" ]]; then
   echo "ERROR: parameters file not found: $PARAMS_FILE" >&2
@@ -407,20 +410,21 @@ banner "Azure Front Door profile count quota"
 if az afd profile show -g "$RG" --profile-name "$AFD" >/dev/null 2>&1; then
   ok "Front Door profile '$AFD' already exists in target RG $RG -- deploy.sh will reuse it (skipping quota check)"
 else
+  afd_quota_err="$PREFLIGHT_TEMP_DIR/afd-quota.err"
   afd_sub_id="$(az account show --query id -o tsv)"
   afd_resp="$(az rest --method post \
     --url "https://management.azure.com/subscriptions/$afd_sub_id/providers/Microsoft.Cdn/checkResourceUsage?api-version=2026-04-01-preview" \
-    2>/tmp/afd_quota_err.$$)"
+    2>"$afd_quota_err")"
   read -r afd_current afd_limit <<<"$(jq -r '.value[]? | select(.resourceType=="afdprofile") | "\(.currentValue) \(.limit)"' <<<"$afd_resp" 2>/dev/null)"
   if [[ -z "$afd_limit" ]]; then
-    note "could not read Front Door profile quota ($(head -1 /tmp/afd_quota_err.$$ 2>/dev/null))"
+    note "could not read Front Door profile quota ($(head -1 "$afd_quota_err" 2>/dev/null))"
   elif [[ $afd_current -lt $afd_limit ]]; then
     ok "quota OK: $afd_current/$afd_limit Azure Front Door (Standard/Premium) profiles used"
   else
     fail "quota SHORTFALL: $afd_current/$afd_limit Azure Front Door profiles already used -- request a quota increase or delete unused profiles"
   fi
-  rm -f /tmp/afd_quota_err.$$
-  unset afd_resp afd_sub_id
+  rm -f "$afd_quota_err"
+  unset afd_resp afd_sub_id afd_quota_err
 fi
 
 # ---------------------------------------------------------------------------
@@ -434,17 +438,19 @@ CHART_DIR="$FLUID_ROOT/server/routerlicious/kubernetes/routerlicious"
 if [[ ! -d "$CHART_DIR" ]]; then
   note "FluidFramework checkout not found at $FLUID_ROOT -- skipping Helm template check (deploy.sh clones it fresh if needed)"
 else
-  tmp_values="$(mktemp)"
+  tmp_values="$PREFLIGHT_TEMP_DIR/routerlicious-values.yaml"
+  helm_template_out="$PREFLIGHT_TEMP_DIR/helm-template.out"
+  helm_template_err="$PREFLIGHT_TEMP_DIR/helm-template.err"
   sed -e "s|<ACR>|placeholderacr|g" -e "s|<IMAGE_TAG>|placeholder-tag|g" \
       -e "s|<REDIS_HOSTNAME>|placeholder.eastus.redis.azure.net|g" \
       "$SELFHOST_ROOT/azure/routerlicious-values.yaml" > "$tmp_values"
-  if helm template fluid "$CHART_DIR" -f "$tmp_values" >/tmp/helm_template_out.$$ 2>/tmp/helm_template_err.$$; then
-    ok "helm template rendered successfully ($(wc -l </tmp/helm_template_out.$$ | tr -d ' ') lines of manifests)"
+  if helm template fluid "$CHART_DIR" -f "$tmp_values" >"$helm_template_out" 2>"$helm_template_err"; then
+    ok "helm template rendered successfully ($(wc -l <"$helm_template_out" | tr -d ' ') lines of manifests)"
   else
     fail "helm template failed to render -- see errors below"
-    sed 's/^/    /' /tmp/helm_template_err.$$ >&2
+    sed 's/^/    /' "$helm_template_err" >&2
   fi
-  rm -f "$tmp_values" /tmp/helm_template_out.$$ /tmp/helm_template_err.$$
+  rm -f "$tmp_values" "$helm_template_out" "$helm_template_err"
 fi
 
 # ---------------------------------------------------------------------------

--- a/tools/selfhost/azure/preflight-check.sh
+++ b/tools/selfhost/azure/preflight-check.sh
@@ -9,9 +9,17 @@ set -uo pipefail   # deliberately NOT -e: a single failed check must not abort t
 
 SELFHOST_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PARAMS_FILE="${1:-$SELFHOST_ROOT/azure/deploy.parameters.json}"
-PREFLIGHT_TEMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/selfhost-preflight.XXXXXX")"
-chmod 700 "$PREFLIGHT_TEMP_DIR"
-trap 'rm -rf "$PREFLIGHT_TEMP_DIR"' EXIT
+PREFLIGHT_TEMP_DIR=""
+if ! PREFLIGHT_TEMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/selfhost-preflight.XXXXXX")"; then
+  echo "ERROR: could not create a private preflight temporary directory." >&2
+  exit 1
+fi
+if ! chmod 700 "$PREFLIGHT_TEMP_DIR"; then
+  echo "ERROR: could not secure the preflight temporary directory." >&2
+  rm -rf -- "$PREFLIGHT_TEMP_DIR"
+  exit 1
+fi
+trap 'rm -rf -- "$PREFLIGHT_TEMP_DIR"' EXIT
 
 if [[ ! -f "$PARAMS_FILE" ]]; then
   echo "ERROR: parameters file not found: $PARAMS_FILE" >&2

--- a/tools/selfhost/azure/test/deploy.test.sh
+++ b/tools/selfhost/azure/test/deploy.test.sh
@@ -233,6 +233,12 @@ assert_has "hub deltas created"                         "$CALLS" "-n deltas"
 assert_has "hubs at 32 partitions"                      "$CALLS" "--partition-count 32"
 assert_has "hubs at 72h retention"                      "$CALLS" "--retention-time-in-hours 72"
 assert_has "connection string written to Key Vault"     "$CALLS" "eventhub-connection-string"
+assert_has "Key Vault receives secret values through a private file" "$CALLS" "--file"
+if grep "keyvault secret set" "$CALLS" | grep -q "SharedAccessKey"; then
+  no "Event Hubs credentials never enter the Azure CLI argument list"
+else
+  ok "Event Hubs credentials never enter the Azure CLI argument list"
+fi
 assert_has "public network access disabled"             "$CALLS" "--public-network-access Disabled"
 assert_has "private endpoint created"                   "$CALLS" "private-endpoint create"
 assert_has "private DNS zone privatelink.servicebus"    "$CALLS" "privatelink.servicebus.windows.net"

--- a/tools/selfhost/azure/test/deploy.test.sh
+++ b/tools/selfhost/azure/test/deploy.test.sh
@@ -571,5 +571,21 @@ grep -q "Microsoft.Cache/redisEnterprise" "$P" && ok "preflight checks Azure Man
 grep -q "REDIS_HIGH_AVAILABILITY STORAGE" "$P" && ok "preflight requires Redis highAvailability"         || no "preflight requires Redis highAvailability"
 grep -q "must be exactly 'Enabled' or 'Disabled'" "$P" && ok "preflight validates Redis highAvailability" || no "preflight validates Redis highAvailability"
 
+PREFLIGHT_FAIL_BIN="$WORK/preflight-fail-bin"
+mkdir -p "$PREFLIGHT_FAIL_BIN"
+cat > "$PREFLIGHT_FAIL_BIN/mktemp" <<'STUB'
+#!/usr/bin/env bash
+exit 1
+STUB
+chmod +x "$PREFLIGHT_FAIL_BIN/mktemp"
+preflight_mktemp_out="$(PATH="$PREFLIGHT_FAIL_BIN:$PATH" bash "$P" "$WORK/missing-parameters.json" 2>&1)"
+preflight_mktemp_rc=$?
+assert_eq "preflight exits when its private temporary directory cannot be created" "$preflight_mktemp_rc" "1"
+if grep -qF "ERROR: could not create a private preflight temporary directory." <<<"$preflight_mktemp_out"; then
+  ok "preflight reports temporary-directory creation failures"
+else
+  no "preflight reports temporary-directory creation failures" "$preflight_mktemp_out"
+fi
+
 printf '\n\033[1mTotal: %d passed, %d failed, %d skipped\033[0m\n' "$PASS" "$FAIL" "$SKIP"
 [[ $FAIL -eq 0 ]] || exit 1

--- a/tools/selfhost/azure/test/deploy.test.sh
+++ b/tools/selfhost/azure/test/deploy.test.sh
@@ -35,6 +35,7 @@ BIN="$WORK/bin"; mkdir -p "$BIN"
 export CALLS="$WORK/calls.log"; : > "$CALLS"
 export MOCK_NS_EXISTS=0 MOCK_TIER=Standard MOCK_REDIS_EXISTS=0 MOCK_REDIS_HA=Enabled
 export MOCK_ACR_EXISTS=0 MOCK_ACR_ADMIN_ENABLED=false MOCK_BUSYBOX_DIGEST_EXISTS=0
+export MOCK_DNS_LINK_TO_VNET=0
 
 cat > "$BIN/az" <<'STUB'
 #!/usr/bin/env bash
@@ -81,6 +82,10 @@ case "$*" in
   *"authorization-rule keys list"*)                           echo 'Endpoint=sb://ns.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=abc+/='; exit 0 ;;
   *"keyvault secret show"*)                                   echo "https://kv.vault.azure.net/secrets/eventhub-connection-string/1"; exit 0 ;;
   *"privateLinkServiceConnections"*)                          echo "Approved"; exit 0 ;;
+  *"network vnet show"*"--query id"*)                         echo "/subscriptions/s/resourceGroups/mock-rg/providers/Microsoft.Network/virtualNetworks/mock-vnet"; exit 0 ;;
+  *"private-dns link vnet list"*)
+    [ "${MOCK_DNS_LINK_TO_VNET:-0}" = 1 ] && echo "link-legacy-resource"
+    exit 0 ;;
   *"private-endpoint show"*|*"private-dns zone show"*|*"private-dns link vnet show"*) exit 1 ;;
 esac
 exit 0
@@ -99,8 +104,9 @@ export PATH="$BIN:$PATH"
 # at import, so the extracted function block has to sit in a repo-shaped tree with preflight
 # stubbed out -- the real one makes live Azure calls.
 # ---------------------------------------------------------------------------
-REPO="$WORK/repo"; mkdir -p "$REPO/azure"
+REPO="$WORK/repo"; mkdir -p "$REPO/azure" "$REPO/release"
 cp "$AZURE_DIR"/*.yaml "$AZURE_DIR"/*.json "$AZURE_DIR"/*.sh "$REPO/azure/" 2>/dev/null || true
+cp "$AZURE_DIR/../release/lib.sh" "$REPO/release/lib.sh"
 printf '#!/usr/bin/env bash\nexit 0\n' > "$REPO/azure/preflight-check.sh"
 chmod +x "$REPO/azure/preflight-check.sh"
 
@@ -114,8 +120,11 @@ printf '{"builtImages":[{"name":"routerlicious","status":"pinned","tag":"mock-ta
 
 PARAMS="$WORK/params.json"
 # fluidRepoDir is mandatory since the release-pipeline merge; git is stubbed, so a directory with
-# a .git marker is enough to get past the checkout logic.
+# a .git marker and compatible Historian source are enough to get past the checkout logic.
 mkdir -p "$WORK/fluid/.git"
+mkdir -p "$WORK/fluid/server/historian/packages/historian-base/src/services"
+printf '%s\n' 'const tokenLifetimeInSec = Math.floor(tokenLifetimeInMSec / 1000);' \
+  > "$WORK/fluid/server/historian/packages/historian-base/src/services/riddlerService.ts"
 cat > "$PARAMS" <<JSON
 {
   "subscriptionId": "00000000-0000-0000-0000-000000000000",
@@ -201,6 +210,9 @@ assert_eq "secret init image uses the release-pinned ACR digest" "${V_BUSYBOX_IM
 TILDE="$WORK/params-tilde.json"
 jq '.fluidRepoDir = "~/fluid"' "$PARAMS" > "$TILDE"
 mkdir -p "$WORK/home/fluid/.git"
+mkdir -p "$WORK/home/fluid/server/historian/packages/historian-base/src/services"
+printf '%s\n' 'const tokenLifetimeInSec = Math.floor(tokenLifetimeInMSec / 1000);' \
+  > "$WORK/home/fluid/server/historian/packages/historian-base/src/services/riddlerService.ts"
 tilde_root="$(HOME="$WORK/home" read_vars "$TILDE" FLUID_REPO_DIR | sed -n 's/^FLUID_REPO_DIR=//p')"
 assert_eq "fluidRepoDir expands a leading tilde" "$tilde_root" "$WORK/home/fluid"
 
@@ -257,6 +269,18 @@ else ok "re-run does not recreate the namespace"; fi
 printf '%s' "$out" | grep -q "already exists, skipping create" \
   && ok "re-run reports the skip" || no "re-run reports the skip"
 export MOCK_NS_EXISTS=0
+
+: > "$CALLS"; export MOCK_DNS_LINK_TO_VNET=1
+out="$(run_phase 'create_private_endpoint /subscriptions/s/resourceGroups/mock-rg/providers/Microsoft.Storage/storageAccounts/new-storage file new-storage privatelink.file.core.windows.net')"; rc=$?
+assert_eq "renamed resource reuses the VNet's existing private DNS link" "$rc" "0"
+if grep -q "private-dns link vnet create" "$CALLS"; then
+  no "existing VNet link is not recreated under the new resource name"
+else
+  ok "existing VNet link is not recreated under the new resource name"
+fi
+printf '%s' "$out" | grep -q "reusing it" \
+  && ok "existing private DNS link reuse is reported" || no "existing private DNS link reuse is reported"
+export MOCK_DNS_LINK_TO_VNET=0
 
 # ---------------------------------------------------------------------------
 group "4. Mock deploy: Azure Managed Redis"

--- a/tools/selfhost/azure/test/deploy.test.sh
+++ b/tools/selfhost/azure/test/deploy.test.sh
@@ -14,6 +14,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 AZURE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
+export TMPDIR="$WORK/tmp"
+mkdir -p "$TMPDIR"
 
 PASS=0; FAIL=0; SKIP=0
 ok()    { printf '  \033[32mPASS\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
@@ -32,11 +34,24 @@ absorb() { while IFS= read -r l; do case "$l" in PASS\ *) ok "${l#PASS }";; FAIL
 BIN="$WORK/bin"; mkdir -p "$BIN"
 export CALLS="$WORK/calls.log"; : > "$CALLS"
 export MOCK_NS_EXISTS=0 MOCK_TIER=Standard MOCK_REDIS_EXISTS=0 MOCK_REDIS_HA=Enabled
+export MOCK_ACR_EXISTS=0 MOCK_ACR_ADMIN_ENABLED=false MOCK_BUSYBOX_DIGEST_EXISTS=0
 
 cat > "$BIN/az" <<'STUB'
 #!/usr/bin/env bash
 echo "az $*" >> "$CALLS"
 case "$*" in
+  *"acr repository show"*"busybox@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"*)
+    [ "${MOCK_BUSYBOX_DIGEST_EXISTS:-0}" = 1 ] && exit 0 || exit 1 ;;
+  *"acr repository show"*"routerlicious:mock-tag"*|*"acr repository show"*"historian:mock-tag"*|*"acr repository show"*"gitrest:mock-tag"*)
+    exit 0 ;;
+  *"acr show"*"--query provisioningState"*) echo "Succeeded"; exit 0 ;;
+  *"acr show"*"--query adminUserEnabled"*)
+    if grep -q "acr update .*--admin-enabled false" "$CALLS"; then echo "false"; else echo "${MOCK_ACR_ADMIN_ENABLED:-false}"; fi
+    exit 0 ;;
+  *"acr show"*"--query resourceGroup"*)
+    [ "${MOCK_ACR_EXISTS:-0}" = 1 ] && echo "mock-rg" && exit 0 || exit 1 ;;
+  *"acr show"*"--query loginServer"*) echo "mockbuildacr.azurecr.io"; exit 0 ;;
+  *"acr show"*) [ "${MOCK_ACR_EXISTS:-0}" = 1 ] && exit 0 || exit 1 ;;
   *"extension show"*"redisenterprise"*)                                  exit 0 ;;
   *"redisenterprise create --help"*)
     printf '%s\n' "--access-keys-authentication"
@@ -95,7 +110,7 @@ REL_DIR="$RELEASE_ROOT/$REL_ID"
 mkdir -p "$REL_DIR/deployment/azure"
 cp "$AZURE_DIR"/*.yaml "$REL_DIR/deployment/azure/" 2>/dev/null || true
 printf '{"sourceRepo":"https://github.com/microsoft/FluidFramework","resolvedCommitSha":"0123456789abcdef0123456789abcdef01234567"}\n' > "$REL_DIR/source.json"
-printf '{"builtImages":[{"name":"routerlicious","status":"pinned","tag":"mock-tag"}]}\n' > "$REL_DIR/images.json"
+printf '{"builtImages":[{"name":"routerlicious","status":"pinned","tag":"mock-tag"}],"dependencyImages":[{"name":"busybox","tag":"1.38.0-glibc","digest":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","status":"pinned"}]}\n' > "$REL_DIR/images.json"
 
 PARAMS="$WORK/params.json"
 # fluidRepoDir is mandatory since the release-pipeline merge; git is stubbed, so a directory with
@@ -168,7 +183,7 @@ group "1. Parameter parsing"
 while IFS='=' read -r k v; do printf -v "V_$k" '%s' "$v"; done < <(
   read_vars "$PARAMS" EVENTHUBS_NAMESPACE EVENTHUBS_SKU EVENTHUBS_CAPACITY EVENTHUBS_PARTITIONS \
             EVENTHUBS_RETENTION_HOURS EVENTHUBS_ZONE_REDUNDANT KAFKA_ENDPOINT REDIS_SKU \
-            REDIS_HIGH_AVAILABILITY REDIS_PORT)
+            REDIS_HIGH_AVAILABILITY REDIS_PORT BUSYBOX_IMAGE)
 assert_eq "namespaceName parsed"  "${V_EVENTHUBS_NAMESPACE:-}"       "mock-eventhubs"
 assert_eq "sku parsed"            "${V_EVENTHUBS_SKU:-}"             "Standard"
 assert_eq "capacity parsed"       "${V_EVENTHUBS_CAPACITY:-}"        "1"
@@ -180,6 +195,8 @@ assert_eq "KAFKA_ENDPOINT is the TLS Kafka head on 9093" \
 assert_eq "Azure Managed Redis defaults to Balanced_B5" "${V_REDIS_SKU:-}" "Balanced_B5"
 assert_eq "Azure Managed Redis high availability is parsed" "${V_REDIS_HIGH_AVAILABILITY:-}" "Enabled"
 assert_eq "Azure Managed Redis uses port 10000" "${V_REDIS_PORT:-}" "10000"
+assert_eq "secret init image uses the release-pinned ACR digest" "${V_BUSYBOX_IMAGE:-}" \
+  "mockacr.azurecr.io/busybox@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
 TILDE="$WORK/params-tilde.json"
 jq '.fluidRepoDir = "~/fluid"' "$PARAMS" > "$TILDE"
@@ -275,6 +292,70 @@ export MOCK_REDIS_HA=Enabled
 # ---------------------------------------------------------------------------
 group "5. Guard rails"
 # ---------------------------------------------------------------------------
+: > "$CALLS"; export MOCK_ACR_EXISTS=0 MOCK_ACR_ADMIN_ENABLED=false
+out="$(run_phase 'phase0_rg_acr')"; rc=$?
+assert_eq "fresh deploy ACR provisioning exits 0" "$rc" "0"
+assert_has "fresh deploy ACR disables the admin account at creation" "$CALLS" "--admin-enabled false"
+
+: > "$CALLS"; export MOCK_ACR_EXISTS=1 MOCK_ACR_ADMIN_ENABLED=true
+out="$(run_phase 'phase0_rg_acr')"; rc=$?
+assert_eq "existing deploy ACR reconciliation exits 0" "$rc" "0"
+assert_has "existing deploy ACR has its admin account disabled" "$CALLS" "acr update -g mock-rg -n mockacr --admin-enabled false"
+
+: > "$CALLS"; export MOCK_ACR_EXISTS=1 MOCK_ACR_ADMIN_ENABLED=true
+build_registry="$(
+  PARAMETERS_FILE="$PARAMS" "$AZURE_DIR/../release/setup-build-registry.sh" mockbuildacr 2>/dev/null
+)"; rc=$?
+assert_eq "existing build ACR reconciliation exits 0" "$rc" "0"
+assert_eq "build ACR setup still returns its login server" "$build_registry" "mockbuildacr.azurecr.io"
+assert_has "existing build ACR has its admin account disabled" "$CALLS" \
+  "acr update -g mock-rg -n mockbuildacr --admin-enabled false"
+
+: > "$CALLS"; export MOCK_BUSYBOX_DIGEST_EXISTS=0
+out="$(run_phase 'phase1_images')"; rc=$?
+assert_eq "dependency image import exits 0" "$rc" "0"
+assert_has "dependency import checks the release-pinned digest" "$CALLS" \
+  "busybox@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+assert_has "missing pinned busybox digest is imported into the deploy ACR" "$CALLS" \
+  "acr import --name mockacr --source docker.io/library/busybox@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+: > "$CALLS"; export MOCK_BUSYBOX_DIGEST_EXISTS=1
+out="$(run_phase 'phase1_images')"; rc=$?
+assert_eq "existing dependency digest check exits 0" "$rc" "0"
+if grep -q "acr import .*busybox" "$CALLS"; then
+  no "existing pinned busybox digest is not re-imported"
+else
+  ok "existing pinned busybox digest is not re-imported"
+fi
+
+export MOCK_ACR_EXISTS=0 MOCK_ACR_ADMIN_ENABLED=false MOCK_BUSYBOX_DIGEST_EXISTS=0
+assert_has "deploy ACR is created with its admin account disabled" "$AZURE_DIR/deploy.sh" "--admin-enabled false"
+if grep -qF -- "--admin-enabled true" "$AZURE_DIR/deploy.sh"; then
+  no "deploy.sh never enables the ACR admin account"
+else
+  ok "deploy.sh never enables the ACR admin account"
+fi
+assert_has "build ACR is created with its admin account disabled" \
+  "$AZURE_DIR/../release/setup-build-registry.sh" "--admin-enabled false"
+if grep -qF -- "--admin-enabled true" "$AZURE_DIR/../release/setup-build-registry.sh"; then
+  no "setup-build-registry.sh never enables the ACR admin account"
+else
+  ok "setup-build-registry.sh never enables the ACR admin account"
+fi
+assert_has "secret init patch receives the pinned image reference" "$AZURE_DIR/deploy.sh" \
+  '--arg busyboxImage "$busybox_image"'
+assert_has "secret init patch renders the pinned image reference" "$AZURE_DIR/deploy.sh" \
+  '"name": "load-secrets", "image": $busyboxImage'
+assert_has "dependency imports verify the expected digest, not only a mutable tag" "$AZURE_DIR/deploy.sh" \
+  '--image "$target_repo@$digest"'
+if grep -qF "source \"\$AFD_HOSTS_FILE\"" "$AZURE_DIR/deploy.sh"; then
+  no "Front Door deployment state is never executed as shell"
+else
+  ok "Front Door deployment state is never executed as shell"
+fi
+assert_has "deployment artifacts use a private unpredictable directory" "$AZURE_DIR/deploy.sh" \
+  'mktemp -d "$TEMP_BASE/selfhost-fluid-${AKS}.XXXXXX"'
+
 export MOCK_NS_EXISTS=1 MOCK_TIER=Basic
 out="$(run_phase 'phase3_eventhubs')"; rc=$?
 [[ $rc -ne 0 ]] && ok "Basic tier rejected (it has no Kafka endpoint)" \

--- a/tools/selfhost/release/README.md
+++ b/tools/selfhost/release/README.md
@@ -33,23 +33,33 @@ Run from the `tools/selfhost` root:
 TARGET_PLATFORM=linux/amd64 \
 ACR_LOGIN_SERVER=myacr.azurecr.io \
 FLUID_DIR=~/src/FluidFramework \
-./release/generate-release.sh <reviewed-client-tag> r0.1.0
+./release/generate-release.sh <reviewed-server-or-client-tag> r0.1.0
 ```
 
-Fluid Framework client tags are published on the
-[FluidFramework tags page](https://github.com/microsoft/FluidFramework/tags). To list them from the
-dedicated clone, including tags not present when the clone was created:
+Fluid Framework server and client release tags are published on the
+[FluidFramework tags page](https://github.com/microsoft/FluidFramework/tags). Prefer a `server_v*`
+release for a self-host deployment: server releases identify a tested set of Routerlicious,
+Historian, Gitrest, and related server-package changes. Server releases are published less
+frequently than client releases, so a reviewed `client_v*` release is also a valid source when a
+more recent monorepo revision is required.
+
+Both tag families are Git references to a specific commit in the FluidFramework monorepo. The
+release scripts check out that complete commit and build the server images from the server source
+present at that revision; they do not install the published client or server npm packages. Fetch
+and list both tag families from the dedicated clone:
 
 ```bash
 cd "$FLUID_DIR"
 git fetch origin --tags
+git tag --list 'server_v*' --sort=-version:refname | head -20
 git tag --list 'client_v*' --sort=-version:refname | head -20
 ```
 
-After selecting and reviewing a tag, pass it directly to `generate-release.sh`:
+After selecting and reviewing either a server or client tag, pass it directly to
+`generate-release.sh`. For example:
 
 ```bash
-FLUID_TAG=client_v2.116.1
+FLUID_TAG=server_vX.Y.Z
 git -C "$FLUID_DIR" show --no-patch --format=fuller "$FLUID_TAG"
 
 TARGET_PLATFORM=linux/amd64 \
@@ -58,10 +68,12 @@ FLUID_DIR="$FLUID_DIR" \
 ./release/generate-release.sh "$FLUID_TAG" r0.1.0
 ```
 
-Review the selected tag and commit according to your source-review and change-management process
-before generating the release. The release tooling resolves the tag and records its immutable
-40-character commit SHA in `release-artifacts/<release-id>/source.json`. A full 40-character SHA can
-still be passed instead when releasing a reviewed commit that has no tag.
+Review the selected tag and its commit according to your source-review and change-management
+process before generating the release. The release tooling resolves either tag family to its
+immutable 40-character commit SHA and records that SHA in
+`release-artifacts/<release-id>/source.json`. You can pass a reviewed full 40-character commit SHA
+directly instead of a tag, including when a required server fix has not yet been included in a
+server or client release.
 
 This runs:
 

--- a/tools/selfhost/release/README.md
+++ b/tools/selfhost/release/README.md
@@ -33,8 +33,35 @@ Run from the `tools/selfhost` root:
 TARGET_PLATFORM=linux/amd64 \
 ACR_LOGIN_SERVER=myacr.azurecr.io \
 FLUID_DIR=~/src/FluidFramework \
-./release/generate-release.sh client_v2.43.0 r0.1.0
+./release/generate-release.sh <reviewed-client-tag> r0.1.0
 ```
+
+Fluid Framework client tags are published on the
+[FluidFramework tags page](https://github.com/microsoft/FluidFramework/tags). To list them from the
+dedicated clone, including tags not present when the clone was created:
+
+```bash
+cd "$FLUID_DIR"
+git fetch origin --tags
+git tag --list 'client_v*' --sort=-version:refname | head -20
+```
+
+After selecting and reviewing a tag, pass it directly to `generate-release.sh`:
+
+```bash
+FLUID_TAG=client_v2.116.1
+git -C "$FLUID_DIR" show --no-patch --format=fuller "$FLUID_TAG"
+
+TARGET_PLATFORM=linux/amd64 \
+ACR_LOGIN_SERVER=myacr.azurecr.io \
+FLUID_DIR="$FLUID_DIR" \
+./release/generate-release.sh "$FLUID_TAG" r0.1.0
+```
+
+Review the selected tag and commit according to your source-review and change-management process
+before generating the release. The release tooling resolves the tag and records its immutable
+40-character commit SHA in `release-artifacts/<release-id>/source.json`. A full 40-character SHA can
+still be passed instead when releasing a reviewed commit that has no tag.
 
 This runs:
 

--- a/tools/selfhost/release/build-images.sh
+++ b/tools/selfhost/release/build-images.sh
@@ -86,6 +86,7 @@ SOURCE_SHA="$(jq -r '.resolvedCommitSha' "$SOURCE_FILE")"
 # --- Check out the pinned SHA in the dedicated FluidFramework clone ----------
 ensure_fluid_checkout "$SOURCE_SHA" "$SOURCE_REPO"
 WORKDIR="$FLUID_DIR"
+validate_selfhost_source_compatibility "$WORKDIR"
 
 for svc in "${BUILT_IMAGES[@]}"; do
   [ -f "$WORKDIR/server/$svc/Dockerfile" ] || fail "checkout at $SOURCE_SHA has no server/$svc/Dockerfile."

--- a/tools/selfhost/release/lib.sh
+++ b/tools/selfhost/release/lib.sh
@@ -15,6 +15,18 @@ validate_checkout() {
   [ -z "$status" ] || fail "FLUID_DIR '$dir' has tracked edits or untracked files. This directory is used as the Docker build context and cannot have any uncommitted changes. Please stash or commit the changes and try again."
 }
 
+# Reject Fluid revisions with the Historian token-cache TTL unit bug fixed by
+# microsoft/FluidFramework#24984. The affected code passes milliseconds to Redis SET EX, causing
+# one-hour access tokens to remain cached for roughly 41 days under sustained unique-token load.
+validate_selfhost_source_compatibility() {
+  local dir="$1" revision
+  local riddler_service="$dir/server/historian/packages/historian-base/src/services/riddlerService.ts"
+  [ -f "$riddler_service" ] || fail "FluidFramework checkout is missing $riddler_service."
+  revision="$(git -C "$dir" rev-parse --short=12 HEAD 2>/dev/null || printf 'unknown')"
+  grep -qF 'Math.floor(tokenLifetimeInMSec / 1000)' "$riddler_service" \
+    || fail "FluidFramework revision $revision has the Historian token-cache TTL unit bug. Select a revision containing microsoft/FluidFramework#24984 (commit ed66a4d10427) and create a new release."
+}
+
 # Escape a value for safe embedding in a JSON string (backslash and double-quote only).
 json_escape() {
   local value="$1"

--- a/tools/selfhost/release/setup-build-registry.sh
+++ b/tools/selfhost/release/setup-build-registry.sh
@@ -65,11 +65,17 @@ if EXISTING_ACR_RESOURCE_GROUP="$(az acr show -n "$ACR_NAME" --query resourceGro
 else
   log "Creating ACR $ACR_NAME ($ACR_SKU) in $LOCATION"
   az acr create -g "$RESOURCE_GROUP" -n "$ACR_NAME" -l "$LOCATION" \
-    --sku "$ACR_SKU" --admin-enabled true --only-show-errors >/dev/null
+    --sku "$ACR_SKU" --admin-enabled false --only-show-errors >/dev/null
 fi
 
 [ "$(az acr show -g "$RESOURCE_GROUP" -n "$ACR_NAME" --query provisioningState -o tsv)" = "Succeeded" ] \
   || fail "ACR $ACR_NAME was not created successfully."
+if [ "$(az acr show -g "$RESOURCE_GROUP" -n "$ACR_NAME" --query adminUserEnabled -o tsv)" = "true" ]; then
+  log "Disabling the admin account on existing ACR $ACR_NAME"
+  az acr update -g "$RESOURCE_GROUP" -n "$ACR_NAME" --admin-enabled false --only-show-errors >/dev/null
+fi
+[ "$(az acr show -g "$RESOURCE_GROUP" -n "$ACR_NAME" --query adminUserEnabled -o tsv)" = "false" ] \
+  || fail "ACR $ACR_NAME admin account is still enabled."
 
 # --- Authenticate for docker push ---------------------------------------------
 log "Authenticating docker to $ACR_NAME (az acr login)"

--- a/tools/selfhost/tenant-admin/README.md
+++ b/tools/selfhost/tenant-admin/README.md
@@ -209,9 +209,16 @@ App reads to sign tokens.
 The full safe sequence is then:
 
 ```bash
-NEW_KEY="$(./tenant-admin.sh rotate contoso --key key2 | jq -r '.keys.key2')"
-az keyvault secret set --vault-name <kv> \
-  --name fluid-tenant-key-contoso --value "$NEW_KEY"
+(
+  NEW_KEY="$(./tenant-admin.sh rotate contoso --key key2 | jq -r '.keys.key2')"
+  KEY_FILE="$(mktemp)"
+  trap 'rm -f "$KEY_FILE"' EXIT
+  chmod 600 "$KEY_FILE"
+  printf '%s' "$NEW_KEY" > "$KEY_FILE"
+  unset NEW_KEY
+  az keyvault secret set --vault-name <kv> \
+    --name fluid-tenant-key-contoso --file "$KEY_FILE" --encoding utf-8
+)
 # restart the Function App or wait for its Key Vault reference to refresh
 # confirm minting is healthy
 ./tenant-admin.sh rotate contoso --key key1                  # key2 now signs tokens

--- a/tools/selfhost/tenant-admin/tenant-admin.sh
+++ b/tools/selfhost/tenant-admin/tenant-admin.sh
@@ -259,7 +259,7 @@ case "$COMMAND" in
     case "$KV_CHECK" in
       performed)
         echo "Write the new key into Key Vault so the token service picks it up:" >&2
-        echo "  az keyvault secret set --vault-name $KV_NAME --name $KV_SECRET --value <the new key>" >&2
+        echo "  az keyvault secret set --vault-name $KV_NAME --name $KV_SECRET --file <0600-file-containing-the-new-key> --encoding utf-8" >&2
         ;;
       skipped-no-secret)
         echo "In-use key check: no secret '$KV_SECRET' in Key Vault '$KV_NAME' -- no token service uses this tenant's key." >&2

--- a/tools/selfhost/token-service/README.md
+++ b/tools/selfhost/token-service/README.md
@@ -451,10 +451,18 @@ So, starting from this service signing with `key1`:
 
 ```bash
 # 1. Rotate the key nobody is using. Allowed, because key1 is the one in the vault.
-NEW_KEY=$(tenant-admin/tenant-admin.sh rotate fluid --key key2 | jq -r .keys.key2)
+(
+  NEW_KEY=$(tenant-admin/tenant-admin.sh rotate fluid --key key2 | jq -r .keys.key2)
 
-# 2. Point this service at it.
-az keyvault secret set --vault-name <vault> --name fluid-tenant-key-fluid --value "$NEW_KEY"
+  # 2. Point this service at it.
+  KEY_FILE="$(mktemp)"
+  trap 'rm -f "$KEY_FILE"' EXIT
+  chmod 600 "$KEY_FILE"
+  printf '%s' "$NEW_KEY" > "$KEY_FILE"
+  unset NEW_KEY
+  az keyvault secret set --vault-name <vault> --name fluid-tenant-key-fluid \
+    --file "$KEY_FILE" --encoding utf-8
+)
 az functionapp restart -g <rg> -n <function app>
 
 # 3. Confirm minting is healthy, then retire the old key. Now allowed: key2 is in the vault.

--- a/tools/selfhost/token-service/deploy-token-service.sh
+++ b/tools/selfhost/token-service/deploy-token-service.sh
@@ -281,7 +281,7 @@ restore_keyvault_public_access() {
 
 cleanup_temporary_role_assignments() {
   local id
-  for id in "${TEMP_ROLE_ASSIGNMENT_IDS[@]}"; do
+  for id in "${TEMP_ROLE_ASSIGNMENT_IDS[@]+"${TEMP_ROLE_ASSIGNMENT_IDS[@]}"}"; do
     [[ -n "$id" ]] || continue
     log "Removing temporary Key Vault role assignment"
     az rest --method delete \
@@ -299,19 +299,26 @@ trap cleanup_deployment_state EXIT
 # A fresh role assignment takes a minute or two to reach the data plane, so Forbidden right
 # after granting one is usually propagation rather than a real denial.
 keyvault_secret_set_with_retry() {
-  local vault="$1" name="$2" value="$3" attempt err="$TOKEN_SERVICE_TEMP_DIR/keyvault.err"
+  local vault="$1" name="$2" value="$3" attempt
+  local err="$TOKEN_SERVICE_TEMP_DIR/keyvault.err"
+  local value_file="$TOKEN_SERVICE_TEMP_DIR/keyvault-value"
+  : > "$value_file"
+  chmod 600 "$value_file"
+  printf '%s' "$value" > "$value_file"
+  unset value
   for attempt in 1 2 3 4 5 6; do
-    if az keyvault secret set --vault-name "$vault" --name "$name" --value "$value" >/dev/null 2>"$err"; then
-      rm -f "$err"; return 0
+    if az keyvault secret set --vault-name "$vault" --name "$name" \
+      --file "$value_file" --encoding utf-8 >/dev/null 2>"$err"; then
+      rm -f "$err" "$value_file"; return 0
     fi
     if grep -q "Public network access is disabled" "$err" 2>/dev/null; then
-      cat "$err" >&2; rm -f "$err"
+      cat "$err" >&2; rm -f "$err" "$value_file"
       fail "Key Vault $vault is unreachable: public network access is disabled and this machine
 is outside its VNet. phase_tenant_key should have enabled it temporarily for this workstation
 write; confirm the update was not blocked by Azure Policy."
     fi
     if ! grep -qi "Forbidden\|ForbiddenByRbac" "$err" 2>/dev/null || [[ $attempt -eq 6 ]]; then
-      cat "$err" >&2; rm -f "$err"
+      cat "$err" >&2; rm -f "$err" "$value_file"
       fail "Could not write secret '$name' to Key Vault $vault."
     fi
     log "  waiting for the role assignment to propagate (attempt $attempt)..."
@@ -1044,23 +1051,30 @@ phase_deploy_code() {
     conn="$(az storage account show-connection-string -g "$FUNC_RG" -n "$FUNC_STORAGE" \
       --query connectionString -o tsv)"
 
-    az storage container create --name "$container" --connection-string "$conn" \
+    AZURE_STORAGE_CONNECTION_STRING="$conn" az storage container create --name "$container" \
       --only-show-errors >/dev/null
 
-    az storage blob upload --container-name "$container" --name "$package" --file "$zip" \
-      --connection-string "$conn" --overwrite --only-show-errors >/dev/null ||
+    AZURE_STORAGE_CONNECTION_STRING="$conn" az storage blob upload \
+      --container-name "$container" --name "$package" --file "$zip" \
+      --overwrite --only-show-errors >/dev/null ||
       fail "Could not upload the deployment package to $FUNC_STORAGE."
 
     # The app reads this URL on every cold start, so the SAS has to outlive the deployment.
     expiry="$(date -u -v+2y '+%Y-%m-%dT%H:%MZ' 2>/dev/null || date -u -d '+2 years' '+%Y-%m-%dT%H:%MZ')"
-    url="$(az storage blob generate-sas --container-name "$container" --name "$package" \
-      --permissions r --expiry "$expiry" --connection-string "$conn" \
+    url="$(AZURE_STORAGE_CONNECTION_STRING="$conn" az storage blob generate-sas \
+      --container-name "$container" --name "$package" \
+      --permissions r --expiry "$expiry" \
       --full-uri --only-show-errors -o tsv)" ||
       fail "Could not generate a read SAS for the deployment package."
+    unset conn
 
+    local package_setting="$TOKEN_SERVICE_TEMP_DIR/package-setting.json"
+    jq -n --arg url "$url" '{WEBSITE_RUN_FROM_PACKAGE: $url}' > "$package_setting"
+    unset url
     site_write "Pointing the app at the new package" \
       az functionapp config appsettings set -g "$FUNC_RG" -n "$FUNC_APP" \
-      --settings "WEBSITE_RUN_FROM_PACKAGE=$url"
+      --settings "@$package_setting"
+    rm -f "$package_setting"
 
     log "Restarting to pick up the new package"
     site_write "Restarting" az functionapp restart -g "$FUNC_RG" -n "$FUNC_APP"

--- a/tools/selfhost/token-service/deploy-token-service.sh
+++ b/tools/selfhost/token-service/deploy-token-service.sh
@@ -215,7 +215,7 @@ ENTRA_TENANT_ID="$(az account show --query tenantId -o tsv)"
 # retried rather than treated as failures. Anything else fails immediately.
 site_write() {
   local desc="$1"; shift
-  local err="${TMPDIR:-/tmp}/tokensvc-write.$$" attempt
+  local err="$TOKEN_SERVICE_TEMP_DIR/site-write.err" attempt
   for attempt in 1 2 3 4; do
     if "$@" >/dev/null 2>"$err"; then
       rm -f "$err"
@@ -266,6 +266,8 @@ ensure_role_assignment() {
   fi
 }
 
+TOKEN_SERVICE_TEMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/selfhost-token-service.XXXXXX")"
+chmod 700 "$TOKEN_SERVICE_TEMP_DIR"
 TEMP_ROLE_ASSIGNMENT_IDS=()
 KV_PUBLIC_ACCESS_ORIGINAL=""
 
@@ -290,13 +292,14 @@ cleanup_temporary_role_assignments() {
 cleanup_deployment_state() {
   restore_keyvault_public_access || true
   cleanup_temporary_role_assignments
+  rm -rf "$TOKEN_SERVICE_TEMP_DIR"
 }
 trap cleanup_deployment_state EXIT
 
 # A fresh role assignment takes a minute or two to reach the data plane, so Forbidden right
 # after granting one is usually propagation rather than a real denial.
 keyvault_secret_set_with_retry() {
-  local vault="$1" name="$2" value="$3" attempt err="${TMPDIR:-/tmp}/tokensvc-kv.$$"
+  local vault="$1" name="$2" value="$3" attempt err="$TOKEN_SERVICE_TEMP_DIR/keyvault.err"
   for attempt in 1 2 3 4 5 6; do
     if az keyvault secret set --vault-name "$vault" --name "$name" --value "$value" >/dev/null 2>"$err"; then
       rm -f "$err"; return 0
@@ -342,7 +345,7 @@ phase_app_registration() {
 
   # Fail on the first Graph call rather than partway through, so a blocked directory is
   # reported once with the way forward instead of as a create error.
-  local probe_err="${TMPDIR:-/tmp}/tokensvc-graphprobe.$$"
+  local probe_err="$TOKEN_SERVICE_TEMP_DIR/graph-probe.err"
   if ! az ad app list --display-name "$APP_REG_NAME" --query "[0].appId" -o tsv >/dev/null 2>"$probe_err"; then
     if grep -q "AADSTS530084\|AADSTS50076\|AADSTS50079" "$probe_err"; then
       cat "$probe_err" >&2
@@ -372,7 +375,7 @@ on the registration. Everything else here uses ARM, which this policy does not a
     # AzureADMyOrg confines sign-in to this directory. A multi-tenant registration would let
     # any Entra account in the world authenticate, leaving the tenant check in identity.js as
     # the only thing standing between an outsider and a token.
-    local create_err="${TMPDIR:-/tmp}/tokensvc-appcreate.$$"
+    local create_err="$TOKEN_SERVICE_TEMP_DIR/app-create.err"
     if ! APP_ID="$(az ad app create \
       --display-name "$APP_REG_NAME" \
       --sign-in-audience AzureADMyOrg \
@@ -603,7 +606,7 @@ then re-run:
     # So a failed create is not treated as a failed creation. Re-issuing it would only add more
     # contention for the same lock; instead the site is polled for, and only a site that never
     # appears is a real failure.
-    local create_err="${TMPDIR:-/tmp}/tokensvc-create.$$"
+    local create_err="$TOKEN_SERVICE_TEMP_DIR/function-create.err"
     local -a create_args=(-g "$FUNC_RG" -n "$FUNC_APP" --storage-account "$FUNC_STORAGE"
       --runtime node --runtime-version "$NODE_VERSION" --assign-identity "[system]")
     if [[ "$HOSTING_PLAN" == "flex" ]]; then
@@ -717,7 +720,7 @@ phase_tenant_key() {
 
   local tenant tenant_check_err
   local -a existing_tenants=()
-  tenant_check_err="${TMPDIR:-/tmp}/tokensvc-tenant-check.$$"
+  tenant_check_err="$TOKEN_SERVICE_TEMP_DIR/tenant-check.err"
   for tenant in "${TENANTS[@]}"; do
     if "$SELFHOST_ROOT/tenant-admin/tenant-admin.sh" --params "$PARAMS_FILE" \
       get "$tenant" >/dev/null 2>"$tenant_check_err"; then
@@ -938,11 +941,12 @@ $FUNC_APP. This needs the authV2 az CLI extension: az extension add --name authV
     | ($gv | .excludedPaths = (((.excludedPaths // []) + ["/api/health"]) | unique)) as $gv2
     | { properties: ($p | .identityProviders = $ip3 | .globalValidation = $gv2) }' 2>/dev/null || true)"
   if [[ -n "$disabled" && "$disabled" != "null" ]]; then
-    printf '%s' "$disabled" > "${TMPDIR:-/tmp}/tokensvc-auth.$$"
+    local auth_body="$TOKEN_SERVICE_TEMP_DIR/auth-settings.json"
+    printf '%s' "$disabled" > "$auth_body"
     site_write "Setting audiences and disabling unused providers" \
       az rest --method PUT --url "$auth_url" --headers "Content-Type=application/json" \
-      --body "@${TMPDIR:-/tmp}/tokensvc-auth.$$"
-    rm -f "${TMPDIR:-/tmp}/tokensvc-auth.$$"
+      --body "@$auth_body"
+    rm -f "$auth_body"
   fi
 
 }

--- a/tools/selfhost/token-service/test/deploymentSecurity.test.js
+++ b/tools/selfhost/token-service/test/deploymentSecurity.test.js
@@ -20,6 +20,10 @@ const TOKEN_FUNCTIONS = fs.readFileSync(
 	"utf8",
 );
 const STACK_DEPLOY = fs.readFileSync(path.join(ROOT, "azure", "deploy.sh"), "utf8");
+const PREFLIGHT = fs.readFileSync(
+	path.join(ROOT, "azure", "preflight-check.sh"),
+	"utf8",
+);
 
 test("workstation deployment restores Key Vault network isolation", () => {
 	assert.match(TOKEN_DEPLOY, /--public-network-access Enabled/);
@@ -38,6 +42,26 @@ test("temporary deployer Key Vault roles are removed on exit", () => {
 	}
 	assert.match(TOKEN_DEPLOY, /trap cleanup_deployment_state EXIT/);
 	assert.match(STACK_DEPLOY, /trap cleanup_deployment_state EXIT/);
+});
+
+test("deployment tooling uses private unpredictable temporary paths", () => {
+	for (const script of [TOKEN_DEPLOY, STACK_DEPLOY, PREFLIGHT]) {
+		assert.doesNotMatch(script, /\/tmp\/[^\s"']*\$\$/);
+		assert.doesNotMatch(script, /\$\{TMPDIR:-\/tmp\}\/[^\s"']*\$\$/);
+	}
+	assert.match(
+		TOKEN_DEPLOY,
+		/mktemp -d "\$\{TMPDIR:-\/tmp\}\/selfhost-token-service\.XXXXXX"/,
+	);
+	assert.match(TOKEN_DEPLOY, /rm -rf "\$TOKEN_SERVICE_TEMP_DIR"/);
+	assert.match(
+		STACK_DEPLOY,
+		/mktemp -d "\$TEMP_BASE\/selfhost-fluid-\$\{AKS\}\.XXXXXX"/,
+	);
+	assert.match(
+		PREFLIGHT,
+		/mktemp -d "\$\{TMPDIR:-\/tmp\}\/selfhost-preflight\.XXXXXX"/,
+	);
 });
 
 test("Function App platform hardening is configured and verified", () => {

--- a/tools/selfhost/token-service/test/deploymentSecurity.test.js
+++ b/tools/selfhost/token-service/test/deploymentSecurity.test.js
@@ -20,10 +20,7 @@ const TOKEN_FUNCTIONS = fs.readFileSync(
 	"utf8",
 );
 const STACK_DEPLOY = fs.readFileSync(path.join(ROOT, "azure", "deploy.sh"), "utf8");
-const PREFLIGHT = fs.readFileSync(
-	path.join(ROOT, "azure", "preflight-check.sh"),
-	"utf8",
-);
+const PREFLIGHT = fs.readFileSync(path.join(ROOT, "azure", "preflight-check.sh"), "utf8");
 
 test("workstation deployment restores Key Vault network isolation", () => {
 	assert.match(TOKEN_DEPLOY, /--public-network-access Enabled/);
@@ -54,14 +51,8 @@ test("deployment tooling uses private unpredictable temporary paths", () => {
 		/mktemp -d "\$\{TMPDIR:-\/tmp\}\/selfhost-token-service\.XXXXXX"/,
 	);
 	assert.match(TOKEN_DEPLOY, /rm -rf "\$TOKEN_SERVICE_TEMP_DIR"/);
-	assert.match(
-		STACK_DEPLOY,
-		/mktemp -d "\$TEMP_BASE\/selfhost-fluid-\$\{AKS\}\.XXXXXX"/,
-	);
-	assert.match(
-		PREFLIGHT,
-		/mktemp -d "\$\{TMPDIR:-\/tmp\}\/selfhost-preflight\.XXXXXX"/,
-	);
+	assert.match(STACK_DEPLOY, /mktemp -d "\$TEMP_BASE\/selfhost-fluid-\$\{AKS\}\.XXXXXX"/);
+	assert.match(PREFLIGHT, /mktemp -d "\$\{TMPDIR:-\/tmp\}\/selfhost-preflight\.XXXXXX"/);
 });
 
 test("deployment tooling keeps secret values out of process arguments", () => {
@@ -82,15 +73,9 @@ test("deployment tooling keeps secret values out of process arguments", () => {
 		/\$\{SENSITIVE_TEMP_FILES\[@\]\+"\$\{SENSITIVE_TEMP_FILES\[@\]\}"\}/,
 	);
 	assert.doesNotMatch(TOKEN_DEPLOY, /--connection-string "\$conn"/);
-	assert.match(
-		TOKEN_DEPLOY,
-		/AZURE_STORAGE_CONNECTION_STRING="\$conn" az storage/,
-	);
+	assert.match(TOKEN_DEPLOY, /AZURE_STORAGE_CONNECTION_STRING="\$conn" az storage/);
 	assert.match(TOKEN_DEPLOY, /--settings "@\$package_setting"/);
-	assert.doesNotMatch(
-		TOKEN_DEPLOY,
-		/--settings "WEBSITE_RUN_FROM_PACKAGE=\$url"/,
-	);
+	assert.doesNotMatch(TOKEN_DEPLOY, /--settings "WEBSITE_RUN_FROM_PACKAGE=\$url"/);
 });
 
 test("Function App platform hardening is configured and verified", () => {

--- a/tools/selfhost/token-service/test/deploymentSecurity.test.js
+++ b/tools/selfhost/token-service/test/deploymentSecurity.test.js
@@ -64,6 +64,35 @@ test("deployment tooling uses private unpredictable temporary paths", () => {
 	);
 });
 
+test("deployment tooling keeps secret values out of process arguments", () => {
+	for (const script of [TOKEN_DEPLOY, STACK_DEPLOY]) {
+		assert.match(script, /keyvault secret set[\s\S]{0,160}--file/);
+		assert.doesNotMatch(script, /keyvault secret set[^\n]*--value/);
+	}
+	assert.match(STACK_DEPLOY, /SENSITIVE_TEMP_FILES/);
+	assert.match(STACK_DEPLOY, /cleanup_sensitive_temp_files/);
+	for (const script of [TOKEN_DEPLOY, STACK_DEPLOY]) {
+		assert.match(
+			script,
+			/\$\{TEMP_ROLE_ASSIGNMENT_IDS\[@\]\+"\$\{TEMP_ROLE_ASSIGNMENT_IDS\[@\]\}"\}/,
+		);
+	}
+	assert.match(
+		STACK_DEPLOY,
+		/\$\{SENSITIVE_TEMP_FILES\[@\]\+"\$\{SENSITIVE_TEMP_FILES\[@\]\}"\}/,
+	);
+	assert.doesNotMatch(TOKEN_DEPLOY, /--connection-string "\$conn"/);
+	assert.match(
+		TOKEN_DEPLOY,
+		/AZURE_STORAGE_CONNECTION_STRING="\$conn" az storage/,
+	);
+	assert.match(TOKEN_DEPLOY, /--settings "@\$package_setting"/);
+	assert.doesNotMatch(
+		TOKEN_DEPLOY,
+		/--settings "WEBSITE_RUN_FROM_PACKAGE=\$url"/,
+	);
+});
+
 test("Function App platform hardening is configured and verified", () => {
 	for (const setting of [
 		"properties.minTlsVersion=1.2",


### PR DESCRIPTION
## Description

Hardens the customer-operated selfhost deployment against supply-chain and local deployment-host risks, removes high-value secrets from process argument lists, and prevents release revisions with known Redis retention regressions from being built or deployed.

### Container and registry hardening

- Resolves the secret-loading BusyBox init container from the release bundle's pinned dependency digest and pulls it from the customer's deploy ACR instead of using the mutable public `busybox:latest` reference.
- Reconciles existing Routerlicious deployments to the pinned init-container image as well as the current secret-loading command.
- Checks dependency-image presence in ACR by the expected digest rather than accepting an unrelated image under the same tag.
- Creates both build and deploy ACRs with their admin accounts disabled and reconciles existing registries back to that state.
- Preserves the existing identity-based paths: operators push through `az acr login`, imports use Azure control-plane authorization, and AKS pulls through the kubelet identity's `AcrPull` role.

### Deployment-host and temporary-file hardening

- Replaces the predictable per-cluster deployment directory with a private randomized directory.
- Removes the executable `afd-hosts.env` state file. Helm now obtains Front Door endpoint hostnames directly from Azure rather than sourcing temporary state as shell code.
- Replaces PID-derived files under shared `/tmp` with files under private randomized deployment or preflight directories.
- Gives the token-service deployer its own private temporary directory and removes it on exit.
- Makes cleanup compatible with the Bash 3.2 empty-array behavior used by the macOS system shell.

### Secret handling

- Writes Cosmos, Redis, Event Hubs, and Fluid tenant values to private `0600` files and supplies them to `az keyvault secret set --file`, avoiding plaintext secret values in process arguments.
- Tracks sensitive deployment files so interruption cleanup removes them before restoring network and RBAC state.
- Uses `AZURE_STORAGE_CONNECTION_STRING` for classic Function package storage operations rather than passing the connection string on the command line.
- Supplies the `WEBSITE_RUN_FROM_PACKAGE` SAS URL through a private JSON settings file.
- Updates tenant-key rotation and manual deployment instructions to use the same private-file pattern.

### Redis retention compatibility

- Adds a shared source-compatibility check used before image builds and deployments.
- Rejects FluidFramework revisions that predate the Historian token-cache TTL unit correction from [microsoft/FluidFramework#24984](https://github.com/microsoft/FluidFramework/pull/24984). Affected revisions passed milliseconds to Redis `SET EX`, allowing one-hour access tokens to remain cached for roughly 41 days under sustained unique-token load.
- Documents selecting and reviewing a current client release tag before generating a selfhost release.

### Runtime configuration corrections

- Renders `usage.clientConnectivityCountingEnabled` as a JSON boolean instead of the truthy string `"false"`. This prevents Nexus from appending disabled connectivity-accounting records to the non-expiring `clientConnectivityUsage` Redis list.
- Emits `maxTokenLifetimeSec` at both the Routerlicious `auth` path and the legacy root path still consumed by Historian, keeping token-cache retention aligned across services.

### Redeployment reliability

- Reuses an existing private DNS link when the target VNet is already linked under a different resource-derived link name. This avoids duplicate-link failures when resources are renamed or deployments are rerun.

Regression coverage was added for pinned init-image selection and reconciliation, digest-aware ACR imports, disabled ACR admin accounts, private temporary paths, secret-free Azure CLI arguments, Bash 3.2 cleanup, source compatibility, Redis configuration typing, legacy Historian token lifetime output, and private DNS link reuse.

## Reviewer Guidance

The review process is outlined in [the pull request guidelines](../docs/content/Contributing/PR-Guidelines.md#guidelines).

The branch contains four intentionally separate commits:

1. Deployment bootstrap, image, and ACR hardening.
2. Predictable temporary-file removal.
3. Secret argument removal.
4. Redis-retention compatibility and private-DNS redeployment fixes.

Please pay particular attention to the release-source compatibility gate, the dual `maxTokenLifetimeSec` output required by Historian and Routerlicious, and the migration of existing `load-secrets` init containers to the ACR-hosted digest.
