### PR TITLE
Advance oldest supported client floor to 2.0.0

### DIFF
--- a/.changeset/advance-oldest-supported-client.md
+++ b/.changeset/advance-oldest-supported-client.md
@@ -1,0 +1,42 @@
+---
+"@fluidframework/runtime-definitions": minor
+"@fluidframework/container-runtime": minor
+"@fluidframework/datastore": minor
+"@fluidframework/tree": minor
+"@fluidframework/aqueduct": minor
+"@fluidframework/fluid-static": minor
+"@fluidframework/azure-client": minor
+"@fluidframework/tinylicious-client": minor
+"@fluidframework/test-runtime-utils": minor
+"@fluidframework/test-utils": minor
+"fluid-framework": minor
+"__section": breaking
+"__highlight": true
+---
+Require oldest supported clients to use Fluid Framework 2.0 or later
+
+Client 3.0 narrows
+[`OldestSupportedClientVersion`](https://fluidframework.com/docs/api/runtime-definitions/oldestsupportedclientversion-typealias)
+to supported values from the 2.x and 3.x release lines. The deprecated
+[`MinimumVersionForCollab`](https://fluidframework.com/docs/api/runtime-definitions/minimumversionforcollab-typealias)
+alias inherits the same restriction and remains available until Client 4.0.
+
+Container runtimes now reject deployed-client values below `"2.0.0"`. APIs that still permit
+the setting to be omitted continue to select the historical runtime defaults through the
+`"2.0.0-defaults"` sentinel. The sentinel also remains available to test and replay
+infrastructure and is not a deployed client version.
+
+Before upgrading an application to Client 3.0, upgrade every active deployment that must
+collaborate to Fluid Framework 2.0.0 or later. Explicit compatibility settings must use the
+canonical property or service-client argument with a supported 2.x or 3.x value:
+
+```typescript
+const { container } = await azureClient.getContainer(
+	id,
+	schema,
+	"2.0.0", // oldestSupportedClient
+);
+```
+
+See [microsoft/FluidFramework#27460](https://github.com/microsoft/FluidFramework/issues/27460)
+for migration context.

--- a/CrossClientCompatibility.md
+++ b/CrossClientCompatibility.md
@@ -81,7 +81,9 @@ compatibility window for a client toward the end of a Range can be up to ~24 mon
 1. **Document access enforcement**: Clients running a Fluid version older than what the document requires may be blocked from opening it, preventing data corruption or runtime errors. This applies even when only one client reads the document. See [Errors and Warnings to Monitor](#errors-and-warnings-to-monitor) for the specific error signals.
 2. **Write format and feature selection**: It automatically enables or disables features based on the specified version so clients at that version or newer can interpret the resulting data format. For example, if `oldestSupportedClient` is set to `"2.0.0"`, features like grouped batching are safely enabled because all clients at version 2.0.0 or later can interpret that format.
 
-If `oldestSupportedClient` is not explicitly set, the runtime uses a default derived from the currently supported compatibility checkpoints. Passing a value below the supported floor is not permitted — the runtime will fail to instantiate and throw a `UsageError` (see [Errors and Warnings to Monitor](#errors-and-warnings-to-monitor)). For details on the default value, see `defaultMinVersionForCollab` in [compatibilityBase.ts](./packages/runtime/runtime-utils/src/compatibilityBase.ts).
+If `oldestSupportedClient` is not explicitly set, the runtime uses the historical default configuration represented internally by `2.0.0-defaults`. This fallback preserves historical runtime behavior; omission does not declare support for a deployed 1.x client. Passing an explicit value below the supported floor is not permitted — the runtime will fail to instantiate and throw a `UsageError` (see [Errors and Warnings to Monitor](#errors-and-warnings-to-monitor)). For details on the default value, see `defaultMinVersionForCollab` in [compatibilityBase.ts](./packages/runtime/runtime-utils/src/compatibilityBase.ts).
+
+Client 3.0 accepts supported 2.x and 3.x values. Before upgrading an application to Client 3.0, ensure every active deployment that must collaborate uses Fluid Framework 2.0.0 or later.
 
 ### What This Means for an Application
 
@@ -147,9 +149,9 @@ const runtime = await loadContainerRuntime(loadContainerRuntimeParams);
 
 `oldestSupportedClient` is a semver string representing the oldest Fluid client version that must be able to access documents written by the runtime. It automatically configures default values for runtime options and write formats to ensure compatibility with the specified version. For example, setting `oldestSupportedClient` to `"2.0.0"` enables features like grouped batching that are safe for all 2.x clients.
 
-You may also set individual runtime options via `IContainerRuntimeOptions`, but they must be consistent with your `oldestSupportedClient` value. If there is a mismatch (e.g., enabling a 2.x feature with `oldestSupportedClient: "1.0.0"`), a `UsageError` will be thrown (see [Errors and Warnings to Monitor](#errors-and-warnings-to-monitor)).
+You may also set individual runtime options via `IContainerRuntimeOptions`, but they must be consistent with your `oldestSupportedClient` value. If there is a mismatch (e.g., enabling a feature introduced in 2.40.0 with `oldestSupportedClient: "2.0.0"`), a `UsageError` will be thrown (see [Errors and Warnings to Monitor](#errors-and-warnings-to-monitor)).
 
-If `oldestSupportedClient` is not explicitly set, the runtime uses a default derived from the currently supported compatibility checkpoints (see `defaultMinVersionForCollab` in [compatibilityBase.ts](./packages/runtime/runtime-utils/src/compatibilityBase.ts)). Passing a value below the supported floor is not permitted and will throw a `UsageError`.
+If `oldestSupportedClient` is not explicitly set, the runtime uses its historical default configuration (see `defaultMinVersionForCollab` in [compatibilityBase.ts](./packages/runtime/runtime-utils/src/compatibilityBase.ts)). Passing an explicit value below the supported floor is not permitted and will throw a `UsageError`.
 
 Setting `oldestSupportedClient` explicitly is **highly recommended**. Set it to the oldest Fluid Framework
 version your users are [saturated](#terminology) on. This will ensure:
@@ -162,9 +164,10 @@ version your users are [saturated](#terminology) on. This will ensure:
 We recommend following the below pattern to ensure cross-client compatibility. Keeping your compatibility configuration up-to-date on an ongoing basis ensures you are always within a safe compatibility window.
 
 1. Observe the distribution of Fluid versions across your application's clients. See [Observing Client Version Distribution](./FluidCompatibilityConsiderations.md#observing-client-version-distribution) for how to do this using telemetry.
-2. Update your compatibility configuration to match the oldest deployed version that your clients are
+2. Update your compatibility configuration to match the oldest active deployed version that your clients are
    [saturated](#terminology) on. In both the declarative and encapsulated models, set `oldestSupportedClient`
-   to that saturated version (e.g., `"2.10.0"`).
+   to that saturated version (e.g., `"2.10.0"`). With Client 3.0, this value and every active deployment
+   that must collaborate must be at least `"2.0.0"`.
 3. Verify that the configured compatibility checkpoint is within the supported compatibility window of the Fluid Framework version you want to upgrade to. If it is, bump your Fluid Framework dependencies and update your lock file (so a newer version isn't picked up implicitly); no further action is required. If not, wait for further saturation and return to step 1.
 4. Monitor telemetry for warnings/errors to ensure safe rollout (see [Errors and Warnings to Monitor](#errors-and-warnings-to-monitor) below). At this point any clients running a version older than the configured `oldestSupportedClient` may be blocked from accessing the document.
 

--- a/CrossClientCompatibilityDevGuide.md
+++ b/CrossClientCompatibilityDevGuide.md
@@ -231,7 +231,9 @@ To tighten runtime enforcement:
 Fluid's end-to-end test suite automatically generates cross-client compatibility
 variations using `describeCompat()` with `"FullCompat"`. The variations test
 cross-client compatibility scenarios by using one version of the Fluid runtime for
-creating containers and a different version for loading containers.
+creating containers and a different version for loading containers. Prior checkpoints
+below `lowestMinVersionForCollab` are excluded because they are outside the supported
+deployed-client range.
 
 **Example:** With current build `3.0.0` (N) and in-window prior Compatibility
 Checkpoints `2.80.0` (CC#4), `2.40.0` (CC#3), and `2.0.9` (CC#2), a SharedCell

--- a/CrossClientCompatibilityDevGuide.md
+++ b/CrossClientCompatibilityDevGuide.md
@@ -44,7 +44,7 @@ However, there are many other types of changes that could impact cross-client co
 
 If a change affects the data format (see above), it should be gated by a **container runtime option**. Runtime options are enforced via the `oldestSupportedClient` property to ensure customers do not accidentally break older clients by enabling cross-client compatibility breaking features prematurely.
 
-`oldestSupportedClient` defines the oldest Fluid client version that must be able to access documents written by the runtime. Customers are encouraged to set `oldestSupportedClient` to the highest version their users are saturated on. If the customer does not set `oldestSupportedClient`, a default value is assigned. `oldestSupportedClient` controls the "default configurations" and "unsafe configuration prevention" mechanisms explained below.
+`oldestSupportedClient` defines the oldest Fluid client version that must be able to access documents written by the runtime. Customers are encouraged to set `oldestSupportedClient` to the highest version their users are saturated on. Client 3.0 accepts supported 2.x and 3.x values, so all active deployments that must collaborate need to be running Fluid Framework 2.0.0 or later. If the customer does not set `oldestSupportedClient`, the runtime uses its historical default configuration; omission does not declare support for a deployed 1.x client. `oldestSupportedClient` controls the "default configurations" and "unsafe configuration prevention" mechanisms explained below.
 
 ### Default Configurations
 
@@ -56,11 +56,12 @@ The runtime uses `oldestSupportedClient` to automatically set certain container 
 // Simplified view of the config map (see containerCompatibility.ts for full details)
 const runtimeOptionsAffectingDocSchemaConfigMap: ConfigMap<RuntimeOptionsAffectingDocSchema> = {
 	enableGroupedBatching: {
-		"1.0.0": false,
 		"2.0.0-defaults": true,
+		"2.0.0": true,
 	},
 	createBlobPayloadPending: {
-		"1.0.0": undefined,
+		"2.0.0-defaults": undefined,
+		"2.0.0": undefined,
 		// Could be enabled by default in a future version
 	},
 	// ... other options
@@ -73,18 +74,18 @@ const runtimeOptionsAffectingDocSchemaConfigMap: ConfigMap<RuntimeOptionsAffecti
 
 If a client tries to enable a runtime option that requires a version higher than the document's `oldestSupportedClient`, the runtime will fail to instantiate and throw a `UsageError`. This is handled by the `runtimeOptionsAffectingDocSchemaConfigValidationMap` in [containerCompatibility.ts](./packages/runtime/container-runtime/src/containerCompatibility.ts).
 
-**Example:** A container author sets `oldestSupportedClient` to `"1.4.0"` and `enableGroupedBatching` to `true`. The runtime fails immediately stating that `oldestSupportedClient` must be updated, since clients running runtime version 1.4.0 cannot understand the data format of grouped batching being enabled.
+**Example:** A container author sets `oldestSupportedClient` to `"2.0.0"` and `createBlobPayloadPending` to `true`. The runtime fails immediately stating that `oldestSupportedClient` must be updated to at least `"2.40.0"`, when support for the associated data format was introduced.
 
 ```typescript
 // Simplified view of the validation map (see containerCompatibility.ts for full details)
 const runtimeOptionsAffectingDocSchemaConfigValidationMap: ConfigValidationMap<RuntimeOptionsAffectingDocSchema> =
 	{
 		enableGroupedBatching: configValueToMinVersionForCollab([
-			[false, "1.0.0"],
-			[true, "2.0.0-defaults"],
+			[false, "2.0.0"],
+			[true, "2.0.0"],
 		]),
 		createBlobPayloadPending: configValueToMinVersionForCollab([
-			[undefined, "1.0.0"],
+			[undefined, "2.0.0"],
 			[true, "2.40.0"],
 		]),
 		// ... other options
@@ -209,10 +210,11 @@ Once a checkpoint has aged out of the supported window, the runtime's compatibil
 
 To tighten runtime enforcement:
 
-1. **Advance `defaultMinVersionForCollab`:** Update the default in
-   [compatibilityBase.ts](./packages/runtime/runtime-utils/src/compatibilityBase.ts)
-   to the oldest checkpoint still in the supported window.
-2. **Advance `lowestMinVersionForCollab`:** Update the floor in
+1. **Preserve the historical default:** `defaultMinVersionForCollab` represents the
+   behavior used when a caller omits an explicit compatibility value. Do not move this
+   sentinel with the deployed-client floor. Ensure configuration and format-selection
+   maps continue to handle it explicitly.
+2. **Advance `lowestMinVersionForCollab`:** Update the deployed-client floor in
    [compatibilityBase.ts](./packages/runtime/runtime-utils/src/compatibilityBase.ts)
    to match the oldest checkpoint still in the supported window.
    `lowestMinVersionForCollab` is the absolute minimum value a customer can
@@ -231,22 +233,22 @@ variations using `describeCompat()` with `"FullCompat"`. The variations test
 cross-client compatibility scenarios by using one version of the Fluid runtime for
 creating containers and a different version for loading containers.
 
-**Example:** With current build `2.101.0` (N) and in-window prior Compatibility
-Checkpoints `2.40.0` (CC#3), `2.0.9` (CC#2), and `1.4.0` (CC#1), a SharedCell
+**Example:** With current build `3.0.0` (N) and in-window prior Compatibility
+Checkpoints `2.80.0` (CC#4), `2.40.0` (CC#3), and `2.0.9` (CC#2), a SharedCell
 test generates these cross-client variations:
 
 ```
-compat cross-client - create with 2.101.0 (N) + load with 2.40.0 (CC#3)
+compat cross-client - create with 3.0.0 (N) + load with 2.80.0 (CC#4)
   ✔ Example test
-compat cross-client - create with 2.101.0 (N) + load with 2.0.9 (CC#2)
+compat cross-client - create with 3.0.0 (N) + load with 2.40.0 (CC#3)
   ✔ Example test
-compat cross-client - create with 2.101.0 (N) + load with 1.4.0 (CC#1)
+compat cross-client - create with 3.0.0 (N) + load with 2.0.9 (CC#2)
   ✔ Example test
-compat cross-client - create with 2.40.0 (CC#3) + load with 2.101.0 (N)
+compat cross-client - create with 2.80.0 (CC#4) + load with 3.0.0 (N)
   ✔ Example test
-compat cross-client - create with 2.0.9 (CC#2) + load with 2.101.0 (N)
+compat cross-client - create with 2.40.0 (CC#3) + load with 3.0.0 (N)
   ✔ Example test
-compat cross-client - create with 1.4.0 (CC#1) + load with 2.101.0 (N)
+compat cross-client - create with 2.0.9 (CC#2) + load with 3.0.0 (N)
   ✔ Example test
 ```
 

--- a/FluidCompatibilityConsiderations.md
+++ b/FluidCompatibilityConsiderations.md
@@ -113,6 +113,7 @@ This is done using an [OldestSupportedClientVersion](https://fluidframework.com/
 Fluid supports `OldestSupportedClientVersion` back to releases at least 18-months ago,
 and will only ever change the minimum supported version in a major release (as doing so is a breaking change).
 This means users of Fluid are given at least 18-months to roll out any version while being able to maintain collaboration across the rollout.
+Client 3.0 supports values from the 2.x and 3.x release lines, so every active deployment that must collaborate needs to use Fluid Framework 2.0.0 or later before upgrading.
 
 Details on exactly how this is tracked can be found in
 [Cross-Client Compatibility Policy](./CrossClientCompatibility.md#cross-client-compatibility-policy).

--- a/packages/dds/shared-object-base/src/test/createSharedObjectKind.spec.ts
+++ b/packages/dds/shared-object-base/src/test/createSharedObjectKind.spec.ts
@@ -190,7 +190,7 @@ describe("createSharedObjectKind with minVersionForCollab", () => {
 	}
 
 	it("SharedObject can be constructed with a minVersionForCollab from the runtime", () => {
-		const minVersionForCollab = "1.2.3";
+		const minVersionForCollab = "2.2.3";
 		const type = "Foo";
 
 		const attributes: IChannelAttributes = {
@@ -217,6 +217,6 @@ describe("createSharedObjectKind with minVersionForCollab", () => {
 		});
 		const foo = SharedFoo.create(runtime, "test-id");
 
-		assert.strictEqual(foo.minVersionForCollab, "1.2.3");
+		assert.strictEqual(foo.minVersionForCollab, "2.2.3");
 	});
 });

--- a/packages/dds/tree/src/feature-libraries/forest-summary/summaryTypes.ts
+++ b/packages/dds/tree/src/feature-libraries/forest-summary/summaryTypes.ts
@@ -5,6 +5,7 @@
 
 import type { OldestSupportedClientVersion } from "@fluidframework/runtime-definitions/internal";
 import {
+	defaultMinVersionForCollab,
 	getConfigForMinVersionForCollab,
 	lowestMinVersionForCollab,
 } from "@fluidframework/runtime-utils/internal";
@@ -22,6 +23,7 @@ export function minVersionToForestSummaryFormatVersion(
 	version: OldestSupportedClientVersion,
 ): ForestSummaryFormatVersion {
 	return getConfigForMinVersionForCollab(normalizeTreeMinVersionForCollab(version), {
+		[defaultMinVersionForCollab]: ForestSummaryFormatVersion.v2,
 		[lowestMinVersionForCollab]: ForestSummaryFormatVersion.v2,
 		[FluidClientVersion.v2_74]: ForestSummaryFormatVersion.v3,
 	});

--- a/packages/dds/tree/src/test/codec/versioned/codec.spec.ts
+++ b/packages/dds/tree/src/test/codec/versioned/codec.spec.ts
@@ -276,7 +276,7 @@ The client which encoded this data likely specified an "minVersionForCollab" val
 							},
 						]),
 					validateAssertionError(
-						`Debug assert failed: Codec Test has multiple entries for version "1.0.0"`,
+						`Debug assert failed: Codec Test has multiple entries for version "${lowestMinVersionForCollab}"`,
 					),
 				);
 

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -185,6 +185,7 @@ describe("SharedTree", () => {
 					1,
 					configuredSharedTree({
 						jsonValidator: FormatValidatorBasic,
+						// @ts-expect-error Client 3.0 excludes 1.x values, but runtime validation must reject type-erased input.
 						minVersionForCollab: "1.99.0",
 					}).getFactory(),
 				),

--- a/packages/dds/tree/src/test/snapshots/output/codecFormats/formats_DetachedFieldIndex_codec.json
+++ b/packages/dds/tree/src/test/snapshots/output/codecFormats/formats_DetachedFieldIndex_codec.json
@@ -1,7 +1,7 @@
 [
   {
     "version": 1,
-    "minVersionForCollab": "1.0.0",
+    "minVersionForCollab": "2.0.0",
     "schema": {
       "additionalProperties": false,
       "type": "object",

--- a/packages/dds/tree/src/test/snapshots/output/codecFormats/formats_Schema_codec.json
+++ b/packages/dds/tree/src/test/snapshots/output/codecFormats/formats_Schema_codec.json
@@ -1,7 +1,7 @@
 [
   {
     "version": 1,
-    "minVersionForCollab": "1.0.0",
+    "minVersionForCollab": "2.0.0",
     "schema": {
       "additionalProperties": false,
       "type": "object",

--- a/packages/dds/tree/src/test/snapshots/output/codecFormats/snapshot of supported codec formats_FieldBatch_codec.json
+++ b/packages/dds/tree/src/test/snapshots/output/codecFormats/snapshot of supported codec formats_FieldBatch_codec.json
@@ -1,7 +1,7 @@
 [
   {
     "version": 1,
-    "minVersionForCollab": "1.0.0",
+    "minVersionForCollab": "2.0.0",
     "schema": {
       "additionalProperties": false,
       "type": "object",

--- a/packages/framework/aqueduct/package.json
+++ b/packages/framework/aqueduct/package.json
@@ -154,10 +154,15 @@
 	"typeValidation": {
 		"broken": {
 			"Interface_DataObjectFactoryProps": {
-				"backCompat": false
+				"backCompat": false,
+				"forwardCompat": false
 			},
 			"Interface_IDataObjectProps": {
-				"backCompat": false
+				"backCompat": false,
+				"forwardCompat": false
+			},
+			"Interface_BaseContainerRuntimeFactoryProps": {
+				"forwardCompat": false
 			}
 		},
 		"entrypoint": "legacy"

--- a/packages/framework/aqueduct/src/test/types/validateAqueductPrevious.generated.ts
+++ b/packages/framework/aqueduct/src/test/types/validateAqueductPrevious.generated.ts
@@ -240,6 +240,7 @@ declare type current_as_old_for_ClassStatics_TreeDataObjectFactory = requireAssi
  * typeValidation.broken:
  * "Interface_BaseContainerRuntimeFactoryProps": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Interface_BaseContainerRuntimeFactoryProps = requireAssignableTo<TypeOnly<old.BaseContainerRuntimeFactoryProps>, TypeOnly<current.BaseContainerRuntimeFactoryProps>>
 
 /*
@@ -267,6 +268,7 @@ declare type current_as_old_for_Interface_ContainerRuntimeFactoryWithDefaultData
  * typeValidation.broken:
  * "Interface_DataObjectFactoryProps": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Interface_DataObjectFactoryProps = requireAssignableTo<TypeOnly<old.DataObjectFactoryProps<never>>, TypeOnly<current.DataObjectFactoryProps<never>>>
 
 /*
@@ -304,6 +306,7 @@ declare type current_as_old_for_Interface_DataObjectTypes = requireAssignableTo<
  * typeValidation.broken:
  * "Interface_IDataObjectProps": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Interface_IDataObjectProps = requireAssignableTo<TypeOnly<old.IDataObjectProps>, TypeOnly<current.IDataObjectProps>>
 
 /*

--- a/packages/runtime/container-runtime/package.json
+++ b/packages/runtime/container-runtime/package.json
@@ -232,7 +232,8 @@
 	"typeValidation": {
 		"broken": {
 			"Interface_LoadContainerRuntimeParams": {
-				"backCompat": false
+				"backCompat": false,
+				"forwardCompat": false
 			}
 		},
 		"entrypoint": "legacy"

--- a/packages/runtime/container-runtime/src/containerCompatibility.ts
+++ b/packages/runtime/container-runtime/src/containerCompatibility.ts
@@ -98,20 +98,17 @@ export type RuntimeOptionKeysThatRequireExplicitSchemaControl = keyof Omit<
  * the format changes introduced by the property, then the default value for that OldestSupportedClientVersion will enable the feature associated with the property.
  * Otherwise, the feature will be disabled.
  *
- * For example if the minVersionForCollab is a 1.x version (i.e. "1.5.0"), then the default value for `enableGroupedBatching` will be false since 1.x
- * clients do not understand the document format when batching is enabled. If the minVersionForCollab is a 2.x client (i.e. "2.0.0" or later), then the
- * default value for `enableGroupedBatching` will be true because clients running 2.0 or later will be able to understand the format changes associated
- * with the batching feature.
+ * For example, the default value for `enableGroupedBatching` is true at the supported
+ * floor of 2.0.0 because clients running 2.0.0 or later understand the associated
+ * document format.
  */
 const runtimeOptionsAffectingDocSchemaConfigMap: ConfigMap<RuntimeOptionsAffectingDocSchema> =
 	{
 		enableGroupedBatching: {
-			"1.0.0": false,
 			"2.0.0-defaults": true,
 			"2.0.0": true,
 		},
 		compressionOptions: {
-			"1.0.0": disabledCompressionConfig,
 			"2.0.0-defaults": enabledCompressionConfig,
 			"2.0.0": enabledCompressionConfig,
 		},
@@ -120,7 +117,6 @@ const runtimeOptionsAffectingDocSchemaConfigMap: ConfigMap<RuntimeOptionsAffecti
 			// However, to satisfy the Required<> constraint while
 			// `exactOptionalPropertyTypes` is `false` (TODO: AB#8215), we need
 			// to have it defined, so we trick the type checker here.
-			"1.0.0": undefined,
 			"2.0.0-defaults": undefined,
 			"2.0.0": undefined,
 			// We do not yet want to enable idCompressor by default since it will
@@ -130,7 +126,7 @@ const runtimeOptionsAffectingDocSchemaConfigMap: ConfigMap<RuntimeOptionsAffecti
 			// change in the future.
 		},
 		explicitSchemaControl: {
-			"1.0.0": false,
+			"2.0.0-defaults": false,
 			// This option's intention is to prevent 1.x clients from joining sessions
 			// when enabled. This is set to true when the minVersionForCollab is set
 			// to >=2.0.0 (explicitly). This is different than other 2.0 defaults
@@ -144,15 +140,10 @@ const runtimeOptionsAffectingDocSchemaConfigMap: ConfigMap<RuntimeOptionsAffecti
 			"2.0.0": true,
 		},
 		flushMode: {
-			// Note: 1.x clients are compatible with TurnBased flushing, but here we elect to remain on Immediate flush mode
-			// as a work-around for inability to send batches larger than 1Mb. Immediate flushing keeps batches smaller as
-			// fewer messages will be included per flush.
-			"1.0.0": FlushMode.Immediate,
 			"2.0.0-defaults": FlushMode.TurnBased,
 			"2.0.0": FlushMode.TurnBased,
 		},
 		gcOptions: {
-			"1.0.0": {},
 			"2.0.0-defaults": {},
 			"2.0.0": {},
 			// Although sweep is supported in 2.x, it is disabled by default until minVersionForCollab>=3.0.0 to be extra safe.
@@ -167,7 +158,6 @@ const runtimeOptionsAffectingDocSchemaConfigMap: ConfigMap<RuntimeOptionsAffecti
 			// This feature is new and disabled by default. In the future we will enable it by default, but we have not
 			// closed on the version where that will happen yet.  Probably a .10 release since blob functionality is not
 			// exposed on the `@public` API surface.
-			"1.0.0": undefined,
 			"2.0.0-defaults": undefined,
 			"2.0.0": undefined,
 		},
@@ -190,32 +180,32 @@ export const runtimeOptionKeysThatRequireExplicitSchemaControl = (
 const runtimeOptionsAffectingDocSchemaConfigValidationMap: ConfigValidationMap<RuntimeOptionsAffectingDocSchema> =
 	{
 		enableGroupedBatching: configValueToMinVersionForCollab([
-			[false, "1.0.0"],
-			[true, "2.0.0-defaults"],
+			[false, "2.0.0"],
+			[true, "2.0.0"],
 		]),
 		compressionOptions: configValueToMinVersionForCollab([
-			[{ ...disabledCompressionConfig }, "1.0.0"],
-			[{ ...enabledCompressionConfig }, "2.0.0-defaults"],
+			[{ ...disabledCompressionConfig }, "2.0.0"],
+			[{ ...enabledCompressionConfig }, "2.0.0"],
 		]),
 		enableRuntimeIdCompressor: configValueToMinVersionForCollab([
-			[undefined, "1.0.0"],
-			["on", "2.0.0-defaults"],
-			["delayed", "2.0.0-defaults"],
+			[undefined, "2.0.0"],
+			["on", "2.0.0"],
+			["delayed", "2.0.0"],
 		]),
 		explicitSchemaControl: configValueToMinVersionForCollab([
-			[false, "1.0.0"],
-			[true, "2.0.0-defaults"],
+			[false, "2.0.0"],
+			[true, "2.0.0"],
 		]),
 		flushMode: configValueToMinVersionForCollab([
-			[FlushMode.Immediate, "1.0.0"],
-			[FlushMode.TurnBased, "2.0.0-defaults"],
+			[FlushMode.Immediate, "2.0.0"],
+			[FlushMode.TurnBased, "2.0.0"],
 		]),
 		gcOptions: configValueToMinVersionForCollab([
-			[{ enableGCSweep: undefined }, "1.0.0"],
-			[{ enableGCSweep: true }, "2.0.0-defaults"],
+			[{ enableGCSweep: undefined }, "2.0.0"],
+			[{ enableGCSweep: true }, "2.0.0"],
 		]),
 		createBlobPayloadPending: configValueToMinVersionForCollab([
-			[undefined, "1.0.0"],
+			[undefined, "2.0.0"],
 			[true, "2.40.0"],
 		]),
 	};
@@ -234,8 +224,8 @@ export function getMinVersionForCollabDefaults(
 
 /**
  * Validates if the runtime options passed in from the user are compatible with the minVersionForCollab.
- * For example, if a user sets the `enableGroupedBatching` option to true, but the minVersionForCollab
- * is set to "1.0.0", then we should throw a UsageError since 1.x clients do not support batching.
+ * For example, if a user enables an option introduced in 2.40.0 while the
+ * minVersionForCollab is set to "2.0.0", then we should throw a UsageError.
  * */
 export function validateRuntimeOptions(
 	minVersionForCollab: OldestSupportedClientVersion,

--- a/packages/runtime/container-runtime/src/containerRuntime.ts
+++ b/packages/runtime/container-runtime/src/containerRuntime.ts
@@ -819,10 +819,10 @@ export interface LoadContainerRuntimeParams {
 	 *
 	 * @privateRemarks
 	 * Used to determine the default configuration for {@link IContainerRuntimeOptionsInternal} that affect the document schema.
-	 * For example, let's say that feature `foo` was added in 2.0 which introduces a new op type. Additionally, option `bar`
-	 * was added to `IContainerRuntimeOptionsInternal` in 2.0 to enable/disable `foo` since clients prior to 2.0 would not
-	 * understand the new op type. If a customer were to set oldestSupportedClient to 2.0.0, then `bar` would be set to
-	 * enable `foo` by default. If a customer were to set oldestSupportedClient to 1.0.0, then `bar` would be set to
+	 * For example, let's say that feature `foo` was added in 2.40 which introduces a new op type. Additionally, option `bar`
+	 * was added to `IContainerRuntimeOptionsInternal` in 2.40 to enable/disable `foo` since clients prior to 2.40 would not
+	 * understand the new op type. If a customer were to set oldestSupportedClient to 2.40.0, then `bar` would be set to
+	 * enable `foo` by default. If a customer were to set oldestSupportedClient to 2.0.0, then `bar` would be set to
 	 * disable `foo` by default.
 	 */
 	oldestSupportedClient?: OldestSupportedClientVersion;
@@ -1034,8 +1034,8 @@ export class ContainerRuntime
 
 		// Some options require a minimum version of the FF runtime to operate, so the default configs will be generated
 		// based on the minVersionForCollab.
-		// For example, if minVersionForCollab is set to "1.0.0", the default configs will ensure compatibility with FF runtime
-		// 1.0.0 or later. If the minVersionForCollab is set to "2.10.0", the default values will be generated to ensure compatibility
+		// For example, if minVersionForCollab is set to "2.0.0", the default configs will ensure compatibility with FF runtime
+		// 2.0.0 or later. If the minVersionForCollab is set to "2.10.0", the default values will be generated to ensure compatibility
 		// with FF runtime 2.10.0 or later.
 		if (!isValidMinVersionForCollab(minVersionForCollab)) {
 			throw new UsageError(

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -54,6 +54,7 @@ import type {
 	ISequencedMessageEnvelope,
 	ITelemetryContext,
 	ISummarizeInternalResult,
+	OldestSupportedClientVersion,
 	StagingModeChangedEvent,
 } from "@fluidframework/runtime-definitions/internal";
 import { FlushMode } from "@fluidframework/runtime-definitions/internal";
@@ -79,7 +80,7 @@ import {
 import Sinon, { type SinonFakeTimers } from "sinon";
 
 import { ChannelCollection } from "../channelCollection.js";
-import { CompressionAlgorithms, enabledCompressionConfig } from "../compressionDefinitions.js";
+import { CompressionAlgorithms } from "../compressionDefinitions.js";
 import {
 	ContainerRuntime,
 	type IContainerRuntimeOptions,
@@ -4434,9 +4435,9 @@ describe("Runtime", () => {
 			});
 
 			// These are examples of minVersionForCollab inputs that are not valid.
-			// minVersionForCollab should be at least 1.0.0 and less than or equal to
+			// minVersionForCollab should be at least 2.0.0 and less than or equal to
 			// the current pkgVersion.
-			const invalidVersions = ["0.50.0", "100.0.0"] as const;
+			const invalidVersions = ["1.99.0", "100.0.0"] as const;
 			for (const version of invalidVersions) {
 				it(`throws when minVersionForCollab = ${version}`, async () => {
 					const logger = new MockLogger();
@@ -4447,52 +4448,11 @@ describe("Runtime", () => {
 							existing: false,
 							runtimeOptions: {},
 							provideEntryPoint: mockProvideEntryPoint,
-							// @ts-expect-error - Invalid version strings are not castable to OldestSupportedClientVersion
-							minVersionForCollab: version,
+							minVersionForCollab: version as OldestSupportedClientVersion,
 						});
 					});
 				});
 			}
-
-			it("minVersionForCollab = 1.0.0", async () => {
-				const minVersionForCollab = "1.0.0";
-				const logger = new MockLogger();
-				await ContainerRuntime.loadRuntime2({
-					context: getMockContext({ logger }) as IContainerContext,
-					registry: new FluidDataStoreRegistry([]),
-					existing: false,
-					runtimeOptions: {},
-					provideEntryPoint: mockProvideEntryPoint,
-					minVersionForCollab,
-				});
-
-				const expectedRuntimeOptions: IContainerRuntimeOptionsInternal = {
-					summaryOptions: {},
-					gcOptions: {},
-					loadSequenceNumberVerification: "close",
-					flushMode: FlushMode.Immediate,
-					compressionOptions: {
-						minimumBatchSizeInBytes: Number.POSITIVE_INFINITY,
-						compressionAlgorithm: CompressionAlgorithms.lz4,
-					},
-					maxBatchSizeInBytes: 716800,
-					chunkSizeInBytes: 204800,
-					enableRuntimeIdCompressor: undefined,
-					enableGroupedBatching: false,
-					explicitSchemaControl: false,
-					stagingModeAutoFlushThreshold: 1000,
-					disableSchemaUpgrade: false,
-				};
-
-				logger.assertMatchAny([
-					{
-						eventName: "ContainerRuntime:ContainerLoadStats",
-						category: "generic",
-						options: JSON.stringify(expectedRuntimeOptions),
-						minVersionForCollab,
-					},
-				]);
-			});
 
 			it('minVersionForCollab = 2.0.0-defaults ("default")', async () => {
 				const minVersionForCollab = "2.0.0-defaults";
@@ -4764,36 +4724,6 @@ describe("Runtime", () => {
 				]);
 			});
 
-			for (const runtimeOption of [
-				{ enableGroupedBatching: true },
-				{ enableGroupedBatching: true, compressionOptions: enabledCompressionConfig },
-				{ explicitSchemaControl: true },
-				{ gcOptions: { enableGCSweep: true } },
-				// Adding in an arbitrary entry into the IGCRuntimeOptions object
-				{ gcOptions: { enableGCSweep: true, sweepGracePeriodMs: 1 } },
-				{ enableRuntimeIdCompressor: "on" },
-				{ enableRuntimeIdCompressor: "delayed" },
-				{ createBlobPayloadPending: true },
-				{ flushMode: FlushMode.TurnBased },
-			]) {
-				it(`throws if minVersionForCollab is incompatible with runtimeOptions: ${JSON.stringify(runtimeOption)}`, async () => {
-					const runtimeOptions = {
-						...runtimeOption,
-					} as unknown as IContainerRuntimeOptionsInternal;
-					const logger = new MockLogger();
-					const minVersionForCollab = "1.0.0";
-					await assert.rejects(async () => {
-						await ContainerRuntime.loadRuntime2({
-							context: getMockContext({ logger }) as IContainerContext,
-							registry: new FluidDataStoreRegistry([]),
-							existing: false,
-							runtimeOptions,
-							provideEntryPoint: mockProvideEntryPoint,
-							minVersionForCollab,
-						});
-					});
-				});
-			}
 			it("throws if createBlobPayloadPending is incompatible with oldestSupportedClient 2.0.0", async () => {
 				await assert.rejects(
 					async () =>

--- a/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
+++ b/packages/runtime/container-runtime/src/test/containerRuntime.spec.ts
@@ -54,7 +54,6 @@ import type {
 	ISequencedMessageEnvelope,
 	ITelemetryContext,
 	ISummarizeInternalResult,
-	OldestSupportedClientVersion,
 	StagingModeChangedEvent,
 } from "@fluidframework/runtime-definitions/internal";
 import { FlushMode } from "@fluidframework/runtime-definitions/internal";
@@ -4448,7 +4447,8 @@ describe("Runtime", () => {
 							existing: false,
 							runtimeOptions: {},
 							provideEntryPoint: mockProvideEntryPoint,
-							minVersionForCollab: version as OldestSupportedClientVersion,
+							// @ts-expect-error Explicit 1.x and future versions are rejected by the public type and at runtime.
+							minVersionForCollab: version,
 						});
 					});
 				});

--- a/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
+++ b/packages/runtime/container-runtime/src/test/types/validateContainerRuntimePrevious.generated.ts
@@ -708,6 +708,7 @@ declare type current_as_old_for_Interface_IVersionMarkResolver = requireAssignab
  * typeValidation.broken:
  * "Interface_LoadContainerRuntimeParams": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Interface_LoadContainerRuntimeParams = requireAssignableTo<TypeOnly<old.LoadContainerRuntimeParams>, TypeOnly<current.LoadContainerRuntimeParams>>
 
 /*

--- a/packages/runtime/datastore/package.json
+++ b/packages/runtime/datastore/package.json
@@ -158,7 +158,8 @@
 	"typeValidation": {
 		"broken": {
 			"Class_FluidDataStoreRuntime": {
-				"backCompat": false
+				"backCompat": false,
+				"forwardCompat": false
 			},
 			"ClassStatics_FluidDataStoreRuntime": {
 				"backCompat": false

--- a/packages/runtime/datastore/src/test/dataStoreRuntime.spec.ts
+++ b/packages/runtime/datastore/src/test/dataStoreRuntime.spec.ts
@@ -634,7 +634,7 @@ describe("FluidDataStoreRuntime.minVersionForCollab", () => {
 	}
 
 	it("minVersionForCollab is read from the FluidDataStoreContext and stored on FluidDataStoreRuntime", () => {
-		const runtime = createRuntime("minVersionTest", "1.2.3");
-		assert.deepStrictEqual(runtime.minVersionForCollab, "1.2.3");
+		const runtime = createRuntime("minVersionTest", "2.2.3");
+		assert.deepStrictEqual(runtime.minVersionForCollab, "2.2.3");
 	});
 });

--- a/packages/runtime/datastore/src/test/types/validateDatastorePrevious.generated.ts
+++ b/packages/runtime/datastore/src/test/types/validateDatastorePrevious.generated.ts
@@ -24,6 +24,7 @@ declare type MakeUnusedImportErrorsGoAway<T> = TypeOnly<T> | MinimalType<T> | Fu
  * typeValidation.broken:
  * "Class_FluidDataStoreRuntime": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_FluidDataStoreRuntime = requireAssignableTo<TypeOnly<old.FluidDataStoreRuntime>, TypeOnly<current.FluidDataStoreRuntime>>
 
 /*

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.beta.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.beta.api.md
@@ -8,7 +8,7 @@
 export type MinimumVersionForCollab = OldestSupportedClientVersion;
 
 // @public @input
-export type OldestSupportedClientVersion = `3.${bigint}.0` | `${1 | 2}.${bigint}.${bigint}` | `${1 | 2}.${bigint}.${bigint}-${string}`;
+export type OldestSupportedClientVersion = `3.${bigint}.0` | `2.${bigint}.${bigint}` | `2.${bigint}.${bigint}-${string}`;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.alpha.api.md
@@ -416,7 +416,7 @@ Promise<FluidDataStoreRegistryEntry> | FluidDataStoreRegistryEntry
 ];
 
 // @public @input
-export type OldestSupportedClientVersion = `3.${bigint}.0` | `${1 | 2}.${bigint}.${bigint}` | `${1 | 2}.${bigint}.${bigint}-${string}`;
+export type OldestSupportedClientVersion = `3.${bigint}.0` | `2.${bigint}.${bigint}` | `2.${bigint}.${bigint}-${string}`;
 
 // @beta @legacy
 export interface OpAttributionKey {

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.beta.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.beta.api.md
@@ -409,7 +409,7 @@ Promise<FluidDataStoreRegistryEntry> | FluidDataStoreRegistryEntry
 ];
 
 // @public @input
-export type OldestSupportedClientVersion = `3.${bigint}.0` | `${1 | 2}.${bigint}.${bigint}` | `${1 | 2}.${bigint}.${bigint}-${string}`;
+export type OldestSupportedClientVersion = `3.${bigint}.0` | `2.${bigint}.${bigint}` | `2.${bigint}.${bigint}-${string}`;
 
 // @beta @legacy
 export interface OpAttributionKey {

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.public.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.legacy.public.api.md
@@ -8,7 +8,7 @@
 export type MinimumVersionForCollab = OldestSupportedClientVersion;
 
 // @public @input
-export type OldestSupportedClientVersion = `3.${bigint}.0` | `${1 | 2}.${bigint}.${bigint}` | `${1 | 2}.${bigint}.${bigint}-${string}`;
+export type OldestSupportedClientVersion = `3.${bigint}.0` | `2.${bigint}.${bigint}` | `2.${bigint}.${bigint}-${string}`;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/runtime/runtime-definitions/api-report/runtime-definitions.public.api.md
+++ b/packages/runtime/runtime-definitions/api-report/runtime-definitions.public.api.md
@@ -8,7 +8,7 @@
 export type MinimumVersionForCollab = OldestSupportedClientVersion;
 
 // @public @input
-export type OldestSupportedClientVersion = `3.${bigint}.0` | `${1 | 2}.${bigint}.${bigint}` | `${1 | 2}.${bigint}.${bigint}-${string}`;
+export type OldestSupportedClientVersion = `3.${bigint}.0` | `2.${bigint}.${bigint}` | `2.${bigint}.${bigint}-${string}`;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/runtime/runtime-definitions/package.json
+++ b/packages/runtime/runtime-definitions/package.json
@@ -140,6 +140,12 @@
 			},
 			"Interface_IFluidParentContext": {
 				"backCompat": false
+			},
+			"TypeAlias_MinimumVersionForCollab": {
+				"forwardCompat": false
+			},
+			"TypeAlias_OldestSupportedClientVersion": {
+				"forwardCompat": false
 			}
 		},
 		"entrypoint": "legacy"

--- a/packages/runtime/runtime-definitions/src/compatibilityDefinitions.ts
+++ b/packages/runtime/runtime-definitions/src/compatibilityDefinitions.ts
@@ -18,7 +18,14 @@
  * Collaboration with other clients is supported when all Fluid Framework client packages used by the client have a version that is greater than or equal
  * to the specified `OldestSupportedClientVersion`.
  *
- * Must be at least {@link @fluidframework/runtime-utils#lowestMinVersionForCollab} and cannot exceed the version of any Fluid Framework client package in use by the local client.
+ * Client 3.0 supports deployed-client values from the 2.x and 3.x release lines. Every active
+ * deployment that must collaborate needs to use Fluid Framework 2.0.0 or later before upgrading.
+ *
+ * Deployed-client values must be at least {@link @fluidframework/runtime-utils#lowestMinVersionForCollab}
+ * and cannot exceed the version of any Fluid Framework client package in use by the local client.
+ * The historical {@link @fluidframework/runtime-utils#defaultMinVersionForCollab} sentinel remains
+ * the fallback for APIs that permit omission and for internal test and replay infrastructure; it
+ * is not a deployed client version.
  *
  * {@link @fluidframework/runtime-utils#validateMinimumVersionForCollab} can be used to check these invariants at runtime.
  * Since TypeScript cannot enforce all of them for literals in code, it is useful for checking values sourced from constants typed as `OldestSupportedClientVersion`.
@@ -35,7 +42,7 @@
  * Since this type is marked with `@input`, it is only consumed by the framework and never returned, so widening the accepted set is a non-breaking change.
  *
  * Historically, this type allowed arbitrary patch versions, but as noted above that is problematic for ordering, so only the major and minor versions are supported for new majors:
- * support for patch versions can be aged out as support for versions 1 and 2 are dropped (or simply deprecated and removed in a later major version).
+ * support for patch versions can be aged out as support for version 2 is dropped (or simply deprecated and removed in a later major version).
  * Once gone that simplification is done, this type will align with {@link @fluidframework/driver-definitions#OldestSupportedServiceClientVersion} and the two types can be deduplicated.
  *
  * In the future, we may want to generalize this to mean
@@ -50,8 +57,8 @@
  */
 export type OldestSupportedClientVersion =
 	| `3.${bigint}.0`
-	| `${1 | 2}.${bigint}.${bigint}`
-	| `${1 | 2}.${bigint}.${bigint}-${string}`;
+	| `2.${bigint}.${bigint}`
+	| `2.${bigint}.${bigint}-${string}`;
 
 /**
  * Oldest version of Fluid Framework client packages that must be able to open and process

--- a/packages/runtime/runtime-definitions/src/test/types/oldestSupportedClientVersion.ts
+++ b/packages/runtime/runtime-definitions/src/test/types/oldestSupportedClientVersion.ts
@@ -1,0 +1,27 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import type { OldestSupportedClientVersion } from "../../index.js";
+
+export const supportedVersions: OldestSupportedClientVersion[] = [
+	"2.0.0",
+	"2.0.0-defaults",
+	"2.116.1-beta.1",
+	"3.0.0",
+	"3.1.0",
+];
+
+export const unsupportedVersions: OldestSupportedClientVersion[] = [
+	// @ts-expect-error Client 3.0 does not support collaborating with 1.x clients.
+	"1.99.0",
+	// @ts-expect-error New major versions use minor-level feature checkpoints.
+	"3.1.2",
+	// @ts-expect-error New major versions do not accept prerelease checkpoints.
+	"3.1.0-beta.1",
+	// @ts-expect-error Client 3.0 does not accept future 4.x versions.
+	"4.0.0",
+	// @ts-expect-error The value must be valid SemVer.
+	"invalid",
+];

--- a/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.generated.ts
+++ b/packages/runtime/runtime-definitions/src/test/types/validateRuntimeDefinitionsPrevious.generated.ts
@@ -747,6 +747,7 @@ declare type current_as_old_for_TypeAlias_ISequencedMessageEnvelope = requireAss
  * typeValidation.broken:
  * "TypeAlias_MinimumVersionForCollab": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_TypeAlias_MinimumVersionForCollab = requireAssignableTo<TypeOnly<old.MinimumVersionForCollab>, TypeOnly<current.MinimumVersionForCollab>>
 
 /*
@@ -810,6 +811,7 @@ declare type current_as_old_for_TypeAlias_NamedFluidDataStoreRegistryEntry2 = re
  * typeValidation.broken:
  * "TypeAlias_OldestSupportedClientVersion": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_TypeAlias_OldestSupportedClientVersion = requireAssignableTo<TypeOnly<old.OldestSupportedClientVersion>, TypeOnly<current.OldestSupportedClientVersion>>
 
 /*

--- a/packages/runtime/runtime-utils/src/compatibilityBase.ts
+++ b/packages/runtime/runtime-utils/src/compatibilityBase.ts
@@ -95,6 +95,7 @@ export interface ConfigMapEntry<T> {
 	// Note that this is NOT an index signature.
 	// This is a regular property with a computed name (See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer#computed_property_names).
 	[lowestMinVersionForCollab]: T;
+	[defaultMinVersionForCollab]: T;
 }
 
 /**

--- a/packages/runtime/runtime-utils/src/compatibilityBase.ts
+++ b/packages/runtime/runtime-utils/src/compatibilityBase.ts
@@ -12,22 +12,14 @@ import { compare, gt, gte, lte, parse } from "semver-ts";
 import { pkgVersion } from "./packageVersion.js";
 
 /**
- * Our policy is to support major versions N and N-1, where N is most
- * recent public major release of the Fluid Framework Client.
- * Therefore, if the customer does not provide a minVersionForCollab, we will
- * default to use N-1.
+ * Historical compatibility configuration used before callers explicitly selected their oldest
+ * supported client.
  *
- * However, this is not consistent with today's behavior. Some options (i.e.
- * batching, compression) are enabled by default despite not being compatible
- * with 1.x clients. Since the policy was introduced during 2.x's lifespan,
- * N/N-1 compatibility by **default** will be in effect starting with 3.0.
- * Importantly though, N/N-2 compatibility is still guaranteed with the proper
- * configurations set.
- *
- * Further to distinguish unspecified `minVersionForCollab` from a specified
- * version and allow `enableExplicitSchemaControl` to default to `true` for
- * any 2.0.0+ version, we will use a special value of `2.0.0-defaults`, which
- * is semantically less than 2.0.0.
+ * @remarks
+ * This sentinel sorts below 2.0.0 so the runtime can preserve the historical defaults, including
+ * `explicitSchemaControl: false`, while explicit 2.0.0 selects the current 2.0 configuration.
+ * It remains the fallback for callers that omit an explicit compatibility value and for internal
+ * test and replay infrastructure, but it is not a deployed client version.
  *
  * @internal
  */
@@ -35,10 +27,11 @@ export const defaultMinVersionForCollab =
 	"2.0.0-defaults" as const satisfies OldestSupportedClientVersion;
 
 /**
- * We don't want allow a version before the major public release of the LTS version.
- * Today we use "1.0.0", because our policy supports N/N-1 & N/N-2, which includes
- * all minor versions of N. Though LTS starts at 1.4.0, we should stay consistent
- * with our policy and allow all 1.x versions to be compatible with 2.x.
+ * Oldest deployed Fluid Framework client version supported for cross-client compatibility.
+ *
+ * @remarks
+ * The historical {@link defaultMinVersionForCollab} sentinel is also accepted as the implicit
+ * fallback even though it sorts below this deployed-version floor.
  *
  * @privateRemarks
  * Exported for use in tests.
@@ -46,7 +39,7 @@ export const defaultMinVersionForCollab =
  * @internal
  */
 export const lowestMinVersionForCollab =
-	"1.0.0" as const satisfies OldestSupportedClientVersion;
+	"2.0.0" as const satisfies OldestSupportedClientVersion;
 
 /**
  * String in a valid semver format specifying bottom of a minor version
@@ -95,8 +88,10 @@ export interface ConfigMapEntry<T> {
 	// This index signature (See https://www.typescriptlang.org/docs/handbook/2/objects.html#index-signatures) requires all properties on this type to to have keys that are a MinimumMinorSemanticVersion and values of type T.
 	// Note that the "version" part of this syntax is really just documentation and has no impact on the type checking (other than some identifier being required to the syntax here to differentiate it from the computed property syntax).
 	[version: MinimumMinorSemanticVersion]: T;
-	// Require an entry for the defaultMinVersionForCollab:
-	// this ensures that all versions of lowestMinVersionForCollab or later have a specified value in the ConfigMap.
+	// Require an entry for lowestMinVersionForCollab:
+	// this ensures that every supported deployed-client version has a specified value in the ConfigMap.
+	// Maps that distinguish the historical default must also provide an explicit
+	// defaultMinVersionForCollab entry.
 	// Note that this is NOT an index signature.
 	// This is a regular property with a computed name (See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer#computed_property_names).
 	[lowestMinVersionForCollab]: T;
@@ -222,8 +217,10 @@ export function checkValidMinVersionForCollabVerbose(minVersionForCollab: Semant
 } {
 	const parsed = parse(minVersionForCollab);
 	const isValidSemver = parsed !== null && parsed.build.length === 0;
+	const isHistoricalDefault = minVersionForCollab === defaultMinVersionForCollab;
 	const isGteLowestMinVersion =
-		isValidSemver && gte(minVersionForCollab, lowestMinVersionForCollab);
+		isValidSemver &&
+		(isHistoricalDefault || gte(minVersionForCollab, lowestMinVersionForCollab));
 	const isLtePkgVersion = isValidSemver && lte(minVersionForCollab, cleanedPackageVersion);
 	const isValidOldestSupportedClientVersion =
 		isGteLowestMinVersion &&

--- a/packages/runtime/runtime-utils/src/test/compatibilityBase.spec.ts
+++ b/packages/runtime/runtime-utils/src/test/compatibilityBase.spec.ts
@@ -16,6 +16,7 @@ import {
 	type SemanticVersion,
 	type ConfigValidationMap,
 	configValueToMinVersionForCollab,
+	defaultMinVersionForCollab,
 	lowestMinVersionForCollab,
 	checkValidMinVersionForCollabVerbose,
 	cleanedPackageVersion,
@@ -33,12 +34,21 @@ describe("compatibilityBase", () => {
 	// The getConfigsForMinVersionForCollab tests provide a lot of coverage for this function as well.
 	describe("getConfigForMinVersionForCollab", () => {
 		it("minimal", () => {
-			const config = getConfigForMinVersionForCollab("2.2.0", { "2.0.0": "X" });
+			const config = getConfigForMinVersionForCollab("2.2.0", {
+				[defaultMinVersionForCollab]: "X",
+				[lowestMinVersionForCollab]: "X",
+			});
 			assert.equal(config, "X");
 		});
 		it("sorting", () => {
 			// These checks are designed to fail if the items are not sorted according to semver, and are either left as ordered or sorted lexically.
-			const config = { "2.0.0": "A", "2.100.0": "D", "2.58.0": "B", "2.60.0": "C" };
+			const config = {
+				[defaultMinVersionForCollab]: "A",
+				[lowestMinVersionForCollab]: "A",
+				"2.100.0": "D",
+				"2.58.0": "B",
+				"2.60.0": "C",
+			};
 			assert.equal(getConfigForMinVersionForCollab("2.50.0", config), "A");
 			assert.equal(getConfigForMinVersionForCollab("2.58.0", config), "B");
 			assert.equal(getConfigForMinVersionForCollab("2.59.0", config), "B");
@@ -431,7 +441,7 @@ describe("compatibilityBase", () => {
 		});
 
 		const testCases: {
-			version: OldestSupportedClientVersion;
+			version: SemanticVersion;
 			checks: {
 				isValidSemver: boolean;
 				isGteLowestMinVersion: boolean;
@@ -458,8 +468,7 @@ describe("compatibilityBase", () => {
 				},
 			},
 			{
-				// Cast since this is not a valid OldestSupportedClientVersion, but is a valid semver.
-				version: "3.999999.1" as OldestSupportedClientVersion,
+				version: "3.999999.1",
 				checks: {
 					isValidSemver: true,
 					isGteLowestMinVersion: true,
@@ -468,8 +477,7 @@ describe("compatibilityBase", () => {
 				},
 			},
 			{
-				// Cast since this is not a valid OldestSupportedClientVersion, but is a valid semver.
-				version: "3.999999.0-test" as OldestSupportedClientVersion,
+				version: "3.999999.0-test",
 				checks: {
 					isValidSemver: true,
 					isGteLowestMinVersion: true,
@@ -487,8 +495,7 @@ describe("compatibilityBase", () => {
 				},
 			},
 			{
-				// Cast since this is no longer a valid OldestSupportedClientVersion.
-				version: "1.99.0" as OldestSupportedClientVersion,
+				version: "1.99.0",
 				checks: {
 					isValidSemver: true,
 					isGteLowestMinVersion: false,
@@ -497,8 +504,7 @@ describe("compatibilityBase", () => {
 				},
 			},
 			{
-				// Cast since this is not a valid OldestSupportedClientVersion, but is a valid semver.
-				version: "0.0.0" as OldestSupportedClientVersion,
+				version: "0.0.0",
 				checks: {
 					isValidSemver: true,
 					isGteLowestMinVersion: false,
@@ -507,8 +513,7 @@ describe("compatibilityBase", () => {
 				},
 			},
 			{
-				// Cast since this is not a valid OldestSupportedClientVersion, but is a valid semver.
-				version: "1000000.0.0" as OldestSupportedClientVersion,
+				version: "1000000.0.0",
 				checks: {
 					isValidSemver: true,
 					isGteLowestMinVersion: true,
@@ -517,8 +522,8 @@ describe("compatibilityBase", () => {
 				},
 			},
 			{
-				// Cast since this is not a valid OldestSupportedClientVersion and is not a valid semver.
-				version: "1.2" as OldestSupportedClientVersion,
+				// @ts-expect-error This intentionally exercises runtime validation of an invalid semantic-version shape.
+				version: "1.2",
 				checks: {
 					isValidSemver: false,
 					isGteLowestMinVersion: false,

--- a/packages/runtime/runtime-utils/src/test/compatibilityBase.spec.ts
+++ b/packages/runtime/runtime-utils/src/test/compatibilityBase.spec.ts
@@ -33,18 +33,18 @@ describe("compatibilityBase", () => {
 	// The getConfigsForMinVersionForCollab tests provide a lot of coverage for this function as well.
 	describe("getConfigForMinVersionForCollab", () => {
 		it("minimal", () => {
-			const config = getConfigForMinVersionForCollab("2.2.0", { "1.0.0": "X" });
+			const config = getConfigForMinVersionForCollab("2.2.0", { "2.0.0": "X" });
 			assert.equal(config, "X");
 		});
 		it("sorting", () => {
 			// These checks are designed to fail if the items are not sorted according to semver, and are either left as ordered or sorted lexically.
-			const config = { "1.0.0": "A", "1.500.0": "D", "1.58.0": "B", "1.60.0": "C" };
-			assert.equal(getConfigForMinVersionForCollab("1.50.0", config), "A");
-			assert.equal(getConfigForMinVersionForCollab("1.58.0", config), "B");
-			assert.equal(getConfigForMinVersionForCollab("1.59.0", config), "B");
-			assert.equal(getConfigForMinVersionForCollab("1.60.0", config), "C");
-			assert.equal(getConfigForMinVersionForCollab("1.400.0", config), "C");
-			assert.equal(getConfigForMinVersionForCollab("1.500.0", config), "D");
+			const config = { "2.0.0": "A", "2.100.0": "D", "2.58.0": "B", "2.60.0": "C" };
+			assert.equal(getConfigForMinVersionForCollab("2.50.0", config), "A");
+			assert.equal(getConfigForMinVersionForCollab("2.58.0", config), "B");
+			assert.equal(getConfigForMinVersionForCollab("2.59.0", config), "B");
+			assert.equal(getConfigForMinVersionForCollab("2.60.0", config), "C");
+			assert.equal(getConfigForMinVersionForCollab("2.99.0", config), "C");
+			assert.equal(getConfigForMinVersionForCollab("2.100.0", config), "D");
 		});
 	});
 
@@ -64,36 +64,39 @@ describe("compatibilityBase", () => {
 				"2.0.0-defaults": "a1",
 				"2.50.0": "a4",
 				"2.40.0": "a3",
-				"1.0.0": "a0",
 			},
 			featureB: {
-				"1.0.0": "b1",
+				"2.0.0-defaults": "b1",
+				"2.0.0": "b1",
 				"2.30.0": "b2",
 				"2.60.0": "b4",
 				"2.46.0": "b3",
 			},
 			featureC: {
-				"1.0.0": "c1",
+				"2.0.0-defaults": "c1",
+				"2.0.0": "c1",
 				"2.40.0": "c2",
 				"2.70.0": "c4",
 				"2.50.0": "c3",
 			},
 			featureD: {
+				"2.0.0-defaults": "d1",
 				"2.46.0": "d3",
 				"2.5.0": "d2",
 				"2.55.0": "d4",
-				"1.0.0": "d1",
+				"2.0.0": "d1",
 			},
 			featureE: {
+				"2.0.0-defaults": "e1",
 				"2.35.0": "e2",
 				"2.73.0": "e4",
 				"2.65.0": "e3",
-				"1.0.0": "e1",
+				"2.0.0": "e1",
 			},
 			featureF: {
-				"1.0.0": 0,
+				"2.0.0-defaults": 1,
+				"2.0.0": 1,
 				"2.45.0": 2,
-				"1.5.0": 1,
 				"2.71.0": 4,
 				"2.65.0": 3,
 			},
@@ -103,28 +106,6 @@ describe("compatibilityBase", () => {
 			minVersionForCollab: OldestSupportedClientVersion;
 			expectedConfig: ITestConfigMap;
 		}[] = [
-			{
-				minVersionForCollab: "1.0.0",
-				expectedConfig: {
-					featureA: "a0",
-					featureB: "b1",
-					featureC: "c1",
-					featureD: "d1",
-					featureE: "e1",
-					featureF: 0,
-				},
-			},
-			{
-				minVersionForCollab: "1.5.0",
-				expectedConfig: {
-					featureA: "a0",
-					featureB: "b1",
-					featureC: "c1",
-					featureD: "d1",
-					featureE: "e1",
-					featureF: 1,
-				},
-			},
 			{
 				minVersionForCollab: "2.0.0-defaults",
 				expectedConfig: {
@@ -354,7 +335,7 @@ describe("compatibilityBase", () => {
 				runtimeOptions: { featureC: { foo: 2, bar: "bax", qaz: true }, featureA: "a4" },
 			},
 			{
-				minVersionForCollab: "1.0.0",
+				minVersionForCollab: "2.0.0",
 				runtimeOptions: { featureC: { notDocSchemaAffecting: true }, featureA: "a1" },
 			},
 		];
@@ -493,6 +474,25 @@ describe("compatibilityBase", () => {
 					isValidSemver: true,
 					isGteLowestMinVersion: true,
 					isLtePkgVersion: false,
+					isValidOldestSupportedClientVersion: false,
+				},
+			},
+			{
+				version: "2.0.0-defaults",
+				checks: {
+					isValidSemver: true,
+					isGteLowestMinVersion: true,
+					isLtePkgVersion: true,
+					isValidOldestSupportedClientVersion: true,
+				},
+			},
+			{
+				// Cast since this is no longer a valid OldestSupportedClientVersion.
+				version: "1.99.0" as OldestSupportedClientVersion,
+				checks: {
+					isValidSemver: true,
+					isGteLowestMinVersion: false,
+					isLtePkgVersion: true,
 					isValidOldestSupportedClientVersion: false,
 				},
 			},

--- a/packages/runtime/test-runtime-utils/package.json
+++ b/packages/runtime/test-runtime-utils/package.json
@@ -154,7 +154,8 @@
 	"typeValidation": {
 		"broken": {
 			"Class_MockFluidDataStoreContext": {
-				"backCompat": false
+				"backCompat": false,
+				"forwardCompat": false
 			},
 			"Class_MockFluidDataStoreRuntime": {
 				"backCompat": false

--- a/packages/runtime/test-runtime-utils/src/test/types/validateTestRuntimeUtilsPrevious.generated.ts
+++ b/packages/runtime/test-runtime-utils/src/test/types/validateTestRuntimeUtilsPrevious.generated.ts
@@ -168,6 +168,7 @@ declare type current_as_old_for_Class_MockDeltaQueue = requireAssignableTo<TypeO
  * typeValidation.broken:
  * "Class_MockFluidDataStoreContext": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Class_MockFluidDataStoreContext = requireAssignableTo<TypeOnly<old.MockFluidDataStoreContext>, TypeOnly<current.MockFluidDataStoreContext>>
 
 /*

--- a/packages/service-clients/azure-client/api-report/azure-client.beta.api.md
+++ b/packages/service-clients/azure-client/api-report/azure-client.beta.api.md
@@ -109,6 +109,6 @@ export interface IUser {
 }
 
 // @public @input
-export type OldestSupportedClientVersion = `3.${bigint}.0` | `${1 | 2}.${bigint}.${bigint}` | `${1 | 2}.${bigint}.${bigint}-${string}`;
+export type OldestSupportedClientVersion = `3.${bigint}.0` | `2.${bigint}.${bigint}` | `2.${bigint}.${bigint}-${string}`;
 
 ```

--- a/packages/service-clients/azure-client/api-report/azure-client.legacy.beta.api.md
+++ b/packages/service-clients/azure-client/api-report/azure-client.legacy.beta.api.md
@@ -109,6 +109,6 @@ export interface IUser {
 }
 
 // @public @input
-export type OldestSupportedClientVersion = `3.${bigint}.0` | `${1 | 2}.${bigint}.${bigint}` | `${1 | 2}.${bigint}.${bigint}-${string}`;
+export type OldestSupportedClientVersion = `3.${bigint}.0` | `2.${bigint}.${bigint}` | `2.${bigint}.${bigint}-${string}`;
 
 ```

--- a/packages/service-clients/azure-client/api-report/azure-client.legacy.public.api.md
+++ b/packages/service-clients/azure-client/api-report/azure-client.legacy.public.api.md
@@ -109,6 +109,6 @@ export interface IUser {
 }
 
 // @public @input
-export type OldestSupportedClientVersion = `3.${bigint}.0` | `${1 | 2}.${bigint}.${bigint}` | `${1 | 2}.${bigint}.${bigint}-${string}`;
+export type OldestSupportedClientVersion = `3.${bigint}.0` | `2.${bigint}.${bigint}` | `2.${bigint}.${bigint}-${string}`;
 
 ```

--- a/packages/service-clients/azure-client/api-report/azure-client.public.api.md
+++ b/packages/service-clients/azure-client/api-report/azure-client.public.api.md
@@ -109,6 +109,6 @@ export interface IUser {
 }
 
 // @public @input
-export type OldestSupportedClientVersion = `3.${bigint}.0` | `${1 | 2}.${bigint}.${bigint}` | `${1 | 2}.${bigint}.${bigint}-${string}`;
+export type OldestSupportedClientVersion = `3.${bigint}.0` | `2.${bigint}.${bigint}` | `2.${bigint}.${bigint}-${string}`;
 
 ```

--- a/packages/service-clients/azure-client/src/test/AzureClient.spec.ts
+++ b/packages/service-clients/azure-client/src/test/AzureClient.spec.ts
@@ -78,7 +78,7 @@ const connectionModeOf = (container: IFluidContainer): ConnectionMode => {
 	return getContainerConnectionMode(container.container);
 };
 
-for (const oldestSupportedClient of ["1.0.0", "2.0.0"] as const) {
+for (const oldestSupportedClient of ["2.0.0"] as const) {
 	describe(`AzureClient (oldestSupportedClient: ${oldestSupportedClient})`, function () {
 		const connectTimeoutMs = 1000;
 		let client: AzureClient;
@@ -364,10 +364,6 @@ for (const oldestSupportedClient of ["1.0.0", "2.0.0"] as const) {
 			});
 
 			it("preserves 'SharedTree' type", async function () {
-				// SharedTree is not supported with oldestSupportedClient "1.0.0" because it requires idCompressor to be enabled.
-				if (oldestSupportedClient === "1.0.0") {
-					this.skip();
-				}
 				const { container } = await client.createContainer(
 					{
 						initialObjects: {
@@ -402,25 +398,7 @@ for (const oldestSupportedClient of ["1.0.0", "2.0.0"] as const) {
 					oldestSupportedClient,
 				);
 
-				const expectedRuntimeOptions1 = {
-					summaryOptions: {},
-					gcOptions: {},
-					loadSequenceNumberVerification: "close",
-					flushMode: 0,
-					compressionOptions: {
-						minimumBatchSizeInBytes: Number.POSITIVE_INFINITY,
-						compressionAlgorithm: CompressionAlgorithms.lz4,
-					},
-					maxBatchSizeInBytes: 716800,
-					chunkSizeInBytes: 204800,
-					enableRuntimeIdCompressor: undefined,
-					enableGroupedBatching: false,
-					explicitSchemaControl: false,
-					createBlobPayloadPending: undefined,
-					disableSchemaUpgrade: false,
-					stagingModeAutoFlushThreshold: 1000,
-				} as const satisfies ContainerRuntimeOptionsInternal;
-				const expectedRuntimeOptions2 = {
+				const expectedRuntimeOptions = {
 					summaryOptions: {},
 					gcOptions: {},
 					loadSequenceNumberVerification: "close",
@@ -439,10 +417,6 @@ for (const oldestSupportedClient of ["1.0.0", "2.0.0"] as const) {
 					stagingModeAutoFlushThreshold: 1000,
 				} as const satisfies ContainerRuntimeOptionsInternal;
 
-				const expectedRuntimeOptions =
-					oldestSupportedClient === "1.0.0"
-						? expectedRuntimeOptions1
-						: expectedRuntimeOptions2;
 				assert(isInternalFluidContainer(container_defaultConfig));
 				const actualRuntimeOptions = getRuntimeOptions(
 					getContainerRuntime(container_defaultConfig.container),

--- a/packages/service-clients/end-to-end-tests/azure-client/src/test/containerCreate.spec.ts
+++ b/packages/service-clients/end-to-end-tests/azure-client/src/test/containerCreate.spec.ts
@@ -314,7 +314,7 @@ for (const testOpts of testMatrix) {
 		 * Expected behavior: an error should not be thrown nor should a rejected promise
 		 * be returned.
 		 */
-		for (const oldestSupportedClient of ["1.0.0", "2.0.0"] as const) {
+		for (const oldestSupportedClient of ["2.0.0"] as const) {
 			it(`Current AzureClient (oldestSupportedClient: "${oldestSupportedClient}") can get container made by legacy AzureClient`, async () => {
 				const { container: containerLegacy } =
 					await clientLegacy.createContainer(schemaLegacy);
@@ -352,11 +352,9 @@ for (const testOpts of testMatrix) {
 				// Await the value being saved, especially important if we dispose the legacy container.
 				await valueSetP;
 
-				if (oldestSupportedClient === "2.0.0") {
-					// We don't support interop between legacy containers and oldestSupportedClient "2.0.0", dispose the legacy
-					// container to avoid this case.
-					containerLegacy.dispose();
-				}
+				// Client 3.0 does not support active collaboration with 1.x clients. Dispose the
+				// legacy client before loading to verify data-at-rest compatibility only.
+				containerLegacy.dispose();
 
 				const resources = clientCurrent.getContainer(
 					containerId,
@@ -390,8 +388,6 @@ for (const testOpts of testMatrix) {
 		const connectTimeoutMs = 10_000;
 		const isEphemeral: boolean = testOpts.options.isEphemeral;
 		let clientCurrent1: AzureClient;
-		let clientCurrent2: AzureClient;
-		let clientLegacy: AzureClientLegacy;
 		let sandbox: SinonSandbox;
 
 		const schemaCurrent = {
@@ -400,20 +396,12 @@ for (const testOpts of testMatrix) {
 			},
 		} satisfies ContainerSchema;
 
-		const schemaLegacy = {
-			initialObjects: {
-				map1: SharedMapLegacy,
-			},
-		};
-
 		before(function () {
 			sandbox = createSandbox();
 		});
 
 		beforeEach("createAzureClients", function () {
 			clientCurrent1 = createAzureClient();
-			clientCurrent2 = createAzureClient();
-			clientLegacy = createAzureClientLegacy();
 			if (isEphemeral) {
 				this.skip();
 			}
@@ -423,193 +411,7 @@ for (const testOpts of testMatrix) {
 			sandbox.restore();
 		});
 
-		/**
-		 * Scenario: test if a legacy AzureClient can get a container made by the current AzureClient.
-		 *
-		 * Expected behavior: an error should not be thrown nor should a rejected promise
-		 * be returned.
-		 */
-		it(`Legacy AzureClient can get container made by current AzureClient (oldestSupportedClient: "1.0.0")`, async () => {
-			const { container: containerCurrent } = await clientCurrent1.createContainer(
-				schemaCurrent,
-				// Note: Only containers created with oldestSupportedClient "1.0.0" may be loaded by a legacy client.
-				"1.0.0",
-			);
-			const containerId = await containerCurrent.attach();
-
-			if (containerCurrent.connectionState !== ConnectionState.Connected) {
-				await timeoutPromise(
-					(resolve) => containerCurrent.once("connected", () => resolve()),
-					{
-						durationMs: connectTimeoutMs,
-						errorMsg: "containerCurrent connect() timeout",
-					},
-				);
-			}
-
-			containerCurrent.initialObjects.map1.set("key", "value");
-
-			const resources = clientLegacy.getContainer(containerId, schemaLegacy);
-			await assert.doesNotReject(resources, () => true, "container could not be loaded");
-
-			const { container: containerLegacy } = await resources;
-			if (containerLegacy.connectionState !== ConnectionState.Connected) {
-				await timeoutPromise((resolve) => containerLegacy.once("connected", () => resolve()), {
-					durationMs: connectTimeoutMs,
-					errorMsg: "containerLegacy connect() timeout",
-				});
-			}
-
-			const result = (containerLegacy.initialObjects.map1 as SharedMapLegacy).get<string>(
-				"key",
-			);
-			assert.strictEqual(result, "value", "Value not found in copied container");
-		});
-
-		/**
-		 * Scenario: test if a current AzureClient using oldestSupportedClient "2.0.0" can get a container made by the current AzureClient using "1.0.0".
-		 *
-		 * Expected behavior: an error should not be thrown nor should a rejected promise be returned.
-		 */
-		it(`Current AzureClient (oldestSupportedClient: "2.0.0") can get container made by current AzureClient (oldestSupportedClient: "1.0.0")`, async () => {
-			const { container: containerCurrent1 } = await clientCurrent1.createContainer(
-				schemaCurrent,
-				"1.0.0",
-			);
-			const containerId = await containerCurrent1.attach();
-
-			if (containerCurrent1.connectionState !== ConnectionState.Connected) {
-				await timeoutPromise(
-					(resolve) => containerCurrent1.once("connected", () => resolve()),
-					{
-						durationMs: connectTimeoutMs,
-						errorMsg: "containerCurrent1 connect() timeout",
-					},
-				);
-			}
-
-			containerCurrent1.initialObjects.map1.set("key", "value");
-
-			const resources = clientCurrent2.getContainer(containerId, schemaCurrent, "2.0.0");
-			await assert.doesNotReject(resources, () => true, "container could not be loaded");
-
-			const { container: containerCurrent2 } = await resources;
-			if (containerCurrent2.connectionState !== ConnectionState.Connected) {
-				await timeoutPromise(
-					(resolve) => containerCurrent2.once("connected", () => resolve()),
-					{
-						durationMs: connectTimeoutMs,
-						errorMsg: "containerCurrent2 connect() timeout",
-					},
-				);
-			}
-
-			const result = containerCurrent2.initialObjects.map1.get<string>("key");
-			assert.strictEqual(result, "value", "Value not found in copied container");
-		});
-
-		/**
-		 * Scenario: test if a current AzureClient using oldestSupportedClient "1.0.0" can get a container made by the current AzureClient using "2.0.0".
-		 *
-		 * Expected behavior: an error should not be thrown nor should a rejected promise be returned.
-		 */
-		it(`Current AzureClient (oldestSupportedClient: "1.0.0") can get container made by current AzureClient (oldestSupportedClient: "2.0.0")`, async () => {
-			const { container: containerCurrent2 } = await clientCurrent2.createContainer(
-				schemaCurrent,
-				"2.0.0",
-			);
-			const containerId = await containerCurrent2.attach();
-
-			if (containerCurrent2.connectionState !== ConnectionState.Connected) {
-				await timeoutPromise(
-					(resolve) => containerCurrent2.once("connected", () => resolve()),
-					{
-						durationMs: connectTimeoutMs,
-						errorMsg: "containerCurrent2 connect() timeout",
-					},
-				);
-			}
-
-			containerCurrent2.initialObjects.map1.set("key", "value");
-
-			const resources = clientCurrent1.getContainer(containerId, schemaCurrent, "1.0.0");
-			await assert.doesNotReject(resources, () => true, "container could not be loaded");
-
-			const { container: containerCurrent1 } = await resources;
-			if (containerCurrent1.connectionState !== ConnectionState.Connected) {
-				await timeoutPromise(
-					(resolve) => containerCurrent1.once("connected", () => resolve()),
-					{
-						durationMs: connectTimeoutMs,
-						errorMsg: "containerCurrent1 connect() timeout",
-					},
-				);
-			}
-
-			const result = containerCurrent1.initialObjects.map1.get<string>("key");
-			assert.strictEqual(result, "value", "Value not found in copied container");
-		});
-
-		it("op grouping disabled as expected for 1.x clients", async () => {
-			const { container: container1 } = await clientCurrent1.createContainer(
-				schemaCurrent,
-				"1.0.0",
-			);
-			const containerId = await container1.attach();
-
-			if (container1.connectionState !== ConnectionState.Connected) {
-				await timeoutPromise((resolve) => container1.once("connected", () => resolve()), {
-					durationMs: connectTimeoutMs,
-					errorMsg: "container connect() timeout",
-				});
-			}
-
-			const containerProcessSpy = sandbox.spy(
-				// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-				(container1 as any).container,
-				"processRemoteMessage",
-			);
-
-			// Explicitly force ops sent to be in the same batch
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-			(container1 as any).container._runtime.orderSequentially(() => {
-				const map1 = container1.initialObjects.map1;
-				map1.set("1", 1);
-				map1.set("2", 2);
-				map1.set("3", 3);
-			});
-
-			const { container: containerLegacy } = await clientLegacy.getContainer(
-				containerId,
-				schemaLegacy,
-			);
-			if (containerLegacy.connectionState !== ConnectionState.Connected) {
-				await timeoutPromise((resolve) => containerLegacy.once("connected", () => resolve()), {
-					durationMs: connectTimeoutMs,
-					errorMsg: "containerLegacy connect() timeout",
-				});
-			}
-
-			const legacyMap = containerLegacy.initialObjects.map1 as SharedMapLegacy;
-
-			// Verify ops are processed by legacy AzureClient
-			assert.strictEqual(legacyMap.get("1"), 1);
-			assert.strictEqual(legacyMap.get("2"), 2);
-			assert.strictEqual(legacyMap.get("3"), 3);
-
-			// Inspect the incoming ops
-			for (const call of containerProcessSpy.getCalls()) {
-				const message = call.firstArg as ISequencedDocumentMessage;
-				if (
-					message.type === MessageType.Operation &&
-					(message.contents as { type: string }).type === "groupedBatch"
-				) {
-					assert.fail("unexpected groupedBatch found");
-				}
-			}
-		});
-
-		for (const oldestSupportedClient of ["1.0.0", "2.0.0"] as const) {
+		for (const oldestSupportedClient of ["2.0.0"] as const) {
 			it(`op grouping works as expected (oldestSupportedClient: ${oldestSupportedClient})`, async () => {
 				const { container: container1 } = await clientCurrent1.createContainer(
 					schemaCurrent,
@@ -664,19 +466,11 @@ for (const testOpts of testMatrix) {
 					}
 				}
 
-				if (oldestSupportedClient === "1.0.0") {
-					assert.strictEqual(
-						groupedBatchCount,
-						0,
-						"expect no op grouping with oldestSupportedClient 1.0.0",
-					);
-				} else {
-					assert.strictEqual(
-						groupedBatchCount,
-						1,
-						"expect op grouping with oldestSupportedClient 2.0.0",
-					);
-				}
+				assert.strictEqual(
+					groupedBatchCount,
+					1,
+					"expect op grouping with oldestSupportedClient 2.0.0",
+				);
 			});
 		}
 	});

--- a/packages/service-clients/tinylicious-client/api-report/tinylicious-client.alpha.api.md
+++ b/packages/service-clients/tinylicious-client/api-report/tinylicious-client.alpha.api.md
@@ -8,7 +8,7 @@
 export type ITinyliciousAudience = IServiceAudience<TinyliciousMember>;
 
 // @public @input
-export type OldestSupportedClientVersion = `3.${bigint}.0` | `${1 | 2}.${bigint}.${bigint}` | `${1 | 2}.${bigint}.${bigint}-${string}`;
+export type OldestSupportedClientVersion = `3.${bigint}.0` | `2.${bigint}.${bigint}` | `2.${bigint}.${bigint}-${string}`;
 
 // @public @sealed
 export class TinyliciousClient {

--- a/packages/service-clients/tinylicious-client/api-report/tinylicious-client.beta.api.md
+++ b/packages/service-clients/tinylicious-client/api-report/tinylicious-client.beta.api.md
@@ -8,7 +8,7 @@
 export type ITinyliciousAudience = IServiceAudience<TinyliciousMember>;
 
 // @public @input
-export type OldestSupportedClientVersion = `3.${bigint}.0` | `${1 | 2}.${bigint}.${bigint}` | `${1 | 2}.${bigint}.${bigint}-${string}`;
+export type OldestSupportedClientVersion = `3.${bigint}.0` | `2.${bigint}.${bigint}` | `2.${bigint}.${bigint}-${string}`;
 
 // @public @sealed
 export class TinyliciousClient {

--- a/packages/service-clients/tinylicious-client/api-report/tinylicious-client.public.api.md
+++ b/packages/service-clients/tinylicious-client/api-report/tinylicious-client.public.api.md
@@ -8,7 +8,7 @@
 export type ITinyliciousAudience = IServiceAudience<TinyliciousMember>;
 
 // @public @input
-export type OldestSupportedClientVersion = `3.${bigint}.0` | `${1 | 2}.${bigint}.${bigint}` | `${1 | 2}.${bigint}.${bigint}-${string}`;
+export type OldestSupportedClientVersion = `3.${bigint}.0` | `2.${bigint}.${bigint}` | `2.${bigint}.${bigint}-${string}`;
 
 // @public @sealed
 export class TinyliciousClient {

--- a/packages/service-clients/tinylicious-client/src/test/TinyliciousClient.spec.ts
+++ b/packages/service-clients/tinylicious-client/src/test/TinyliciousClient.spec.ts
@@ -51,7 +51,7 @@ const waitForDataCorruption = async (container: IFluidContainer): Promise<void> 
 		}),
 	);
 
-for (const oldestSupportedClient of ["1.0.0", "2.0.0"] as const) {
+for (const oldestSupportedClient of ["2.0.0"] as const) {
 	describe(`TinyliciousClient (oldestSupportedClient: ${oldestSupportedClient})`, function () {
 		let tinyliciousClient: TinyliciousClient;
 		const schema = {

--- a/packages/test/test-utils/package.json
+++ b/packages/test/test-utils/package.json
@@ -162,10 +162,12 @@
 	"typeValidation": {
 		"broken": {
 			"Interface_IProvideTestFluidObject": {
-				"backCompat": false
+				"backCompat": false,
+				"forwardCompat": false
 			},
 			"Interface_ITestFluidObject": {
-				"backCompat": false
+				"backCompat": false,
+				"forwardCompat": false
 			}
 		},
 		"entrypoint": "legacy"

--- a/packages/test/test-utils/src/test/types/validateTestUtilsPrevious.generated.ts
+++ b/packages/test/test-utils/src/test/types/validateTestUtilsPrevious.generated.ts
@@ -78,6 +78,7 @@ declare type current_as_old_for_Interface_IOpProcessingController = requireAssig
  * typeValidation.broken:
  * "Interface_IProvideTestFluidObject": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Interface_IProvideTestFluidObject = requireAssignableTo<TypeOnly<old.IProvideTestFluidObject>, TypeOnly<current.IProvideTestFluidObject>>
 
 /*
@@ -97,6 +98,7 @@ declare type current_as_old_for_Interface_IProvideTestFluidObject = requireAssig
  * typeValidation.broken:
  * "Interface_ITestFluidObject": {"forwardCompat": false}
  */
+// @ts-expect-error compatibility expected to be broken
 declare type old_as_current_for_Interface_ITestFluidObject = requireAssignableTo<TypeOnly<old.ITestFluidObject>, TypeOnly<current.ITestFluidObject>>
 
 /*

--- a/packages/test/test-version-utils/README.md
+++ b/packages/test/test-version-utils/README.md
@@ -48,8 +48,10 @@ In addition to the layer version combinations seen above, this package also prov
 intended to test all layers of one version against all layers of another version in tests that feature more than one client.
 The intention is to simulate scenarios where the client that created a document was using a different version than the client
 loading the document. The matrix pairs the current build against every in-window prior **Compatibility Checkpoint**
-(see [`CompatibilityCheckpoints.md`](../../../CompatibilityCheckpoints.md)) in both directions, with each prior
-checkpoint resolved to the **earliest minor** in its range (e.g. CC#3 → latest patch of `2.40.x`).
+at or above the deployed-client compatibility floor (see
+[`CompatibilityCheckpoints.md`](../../../CompatibilityCheckpoints.md)) in both directions, with
+each prior checkpoint resolved to the **earliest minor** in its range (e.g. CC#3 → latest patch of
+`2.40.x`).
 
 The data driving the matrix lives in [`src/checkpoints.ts`](./src/checkpoints.ts).
 

--- a/packages/test/test-version-utils/package.json
+++ b/packages/test/test-version-utils/package.json
@@ -97,6 +97,7 @@
 		"@fluidframework/ordered-collection": "workspace:~",
 		"@fluidframework/register-collection": "workspace:~",
 		"@fluidframework/runtime-definitions": "workspace:~",
+		"@fluidframework/runtime-utils": "workspace:~",
 		"@fluidframework/sequence": "workspace:~",
 		"@fluidframework/shared-object-base": "workspace:~",
 		"@fluidframework/telemetry-utils": "workspace:~",

--- a/packages/test/test-version-utils/scripts/updateCompatVersions.ts
+++ b/packages/test/test-version-utils/scripts/updateCompatVersions.ts
@@ -48,6 +48,7 @@ import * as path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { findGitRootSync } from "@fluid-tools/build-infrastructure";
+import { lowestMinVersionForCollab } from "@fluidframework/runtime-utils/internal";
 import * as semver from "semver";
 
 // Re-use version arithmetic and package list from the main source to keep them in sync.
@@ -224,7 +225,7 @@ async function main(): Promise<void> {
 	// in-window checkpoints follow.
 	for (const checkpoint of [
 		currentCheckpoint,
-		...getInWindowPriorCheckpoints(currentCheckpoint),
+		...getInWindowPriorCheckpoints(currentCheckpoint, lowestMinVersionForCollab),
 	]) {
 		const range = checkpointResolutionRange(checkpoint);
 		// Unlike the back-compat deltas below, designated checkpoints are expected to always

--- a/packages/test/test-version-utils/src/checkpoints.ts
+++ b/packages/test/test-version-utils/src/checkpoints.ts
@@ -193,17 +193,28 @@ export function getCurrentCheckpoint(version: string): Checkpoint {
 
 /**
  * Returns the prior in-window checkpoints relative to `current` from newest
- * to oldest. May return fewer than `fullCompatibilityWindowSize` entries when `current`
+ * to oldest.
+ *
+ * @param minimumVersion - When provided, checkpoints below this deployed-client
+ * compatibility floor are omitted.
+ *
+ * May return fewer than `fullCompatibilityWindowSize` entries when `current`
  * is near the start of the checkpoint list (e.g., `current === CC#1` returns
- * `[]`).
+ * `[]`) or when older checkpoints fall below `minimumVersion`.
  *
  * @internal
  */
-export function getInWindowPriorCheckpoints(current: Checkpoint): Checkpoint[] {
+export function getInWindowPriorCheckpoints(
+	current: Checkpoint,
+	minimumVersion?: string,
+): Checkpoint[] {
 	const result: Checkpoint[] = [];
 	for (let i = 1; i <= fullCompatibilityWindowSize; i++) {
 		const target = checkpoints.find((c) => c.index === current.index - i);
-		if (target) {
+		if (
+			target !== undefined &&
+			(minimumVersion === undefined || semver.gte(target.lowerBoundVersion, minimumVersion))
+		) {
 			result.push(target);
 		}
 	}

--- a/packages/test/test-version-utils/src/compatConfig.ts
+++ b/packages/test/test-version-utils/src/compatConfig.ts
@@ -4,6 +4,7 @@
  */
 
 import { assert, Lazy } from "@fluidframework/core-utils/internal";
+import { lowestMinVersionForCollab } from "@fluidframework/runtime-utils/internal";
 import * as semver from "semver";
 
 import {
@@ -350,7 +351,7 @@ export const genCrossClientCompatConfig = (): CompatConfig[] => {
 		deltaVersions.set(currentCheckpointVersion, current.name);
 	}
 
-	for (const c of getInWindowPriorCheckpoints(current)) {
+	for (const c of getInWindowPriorCheckpoints(current, lowestMinVersionForCollab)) {
 		const v = resolveRangeViaManifest(checkpointResolutionRange(c));
 		deltaVersions.set(v, c.name);
 	}

--- a/packages/test/test-version-utils/src/test/checkpoints.spec.ts
+++ b/packages/test/test-version-utils/src/test/checkpoints.spec.ts
@@ -128,6 +128,15 @@ describe("checkpoints", () => {
 			);
 		});
 
+		it("omits checkpoints below the deployed-client compatibility floor", () => {
+			const cc4 = checkpoints.find((c) => c.name === "CC#4");
+			assert(cc4 !== undefined, "CC#4 expected in checkpoints");
+			assert.deepStrictEqual(
+				getInWindowPriorCheckpoints(cc4, "2.0.0").map((c) => c.name),
+				["CC#3", "CC#2"],
+			);
+		});
+
 		it("returns indexes strictly descending, contiguous, and below current", () => {
 			for (const current of checkpoints) {
 				const priors = getInWindowPriorCheckpoints(current);

--- a/packages/test/test-version-utils/src/test/compatConfig.spec.ts
+++ b/packages/test/test-version-utils/src/test/compatConfig.spec.ts
@@ -1,0 +1,31 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "node:assert";
+
+import { lowestMinVersionForCollab } from "@fluidframework/runtime-utils/internal";
+import * as semver from "semver";
+
+import { genCrossClientCompatConfig } from "../compatConfig.js";
+
+describe("genCrossClientCompatConfig", () => {
+	it("excludes versions below the deployed-client compatibility floor", () => {
+		const configs = genCrossClientCompatConfig();
+		assert.notEqual(configs.length, 0, "Expected cross-client compatibility configurations");
+
+		for (const config of configs) {
+			assert(
+				config.createVersion !== undefined && config.loadVersion !== undefined,
+				"Expected cross-client create and load versions",
+			);
+			for (const version of [config.createVersion, config.loadVersion]) {
+				assert(
+					semver.gte(version, lowestMinVersionForCollab),
+					`${version} should not be below ${lowestMinVersionForCollab}`,
+				);
+			}
+		}
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15161,6 +15161,9 @@ importers:
       '@fluidframework/runtime-definitions':
         specifier: workspace:~
         version: link:../../runtime/runtime-definitions
+      '@fluidframework/runtime-utils':
+        specifier: workspace:~
+        version: link:../../runtime/runtime-utils
       '@fluidframework/sequence':
         specifier: workspace:~
         version: link:../../dds/sequence


### PR DESCRIPTION
## Description

Advances the Client 3.0 cross-client compatibility floor so explicit deployed-client values use supported 2.x or 3.x versions and 1.x values are rejected.

This PR is directly stacked on the nonbreaking sentinel preparation in [#28121](https://github.com/microsoft/FluidFramework/pull/28121), so its diff contains only the 54-file floor layer. It does not include the separate `oldestSupportedClient` requiredness change from #27971, which is being postponed to the Client 3.10 beta/legacy break window.

The floor layer:

- narrows `OldestSupportedClientVersion` while preserving the merged `3.${bigint}.0` contract from #28022;
- advances runtime validation to `2.0.0` while retaining the historical `2.0.0-defaults` fallback for APIs that permit omission
- removes 1.x-only configuration and active-collaboration test branches
- filters generated cross-client compatibility coverage to checkpoints at or above the deployed-client floor
- preserves historical data-at-rest coverage
- updates SharedTree codec metadata to the 2.0 baseline prepared by #28121
- regenerates affected API reports and type-compatibility baselines.

Fixes #27460. Tracks [AB#79024](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/79024).

## Breaking Changes

Before upgrading an application to Client 3.0:

1. Upgrade every active deployment that must collaborate to Fluid Framework 2.0.0 or later.
2. Replace explicit 1.x compatibility settings with a supported 2.x or 3.x value.
3. Prefer the canonical `oldestSupportedClient` name when updating configuration.

Typed 1.x literals no longer satisfy `OldestSupportedClientVersion`, and JavaScript or type-erased 1.x inputs fail runtime validation. The deprecated `MinimumVersionForCollab` alias remains available until Client 4.0 but inherits the same accepted-value restriction.

Callers that omit the setting through APIs where it remains optional continue to receive the historical `2.0.0-defaults` configuration. That fallback preserves historical runtime behavior; it is not a deployed client version or a declaration of supported 1.x collaboration.

See [Breaking vs. Non-Breaking Changes](https://github.com/microsoft/FluidFramework/blob/main/docs/content/Contributing/Breaking-vs-Non-Breaking-Changes.md).

## Validation

- Client build [421442](https://dev.azure.com/fluidframework/internal/_build/results?buildId=421442) passed every build, policy, coverage, ATTW, Jest, Playwright, stress, and Tinylicious leg on the final reviewed stack.
- Both exact real-service tasks that previously exposed stale CC#1 scenarios pass locally after filtering the generated matrix.
- Two independent deep reviews found no remaining critical, high, or medium issues in either PR layer.
