### PR TITLE
refactor(tree): no object spread in commit codec

### DIFF
--- a/packages/dds/tree/src/shared-tree-core/editManagerCodecsCommons.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerCodecsCommons.ts
@@ -28,7 +28,6 @@ import type { SharedBranchSummaryData } from "./editManager.js";
 import type {
 	Commit,
 	EncodedCommit,
-	EncodedSequencedCommit,
 	EncodedSharedBranch,
 	SequenceId,
 	SequencedCommit,
@@ -74,7 +73,7 @@ function encodeCommit<TChangeset, T extends Commit<TChangeset>>(
 	commit: T,
 	context: ChangeEncodingContext,
 	includeCustomMetadata: boolean,
-): EncodedCommit<JsonCompatibleReadOnly> {
+): Mutable<EncodedCommit<JsonCompatibleReadOnly>> {
 	const encoded: Mutable<EncodedCommit<JsonCompatibleReadOnly>> = {
 		change: changeCodec.encode(commit.change, { ...context, revision: commit.revision }),
 		revision: revisionTagCodec.encode(commit.revision, {
@@ -143,22 +142,20 @@ export function encodeSharedBranch<TChangeset>(
 ): EncodedSharedBranch<JsonCompatibleReadOnly> {
 	const json: Mutable<EncodedSharedBranch<JsonCompatibleReadOnly>> = {
 		trunk: data.trunk.map((commit) => {
-			const encoded: Mutable<EncodedSequencedCommit<JsonCompatibleReadOnly>> = {
-				...encodeCommit(
-					changeCodec,
-					revisionTagCodec,
-					commit,
-					{
-						originatorId: commit.sessionId,
-						idCompressor: context.idCompressor,
-						schema: context.schema,
-						revision: undefined,
-						isSummary: context.isSummary,
-					},
-					includeCustomMetadata,
-				),
-				sequenceNumber: commit.sequenceNumber,
-			};
+			const encoded = encodeCommit(
+				changeCodec,
+				revisionTagCodec,
+				commit,
+				{
+					originatorId: commit.sessionId,
+					idCompressor: context.idCompressor,
+					schema: context.schema,
+					revision: undefined,
+					isSummary: context.isSummary,
+				},
+				includeCustomMetadata,
+			);
+			copyProperty(commit, "sequenceNumber", encoded);
 			copyProperty(commit, "indexInBatch", encoded);
 			return encoded;
 		}),
@@ -233,20 +230,17 @@ export function decodeSharedBranch<TChangeset>(
 	context: EditManagerDecodingContext,
 	originatorId: SessionId | undefined,
 ): SharedBranchSummaryData<TChangeset> {
-	// TODO: sort out EncodedCommit vs Commit, and make this type check without type assertion.
 	const trunk = json.trunk as readonly (EncodedCommit<JsonCompatibleReadOnly> & SequenceId)[];
 	const data: Mutable<SharedBranchSummaryData<TChangeset>> = {
 		trunk: trunk.map((commit): SequencedCommit<TChangeset> => {
-			const decoded = {
-				...decodeCommit(changeCodec, revisionTagCodec, commit, {
-					originatorId: commit.sessionId,
-					idCompressor: context.idCompressor,
-					revision: undefined,
-					isSummary: context.isSummary,
-					healing: context.healing,
-				}),
-				sequenceNumber: commit.sequenceNumber,
-			};
+			const decoded = decodeCommit(changeCodec, revisionTagCodec, commit, {
+				originatorId: commit.sessionId,
+				idCompressor: context.idCompressor,
+				revision: undefined,
+				isSummary: context.isSummary,
+				healing: context.healing,
+			});
+			copyProperty(commit, "sequenceNumber", decoded);
 			copyProperty(commit, "indexInBatch", decoded);
 			return decoded;
 		}),

--- a/packages/dds/tree/src/shared-tree-core/editManagerCodecsCommons.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerCodecsCommons.ts
@@ -15,6 +15,7 @@ import type {
 	SchemaAndPolicy,
 } from "../core/index.js";
 import {
+	copyProperty,
 	mapIterable,
 	type IdentifierHealingConfig,
 	type JsonCompatibleReadOnly,
@@ -27,6 +28,7 @@ import type { SharedBranchSummaryData } from "./editManager.js";
 import type {
 	Commit,
 	EncodedCommit,
+	EncodedSequencedCommit,
 	EncodedSharedBranch,
 	SequenceId,
 	SequencedCommit,
@@ -56,7 +58,6 @@ export interface EditManagerDecodingContext {
 	readonly healing?: IdentifierHealingConfig;
 }
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 function encodeCommit<TChangeset, T extends Commit<TChangeset>>(
 	changeCodec: IJsonCodec<
 		TChangeset,
@@ -73,27 +74,21 @@ function encodeCommit<TChangeset, T extends Commit<TChangeset>>(
 	commit: T,
 	context: ChangeEncodingContext,
 	includeCustomMetadata: boolean,
-) {
-	const encoded = {
-		...commit,
+): EncodedCommit<JsonCompatibleReadOnly> {
+	const encoded: Mutable<EncodedCommit<JsonCompatibleReadOnly>> = {
+		change: changeCodec.encode(commit.change, { ...context, revision: commit.revision }),
 		revision: revisionTagCodec.encode(commit.revision, {
 			originatorId: commit.sessionId,
 			idCompressor: context.idCompressor,
 			revision: undefined,
 			isSummary: context.isSummary,
 		}),
-		change: changeCodec.encode(commit.change, { ...context, revision: commit.revision }),
+		sessionId: commit.sessionId,
 	};
-	// Rebuilt rather than spread through, both to convert it to the persisted form and so that a client
-	// writing an older format never emits a field that format does not define.
-	if (encoded.customMetadata === undefined) {
-		const { customMetadata: _, ...withoutMetadata } = encoded;
-		return withoutMetadata;
+	if (includeCustomMetadata && commit.customMetadata !== undefined) {
+		encoded.customMetadata = encodeCustomMetadataTree(commit.customMetadata);
 	}
-	const { customMetadata, ...rest } = encoded;
-	return includeCustomMetadata
-		? { ...rest, customMetadata: encodeCustomMetadataTree(customMetadata) }
-		: rest;
+	return encoded;
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
@@ -121,7 +116,7 @@ function decodeCommit<TChangeset, T extends EncodedCommit<JsonCompatibleReadOnly
 	});
 
 	return {
-		...commit,
+		sessionId: commit.sessionId,
 		revision,
 		change: changeCodec.decode(commit.change, { ...context, revision }),
 		customMetadata: decodeCustomMetadataTree(commit.customMetadata),
@@ -145,23 +140,28 @@ export function encodeSharedBranch<TChangeset>(
 	context: EditManagerEncodingContext,
 	originatorId: SessionId | undefined,
 	includeCustomMetadata: boolean,
-): EncodedSharedBranch<TChangeset> {
-	const json: Mutable<EncodedSharedBranch<TChangeset>> = {
-		trunk: data.trunk.map((commit) =>
-			encodeCommit(
-				changeCodec,
-				revisionTagCodec,
-				commit,
-				{
-					originatorId: commit.sessionId,
-					idCompressor: context.idCompressor,
-					schema: context.schema,
-					revision: undefined,
-					isSummary: context.isSummary,
-				},
-				includeCustomMetadata,
-			),
-		),
+): EncodedSharedBranch<JsonCompatibleReadOnly> {
+	const json: Mutable<EncodedSharedBranch<JsonCompatibleReadOnly>> = {
+		trunk: data.trunk.map((commit) => {
+			const encoded: Mutable<EncodedSequencedCommit<JsonCompatibleReadOnly>> = {
+				...encodeCommit(
+					changeCodec,
+					revisionTagCodec,
+					commit,
+					{
+						originatorId: commit.sessionId,
+						idCompressor: context.idCompressor,
+						schema: context.schema,
+						revision: undefined,
+						isSummary: context.isSummary,
+					},
+					includeCustomMetadata,
+				),
+				sequenceNumber: commit.sequenceNumber,
+			};
+			copyProperty(commit, "indexInBatch", encoded);
+			return encoded;
+		}),
 		peers: Array.from(data.peerLocalBranches.entries(), ([sessionId, branch]) => [
 			sessionId,
 			{
@@ -236,17 +236,20 @@ export function decodeSharedBranch<TChangeset>(
 	// TODO: sort out EncodedCommit vs Commit, and make this type check without type assertion.
 	const trunk = json.trunk as readonly (EncodedCommit<JsonCompatibleReadOnly> & SequenceId)[];
 	const data: Mutable<SharedBranchSummaryData<TChangeset>> = {
-		trunk: trunk.map(
-			(commit): SequencedCommit<TChangeset> =>
-				// TODO: sort out EncodedCommit vs Commit, and make this type check without `as`.
-				decodeCommit(changeCodec, revisionTagCodec, commit, {
+		trunk: trunk.map((commit): SequencedCommit<TChangeset> => {
+			const decoded = {
+				...decodeCommit(changeCodec, revisionTagCodec, commit, {
 					originatorId: commit.sessionId,
 					idCompressor: context.idCompressor,
 					revision: undefined,
 					isSummary: context.isSummary,
 					healing: context.healing,
 				}),
-		),
+				sequenceNumber: commit.sequenceNumber,
+			};
+			copyProperty(commit, "indexInBatch", decoded);
+			return decoded;
+		}),
 		peerLocalBranches: new Map(
 			mapIterable(json.peers, ([sessionId, branch]) => [
 				sessionId,
@@ -258,7 +261,6 @@ export function decodeSharedBranch<TChangeset>(
 						isSummary: context.isSummary,
 					}),
 					commits: branch.commits.map((commit) =>
-						// TODO: sort out EncodedCommit vs Commit, and make this type check without `as`.
 						decodeCommit(
 							changeCodec,
 							revisionTagCodec,

--- a/packages/dds/tree/src/shared-tree-core/editManagerCodecsV1toV4.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerCodecsV1toV4.ts
@@ -72,7 +72,7 @@ export function makeV1toV4andV6CodecWithVersion<TChangeset>(
 				data.originator,
 				includeCustomMetadata,
 			);
-			const encoded: EncodedEditManager<TChangeset> = {
+			const encoded: EncodedEditManager<JsonCompatibleReadOnly> = {
 				trunk: mainBranch.trunk,
 				branches: mainBranch.peers,
 				version,

--- a/packages/dds/tree/src/shared-tree-core/editManagerCodecsVSharedBranches.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManagerCodecsVSharedBranches.ts
@@ -65,13 +65,13 @@ export function makeSharedBranchesCodecWithVersion<TChangeset>(
 				data.originator !== undefined,
 				0xca5 /* Cannot encode vSharedBranches summary without originator */,
 			);
-			const json: Mutable<EncodedEditManager<TChangeset>> = {
+			const json: Mutable<EncodedEditManager<JsonCompatibleReadOnly>> = {
 				main: mainBranch,
 				originator: data.originator,
 				version,
 			};
 			if (data.branches !== undefined && data.branches.size > 0) {
-				const branches: EncodedSharedBranch<TChangeset>[] = [];
+				const branches: EncodedSharedBranch<JsonCompatibleReadOnly>[] = [];
 				for (const [_, branch] of data.branches) {
 					branches.push(
 						encodeSharedBranch(

--- a/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerCodecs.test.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerCodecs.test.ts
@@ -280,7 +280,7 @@ export function testCodec(): void {
 				// this invocation should throw if extra properties are not filtered out during encoding.
 				const encoded = codec.encode(data, dummyContext);
 				const stringified = JSON.stringify(encoded);
-				// This assert added as redundant check in case we stop validating encoded data against the schema
+				// This assert is added as a redundant check in case we stop validating encoded data against the schema
 				// or in case the schema is relaxed by mistake (e.g., using `CommitBase` instead of `Commit`, which allows extra properties).
 				assert(
 					!stringified.includes("☠️"),

--- a/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerCodecs.test.ts
+++ b/packages/dds/tree/src/test/shared-tree-core/edit-manager/editManagerCodecs.test.ts
@@ -14,6 +14,9 @@ import { FormatValidatorBasic } from "../../../external-utilities/index.js";
 import { makeEditManagerCodecBuilder } from "../../../shared-tree-core/editManagerCodecs.js";
 import {
 	EditManagerFormatVersion,
+	supportedEditManagerFormatVersions,
+	type Commit,
+	type SequencedCommit,
 	type SharedBranchSummaryData,
 	type SummaryData,
 } from "../../../shared-tree-core/index.js";
@@ -236,6 +239,55 @@ export function testCodec(): void {
 		makeEncodingTestSuite(family, testCases, undefined, [
 			EditManagerFormatVersion.vSharedBranches,
 		]);
+
+		it("Extra properties on commits are omitted from encoding", () => {
+			interface ExtraData {
+				"☠️": "☠️";
+			}
+			const trunkCommit = {
+				revision: tags[0],
+				sessionId: "1" as SessionId,
+				change: TestChange.mint([0], 1),
+				sequenceNumber: brand(1),
+				customMetadata: undefined,
+				"☠️": "☠️",
+			} satisfies SequencedCommit<TestChange> & ExtraData;
+			const branchCommit = {
+				sessionId: "4" as SessionId,
+				revision: mintRevisionTag(),
+				change: TestChange.mint([0, 1], 4),
+				customMetadata: undefined,
+				"☠️": "☠️",
+			} satisfies Commit<TestChange> & ExtraData;
+			const data = {
+				originator: dummyContext.originatorId,
+				main: {
+					trunk: [trunkCommit],
+					peerLocalBranches: new Map([
+						[
+							"4" as SessionId,
+							{
+								base: tags[1],
+								commits: [branchCommit],
+							},
+						],
+					]),
+				},
+			} satisfies SummaryData<TestChange>;
+			for (const version of supportedEditManagerFormatVersions) {
+				const codec = family.resolve(version);
+				// So long as we keep validating encoded data against the schema,
+				// this invocation should throw if extra properties are not filtered out during encoding.
+				const encoded = codec.encode(data, dummyContext);
+				const stringified = JSON.stringify(encoded);
+				// This assert added as redundant check in case we stop validating encoded data against the schema
+				// or in case the schema is relaxed by mistake (e.g., using `CommitBase` instead of `Commit`, which allows extra properties).
+				assert(
+					!stringified.includes("☠️"),
+					"Extra properties should be filtered out during encoding",
+				);
+			}
+		});
 
 		// TODO: testing EditManagerSummarizer class itself, specifically for attachment and normal summaries.
 		// TODO: format compatibility tests to detect breaking of existing documents.

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_0/competing-removes-index-0.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_0/competing-removes-index-0.json
@@ -75,8 +75,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -120,8 +120,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -165,8 +165,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_0/competing-removes-index-1.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_0/competing-removes-index-1.json
@@ -78,8 +78,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -126,8 +126,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -174,8 +174,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_0/competing-removes-index-2.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_0/competing-removes-index-2.json
@@ -78,8 +78,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -126,8 +126,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -174,8 +174,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_0/competing-removes-index-3.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_0/competing-removes-index-3.json
@@ -78,8 +78,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -126,8 +126,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -174,8 +174,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_0/complete-3x3-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_0/complete-3x3-final.json
@@ -555,8 +555,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_0/concurrent-inserts-tree2.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_0/concurrent-inserts-tree2.json
@@ -106,8 +106,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -178,8 +178,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 6,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -264,8 +264,8 @@
                             }
                           ],
                           "revision": 3,
-                          "sequenceNumber": 8,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 8
                         },
                         {
                           "change": [
@@ -339,8 +339,8 @@
                             }
                           ],
                           "revision": 4,
-                          "sequenceNumber": 9,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 9
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_0/concurrent-inserts-tree3.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_0/concurrent-inserts-tree3.json
@@ -109,8 +109,8 @@
                             }
                           ],
                           "revision": 4,
-                          "sequenceNumber": 9,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 9
                         },
                         {
                           "change": [
@@ -181,8 +181,8 @@
                             }
                           ],
                           "revision": 7,
-                          "sequenceNumber": 11,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 11
                         },
                         {
                           "change": [
@@ -267,8 +267,8 @@
                             }
                           ],
                           "revision": 8,
-                          "sequenceNumber": 13,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 13
                         },
                         {
                           "change": [
@@ -342,8 +342,8 @@
                             }
                           ],
                           "revision": 9,
-                          "sequenceNumber": 14,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 14
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_0/custom-metadata-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_0/custom-metadata-final.json
@@ -192,8 +192,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         },
                         {
                           "change": [
@@ -264,8 +264,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_0/empty-root-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_0/empty-root-final.json
@@ -84,8 +84,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_0/has-handle-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_0/has-handle-final.json
@@ -105,8 +105,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_0/insert-and-remove-tree-0-after-insert.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_0/insert-and-remove-tree-0-after-insert.json
@@ -106,8 +106,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_0/insert-and-remove-tree-0-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_0/insert-and-remove-tree-0-final.json
@@ -75,8 +75,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 6,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 6
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_0/insert-and-remove-tree-1-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_0/insert-and-remove-tree-1-final.json
@@ -75,8 +75,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 6,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 6
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_0/move-across-fields-tree-0-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_0/move-across-fields-tree-0-final.json
@@ -265,8 +265,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         },
                         {
                           "change": [
@@ -353,8 +353,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_0/nested-sequence-change-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_0/nested-sequence-change-final.json
@@ -155,8 +155,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_0/optional-field-scenarios-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_0/optional-field-scenarios-final.json
@@ -102,8 +102,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -176,8 +176,8 @@
                             }
                           ],
                           "revision": 514,
-                          "sequenceNumber": 8,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 8
                         },
                         {
                           "change": [
@@ -301,8 +301,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 10,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 10
                         },
                         {
                           "change": [
@@ -371,8 +371,8 @@
                             }
                           ],
                           "revision": 3,
-                          "sequenceNumber": 12,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 12
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_0/tree-with-identifier-field-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_0/tree-with-identifier-field-final.json
@@ -189,8 +189,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_117/competing-removes-index-0.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_117/competing-removes-index-0.json
@@ -75,8 +75,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -120,8 +120,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -165,8 +165,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_117/competing-removes-index-1.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_117/competing-removes-index-1.json
@@ -78,8 +78,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -126,8 +126,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -174,8 +174,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_117/competing-removes-index-2.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_117/competing-removes-index-2.json
@@ -78,8 +78,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -126,8 +126,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -174,8 +174,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_117/competing-removes-index-3.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_117/competing-removes-index-3.json
@@ -78,8 +78,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -126,8 +126,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -174,8 +174,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_117/complete-3x3-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_117/complete-3x3-final.json
@@ -573,8 +573,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_117/concurrent-inserts-tree2.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_117/concurrent-inserts-tree2.json
@@ -106,8 +106,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -178,8 +178,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 6,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -264,8 +264,8 @@
                             }
                           ],
                           "revision": 3,
-                          "sequenceNumber": 8,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 8
                         },
                         {
                           "change": [
@@ -339,8 +339,8 @@
                             }
                           ],
                           "revision": 4,
-                          "sequenceNumber": 9,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 9
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_117/concurrent-inserts-tree3.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_117/concurrent-inserts-tree3.json
@@ -109,8 +109,8 @@
                             }
                           ],
                           "revision": 4,
-                          "sequenceNumber": 9,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 9
                         },
                         {
                           "change": [
@@ -181,8 +181,8 @@
                             }
                           ],
                           "revision": 7,
-                          "sequenceNumber": 11,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 11
                         },
                         {
                           "change": [
@@ -267,8 +267,8 @@
                             }
                           ],
                           "revision": 8,
-                          "sequenceNumber": 13,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 13
                         },
                         {
                           "change": [
@@ -342,8 +342,8 @@
                             }
                           ],
                           "revision": 9,
-                          "sequenceNumber": 14,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 14
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_117/custom-metadata-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_117/custom-metadata-final.json
@@ -204,8 +204,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         },
                         {
                           "change": [
@@ -276,7 +276,6 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
                           "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
                           "customMetadata": {
                             "m": {
@@ -289,7 +288,8 @@
                                 }
                               }
                             ]
-                          }
+                          },
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_117/empty-root-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_117/empty-root-final.json
@@ -86,8 +86,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_117/has-handle-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_117/has-handle-final.json
@@ -105,8 +105,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_117/insert-and-remove-tree-0-after-insert.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_117/insert-and-remove-tree-0-after-insert.json
@@ -106,8 +106,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_117/insert-and-remove-tree-0-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_117/insert-and-remove-tree-0-final.json
@@ -75,8 +75,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 6,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 6
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_117/insert-and-remove-tree-1-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_117/insert-and-remove-tree-1-final.json
@@ -75,8 +75,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 6,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 6
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_117/move-across-fields-tree-0-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_117/move-across-fields-tree-0-final.json
@@ -283,8 +283,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         },
                         {
                           "change": [
@@ -371,8 +371,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_117/nested-sequence-change-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_117/nested-sequence-change-final.json
@@ -155,8 +155,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_117/optional-field-scenarios-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_117/optional-field-scenarios-final.json
@@ -102,8 +102,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -176,8 +176,8 @@
                             }
                           ],
                           "revision": 514,
-                          "sequenceNumber": 8,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 8
                         },
                         {
                           "change": [
@@ -301,8 +301,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 10,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 10
                         },
                         {
                           "change": [
@@ -371,8 +371,8 @@
                             }
                           ],
                           "revision": 3,
-                          "sequenceNumber": 12,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 12
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_117/tree-with-identifier-field-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_117/tree-with-identifier-field-final.json
@@ -201,8 +201,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_43/competing-removes-index-0.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_43/competing-removes-index-0.json
@@ -75,8 +75,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -120,8 +120,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -165,8 +165,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_43/competing-removes-index-1.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_43/competing-removes-index-1.json
@@ -78,8 +78,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -126,8 +126,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -174,8 +174,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_43/competing-removes-index-2.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_43/competing-removes-index-2.json
@@ -78,8 +78,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -126,8 +126,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -174,8 +174,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_43/competing-removes-index-3.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_43/competing-removes-index-3.json
@@ -78,8 +78,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -126,8 +126,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -174,8 +174,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_43/complete-3x3-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_43/complete-3x3-final.json
@@ -573,8 +573,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_43/concurrent-inserts-tree2.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_43/concurrent-inserts-tree2.json
@@ -106,8 +106,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -178,8 +178,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 6,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -264,8 +264,8 @@
                             }
                           ],
                           "revision": 3,
-                          "sequenceNumber": 8,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 8
                         },
                         {
                           "change": [
@@ -339,8 +339,8 @@
                             }
                           ],
                           "revision": 4,
-                          "sequenceNumber": 9,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 9
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_43/concurrent-inserts-tree3.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_43/concurrent-inserts-tree3.json
@@ -109,8 +109,8 @@
                             }
                           ],
                           "revision": 4,
-                          "sequenceNumber": 9,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 9
                         },
                         {
                           "change": [
@@ -181,8 +181,8 @@
                             }
                           ],
                           "revision": 7,
-                          "sequenceNumber": 11,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 11
                         },
                         {
                           "change": [
@@ -267,8 +267,8 @@
                             }
                           ],
                           "revision": 8,
-                          "sequenceNumber": 13,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 13
                         },
                         {
                           "change": [
@@ -342,8 +342,8 @@
                             }
                           ],
                           "revision": 9,
-                          "sequenceNumber": 14,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 14
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_43/custom-metadata-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_43/custom-metadata-final.json
@@ -204,8 +204,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         },
                         {
                           "change": [
@@ -276,8 +276,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_43/empty-root-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_43/empty-root-final.json
@@ -86,8 +86,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_43/has-handle-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_43/has-handle-final.json
@@ -105,8 +105,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_43/insert-and-remove-tree-0-after-insert.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_43/insert-and-remove-tree-0-after-insert.json
@@ -106,8 +106,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_43/insert-and-remove-tree-0-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_43/insert-and-remove-tree-0-final.json
@@ -75,8 +75,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 6,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 6
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_43/insert-and-remove-tree-1-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_43/insert-and-remove-tree-1-final.json
@@ -75,8 +75,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 6,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 6
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_43/move-across-fields-tree-0-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_43/move-across-fields-tree-0-final.json
@@ -283,8 +283,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         },
                         {
                           "change": [
@@ -371,8 +371,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_43/nested-sequence-change-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_43/nested-sequence-change-final.json
@@ -155,8 +155,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_43/optional-field-scenarios-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_43/optional-field-scenarios-final.json
@@ -102,8 +102,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -176,8 +176,8 @@
                             }
                           ],
                           "revision": 514,
-                          "sequenceNumber": 8,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 8
                         },
                         {
                           "change": [
@@ -301,8 +301,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 10,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 10
                         },
                         {
                           "change": [
@@ -371,8 +371,8 @@
                             }
                           ],
                           "revision": 3,
-                          "sequenceNumber": 12,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 12
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_43/tree-with-identifier-field-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_43/tree-with-identifier-field-final.json
@@ -201,8 +201,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_52/competing-removes-index-0.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_52/competing-removes-index-0.json
@@ -75,8 +75,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -120,8 +120,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -165,8 +165,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_52/competing-removes-index-1.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_52/competing-removes-index-1.json
@@ -78,8 +78,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -126,8 +126,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -174,8 +174,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_52/competing-removes-index-2.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_52/competing-removes-index-2.json
@@ -78,8 +78,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -126,8 +126,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -174,8 +174,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_52/competing-removes-index-3.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_52/competing-removes-index-3.json
@@ -78,8 +78,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -126,8 +126,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -174,8 +174,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_52/complete-3x3-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_52/complete-3x3-final.json
@@ -573,8 +573,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_52/concurrent-inserts-tree2.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_52/concurrent-inserts-tree2.json
@@ -106,8 +106,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -178,8 +178,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 6,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -264,8 +264,8 @@
                             }
                           ],
                           "revision": 3,
-                          "sequenceNumber": 8,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 8
                         },
                         {
                           "change": [
@@ -339,8 +339,8 @@
                             }
                           ],
                           "revision": 4,
-                          "sequenceNumber": 9,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 9
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_52/concurrent-inserts-tree3.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_52/concurrent-inserts-tree3.json
@@ -109,8 +109,8 @@
                             }
                           ],
                           "revision": 4,
-                          "sequenceNumber": 9,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 9
                         },
                         {
                           "change": [
@@ -181,8 +181,8 @@
                             }
                           ],
                           "revision": 7,
-                          "sequenceNumber": 11,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 11
                         },
                         {
                           "change": [
@@ -267,8 +267,8 @@
                             }
                           ],
                           "revision": 8,
-                          "sequenceNumber": 13,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 13
                         },
                         {
                           "change": [
@@ -342,8 +342,8 @@
                             }
                           ],
                           "revision": 9,
-                          "sequenceNumber": 14,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 14
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_52/custom-metadata-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_52/custom-metadata-final.json
@@ -204,8 +204,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         },
                         {
                           "change": [
@@ -276,8 +276,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_52/empty-root-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_52/empty-root-final.json
@@ -86,8 +86,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_52/has-handle-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_52/has-handle-final.json
@@ -105,8 +105,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_52/insert-and-remove-tree-0-after-insert.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_52/insert-and-remove-tree-0-after-insert.json
@@ -106,8 +106,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_52/insert-and-remove-tree-0-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_52/insert-and-remove-tree-0-final.json
@@ -75,8 +75,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 6,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 6
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_52/insert-and-remove-tree-1-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_52/insert-and-remove-tree-1-final.json
@@ -75,8 +75,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 6,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 6
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_52/move-across-fields-tree-0-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_52/move-across-fields-tree-0-final.json
@@ -283,8 +283,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         },
                         {
                           "change": [
@@ -371,8 +371,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_52/nested-sequence-change-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_52/nested-sequence-change-final.json
@@ -155,8 +155,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_52/optional-field-scenarios-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_52/optional-field-scenarios-final.json
@@ -102,8 +102,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -176,8 +176,8 @@
                             }
                           ],
                           "revision": 514,
-                          "sequenceNumber": 8,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 8
                         },
                         {
                           "change": [
@@ -301,8 +301,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 10,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 10
                         },
                         {
                           "change": [
@@ -371,8 +371,8 @@
                             }
                           ],
                           "revision": 3,
-                          "sequenceNumber": 12,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 12
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_52/tree-with-identifier-field-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_52/tree-with-identifier-field-final.json
@@ -201,8 +201,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_73/competing-removes-index-0.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_73/competing-removes-index-0.json
@@ -75,8 +75,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -120,8 +120,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -165,8 +165,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_73/competing-removes-index-1.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_73/competing-removes-index-1.json
@@ -78,8 +78,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -126,8 +126,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -174,8 +174,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_73/competing-removes-index-2.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_73/competing-removes-index-2.json
@@ -78,8 +78,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -126,8 +126,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -174,8 +174,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_73/competing-removes-index-3.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_73/competing-removes-index-3.json
@@ -78,8 +78,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -126,8 +126,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -174,8 +174,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_73/complete-3x3-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_73/complete-3x3-final.json
@@ -573,8 +573,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_73/concurrent-inserts-tree2.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_73/concurrent-inserts-tree2.json
@@ -106,8 +106,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -178,8 +178,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 6,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -264,8 +264,8 @@
                             }
                           ],
                           "revision": 3,
-                          "sequenceNumber": 8,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 8
                         },
                         {
                           "change": [
@@ -339,8 +339,8 @@
                             }
                           ],
                           "revision": 4,
-                          "sequenceNumber": 9,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 9
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_73/concurrent-inserts-tree3.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_73/concurrent-inserts-tree3.json
@@ -109,8 +109,8 @@
                             }
                           ],
                           "revision": 4,
-                          "sequenceNumber": 9,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 9
                         },
                         {
                           "change": [
@@ -181,8 +181,8 @@
                             }
                           ],
                           "revision": 7,
-                          "sequenceNumber": 11,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 11
                         },
                         {
                           "change": [
@@ -267,8 +267,8 @@
                             }
                           ],
                           "revision": 8,
-                          "sequenceNumber": 13,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 13
                         },
                         {
                           "change": [
@@ -342,8 +342,8 @@
                             }
                           ],
                           "revision": 9,
-                          "sequenceNumber": 14,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 14
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_73/custom-metadata-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_73/custom-metadata-final.json
@@ -204,8 +204,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         },
                         {
                           "change": [
@@ -276,8 +276,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_73/empty-root-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_73/empty-root-final.json
@@ -86,8 +86,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_73/has-handle-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_73/has-handle-final.json
@@ -105,8 +105,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_73/insert-and-remove-tree-0-after-insert.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_73/insert-and-remove-tree-0-after-insert.json
@@ -106,8 +106,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_73/insert-and-remove-tree-0-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_73/insert-and-remove-tree-0-final.json
@@ -75,8 +75,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 6,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 6
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_73/insert-and-remove-tree-1-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_73/insert-and-remove-tree-1-final.json
@@ -75,8 +75,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 6,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 6
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_73/move-across-fields-tree-0-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_73/move-across-fields-tree-0-final.json
@@ -283,8 +283,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         },
                         {
                           "change": [
@@ -371,8 +371,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_73/nested-sequence-change-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_73/nested-sequence-change-final.json
@@ -155,8 +155,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_73/optional-field-scenarios-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_73/optional-field-scenarios-final.json
@@ -102,8 +102,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -176,8 +176,8 @@
                             }
                           ],
                           "revision": 514,
-                          "sequenceNumber": 8,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 8
                         },
                         {
                           "change": [
@@ -301,8 +301,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 10,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 10
                         },
                         {
                           "change": [
@@ -371,8 +371,8 @@
                             }
                           ],
                           "revision": 3,
-                          "sequenceNumber": 12,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 12
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_73/tree-with-identifier-field-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_73/tree-with-identifier-field-final.json
@@ -201,8 +201,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_74/competing-removes-index-0.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_74/competing-removes-index-0.json
@@ -75,8 +75,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -120,8 +120,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -165,8 +165,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_74/competing-removes-index-1.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_74/competing-removes-index-1.json
@@ -78,8 +78,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -126,8 +126,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -174,8 +174,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_74/competing-removes-index-2.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_74/competing-removes-index-2.json
@@ -78,8 +78,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -126,8 +126,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -174,8 +174,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_74/competing-removes-index-3.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_74/competing-removes-index-3.json
@@ -78,8 +78,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -126,8 +126,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -174,8 +174,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_74/complete-3x3-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_74/complete-3x3-final.json
@@ -573,8 +573,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_74/concurrent-inserts-tree2.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_74/concurrent-inserts-tree2.json
@@ -106,8 +106,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -178,8 +178,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 6,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -264,8 +264,8 @@
                             }
                           ],
                           "revision": 3,
-                          "sequenceNumber": 8,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 8
                         },
                         {
                           "change": [
@@ -339,8 +339,8 @@
                             }
                           ],
                           "revision": 4,
-                          "sequenceNumber": 9,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 9
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_74/concurrent-inserts-tree3.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_74/concurrent-inserts-tree3.json
@@ -109,8 +109,8 @@
                             }
                           ],
                           "revision": 4,
-                          "sequenceNumber": 9,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 9
                         },
                         {
                           "change": [
@@ -181,8 +181,8 @@
                             }
                           ],
                           "revision": 7,
-                          "sequenceNumber": 11,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 11
                         },
                         {
                           "change": [
@@ -267,8 +267,8 @@
                             }
                           ],
                           "revision": 8,
-                          "sequenceNumber": 13,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 13
                         },
                         {
                           "change": [
@@ -342,8 +342,8 @@
                             }
                           ],
                           "revision": 9,
-                          "sequenceNumber": 14,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 14
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_74/custom-metadata-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_74/custom-metadata-final.json
@@ -204,8 +204,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         },
                         {
                           "change": [
@@ -276,8 +276,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_74/empty-root-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_74/empty-root-final.json
@@ -86,8 +86,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_74/has-handle-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_74/has-handle-final.json
@@ -105,8 +105,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_74/insert-and-remove-tree-0-after-insert.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_74/insert-and-remove-tree-0-after-insert.json
@@ -106,8 +106,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_74/insert-and-remove-tree-0-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_74/insert-and-remove-tree-0-final.json
@@ -75,8 +75,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 6,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 6
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_74/insert-and-remove-tree-1-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_74/insert-and-remove-tree-1-final.json
@@ -75,8 +75,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 6,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 6
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_74/move-across-fields-tree-0-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_74/move-across-fields-tree-0-final.json
@@ -283,8 +283,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         },
                         {
                           "change": [
@@ -371,8 +371,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_74/nested-sequence-change-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_74/nested-sequence-change-final.json
@@ -155,8 +155,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_74/optional-field-scenarios-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_74/optional-field-scenarios-final.json
@@ -102,8 +102,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -176,8 +176,8 @@
                             }
                           ],
                           "revision": 514,
-                          "sequenceNumber": 8,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 8
                         },
                         {
                           "change": [
@@ -301,8 +301,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 10,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 10
                         },
                         {
                           "change": [
@@ -371,8 +371,8 @@
                             }
                           ],
                           "revision": 3,
-                          "sequenceNumber": 12,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 12
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_74/tree-with-identifier-field-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_74/tree-with-identifier-field-final.json
@@ -201,8 +201,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_80/competing-removes-index-0.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_80/competing-removes-index-0.json
@@ -75,8 +75,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -120,8 +120,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -165,8 +165,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_80/competing-removes-index-1.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_80/competing-removes-index-1.json
@@ -78,8 +78,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -126,8 +126,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -174,8 +174,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_80/competing-removes-index-2.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_80/competing-removes-index-2.json
@@ -78,8 +78,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -126,8 +126,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -174,8 +174,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_80/competing-removes-index-3.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_80/competing-removes-index-3.json
@@ -78,8 +78,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -126,8 +126,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -174,8 +174,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_80/complete-3x3-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_80/complete-3x3-final.json
@@ -573,8 +573,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_80/concurrent-inserts-tree2.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_80/concurrent-inserts-tree2.json
@@ -106,8 +106,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -178,8 +178,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 6,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -264,8 +264,8 @@
                             }
                           ],
                           "revision": 3,
-                          "sequenceNumber": 8,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 8
                         },
                         {
                           "change": [
@@ -339,8 +339,8 @@
                             }
                           ],
                           "revision": 4,
-                          "sequenceNumber": 9,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 9
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_80/concurrent-inserts-tree3.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_80/concurrent-inserts-tree3.json
@@ -109,8 +109,8 @@
                             }
                           ],
                           "revision": 4,
-                          "sequenceNumber": 9,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 9
                         },
                         {
                           "change": [
@@ -181,8 +181,8 @@
                             }
                           ],
                           "revision": 7,
-                          "sequenceNumber": 11,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 11
                         },
                         {
                           "change": [
@@ -267,8 +267,8 @@
                             }
                           ],
                           "revision": 8,
-                          "sequenceNumber": 13,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 13
                         },
                         {
                           "change": [
@@ -342,8 +342,8 @@
                             }
                           ],
                           "revision": 9,
-                          "sequenceNumber": 14,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 14
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_80/custom-metadata-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_80/custom-metadata-final.json
@@ -204,8 +204,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         },
                         {
                           "change": [
@@ -276,8 +276,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_80/empty-root-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_80/empty-root-final.json
@@ -86,8 +86,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_80/has-handle-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_80/has-handle-final.json
@@ -105,8 +105,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_80/insert-and-remove-tree-0-after-insert.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_80/insert-and-remove-tree-0-after-insert.json
@@ -106,8 +106,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_80/insert-and-remove-tree-0-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_80/insert-and-remove-tree-0-final.json
@@ -75,8 +75,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 6,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 6
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_80/insert-and-remove-tree-1-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_80/insert-and-remove-tree-1-final.json
@@ -75,8 +75,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 6,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 6
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_80/move-across-fields-tree-0-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_80/move-across-fields-tree-0-final.json
@@ -283,8 +283,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         },
                         {
                           "change": [
@@ -371,8 +371,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_80/nested-sequence-change-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_80/nested-sequence-change-final.json
@@ -155,8 +155,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_80/optional-field-scenarios-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_80/optional-field-scenarios-final.json
@@ -102,8 +102,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -176,8 +176,8 @@
                             }
                           ],
                           "revision": 514,
-                          "sequenceNumber": 8,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 8
                         },
                         {
                           "change": [
@@ -301,8 +301,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 10,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 10
                         },
                         {
                           "change": [
@@ -371,8 +371,8 @@
                             }
                           ],
                           "revision": 3,
-                          "sequenceNumber": 12,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 12
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_80/tree-with-identifier-field-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Compressed/v2_80/tree-with-identifier-field-final.json
@@ -201,8 +201,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_0/competing-removes-index-0.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_0/competing-removes-index-0.json
@@ -75,8 +75,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -120,8 +120,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -165,8 +165,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_0/competing-removes-index-1.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_0/competing-removes-index-1.json
@@ -78,8 +78,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -126,8 +126,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -174,8 +174,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_0/competing-removes-index-2.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_0/competing-removes-index-2.json
@@ -78,8 +78,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -126,8 +126,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -174,8 +174,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_0/competing-removes-index-3.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_0/competing-removes-index-3.json
@@ -78,8 +78,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -126,8 +126,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -174,8 +174,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_0/complete-3x3-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_0/complete-3x3-final.json
@@ -892,8 +892,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_0/concurrent-inserts-tree2.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_0/concurrent-inserts-tree2.json
@@ -113,8 +113,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -192,8 +192,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 6,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -278,8 +278,8 @@
                             }
                           ],
                           "revision": 3,
-                          "sequenceNumber": 8,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 8
                         },
                         {
                           "change": [
@@ -360,8 +360,8 @@
                             }
                           ],
                           "revision": 4,
-                          "sequenceNumber": 9,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 9
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_0/concurrent-inserts-tree3.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_0/concurrent-inserts-tree3.json
@@ -116,8 +116,8 @@
                             }
                           ],
                           "revision": 4,
-                          "sequenceNumber": 9,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 9
                         },
                         {
                           "change": [
@@ -195,8 +195,8 @@
                             }
                           ],
                           "revision": 7,
-                          "sequenceNumber": 11,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 11
                         },
                         {
                           "change": [
@@ -281,8 +281,8 @@
                             }
                           ],
                           "revision": 8,
-                          "sequenceNumber": 13,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 13
                         },
                         {
                           "change": [
@@ -363,8 +363,8 @@
                             }
                           ],
                           "revision": 9,
-                          "sequenceNumber": 14,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 14
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_0/custom-metadata-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_0/custom-metadata-final.json
@@ -183,8 +183,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         },
                         {
                           "change": [
@@ -262,8 +262,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_0/empty-root-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_0/empty-root-final.json
@@ -84,8 +84,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_0/has-handle-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_0/has-handle-final.json
@@ -112,8 +112,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_0/insert-and-remove-tree-0-after-insert.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_0/insert-and-remove-tree-0-after-insert.json
@@ -113,8 +113,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_0/insert-and-remove-tree-0-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_0/insert-and-remove-tree-0-final.json
@@ -75,8 +75,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 6,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 6
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_0/insert-and-remove-tree-1-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_0/insert-and-remove-tree-1-final.json
@@ -75,8 +75,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 6,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 6
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_0/move-across-fields-tree-0-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_0/move-across-fields-tree-0-final.json
@@ -276,8 +276,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         },
                         {
                           "change": [
@@ -364,8 +364,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_0/nested-sequence-change-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_0/nested-sequence-change-final.json
@@ -153,8 +153,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_0/optional-field-scenarios-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_0/optional-field-scenarios-final.json
@@ -109,8 +109,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -178,8 +178,8 @@
                             }
                           ],
                           "revision": 514,
-                          "sequenceNumber": 8,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 8
                         },
                         {
                           "change": [
@@ -306,8 +306,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 10,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 10
                         },
                         {
                           "change": [
@@ -383,8 +383,8 @@
                             }
                           ],
                           "revision": 3,
-                          "sequenceNumber": 12,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 12
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_0/tree-with-identifier-field-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_0/tree-with-identifier-field-final.json
@@ -191,8 +191,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_117/competing-removes-index-0.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_117/competing-removes-index-0.json
@@ -75,8 +75,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -120,8 +120,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -165,8 +165,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_117/competing-removes-index-1.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_117/competing-removes-index-1.json
@@ -78,8 +78,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -126,8 +126,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -174,8 +174,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_117/competing-removes-index-2.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_117/competing-removes-index-2.json
@@ -78,8 +78,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -126,8 +126,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -174,8 +174,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_117/competing-removes-index-3.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_117/competing-removes-index-3.json
@@ -78,8 +78,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -126,8 +126,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -174,8 +174,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_117/complete-3x3-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_117/complete-3x3-final.json
@@ -910,8 +910,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_117/concurrent-inserts-tree2.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_117/concurrent-inserts-tree2.json
@@ -113,8 +113,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -192,8 +192,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 6,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -278,8 +278,8 @@
                             }
                           ],
                           "revision": 3,
-                          "sequenceNumber": 8,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 8
                         },
                         {
                           "change": [
@@ -360,8 +360,8 @@
                             }
                           ],
                           "revision": 4,
-                          "sequenceNumber": 9,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 9
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_117/concurrent-inserts-tree3.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_117/concurrent-inserts-tree3.json
@@ -116,8 +116,8 @@
                             }
                           ],
                           "revision": 4,
-                          "sequenceNumber": 9,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 9
                         },
                         {
                           "change": [
@@ -195,8 +195,8 @@
                             }
                           ],
                           "revision": 7,
-                          "sequenceNumber": 11,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 11
                         },
                         {
                           "change": [
@@ -281,8 +281,8 @@
                             }
                           ],
                           "revision": 8,
-                          "sequenceNumber": 13,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 13
                         },
                         {
                           "change": [
@@ -363,8 +363,8 @@
                             }
                           ],
                           "revision": 9,
-                          "sequenceNumber": 14,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 14
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_117/custom-metadata-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_117/custom-metadata-final.json
@@ -195,8 +195,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         },
                         {
                           "change": [
@@ -274,7 +274,6 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
                           "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
                           "customMetadata": {
                             "m": {
@@ -287,7 +286,8 @@
                                 }
                               }
                             ]
-                          }
+                          },
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_117/empty-root-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_117/empty-root-final.json
@@ -86,8 +86,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_117/has-handle-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_117/has-handle-final.json
@@ -112,8 +112,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_117/insert-and-remove-tree-0-after-insert.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_117/insert-and-remove-tree-0-after-insert.json
@@ -113,8 +113,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_117/insert-and-remove-tree-0-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_117/insert-and-remove-tree-0-final.json
@@ -75,8 +75,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 6,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 6
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_117/insert-and-remove-tree-1-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_117/insert-and-remove-tree-1-final.json
@@ -75,8 +75,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 6,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 6
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_117/move-across-fields-tree-0-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_117/move-across-fields-tree-0-final.json
@@ -294,8 +294,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         },
                         {
                           "change": [
@@ -382,8 +382,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_117/nested-sequence-change-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_117/nested-sequence-change-final.json
@@ -153,8 +153,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_117/optional-field-scenarios-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_117/optional-field-scenarios-final.json
@@ -109,8 +109,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -178,8 +178,8 @@
                             }
                           ],
                           "revision": 514,
-                          "sequenceNumber": 8,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 8
                         },
                         {
                           "change": [
@@ -306,8 +306,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 10,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 10
                         },
                         {
                           "change": [
@@ -383,8 +383,8 @@
                             }
                           ],
                           "revision": 3,
-                          "sequenceNumber": 12,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 12
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_117/tree-with-identifier-field-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_117/tree-with-identifier-field-final.json
@@ -203,8 +203,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_43/competing-removes-index-0.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_43/competing-removes-index-0.json
@@ -75,8 +75,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -120,8 +120,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -165,8 +165,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_43/competing-removes-index-1.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_43/competing-removes-index-1.json
@@ -78,8 +78,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -126,8 +126,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -174,8 +174,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_43/competing-removes-index-2.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_43/competing-removes-index-2.json
@@ -78,8 +78,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -126,8 +126,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -174,8 +174,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_43/competing-removes-index-3.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_43/competing-removes-index-3.json
@@ -78,8 +78,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -126,8 +126,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -174,8 +174,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_43/complete-3x3-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_43/complete-3x3-final.json
@@ -910,8 +910,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_43/concurrent-inserts-tree2.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_43/concurrent-inserts-tree2.json
@@ -113,8 +113,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -192,8 +192,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 6,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -278,8 +278,8 @@
                             }
                           ],
                           "revision": 3,
-                          "sequenceNumber": 8,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 8
                         },
                         {
                           "change": [
@@ -360,8 +360,8 @@
                             }
                           ],
                           "revision": 4,
-                          "sequenceNumber": 9,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 9
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_43/concurrent-inserts-tree3.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_43/concurrent-inserts-tree3.json
@@ -116,8 +116,8 @@
                             }
                           ],
                           "revision": 4,
-                          "sequenceNumber": 9,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 9
                         },
                         {
                           "change": [
@@ -195,8 +195,8 @@
                             }
                           ],
                           "revision": 7,
-                          "sequenceNumber": 11,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 11
                         },
                         {
                           "change": [
@@ -281,8 +281,8 @@
                             }
                           ],
                           "revision": 8,
-                          "sequenceNumber": 13,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 13
                         },
                         {
                           "change": [
@@ -363,8 +363,8 @@
                             }
                           ],
                           "revision": 9,
-                          "sequenceNumber": 14,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 14
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_43/custom-metadata-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_43/custom-metadata-final.json
@@ -195,8 +195,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         },
                         {
                           "change": [
@@ -274,8 +274,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_43/empty-root-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_43/empty-root-final.json
@@ -86,8 +86,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_43/has-handle-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_43/has-handle-final.json
@@ -112,8 +112,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_43/insert-and-remove-tree-0-after-insert.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_43/insert-and-remove-tree-0-after-insert.json
@@ -113,8 +113,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_43/insert-and-remove-tree-0-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_43/insert-and-remove-tree-0-final.json
@@ -75,8 +75,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 6,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 6
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_43/insert-and-remove-tree-1-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_43/insert-and-remove-tree-1-final.json
@@ -75,8 +75,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 6,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 6
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_43/move-across-fields-tree-0-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_43/move-across-fields-tree-0-final.json
@@ -294,8 +294,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         },
                         {
                           "change": [
@@ -382,8 +382,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_43/nested-sequence-change-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_43/nested-sequence-change-final.json
@@ -153,8 +153,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_43/optional-field-scenarios-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_43/optional-field-scenarios-final.json
@@ -109,8 +109,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -178,8 +178,8 @@
                             }
                           ],
                           "revision": 514,
-                          "sequenceNumber": 8,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 8
                         },
                         {
                           "change": [
@@ -306,8 +306,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 10,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 10
                         },
                         {
                           "change": [
@@ -383,8 +383,8 @@
                             }
                           ],
                           "revision": 3,
-                          "sequenceNumber": 12,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 12
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_43/tree-with-identifier-field-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_43/tree-with-identifier-field-final.json
@@ -203,8 +203,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_52/competing-removes-index-0.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_52/competing-removes-index-0.json
@@ -75,8 +75,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -120,8 +120,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -165,8 +165,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_52/competing-removes-index-1.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_52/competing-removes-index-1.json
@@ -78,8 +78,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -126,8 +126,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -174,8 +174,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_52/competing-removes-index-2.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_52/competing-removes-index-2.json
@@ -78,8 +78,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -126,8 +126,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -174,8 +174,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_52/competing-removes-index-3.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_52/competing-removes-index-3.json
@@ -78,8 +78,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -126,8 +126,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -174,8 +174,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_52/complete-3x3-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_52/complete-3x3-final.json
@@ -910,8 +910,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_52/concurrent-inserts-tree2.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_52/concurrent-inserts-tree2.json
@@ -113,8 +113,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -192,8 +192,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 6,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -278,8 +278,8 @@
                             }
                           ],
                           "revision": 3,
-                          "sequenceNumber": 8,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 8
                         },
                         {
                           "change": [
@@ -360,8 +360,8 @@
                             }
                           ],
                           "revision": 4,
-                          "sequenceNumber": 9,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 9
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_52/concurrent-inserts-tree3.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_52/concurrent-inserts-tree3.json
@@ -116,8 +116,8 @@
                             }
                           ],
                           "revision": 4,
-                          "sequenceNumber": 9,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 9
                         },
                         {
                           "change": [
@@ -195,8 +195,8 @@
                             }
                           ],
                           "revision": 7,
-                          "sequenceNumber": 11,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 11
                         },
                         {
                           "change": [
@@ -281,8 +281,8 @@
                             }
                           ],
                           "revision": 8,
-                          "sequenceNumber": 13,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 13
                         },
                         {
                           "change": [
@@ -363,8 +363,8 @@
                             }
                           ],
                           "revision": 9,
-                          "sequenceNumber": 14,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 14
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_52/custom-metadata-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_52/custom-metadata-final.json
@@ -195,8 +195,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         },
                         {
                           "change": [
@@ -274,8 +274,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_52/empty-root-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_52/empty-root-final.json
@@ -86,8 +86,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_52/has-handle-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_52/has-handle-final.json
@@ -112,8 +112,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_52/insert-and-remove-tree-0-after-insert.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_52/insert-and-remove-tree-0-after-insert.json
@@ -113,8 +113,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_52/insert-and-remove-tree-0-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_52/insert-and-remove-tree-0-final.json
@@ -75,8 +75,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 6,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 6
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_52/insert-and-remove-tree-1-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_52/insert-and-remove-tree-1-final.json
@@ -75,8 +75,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 6,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 6
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_52/move-across-fields-tree-0-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_52/move-across-fields-tree-0-final.json
@@ -294,8 +294,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         },
                         {
                           "change": [
@@ -382,8 +382,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_52/nested-sequence-change-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_52/nested-sequence-change-final.json
@@ -153,8 +153,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_52/optional-field-scenarios-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_52/optional-field-scenarios-final.json
@@ -109,8 +109,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -178,8 +178,8 @@
                             }
                           ],
                           "revision": 514,
-                          "sequenceNumber": 8,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 8
                         },
                         {
                           "change": [
@@ -306,8 +306,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 10,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 10
                         },
                         {
                           "change": [
@@ -383,8 +383,8 @@
                             }
                           ],
                           "revision": 3,
-                          "sequenceNumber": 12,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 12
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_52/tree-with-identifier-field-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_52/tree-with-identifier-field-final.json
@@ -203,8 +203,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_73/competing-removes-index-0.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_73/competing-removes-index-0.json
@@ -75,8 +75,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -120,8 +120,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -165,8 +165,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_73/competing-removes-index-1.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_73/competing-removes-index-1.json
@@ -78,8 +78,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -126,8 +126,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -174,8 +174,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_73/competing-removes-index-2.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_73/competing-removes-index-2.json
@@ -78,8 +78,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -126,8 +126,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -174,8 +174,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_73/competing-removes-index-3.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_73/competing-removes-index-3.json
@@ -78,8 +78,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -126,8 +126,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -174,8 +174,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_73/complete-3x3-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_73/complete-3x3-final.json
@@ -910,8 +910,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_73/concurrent-inserts-tree2.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_73/concurrent-inserts-tree2.json
@@ -113,8 +113,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -192,8 +192,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 6,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -278,8 +278,8 @@
                             }
                           ],
                           "revision": 3,
-                          "sequenceNumber": 8,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 8
                         },
                         {
                           "change": [
@@ -360,8 +360,8 @@
                             }
                           ],
                           "revision": 4,
-                          "sequenceNumber": 9,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 9
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_73/concurrent-inserts-tree3.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_73/concurrent-inserts-tree3.json
@@ -116,8 +116,8 @@
                             }
                           ],
                           "revision": 4,
-                          "sequenceNumber": 9,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 9
                         },
                         {
                           "change": [
@@ -195,8 +195,8 @@
                             }
                           ],
                           "revision": 7,
-                          "sequenceNumber": 11,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 11
                         },
                         {
                           "change": [
@@ -281,8 +281,8 @@
                             }
                           ],
                           "revision": 8,
-                          "sequenceNumber": 13,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 13
                         },
                         {
                           "change": [
@@ -363,8 +363,8 @@
                             }
                           ],
                           "revision": 9,
-                          "sequenceNumber": 14,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 14
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_73/custom-metadata-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_73/custom-metadata-final.json
@@ -195,8 +195,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         },
                         {
                           "change": [
@@ -274,8 +274,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_73/empty-root-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_73/empty-root-final.json
@@ -86,8 +86,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_73/has-handle-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_73/has-handle-final.json
@@ -112,8 +112,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_73/insert-and-remove-tree-0-after-insert.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_73/insert-and-remove-tree-0-after-insert.json
@@ -113,8 +113,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_73/insert-and-remove-tree-0-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_73/insert-and-remove-tree-0-final.json
@@ -75,8 +75,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 6,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 6
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_73/insert-and-remove-tree-1-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_73/insert-and-remove-tree-1-final.json
@@ -75,8 +75,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 6,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 6
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_73/move-across-fields-tree-0-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_73/move-across-fields-tree-0-final.json
@@ -294,8 +294,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         },
                         {
                           "change": [
@@ -382,8 +382,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_73/nested-sequence-change-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_73/nested-sequence-change-final.json
@@ -153,8 +153,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_73/optional-field-scenarios-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_73/optional-field-scenarios-final.json
@@ -109,8 +109,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -178,8 +178,8 @@
                             }
                           ],
                           "revision": 514,
-                          "sequenceNumber": 8,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 8
                         },
                         {
                           "change": [
@@ -306,8 +306,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 10,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 10
                         },
                         {
                           "change": [
@@ -383,8 +383,8 @@
                             }
                           ],
                           "revision": 3,
-                          "sequenceNumber": 12,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 12
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_73/tree-with-identifier-field-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_73/tree-with-identifier-field-final.json
@@ -203,8 +203,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_74/competing-removes-index-0.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_74/competing-removes-index-0.json
@@ -75,8 +75,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -120,8 +120,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -165,8 +165,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_74/competing-removes-index-1.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_74/competing-removes-index-1.json
@@ -78,8 +78,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -126,8 +126,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -174,8 +174,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_74/competing-removes-index-2.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_74/competing-removes-index-2.json
@@ -78,8 +78,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -126,8 +126,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -174,8 +174,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_74/competing-removes-index-3.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_74/competing-removes-index-3.json
@@ -78,8 +78,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -126,8 +126,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -174,8 +174,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_74/complete-3x3-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_74/complete-3x3-final.json
@@ -910,8 +910,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_74/concurrent-inserts-tree2.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_74/concurrent-inserts-tree2.json
@@ -113,8 +113,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -192,8 +192,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 6,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -278,8 +278,8 @@
                             }
                           ],
                           "revision": 3,
-                          "sequenceNumber": 8,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 8
                         },
                         {
                           "change": [
@@ -360,8 +360,8 @@
                             }
                           ],
                           "revision": 4,
-                          "sequenceNumber": 9,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 9
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_74/concurrent-inserts-tree3.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_74/concurrent-inserts-tree3.json
@@ -116,8 +116,8 @@
                             }
                           ],
                           "revision": 4,
-                          "sequenceNumber": 9,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 9
                         },
                         {
                           "change": [
@@ -195,8 +195,8 @@
                             }
                           ],
                           "revision": 7,
-                          "sequenceNumber": 11,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 11
                         },
                         {
                           "change": [
@@ -281,8 +281,8 @@
                             }
                           ],
                           "revision": 8,
-                          "sequenceNumber": 13,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 13
                         },
                         {
                           "change": [
@@ -363,8 +363,8 @@
                             }
                           ],
                           "revision": 9,
-                          "sequenceNumber": 14,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 14
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_74/custom-metadata-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_74/custom-metadata-final.json
@@ -195,8 +195,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         },
                         {
                           "change": [
@@ -274,8 +274,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_74/empty-root-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_74/empty-root-final.json
@@ -86,8 +86,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_74/has-handle-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_74/has-handle-final.json
@@ -112,8 +112,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_74/insert-and-remove-tree-0-after-insert.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_74/insert-and-remove-tree-0-after-insert.json
@@ -113,8 +113,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_74/insert-and-remove-tree-0-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_74/insert-and-remove-tree-0-final.json
@@ -75,8 +75,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 6,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 6
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_74/insert-and-remove-tree-1-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_74/insert-and-remove-tree-1-final.json
@@ -75,8 +75,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 6,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 6
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_74/move-across-fields-tree-0-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_74/move-across-fields-tree-0-final.json
@@ -294,8 +294,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         },
                         {
                           "change": [
@@ -382,8 +382,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_74/nested-sequence-change-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_74/nested-sequence-change-final.json
@@ -153,8 +153,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_74/optional-field-scenarios-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_74/optional-field-scenarios-final.json
@@ -109,8 +109,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -178,8 +178,8 @@
                             }
                           ],
                           "revision": 514,
-                          "sequenceNumber": 8,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 8
                         },
                         {
                           "change": [
@@ -306,8 +306,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 10,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 10
                         },
                         {
                           "change": [
@@ -383,8 +383,8 @@
                             }
                           ],
                           "revision": 3,
-                          "sequenceNumber": 12,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 12
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_74/tree-with-identifier-field-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_74/tree-with-identifier-field-final.json
@@ -203,8 +203,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_80/competing-removes-index-0.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_80/competing-removes-index-0.json
@@ -75,8 +75,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -120,8 +120,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -165,8 +165,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_80/competing-removes-index-1.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_80/competing-removes-index-1.json
@@ -78,8 +78,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -126,8 +126,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -174,8 +174,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_80/competing-removes-index-2.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_80/competing-removes-index-2.json
@@ -78,8 +78,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -126,8 +126,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -174,8 +174,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_80/competing-removes-index-3.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_80/competing-removes-index-3.json
@@ -78,8 +78,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -126,8 +126,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -174,8 +174,8 @@
                             }
                           ],
                           "revision": 1026,
-                          "sequenceNumber": 8,
-                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae"
+                          "sessionId": "5a126183-91e7-488a-b7e9-3342a05c25ae",
+                          "sequenceNumber": 8
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_80/complete-3x3-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_80/complete-3x3-final.json
@@ -910,8 +910,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_80/concurrent-inserts-tree2.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_80/concurrent-inserts-tree2.json
@@ -113,8 +113,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         },
                         {
                           "change": [
@@ -192,8 +192,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 6,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -278,8 +278,8 @@
                             }
                           ],
                           "revision": 3,
-                          "sequenceNumber": 8,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 8
                         },
                         {
                           "change": [
@@ -360,8 +360,8 @@
                             }
                           ],
                           "revision": 4,
-                          "sequenceNumber": 9,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 9
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_80/concurrent-inserts-tree3.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_80/concurrent-inserts-tree3.json
@@ -116,8 +116,8 @@
                             }
                           ],
                           "revision": 4,
-                          "sequenceNumber": 9,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 9
                         },
                         {
                           "change": [
@@ -195,8 +195,8 @@
                             }
                           ],
                           "revision": 7,
-                          "sequenceNumber": 11,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 11
                         },
                         {
                           "change": [
@@ -281,8 +281,8 @@
                             }
                           ],
                           "revision": 8,
-                          "sequenceNumber": 13,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 13
                         },
                         {
                           "change": [
@@ -363,8 +363,8 @@
                             }
                           ],
                           "revision": 9,
-                          "sequenceNumber": 14,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 14
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_80/custom-metadata-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_80/custom-metadata-final.json
@@ -195,8 +195,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         },
                         {
                           "change": [
@@ -274,8 +274,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_80/empty-root-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_80/empty-root-final.json
@@ -86,8 +86,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_80/has-handle-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_80/has-handle-final.json
@@ -112,8 +112,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_80/insert-and-remove-tree-0-after-insert.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_80/insert-and-remove-tree-0-after-insert.json
@@ -113,8 +113,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_80/insert-and-remove-tree-0-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_80/insert-and-remove-tree-0-final.json
@@ -75,8 +75,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 6,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 6
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_80/insert-and-remove-tree-1-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_80/insert-and-remove-tree-1-final.json
@@ -75,8 +75,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 6,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 6
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_80/move-across-fields-tree-0-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_80/move-across-fields-tree-0-final.json
@@ -294,8 +294,8 @@
                             }
                           ],
                           "revision": 0,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         },
                         {
                           "change": [
@@ -382,8 +382,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_80/nested-sequence-change-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_80/nested-sequence-change-final.json
@@ -153,8 +153,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 4,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 4
                         }
                       ],
                       "branches": [],

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_80/optional-field-scenarios-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_80/optional-field-scenarios-final.json
@@ -109,8 +109,8 @@
                             }
                           ],
                           "revision": 513,
-                          "sequenceNumber": 6,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 6
                         },
                         {
                           "change": [
@@ -178,8 +178,8 @@
                             }
                           ],
                           "revision": 514,
-                          "sequenceNumber": 8,
-                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2"
+                          "sessionId": "a0693eac-892a-4396-86f7-ad20dc1cade2",
+                          "sequenceNumber": 8
                         },
                         {
                           "change": [
@@ -306,8 +306,8 @@
                             }
                           ],
                           "revision": 2,
-                          "sequenceNumber": 10,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 10
                         },
                         {
                           "change": [
@@ -383,8 +383,8 @@
                             }
                           ],
                           "revision": 3,
-                          "sequenceNumber": 12,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 12
                         }
                       ],
                       "branches": [

--- a/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_80/tree-with-identifier-field-final.json
+++ b/packages/dds/tree/src/test/snapshots/output/summary/Uncompressed/v2_80/tree-with-identifier-field-final.json
@@ -203,8 +203,8 @@
                             }
                           ],
                           "revision": 1,
-                          "sequenceNumber": 2,
-                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06"
+                          "sessionId": "8f95be09-8376-4ff7-8755-ccd7e8124b06",
+                          "sequenceNumber": 2
                         }
                       ],
                       "branches": [],


### PR DESCRIPTION
## Description

This removes the usage of object spread from one of our codecs, aligning it with our recommended codec practices. 

## Breaking Changes

This change leads to a reordering of fields in encoded commits. This is not expected to cause issues in prior versions of the affected codecs.