### PR TITLE
Prepare historical compatibility defaults for the Client 3.0 floor

### DIFF
--- a/.changeset/giant-animals-arrive.md
+++ b/.changeset/giant-animals-arrive.md
@@ -3,7 +3,6 @@
 "fluid-framework": minor
 "__section": fix
 ---
-
 Preserve SharedTree's baseline format for historical runtime defaults
 
 SharedTree now treats the historical `2.0.0-defaults` runtime setting as its 2.0 baseline

--- a/.changeset/giant-animals-arrive.md
+++ b/.changeset/giant-animals-arrive.md
@@ -1,0 +1,13 @@
+---
+"@fluidframework/tree": minor
+"fluid-framework": minor
+"__section": fix
+---
+
+Preserve SharedTree's baseline format for historical runtime defaults
+
+SharedTree now treats the historical `2.0.0-defaults` runtime setting as its 2.0 baseline
+because SharedTree has no 1.x format behavior. This keeps its baseline codecs and summaries
+selectable when the supported deployed-client floor advances in
+[microsoft/FluidFramework#27460](https://github.com/microsoft/FluidFramework/issues/27460).
+The selected formats do not change for currently supported inputs.

--- a/packages/dds/tree/src/codec/compatibility.ts
+++ b/packages/dds/tree/src/codec/compatibility.ts
@@ -1,0 +1,24 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import type { OldestSupportedClientVersion } from "@fluidframework/runtime-definitions/internal";
+import { defaultMinVersionForCollab } from "@fluidframework/runtime-utils/internal";
+
+import { FluidClientVersion } from "./codec.js";
+
+/**
+ * Maps the runtime's historical compatibility sentinel to SharedTree's oldest supported version.
+ *
+ * SharedTree was introduced in Fluid Framework 2.0, so it has no distinct 1.x format behavior to
+ * preserve. Normalizing the sentinel at the SharedTree boundary keeps its baseline formats
+ * selectable independently of the runtime's deployed-client compatibility floor.
+ */
+export function normalizeTreeMinVersionForCollab(
+	minVersionForCollab: OldestSupportedClientVersion,
+): OldestSupportedClientVersion {
+	return minVersionForCollab === defaultMinVersionForCollab
+		? FluidClientVersion.v2_0
+		: minVersionForCollab;
+}

--- a/packages/dds/tree/src/codec/index.ts
+++ b/packages/dds/tree/src/codec/index.ts
@@ -30,6 +30,7 @@ export {
 	eraseEncodedType,
 	type JsonCodecPart,
 } from "./codec.js";
+export { normalizeTreeMinVersionForCollab } from "./compatibility.js";
 export {
 	DiscriminatedUnionDispatcher,
 	type DiscriminatedUnionLibrary,

--- a/packages/dds/tree/src/codec/versioned/codec.ts
+++ b/packages/dds/tree/src/codec/versioned/codec.ts
@@ -30,6 +30,7 @@ import {
 	type CodecName,
 	type CodecTree,
 } from "../codec.js";
+import { normalizeTreeMinVersionForCollab } from "../compatibility.js";
 
 import { Versioned } from "./format.js";
 
@@ -580,6 +581,7 @@ function getWriteVersion<T extends CodecVersionBase>(
 	options: CodecWriteOptions,
 	versions: readonly T[],
 ): T {
+	const minVersionForCollab = normalizeTreeMinVersionForCollab(options.minVersionForCollab);
 	if (options.writeVersionOverrides?.has(name) === true) {
 		const selectedFormatVersion = options.writeVersionOverrides.get(name);
 		const selected = versions.find((codec) => codec.formatVersion === selectedFormatVersion);
@@ -593,7 +595,7 @@ function getWriteVersion<T extends CodecVersionBase>(
 				throw new UsageError(
 					`Codec "${name}" does not support requested format version ${JSON.stringify(selectedFormatVersion)} because it has minVersionForCollab undefined. Use "allowPossiblyIncompatibleWriteVersionOverrides" to suppress this error if appropriate.`,
 				);
-			} else if (gt(selectedMinVersionForCollab, options.minVersionForCollab)) {
+			} else if (gt(selectedMinVersionForCollab, minVersionForCollab)) {
 				throw new UsageError(
 					`Codec "${name}" does not support requested format version ${JSON.stringify(selectedFormatVersion)} because it is only compatible back to client version ${selectedMinVersionForCollab} and the requested oldest compatible client was ${options.minVersionForCollab}. Use "allowPossiblyIncompatibleWriteVersionOverrides" to suppress this error if appropriate.`,
 				);
@@ -621,7 +623,7 @@ function getWriteVersionNoOverrides<T extends CodecVersionBase>(
 	}
 
 	const result: T = getConfigForMinVersionForCollabIterable(
-		minVersionForCollab,
+		normalizeTreeMinVersionForCollab(minVersionForCollab),
 		stableVersions,
 	);
 	return result;

--- a/packages/dds/tree/src/feature-libraries/forest-summary/summaryTypes.ts
+++ b/packages/dds/tree/src/feature-libraries/forest-summary/summaryTypes.ts
@@ -9,7 +9,7 @@ import {
 	lowestMinVersionForCollab,
 } from "@fluidframework/runtime-utils/internal";
 
-import { FluidClientVersion } from "../../codec/index.js";
+import { FluidClientVersion, normalizeTreeMinVersionForCollab } from "../../codec/index.js";
 
 import { ForestSummaryFormatVersion } from "./summaryFormatCommon.js";
 import { summaryContentBlobKey as summaryContentBlobKeyV1ToV2 } from "./summaryFormatV1ToV2.js";
@@ -21,7 +21,7 @@ import { summaryContentBlobKey as summaryContentBlobKeyV3 } from "./summaryForma
 export function minVersionToForestSummaryFormatVersion(
 	version: OldestSupportedClientVersion,
 ): ForestSummaryFormatVersion {
-	return getConfigForMinVersionForCollab(version, {
+	return getConfigForMinVersionForCollab(normalizeTreeMinVersionForCollab(version), {
 		[lowestMinVersionForCollab]: ForestSummaryFormatVersion.v2,
 		[FluidClientVersion.v2_74]: ForestSummaryFormatVersion.v3,
 	});

--- a/packages/dds/tree/src/shared-tree/sharedTree.ts
+++ b/packages/dds/tree/src/shared-tree/sharedTree.ts
@@ -13,7 +13,9 @@ import type {
 	IFluidSerializer,
 	SharedKernel,
 } from "@fluidframework/shared-object-base/internal";
+import { defaultMinVersionForCollab } from "@fluidframework/runtime-utils/internal";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
+import { lt } from "semver-ts";
 
 import {
 	type CodecTree,
@@ -23,6 +25,7 @@ import {
 	FluidClientVersion,
 	FormatValidatorNoOp,
 	type ICodecOptions,
+	normalizeTreeMinVersionForCollab,
 } from "../codec/index.js";
 import {
 	type FieldKey,
@@ -209,13 +212,19 @@ export class SharedTreeKernel
 		idCompressor: IIdCompressor,
 		optionsParam: SharedTreeOptionsInternal,
 	) {
+		const minVersionForCollab =
+			optionsParam.minVersionForCollab ?? defaultSharedTreeOptions.minVersionForCollab;
+		if (
+			minVersionForCollab !== defaultMinVersionForCollab &&
+			lt(minVersionForCollab, FluidClientVersion.v2_0)
+		) {
+			throw new UsageError("SharedTree requires minVersionForCollab of at least 2.0.0");
+		}
 		const options: Required<SharedTreeOptionsInternal> = {
 			...defaultSharedTreeOptions,
 			...optionsParam,
+			minVersionForCollab: normalizeTreeMinVersionForCollab(minVersionForCollab),
 		};
-		if (options.minVersionForCollab < FluidClientVersion.v2_0) {
-			throw new UsageError("SharedTree requires minVersionForCollab of at least 2.0.0");
-		}
 		const schema = new TreeStoredSchemaRepository();
 		const forest = buildConfiguredForest(
 			breaker,

--- a/packages/dds/tree/src/test/codec/versioned/codec.spec.ts
+++ b/packages/dds/tree/src/test/codec/versioned/codec.spec.ts
@@ -6,13 +6,20 @@
 import { strict as assert } from "node:assert";
 
 import { nonProductionConditionalsIncluded } from "@fluidframework/core-utils/internal";
-import { lowestMinVersionForCollab } from "@fluidframework/runtime-utils/internal";
+import {
+	defaultMinVersionForCollab,
+	lowestMinVersionForCollab,
+} from "@fluidframework/runtime-utils/internal";
 import {
 	validateAssertionError,
 	validateUsageError,
 } from "@fluidframework/test-runtime-utils/internal";
 
-import { FluidClientVersion, Versioned } from "../../../codec/index.js";
+import {
+	FluidClientVersion,
+	normalizeTreeMinVersionForCollab,
+	Versioned,
+} from "../../../codec/index.js";
 import {
 	VersionDispatchingCodecBuilder,
 	type CodecAndSchema,
@@ -92,6 +99,24 @@ describe("versioned Codecs", () => {
 				validateUsageError(`Unsupported version 3 encountered while decoding Test data. Supported versions for this data are: [1,2,"X"].
 The client which encoded this data likely specified an "minVersionForCollab" value which corresponds to a version newer than the version of this client ("${pkgVersion}").`),
 			);
+		});
+
+		it("uses the SharedTree 2.0 baseline for the historical compatibility sentinel", () => {
+			assert.equal(
+				normalizeTreeMinVersionForCollab(defaultMinVersionForCollab),
+				FluidClientVersion.v2_0,
+			);
+
+			const codec = builder.build({
+				minVersionForCollab: defaultMinVersionForCollab,
+				jsonValidator: FormatValidatorBasic,
+				writeVersionOverrides: new Map([["Test", 1]]),
+			});
+			assert.deepEqual(codec.encode(42), { version: 1, value1: 42 });
+			assert.deepEqual(builder.getCodecTree(defaultMinVersionForCollab), {
+				name: "Test",
+				version: 1,
+			});
 		});
 
 		it("unstable version", () => {

--- a/packages/dds/tree/src/test/feature-libraries/forest-summary/forestSummarizer.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/forest-summary/forestSummarizer.spec.ts
@@ -15,6 +15,7 @@ import type {
 	IExperimentalIncrementalSummaryContext,
 	OldestSupportedClientVersion,
 } from "@fluidframework/runtime-definitions/internal";
+import { defaultMinVersionForCollab } from "@fluidframework/runtime-utils/internal";
 import { MockStorage, validateUsageError } from "@fluidframework/test-runtime-utils/internal";
 
 import { FluidClientVersion, type CodecWriteOptions } from "../../../codec/index.js";
@@ -1269,6 +1270,23 @@ describe("ForestSummarizer", () => {
 	});
 
 	describe("Summary metadata validation", () => {
+		it("writes baseline metadata for the historical compatibility sentinel", () => {
+			const { forestSummarizer } = createForestSummarizer({
+				encodeType: TreeCompressionStrategy.Compressed,
+				forestType: ForestTypeOptimized,
+				minVersionForCollab: defaultMinVersionForCollab,
+			});
+
+			const summary = forestSummarizer.summarize({ stringify: JSON.stringify });
+			const metadataBlob = summary.summary.tree[summarizablesMetadataKey];
+			assert(metadataBlob !== undefined, "Metadata blob should exist");
+			assert.equal(metadataBlob.type, SummaryType.Blob, "Metadata should be a blob");
+			const metadataContent = JSON.parse(
+				metadataBlob.content as string,
+			) as SharedTreeSummarizableMetadata;
+			assert.equal(metadataContent.version, ForestSummaryFormatVersion.v2);
+		});
+
 		it("writes metadata blob with version 2", () => {
 			const { forestSummarizer } = createForestSummarizer({
 				encodeType: TreeCompressionStrategy.Compressed,

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -19,6 +19,7 @@ import type {
 	ISharedObjectKind,
 	SharedObjectKindAlpha,
 } from "@fluidframework/shared-object-base/internal";
+import { defaultMinVersionForCollab } from "@fluidframework/runtime-utils/internal";
 import {
 	MockContainerRuntimeFactory,
 	MockFluidDataStoreRuntime,
@@ -162,6 +163,35 @@ function treeTestFactory(): ISharedTree {
 }
 
 describe("SharedTree", () => {
+	it("supports the runtime's historical compatibility sentinel", () => {
+		const provider = new TestTreeProviderLite(
+			1,
+			configuredSharedTree({
+				jsonValidator: FormatValidatorBasic,
+				minVersionForCollab: defaultMinVersionForCollab,
+			}).getFactory(),
+		);
+		const view = provider.trees[0].viewWith(
+			new TreeViewConfiguration({ schema: numberSchema }),
+		);
+		view.initialize(10);
+		assert.equal(view.root, 10);
+	});
+
+	it("rejects compatibility versions before SharedTree 2.0", () => {
+		assert.throws(
+			() =>
+				new TestTreeProviderLite(
+					1,
+					configuredSharedTree({
+						jsonValidator: FormatValidatorBasic,
+						minVersionForCollab: "1.99.0",
+					}).getFactory(),
+				),
+			validateUsageError("SharedTree requires minVersionForCollab of at least 2.0.0"),
+		);
+	});
+
 	describe("viewWith", () => {
 		it("@Smoke initialize tree", () => {
 			const tree = treeTestFactory();

--- a/packages/framework/fluid-static/src/compatibilityConfiguration.ts
+++ b/packages/framework/fluid-static/src/compatibilityConfiguration.ts
@@ -17,11 +17,11 @@ import { gte } from "semver-ts";
  * (e.g. enableRuntimeIdCompressor to support SharedTree).
  */
 const minVersionForCollabToDefaultRuntimeOptions: Record<
-	"1" | "2",
+	"historical" | "supported",
 	IContainerRuntimeOptionsInternal
 > = {
-	"1": {},
-	"2": {
+	historical: {},
+	supported: {
 		// The runtime ID compressor is a prerequisite to use SharedTree but is off by default and must be explicitly enabled.
 		// In general, we don't want to enable this by default since it increases the bundle size. However, since SharedTree
 		// is bundled with the fluid-framework package, we need to enable it here to support SharedTree.
@@ -42,6 +42,6 @@ export function defaultRuntimeOptionsForMinVersion(
 	minVersionForCollab: OldestSupportedClientVersion,
 ): IContainerRuntimeOptionsInternal {
 	return minVersionForCollabToDefaultRuntimeOptions[
-		gte(minVersionForCollab, "2.0.0") ? "2" : "1"
+		gte(minVersionForCollab, "2.0.0") ? "supported" : "historical"
 	];
 }

--- a/packages/framework/fluid-static/src/test/compatibilityConfiguration.spec.ts
+++ b/packages/framework/fluid-static/src/test/compatibilityConfiguration.spec.ts
@@ -1,0 +1,20 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "node:assert";
+
+import { defaultRuntimeOptionsForMinVersion } from "../compatibilityConfiguration.js";
+
+describe("defaultRuntimeOptionsForMinVersion", () => {
+	it("preserves the historical defaults sentinel", () => {
+		assert.deepEqual(defaultRuntimeOptionsForMinVersion("2.0.0-defaults"), {});
+	});
+
+	it("enables the supported 2.0 configuration for deployed clients", () => {
+		assert.deepEqual(defaultRuntimeOptionsForMinVersion("2.0.0"), {
+			enableRuntimeIdCompressor: "on",
+		});
+	});
+});

--- a/packages/runtime/container-runtime/src/containerCompatibility.ts
+++ b/packages/runtime/container-runtime/src/containerCompatibility.ts
@@ -108,10 +108,12 @@ const runtimeOptionsAffectingDocSchemaConfigMap: ConfigMap<RuntimeOptionsAffecti
 		enableGroupedBatching: {
 			"1.0.0": false,
 			"2.0.0-defaults": true,
+			"2.0.0": true,
 		},
 		compressionOptions: {
 			"1.0.0": disabledCompressionConfig,
 			"2.0.0-defaults": enabledCompressionConfig,
+			"2.0.0": enabledCompressionConfig,
 		},
 		enableRuntimeIdCompressor: {
 			// For IdCompressorMode, `undefined` represents a logical state (off).
@@ -119,6 +121,8 @@ const runtimeOptionsAffectingDocSchemaConfigMap: ConfigMap<RuntimeOptionsAffecti
 			// `exactOptionalPropertyTypes` is `false` (TODO: AB#8215), we need
 			// to have it defined, so we trick the type checker here.
 			"1.0.0": undefined,
+			"2.0.0-defaults": undefined,
+			"2.0.0": undefined,
 			// We do not yet want to enable idCompressor by default since it will
 			// increase bundle sizes, and not all customers will benefit from it.
 			// Therefore, we will require customers to explicitly enable it. We
@@ -145,9 +149,12 @@ const runtimeOptionsAffectingDocSchemaConfigMap: ConfigMap<RuntimeOptionsAffecti
 			// fewer messages will be included per flush.
 			"1.0.0": FlushMode.Immediate,
 			"2.0.0-defaults": FlushMode.TurnBased,
+			"2.0.0": FlushMode.TurnBased,
 		},
 		gcOptions: {
 			"1.0.0": {},
+			"2.0.0-defaults": {},
+			"2.0.0": {},
 			// Although sweep is supported in 2.x, it is disabled by default until minVersionForCollab>=3.0.0 to be extra safe.
 			// Note that enabling this is a significant change, that should likely be announced in the relevant version:
 			// It would be bad if this simple caused the enablement when when the current package version passed this point without anyone being aware.
@@ -161,6 +168,8 @@ const runtimeOptionsAffectingDocSchemaConfigMap: ConfigMap<RuntimeOptionsAffecti
 			// closed on the version where that will happen yet.  Probably a .10 release since blob functionality is not
 			// exposed on the `@public` API surface.
 			"1.0.0": undefined,
+			"2.0.0-defaults": undefined,
+			"2.0.0": undefined,
 		},
 	};
 

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -4794,7 +4794,7 @@ describe("Runtime", () => {
 					});
 				});
 			}
-			it("throws if createBlobPayloadPending is incompatible with minVersionForCollab 2.0.0", async () => {
+			it("throws if createBlobPayloadPending is incompatible with oldestSupportedClient 2.0.0", async () => {
 				await assert.rejects(
 					async () =>
 						ContainerRuntime.loadRuntime2({
@@ -4806,7 +4806,7 @@ describe("Runtime", () => {
 								explicitSchemaControl: true,
 							},
 							provideEntryPoint: mockProvideEntryPoint,
-							minVersionForCollab: "2.0.0",
+							oldestSupportedClient: "2.0.0",
 						}),
 					(error: IErrorBase) =>
 						error.errorType === ContainerErrorTypes.usageError &&

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -4794,6 +4794,27 @@ describe("Runtime", () => {
 					});
 				});
 			}
+			it("throws if createBlobPayloadPending is incompatible with minVersionForCollab 2.0.0", async () => {
+				await assert.rejects(
+					async () =>
+						ContainerRuntime.loadRuntime2({
+							context: getMockContext() as IContainerContext,
+							registry: new FluidDataStoreRegistry([]),
+							existing: false,
+							runtimeOptions: {
+								createBlobPayloadPending: true,
+								explicitSchemaControl: true,
+							},
+							provideEntryPoint: mockProvideEntryPoint,
+							minVersionForCollab: "2.0.0",
+						}),
+					(error: IErrorBase) =>
+						error.errorType === ContainerErrorTypes.usageError &&
+						error.message ===
+							"Runtime option createBlobPayloadPending:true requires runtime version 2.40.0. Please update minVersionForCollab (currently 2.0.0) to 2.40.0 or later to proceed.",
+				);
+			});
+
 			it("does not throw if minVersionForCollab is not set and the default is incompatible with runtimeOptions", async () => {
 				const logger = new MockLogger();
 				await assert.doesNotReject(async () => {


### PR DESCRIPTION
## Description

Prepares runtime compatibility configuration for the Client 3.0 floor tracked by [#27460](https://github.com/microsoft/FluidFramework/issues/27460) and [AB#79024](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/79024) without changing the currently supported client range.

When `lowestMinVersionForCollab` advances to `2.0.0`, the historical `2.0.0-defaults` sentinel sorts below SharedTree's lowest codec entry. Without preparation, SharedTree cannot select a baseline codec or summary format for callers that retain the historical runtime defaults.

This change:

- maps the historical sentinel to SharedTree's 2.0 baseline, since SharedTree has no 1.x format behavior;
- makes SharedTree's minimum-version check SemVer-aware while retaining the sentinel exception;
- adds explicit historical-sentinel and deployed-2.0 entries to Container Runtime's configuration maps while retaining all existing 1.x entries;
- clarifies Fluid Static's historical-versus-supported runtime-option mapping; and
- adds regression coverage for SharedTree construction, codec overrides, forest summaries, Fluid Static defaults, and Container Runtime option validation.

This is a nonbreaking preparation change. It does not narrow `OldestSupportedClientVersion`, raise runtime validation to 2.0, or remove any 1.x configuration or tests. Those changes will remain together in the replacement breaking PR for #27972.