### PR TITLE
Dual-write external error telemetry property

### DIFF
--- a/packages/utils/telemetry-utils/src/errorLogging.ts
+++ b/packages/utils/telemetry-utils/src/errorLogging.ts
@@ -159,7 +159,7 @@ export function normalizeError(
 		? error.getTelemetryProperties()
 		: {
 				untrustedOrigin: 1, // This will let us filter errors that did not originate from our own codebase
-				errorRunningExternalCode: "yes",
+				errorRunningExternalCode: "unclassified",
 			};
 
 	fluidError.addTelemetryProperties({
@@ -251,7 +251,7 @@ export function wrapError<T extends LoggingError>(
 	if (isExternalError(innerError)) {
 		newError.addTelemetryProperties({
 			untrustedOrigin: 1,
-			errorRunningExternalCode: "yes",
+			errorRunningExternalCode: "unclassified",
 		});
 	}
 
@@ -334,7 +334,11 @@ export function isExternalError(error: unknown): boolean {
 	if (LoggingError.typeCheck(error)) {
 		if ((error as NormalizedLoggingError).errorType === NORMALIZED_ERROR_TYPE) {
 			const props = error.getTelemetryProperties();
-			return props.untrustedOrigin === 1 || Boolean(props.errorRunningExternalCode);
+			return (
+				props.untrustedOrigin === 1 ||
+				(typeof props.errorRunningExternalCode === "string" &&
+					props.errorRunningExternalCode.length > 0)
+			);
 		}
 		return false;
 	}

--- a/packages/utils/telemetry-utils/src/errorLogging.ts
+++ b/packages/utils/telemetry-utils/src/errorLogging.ts
@@ -159,9 +159,7 @@ export function normalizeError(
 		? error.getTelemetryProperties()
 		: {
 				untrustedOrigin: 1, // This will let us filter errors that did not originate from our own codebase
-				// FUTURE: Once 2.0 becomes LTS, switch to this more explicit property name
-				// Consider using a string to distinguish cases like "dependency" v. "callback"
-				// errorRunningExternalCode: 1,
+				errorRunningExternalCode: "yes",
 			};
 
 	fluidError.addTelemetryProperties({
@@ -249,13 +247,11 @@ export function wrapError<T extends LoggingError>(
 		overwriteStack(newError, stack);
 	}
 
-	// Mark external errors with untrustedOrigin flag
+	// Mark external errors with both the legacy and replacement properties during migration.
 	if (isExternalError(innerError)) {
 		newError.addTelemetryProperties({
 			untrustedOrigin: 1,
-			// FUTURE: Once 2.0 becomes LTS, switch to this more explicit property name
-			// Consider using a string to distinguish cases like "dependency" v. "callback"
-			// errorRunningExternalCode: 1,
+			errorRunningExternalCode: "yes",
 		});
 	}
 
@@ -338,8 +334,6 @@ export function isExternalError(error: unknown): boolean {
 	if (LoggingError.typeCheck(error)) {
 		if ((error as NormalizedLoggingError).errorType === NORMALIZED_ERROR_TYPE) {
 			const props = error.getTelemetryProperties();
-			// NOTE: errorRunningExternalCode is not currently used - once this "read" code reaches LTS,
-			// we can switch to writing this more explicit property
 			return props.untrustedOrigin === 1 || Boolean(props.errorRunningExternalCode);
 		}
 		return false;

--- a/packages/utils/telemetry-utils/src/test/error.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/error.spec.ts
@@ -24,6 +24,7 @@ describe("Errors", () => {
 			assert(dce.getTelemetryProperties().dataProcessingError === 1);
 			assert(dce.getTelemetryProperties().dataProcessingCodepath === "someCodepath");
 			assert(dce.getTelemetryProperties().untrustedOrigin === 1);
+			assert(dce.getTelemetryProperties().errorRunningExternalCode === "yes");
 		});
 	});
 	describe("DataProcessingError.create", () => {
@@ -38,6 +39,7 @@ describe("Errors", () => {
 			assert(dpe.getTelemetryProperties().dataProcessingError === 1);
 			assert(dpe.getTelemetryProperties().dataProcessingCodepath === "someCodepath");
 			assert(dpe.getTelemetryProperties().untrustedOrigin === 1);
+			assert(dpe.getTelemetryProperties().errorRunningExternalCode === "yes");
 		});
 	});
 	describe("DataProcessingError coercion via DataProcessingError.wrapIfUnrecognized", () => {
@@ -94,6 +96,7 @@ describe("Errors", () => {
 			assert(coercedError.getTelemetryProperties().dataProcessingError === 1);
 			assert(coercedError.getTelemetryProperties().dataProcessingCodepath === "someCodepath");
 			assert(coercedError.getTelemetryProperties().untrustedOrigin === 1);
+			assert(coercedError.getTelemetryProperties().errorRunningExternalCode === "yes");
 		});
 		it("Should coerce external error object even with errorType", () => {
 			const originalError = {
@@ -111,6 +114,7 @@ describe("Errors", () => {
 			assert(coercedError.getTelemetryProperties().dataProcessingError === 1);
 			assert(coercedError.getTelemetryProperties().dataProcessingCodepath === "someCodepath");
 			assert(coercedError.getTelemetryProperties().untrustedOrigin === 1);
+			assert(coercedError.getTelemetryProperties().errorRunningExternalCode === "yes");
 			assert(coercedError.message === "[object Object]");
 		});
 		it("Should coerce LoggingError missing errorType", () => {
@@ -129,6 +133,7 @@ describe("Errors", () => {
 			assert(coercedError.getTelemetryProperties().dataProcessingError === 1);
 			assert(coercedError.getTelemetryProperties().dataProcessingCodepath === "someCodepath");
 			assert(coercedError.getTelemetryProperties().untrustedOrigin === undefined);
+			assert(coercedError.getTelemetryProperties().errorRunningExternalCode === undefined);
 			assert(coercedError.message === "Inherited error message");
 			assert(
 				coercedError.getTelemetryProperties().otherProperty === "some safe-to-log property",
@@ -152,6 +157,7 @@ describe("Errors", () => {
 			assert(coercedError.getTelemetryProperties().dataProcessingError === 1);
 			assert(coercedError.getTelemetryProperties().dataProcessingCodepath === "someCodepath");
 			assert(coercedError.getTelemetryProperties().untrustedOrigin === undefined);
+			assert(coercedError.getTelemetryProperties().errorRunningExternalCode === undefined);
 			assert(coercedError.message === "Inherited error message");
 			assert(
 				coercedError.getTelemetryProperties().otherProperty === "some safe-to-log property",
@@ -183,7 +189,8 @@ describe("Errors", () => {
 						error.errorType === FluidErrorTypes.dataProcessingError &&
 						error.getTelemetryProperties().dataProcessingError === 1 &&
 						error.getTelemetryProperties().dataProcessingCodepath === "someCodepath" &&
-						error.getTelemetryProperties().untrustedOrigin === 1,
+						error.getTelemetryProperties().untrustedOrigin === 1 &&
+						error.getTelemetryProperties().errorRunningExternalCode === "yes",
 				),
 			);
 			assert(

--- a/packages/utils/telemetry-utils/src/test/error.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/error.spec.ts
@@ -24,7 +24,7 @@ describe("Errors", () => {
 			assert(dce.getTelemetryProperties().dataProcessingError === 1);
 			assert(dce.getTelemetryProperties().dataProcessingCodepath === "someCodepath");
 			assert(dce.getTelemetryProperties().untrustedOrigin === 1);
-			assert(dce.getTelemetryProperties().errorRunningExternalCode === "yes");
+			assert(dce.getTelemetryProperties().errorRunningExternalCode === "unclassified");
 		});
 	});
 	describe("DataProcessingError.create", () => {
@@ -39,7 +39,7 @@ describe("Errors", () => {
 			assert(dpe.getTelemetryProperties().dataProcessingError === 1);
 			assert(dpe.getTelemetryProperties().dataProcessingCodepath === "someCodepath");
 			assert(dpe.getTelemetryProperties().untrustedOrigin === 1);
-			assert(dpe.getTelemetryProperties().errorRunningExternalCode === "yes");
+			assert(dpe.getTelemetryProperties().errorRunningExternalCode === "unclassified");
 		});
 	});
 	describe("DataProcessingError coercion via DataProcessingError.wrapIfUnrecognized", () => {
@@ -96,7 +96,9 @@ describe("Errors", () => {
 			assert(coercedError.getTelemetryProperties().dataProcessingError === 1);
 			assert(coercedError.getTelemetryProperties().dataProcessingCodepath === "someCodepath");
 			assert(coercedError.getTelemetryProperties().untrustedOrigin === 1);
-			assert(coercedError.getTelemetryProperties().errorRunningExternalCode === "yes");
+			assert(
+				coercedError.getTelemetryProperties().errorRunningExternalCode === "unclassified",
+			);
 		});
 		it("Should coerce external error object even with errorType", () => {
 			const originalError = {
@@ -114,7 +116,9 @@ describe("Errors", () => {
 			assert(coercedError.getTelemetryProperties().dataProcessingError === 1);
 			assert(coercedError.getTelemetryProperties().dataProcessingCodepath === "someCodepath");
 			assert(coercedError.getTelemetryProperties().untrustedOrigin === 1);
-			assert(coercedError.getTelemetryProperties().errorRunningExternalCode === "yes");
+			assert(
+				coercedError.getTelemetryProperties().errorRunningExternalCode === "unclassified",
+			);
 			assert(coercedError.message === "[object Object]");
 		});
 		it("Should coerce LoggingError missing errorType", () => {
@@ -190,7 +194,7 @@ describe("Errors", () => {
 						error.getTelemetryProperties().dataProcessingError === 1 &&
 						error.getTelemetryProperties().dataProcessingCodepath === "someCodepath" &&
 						error.getTelemetryProperties().untrustedOrigin === 1 &&
-						error.getTelemetryProperties().errorRunningExternalCode === "yes",
+						error.getTelemetryProperties().errorRunningExternalCode === "unclassified",
 				),
 			);
 			assert(

--- a/packages/utils/telemetry-utils/src/test/errorLogging.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/errorLogging.spec.ts
@@ -777,7 +777,7 @@ describe("normalizeError", () => {
 					"<<stack from input>>",
 				).withExpectedTelemetryProps({
 					untrustedOrigin: 1,
-					errorRunningExternalCode: "yes",
+					errorRunningExternalCode: "unclassified",
 				}),
 			}),
 			"LoggingError": () => ({
@@ -791,7 +791,7 @@ describe("normalizeError", () => {
 					"<<natural stack>>",
 				).withExpectedTelemetryProps({
 					untrustedOrigin: 1,
-					errorRunningExternalCode: "yes",
+					errorRunningExternalCode: "unclassified",
 				}),
 			}),
 			"object with stack": () => ({
@@ -801,7 +801,7 @@ describe("normalizeError", () => {
 					"<<stack from input>>",
 				).withExpectedTelemetryProps({
 					untrustedOrigin: 1,
-					errorRunningExternalCode: "yes",
+					errorRunningExternalCode: "unclassified",
 				}),
 			}),
 			"object with non-string message and name": () => ({
@@ -811,14 +811,14 @@ describe("normalizeError", () => {
 					"<<natural stack>>",
 				).withExpectedTelemetryProps({
 					untrustedOrigin: 1,
-					errorRunningExternalCode: "yes",
+					errorRunningExternalCode: "unclassified",
 				}),
 			}),
 			"nullValue": () => ({
 				input: null,
 				expectedOutput: typicalOutput("null", "<<natural stack>>").withExpectedTelemetryProps({
 					untrustedOrigin: 1,
-					errorRunningExternalCode: "yes",
+					errorRunningExternalCode: "unclassified",
 				}),
 			}),
 			"undef": () => ({
@@ -829,7 +829,7 @@ describe("normalizeError", () => {
 				).withExpectedTelemetryProps({
 					typeofError: "undefined",
 					untrustedOrigin: 1,
-					errorRunningExternalCode: "yes",
+					errorRunningExternalCode: "unclassified",
 				}),
 			}),
 			"false": () => ({
@@ -838,7 +838,7 @@ describe("normalizeError", () => {
 					{
 						typeofError: "boolean",
 						untrustedOrigin: 1,
-						errorRunningExternalCode: "yes",
+						errorRunningExternalCode: "unclassified",
 					},
 				),
 			}),
@@ -847,7 +847,7 @@ describe("normalizeError", () => {
 				expectedOutput: typicalOutput("true", "<<natural stack>>").withExpectedTelemetryProps({
 					typeofError: "boolean",
 					untrustedOrigin: 1,
-					errorRunningExternalCode: "yes",
+					errorRunningExternalCode: "unclassified",
 				}),
 			}),
 			"number": () => ({
@@ -855,7 +855,7 @@ describe("normalizeError", () => {
 				expectedOutput: typicalOutput("3.14", "<<natural stack>>").withExpectedTelemetryProps({
 					typeofError: "number",
 					untrustedOrigin: 1,
-					errorRunningExternalCode: "yes",
+					errorRunningExternalCode: "unclassified",
 				}),
 			}),
 			"symbol": () => ({
@@ -866,7 +866,7 @@ describe("normalizeError", () => {
 				).withExpectedTelemetryProps({
 					typeofError: "symbol",
 					untrustedOrigin: 1,
-					errorRunningExternalCode: "yes",
+					errorRunningExternalCode: "unclassified",
 				}),
 			}),
 			"function": () => ({
@@ -877,20 +877,20 @@ describe("normalizeError", () => {
 				).withExpectedTelemetryProps({
 					typeofError: "function",
 					untrustedOrigin: 1,
-					errorRunningExternalCode: "yes",
+					errorRunningExternalCode: "unclassified",
 				}),
 			}),
 			"emptyArray": () => ({
 				input: [],
 				expectedOutput: typicalOutput("", "<<natural stack>>").withExpectedTelemetryProps({
 					untrustedOrigin: 1,
-					errorRunningExternalCode: "yes",
+					errorRunningExternalCode: "unclassified",
 				}),
 			}),
 			"array": () => ({
 				input: [1, 2, 3],
 				expectedOutput: typicalOutput("1,2,3", "<<natural stack>>").withExpectedTelemetryProps(
-					{ untrustedOrigin: 1, errorRunningExternalCode: "yes" },
+					{ untrustedOrigin: 1, errorRunningExternalCode: "unclassified" },
 				),
 			}),
 		};
@@ -1052,7 +1052,7 @@ describe("wrapError", () => {
 			"wrapped external error should be 'untrustedOrigin'",
 		);
 		assert(
-			singleWrappedProps.errorRunningExternalCode === "yes",
+			singleWrappedProps.errorRunningExternalCode === "unclassified",
 			"wrapped external error should be 'errorRunningExternalCode'",
 		);
 
@@ -1063,7 +1063,7 @@ describe("wrapError", () => {
 			"doubly-wrapped external error should be 'untrustedOrigin'",
 		);
 		assert(
-			doubleWrappedProps.errorRunningExternalCode === "yes",
+			doubleWrappedProps.errorRunningExternalCode === "unclassified",
 			"doubly-wrapped external error should be 'errorRunningExternalCode'",
 		);
 
@@ -1075,7 +1075,7 @@ describe("wrapError", () => {
 			"normalized-then-wrapped external error should be 'untrustedOrigin'",
 		);
 		assert(
-			wrappedNormalizedProps.errorRunningExternalCode === "yes",
+			wrappedNormalizedProps.errorRunningExternalCode === "unclassified",
 			"normalized-then-wrapped external error should be 'errorRunningExternalCode'",
 		);
 
@@ -1129,7 +1129,7 @@ describe("Error Discovery", () => {
 		const wrappedError = wrapError("wrap me", createTestError);
 		assert(!isExternalError(wrappedError));
 		assert(wrappedError.getTelemetryProperties().untrustedOrigin === 1); // But it should still say untrustedOrigin
-		assert(wrappedError.getTelemetryProperties().errorRunningExternalCode === "yes");
+		assert(wrappedError.getTelemetryProperties().errorRunningExternalCode === "unclassified");
 
 		const loggingError = new LoggingError("testLoggingError");
 		assert(!isExternalError(loggingError), "new LoggingError is not external");
@@ -1138,12 +1138,18 @@ describe("Error Discovery", () => {
 			"normalized LoggingError is not external",
 		);
 
-		// Cross-version compatibility requires accepting prior values of this property.
 		assert(
-			isExternalError(
+			!isExternalError(
 				normalizeError(loggingError, { props: { errorRunningExternalCode: 1 } }),
 			),
-			"normalized loggingError with errorRunningExternalCode flag is external",
+			"normalized loggingError with non-string errorRunningExternalCode is not external",
+		);
+
+		assert(
+			!isExternalError(
+				normalizeError(loggingError, { props: { errorRunningExternalCode: "" } }),
+			),
+			"normalized loggingError with empty errorRunningExternalCode is not external",
 		);
 
 		assert(

--- a/packages/utils/telemetry-utils/src/test/errorLogging.spec.ts
+++ b/packages/utils/telemetry-utils/src/test/errorLogging.spec.ts
@@ -775,7 +775,10 @@ describe("normalizeError", () => {
 				expectedOutput: typicalOutput(
 					"boom",
 					"<<stack from input>>",
-				).withExpectedTelemetryProps({ untrustedOrigin: 1 }),
+				).withExpectedTelemetryProps({
+					untrustedOrigin: 1,
+					errorRunningExternalCode: "yes",
+				}),
 			}),
 			"LoggingError": () => ({
 				input: new LoggingError("boom"),
@@ -786,26 +789,36 @@ describe("normalizeError", () => {
 				expectedOutput: typicalOutput(
 					"[object Object]",
 					"<<natural stack>>",
-				).withExpectedTelemetryProps({ untrustedOrigin: 1 }),
+				).withExpectedTelemetryProps({
+					untrustedOrigin: 1,
+					errorRunningExternalCode: "yes",
+				}),
 			}),
 			"object with stack": () => ({
 				input: { message: "whatever", stack: "fake stack goes here" },
 				expectedOutput: typicalOutput(
 					"whatever",
 					"<<stack from input>>",
-				).withExpectedTelemetryProps({ untrustedOrigin: 1 }),
+				).withExpectedTelemetryProps({
+					untrustedOrigin: 1,
+					errorRunningExternalCode: "yes",
+				}),
 			}),
 			"object with non-string message and name": () => ({
 				input: { message: 42, name: true },
 				expectedOutput: typicalOutput(
 					"[object Object]",
 					"<<natural stack>>",
-				).withExpectedTelemetryProps({ untrustedOrigin: 1 }),
+				).withExpectedTelemetryProps({
+					untrustedOrigin: 1,
+					errorRunningExternalCode: "yes",
+				}),
 			}),
 			"nullValue": () => ({
 				input: null,
 				expectedOutput: typicalOutput("null", "<<natural stack>>").withExpectedTelemetryProps({
 					untrustedOrigin: 1,
+					errorRunningExternalCode: "yes",
 				}),
 			}),
 			"undef": () => ({
@@ -813,12 +826,20 @@ describe("normalizeError", () => {
 				expectedOutput: typicalOutput(
 					"undefined",
 					"<<natural stack>>",
-				).withExpectedTelemetryProps({ typeofError: "undefined", untrustedOrigin: 1 }),
+				).withExpectedTelemetryProps({
+					typeofError: "undefined",
+					untrustedOrigin: 1,
+					errorRunningExternalCode: "yes",
+				}),
 			}),
 			"false": () => ({
 				input: false,
 				expectedOutput: typicalOutput("false", "<<natural stack>>").withExpectedTelemetryProps(
-					{ typeofError: "boolean", untrustedOrigin: 1 },
+					{
+						typeofError: "boolean",
+						untrustedOrigin: 1,
+						errorRunningExternalCode: "yes",
+					},
 				),
 			}),
 			"true": () => ({
@@ -826,6 +847,7 @@ describe("normalizeError", () => {
 				expectedOutput: typicalOutput("true", "<<natural stack>>").withExpectedTelemetryProps({
 					typeofError: "boolean",
 					untrustedOrigin: 1,
+					errorRunningExternalCode: "yes",
 				}),
 			}),
 			"number": () => ({
@@ -833,6 +855,7 @@ describe("normalizeError", () => {
 				expectedOutput: typicalOutput("3.14", "<<natural stack>>").withExpectedTelemetryProps({
 					typeofError: "number",
 					untrustedOrigin: 1,
+					errorRunningExternalCode: "yes",
 				}),
 			}),
 			"symbol": () => ({
@@ -840,25 +863,34 @@ describe("normalizeError", () => {
 				expectedOutput: typicalOutput(
 					"Symbol(Unique)",
 					"<<natural stack>>",
-				).withExpectedTelemetryProps({ typeofError: "symbol", untrustedOrigin: 1 }),
+				).withExpectedTelemetryProps({
+					typeofError: "symbol",
+					untrustedOrigin: 1,
+					errorRunningExternalCode: "yes",
+				}),
 			}),
 			"function": () => ({
 				input: (): void => {},
 				expectedOutput: typicalOutput(
 					"() => { }",
 					"<<natural stack>>",
-				).withExpectedTelemetryProps({ typeofError: "function", untrustedOrigin: 1 }),
+				).withExpectedTelemetryProps({
+					typeofError: "function",
+					untrustedOrigin: 1,
+					errorRunningExternalCode: "yes",
+				}),
 			}),
 			"emptyArray": () => ({
 				input: [],
 				expectedOutput: typicalOutput("", "<<natural stack>>").withExpectedTelemetryProps({
 					untrustedOrigin: 1,
+					errorRunningExternalCode: "yes",
 				}),
 			}),
 			"array": () => ({
 				input: [1, 2, 3],
 				expectedOutput: typicalOutput("1,2,3", "<<natural stack>>").withExpectedTelemetryProps(
-					{ untrustedOrigin: 1 },
+					{ untrustedOrigin: 1, errorRunningExternalCode: "yes" },
 				),
 			}),
 		};
@@ -1010,33 +1042,53 @@ describe("wrapError", () => {
 			newError.getTelemetryProperties().innerErrorInstanceId === innerError.errorInstanceId,
 		);
 	});
-	it("Properly set untrustedOrigin", () => {
+	it("Properly sets external error telemetry properties", () => {
 		const untrustedError = createExternalError("untrusted");
 
 		const singleWrapped = wrapError(untrustedError, createTestError);
+		const singleWrappedProps = singleWrapped.getTelemetryProperties();
 		assert(
-			singleWrapped.getTelemetryProperties().untrustedOrigin === 1,
+			singleWrappedProps.untrustedOrigin === 1,
 			"wrapped external error should be 'untrustedOrigin'",
+		);
+		assert(
+			singleWrappedProps.errorRunningExternalCode === "yes",
+			"wrapped external error should be 'errorRunningExternalCode'",
 		);
 
 		const doubleWrapped = wrapError(singleWrapped, createTestError);
+		const doubleWrappedProps = doubleWrapped.getTelemetryProperties();
 		assert(
-			doubleWrapped.getTelemetryProperties().untrustedOrigin === 1,
+			doubleWrappedProps.untrustedOrigin === 1,
 			"doubly-wrapped external error should be 'untrustedOrigin'",
+		);
+		assert(
+			doubleWrappedProps.errorRunningExternalCode === "yes",
+			"doubly-wrapped external error should be 'errorRunningExternalCode'",
 		);
 
 		const normalizedError = normalizeError(untrustedError);
 		const wrappedNormalized = wrapError(normalizedError, createTestError);
+		const wrappedNormalizedProps = wrappedNormalized.getTelemetryProperties();
 		assert(
-			wrappedNormalized.getTelemetryProperties().untrustedOrigin === 1,
+			wrappedNormalizedProps.untrustedOrigin === 1,
 			"normalized-then-wrapped external error should be 'untrustedOrigin'",
+		);
+		assert(
+			wrappedNormalizedProps.errorRunningExternalCode === "yes",
+			"normalized-then-wrapped external error should be 'errorRunningExternalCode'",
 		);
 
 		const trustedError = createTestError("trusted");
 		const wrappedTrusted = wrapError(trustedError, createTestError);
+		const wrappedTrustedProps = wrappedTrusted.getTelemetryProperties();
 		assert(
-			wrappedTrusted.getTelemetryProperties().untrustedOrigin === undefined,
+			wrappedTrustedProps.untrustedOrigin === undefined,
 			"wrapped Fluid error should not be 'untrustedOrigin'",
+		);
+		assert(
+			wrappedTrustedProps.errorRunningExternalCode === undefined,
+			"wrapped Fluid error should not be 'errorRunningExternalCode'",
 		);
 	});
 });
@@ -1077,6 +1129,7 @@ describe("Error Discovery", () => {
 		const wrappedError = wrapError("wrap me", createTestError);
 		assert(!isExternalError(wrappedError));
 		assert(wrappedError.getTelemetryProperties().untrustedOrigin === 1); // But it should still say untrustedOrigin
+		assert(wrappedError.getTelemetryProperties().errorRunningExternalCode === "yes");
 
 		const loggingError = new LoggingError("testLoggingError");
 		assert(!isExternalError(loggingError), "new LoggingError is not external");
@@ -1085,7 +1138,7 @@ describe("Error Discovery", () => {
 			"normalized LoggingError is not external",
 		);
 
-		// Future compat - Eventually we want to switch untrustedOrigin to errorRunningExternalCode, so set up "read" code now in 2.0
+		// Cross-version compatibility requires accepting prior values of this property.
 		assert(
 			isExternalError(
 				normalizeError(loggingError, { props: { errorRunningExternalCode: 1 } }),
@@ -1093,7 +1146,6 @@ describe("Error Discovery", () => {
 			"normalized loggingError with errorRunningExternalCode flag is external",
 		);
 
-		// Future compat - Eventually we want to switch untrustedOrigin to errorRunningExternalCode, so set up "read" code now in 2.0
 		assert(
 			isExternalError(
 				normalizeError(loggingError, { props: { errorRunningExternalCode: "callback" } }),


### PR DESCRIPTION
## Description

External errors currently emit the legacy `untrustedOrigin` telemetry property. To prepare for retiring that property, this change also emits `errorRunningExternalCode: "unclassified"` whenever `untrustedOrigin: 1` is written.

The reader continues recognizing the legacy marker and recognizes `errorRunningExternalCode` only when its value is a non-empty string, ensuring malformed non-string or empty values do not classify an error as external.

Tests cover normalization, wrapping, repeated wrapping, data-processing error coercion, trusted errors that should not receive either marker, and validation of the replacement property's value type.

### Future guidance

Keep `"unclassified"` as the generic value where the error boundary only establishes that external code was running. If explicit execution boundaries are instrumented later, more specific stable values could include:

- `consumerCallback` for application-provided callbacks.
- `loadedExtension` for dynamically loaded extensions or plugins.
- `thirdPartyDependency` for dependencies invoked by Fluid.

Only emit a specific value when ownership is known. Avoid callback names, package names, event names, or code paths to keep cardinality bounded and the taxonomy stable.

## Reviewer Guidance

The review process is outlined on [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

Please confirm that dual-writing `"unclassified"` provides the intended migration path while preserving cross-version compatibility.