### PR TITLE
test(tree): cover divergent optional field compatibility

### DIFF
--- a/packages/dds/tree/src/test/shared-tree/schematizingTreeView.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/schematizingTreeView.spec.ts
@@ -499,6 +499,70 @@ describe("SchematizingSimpleTreeView", () => {
 		assert.equal(viewGeneralized.root[1].address, "123 Main St");
 	});
 
+	it("views with different optional fields are incompatible despite allowing unknown optional fields", () => {
+		const factoryA = new SchemaFactoryBeta(undefined);
+		const factoryB = new SchemaFactoryBeta(undefined);
+
+		class ThingA extends factoryA.object(
+			"Thing",
+			{
+				name: factoryA.string,
+				fieldA: factoryA.optional(factoryA.string),
+			},
+			{ allowUnknownOptionalFields: true },
+		) {}
+
+		class ThingB extends factoryB.object(
+			"Thing",
+			{
+				name: factoryB.string,
+				fieldB: factoryB.optional(factoryB.string),
+			},
+			{ allowUnknownOptionalFields: true },
+		) {}
+
+		const configA = new TreeViewConfiguration({ schema: ThingA });
+		const configB = new TreeViewConfiguration({ schema: ThingB });
+
+		const checkoutA = checkoutWithInitialTree(
+			configA,
+			new ThingA({ name: "docA", fieldA: "valueA" }),
+		);
+		const viewBOnDocA = new SchematizingSimpleTreeView(
+			checkoutA,
+			configB,
+			new MockNodeIdentifierManager(),
+		);
+
+		assert.deepEqual(viewBOnDocA.compatibility, {
+			canView: false,
+			canUpgrade: false,
+			isEquivalent: false,
+			canInitialize: false,
+		});
+		assert.throws(() => viewBOnDocA.root, validateUsageError(/not compatible/));
+		viewBOnDocA.dispose();
+
+		const checkoutB = checkoutWithInitialTree(
+			configB,
+			new ThingB({ name: "docB", fieldB: "valueB" }),
+		);
+		const viewAOnDocB = new SchematizingSimpleTreeView(
+			checkoutB,
+			configA,
+			new MockNodeIdentifierManager(),
+		);
+
+		assert.deepEqual(viewAOnDocB.compatibility, {
+			canView: false,
+			canUpgrade: false,
+			isEquivalent: false,
+			canInitialize: false,
+		});
+		assert.throws(() => viewAOnDocB.root, validateUsageError(/not compatible/));
+		viewAOnDocB.dispose();
+	});
+
 	describe("upgradeSchema", () => {
 		const builder = new SchemaFactory("test");
 		const root = builder.number;


### PR DESCRIPTION
## Description

Adds a unit test covering TreeView compatibility when two schemas share the same node identifier and allow unknown optional fields, but independently add different optional fields.

The test creates one document with `fieldA` and another with `fieldB`, then opens each document using the other view schema. It documents that both cross-open scenarios are incompatible: `canView`, `canUpgrade`, and `isEquivalent` are false, and accessing the root throws a compatibility error.

## Reviewer Guidance

The review process is outlined in [the pull request guidelines](../docs/content/Contributing/PR-Guidelines.md#guidelines).

Please confirm that the asserted incompatibility is the intended behavior for divergent optional fields when `allowUnknownOptionalFields` is enabled.