### PR TITLE
Document FLUID_DIR, SHA resolution, and az acr login in tools/selfhost README

### DIFF
--- a/tools/selfhost/README.md
+++ b/tools/selfhost/README.md
@@ -37,15 +37,19 @@ Steps 1–4 get you a running, verified deployment. Steps 5–6 are what you nee
 
 Once step 1 is done, `release/create-and-deploy-release.sh` runs steps 2 and 3 as a single command
 if you would rather not do them separately. It needs the `FLUID_DIR` environment variable set (see
-below) and a real commit SHA rather than a branch name — resolve one with `git rev-parse`. Also
-sign in to the build registry first: this step pushes freshly built images, and an expired ACR
+below) and a tag or a real commit SHA rather than a branch name — two ways to get one:
+
+- **Use an existing release tag** — search [the release list](https://github.com/microsoft/FluidFramework/releases?page=1)
+  for one (for example, `server_v7.0.1`).
+- **Resolve a SHA from a branch** with `git rev-parse`, e.g. `git rev-parse origin/main`.
+
+Also sign in to the build registry first: this step pushes freshly built images, and an expired ACR
 login is a common cause of a failed push partway through the build.
 
 ```bash
 az acr login -n <buildAcr.name from your parameters file>
-git rev-parse origin/main
 FLUID_DIR=/path/to/your/FluidFramework/clone ACR_LOGIN_SERVER=<buildAcr.name>.azurecr.io \
-  ./release/create-and-deploy-release.sh <sha-from-git-rev-parse> <release-id>
+  ./release/create-and-deploy-release.sh <tag-or-sha> <release-id>
 ```
 
 ## What each folder is

--- a/tools/selfhost/README.md
+++ b/tools/selfhost/README.md
@@ -36,7 +36,17 @@ Work through these in order. Each folder has its own README with the detail.
 Steps 1–4 get you a running, verified deployment. Steps 5–6 are what you need before real users.
 
 Once step 1 is done, `release/create-and-deploy-release.sh` runs steps 2 and 3 as a single command
-if you would rather not do them separately.
+if you would rather not do them separately. It needs the `FLUID_DIR` environment variable set (see
+below) and a real commit SHA rather than a branch name — resolve one with `git rev-parse`. Also
+sign in to the build registry first: this step pushes freshly built images, and an expired ACR
+login is a common cause of a failed push partway through the build.
+
+```bash
+az acr login -n <buildAcr.name from your parameters file>
+git rev-parse origin/main
+FLUID_DIR=/path/to/your/FluidFramework/clone ACR_LOGIN_SERVER=<buildAcr.name>.azurecr.io \
+  ./release/create-and-deploy-release.sh <sha-from-git-rev-parse> <release-id>
+```
 
 ## What each folder is
 


### PR DESCRIPTION
## Description

Adds a concrete example to `tools/selfhost/README.md`'s "Where to start" section for running
`release/create-and-deploy-release.sh`: setting the `FLUID_DIR` environment variable, resolving a
real commit SHA with `git rev-parse` (the release scripts reject a branch name), and signing in to
the build ACR first — an expired `az acr login` token is a common cause of a failed image push
partway through the release build.

## Reviewer Guidance

The review process is outlined in [the pull request guidelines](../docs/content/Contributing/PR-Guidelines.md#guidelines).

Docs-only change; no functional/script changes.