### PR TITLE
Fix(tree): unsafe commit metadata access after trimming

### DIFF
--- a/.changeset/silent-pots-repeat.md
+++ b/.changeset/silent-pots-repeat.md
@@ -1,0 +1,20 @@
+---
+"@fluidframework/tree": minor
+"fluid-framework": minor
+"__section": tree
+---
+Bug fix: commit metadata access after history trimming
+
+Before this change, accessing the properties on a `TreeBranchCommitMetadata` object could throw an error with any the following error codes: `0xa5e`, `0xa5f`, `0xa60`, `0xd36`.
+This would happen when the access was made after the corresponding commit was trimmed from history:
+
+```typescript
+const commitMetadata = view.branchHistory.getHead();
+
+// ...History trimming occurs...
+
+// Would assert:
+console.log(commitMetadata.revision);
+```
+
+The properties now remain safe to access after the corresponding commit is trimmed from history.

--- a/packages/dds/tree/src/core/rebase/types.ts
+++ b/packages/dds/tree/src/core/rebase/types.ts
@@ -185,7 +185,6 @@ export interface GraphCommit<TChange> {
 	 * Indicates whether this commit was trimmed from the history.
 	 * @remarks
 	 * This property is set to `true` during trunk trimming on all trimmed commits (including the new trunk base).
-	 * When true, this property and the `parent` property are the only properties that are safe to read from this commit.
 	 */
 	readonly wasTrimmed?: true;
 }

--- a/packages/dds/tree/src/core/rebase/types.ts
+++ b/packages/dds/tree/src/core/rebase/types.ts
@@ -165,7 +165,11 @@ export interface GraphCommit<TChange> {
 	readonly revision: RevisionTag;
 	/** The change that will result from applying this commit */
 	readonly change: TChange;
-	/** The parent of this commit, on whose change this commit's change is based */
+	/**
+	 * The parent of this commit, on whose change this commit's change is based.
+	 * @remarks
+	 * This property is `undefined` for the trunk base commit, which is the root of the commit graph.
+	 */
 	readonly parent?: GraphCommit<TChange>;
 	/**
 	 * Arbitrary, application-defined metadata that is persisted alongside this commit.
@@ -176,6 +180,14 @@ export interface GraphCommit<TChange> {
 	 * Always copy this property when copying a commit.
 	 */
 	readonly customMetadata: CustomMetadataTree | undefined;
+
+	/**
+	 * Indicates whether this commit was trimmed from the history.
+	 * @remarks
+	 * This property is set to `true` during trunk trimming on all trimmed commits (including the new trunk base).
+	 * When true, this property and the `parent` property are the only properties that are safe to read from this commit.
+	 */
+	readonly wasTrimmed?: true;
 }
 
 /**

--- a/packages/dds/tree/src/core/rebase/types.ts
+++ b/packages/dds/tree/src/core/rebase/types.ts
@@ -168,7 +168,7 @@ export interface GraphCommit<TChange> {
 	/**
 	 * The parent of this commit, on whose change this commit's change is based.
 	 * @remarks
-	 * This property is `undefined` for the trunk base commit, which is the root of the commit graph.
+	 * This property is only `undefined` for the trunk base commit, which is the root of the commit graph.
 	 */
 	readonly parent?: GraphCommit<TChange>;
 	/**

--- a/packages/dds/tree/src/core/rebase/types.ts
+++ b/packages/dds/tree/src/core/rebase/types.ts
@@ -184,7 +184,7 @@ export interface GraphCommit<TChange> {
 	/**
 	 * Indicates whether this commit was trimmed from the history.
 	 * @remarks
-	 * This property is set to `true` during trunk trimming on all trimmed commits (including the new trunk base).
+	 * During trunk trimming, this property is set to `true` on all trimmed commits (including the new trunk base).
 	 */
 	readonly wasTrimmed?: true;
 }

--- a/packages/dds/tree/src/shared-tree-core/editManager.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManager.ts
@@ -340,10 +340,12 @@ export class EditManager<
 		// `newTrunkBase`. Therefore, no branches should have unique references to any of the commits being evicted here.
 		// We mutate the most recent of the evicted commits to become the new trunk base. That way, any other commits that
 		// have parent pointers to the latest evicted commit will stay linked, even though that it is no longer part of the trunk.
-		const newTrunkBase = latestEvicted as Mutable<typeof latestEvicted>;
+		const newTrunkBase = latestEvicted as Mutable<GraphCommit<TChangeset>>;
 
 		// collect the revisions that will be trimmed to send as part of the branch trimmed event
-		const trimmedCommits = getPathFromBase(newTrunkBase, this.trunkBase);
+		const trimmedCommits = getPathFromBase(newTrunkBase, this.trunkBase) as Mutable<
+			GraphCommit<TChangeset>
+		>[];
 		const trimmedRevisions = trimmedCommits.map((c) => c.revision);
 
 		// The minimum sequence number informs us that all peer branches are at least caught up to the tail commit,
@@ -353,9 +355,10 @@ export class EditManager<
 		// Custom metadata shares the lifetime of its commit, so it must be dropped when the commit is
 		// trimmed. The new trunk base stays reachable as the sentinel for the remaining history, so its
 		// metadata is cleared rather than trapped; fully evicted commits get the throwing trap below.
-		(newTrunkBase as Mutable<typeof newTrunkBase>).customMetadata = undefined;
+		newTrunkBase.customMetadata = undefined;
 
-		// Only the last trimmed commit, which is the new trunk base, should remain accessible.
+		// Access to the intrinsic properties of trimmed commits indicates a bug in SharedTree.
+		// Throwing lowers the risk of such a bug causing data loss or corruption.
 		for (const commit of trimmedCommits.slice(0, -1)) {
 			Reflect.defineProperty(commit, "change", {
 				get: () => fail(0xa5e /* Should not access 'change' property of an evicted commit */),
@@ -367,16 +370,17 @@ export class EditManager<
 						0xa5f /* Should not access 'revision' property of an evicted commit */,
 					),
 			});
-			Reflect.defineProperty(commit, "parent", {
-				get: () => fail(0xa60 /* Should not access 'parent' property of an evicted commit */),
-			});
 			Reflect.defineProperty(commit, "customMetadata", {
 				get: () => fail("Should not access 'customMetadata' property of an evicted commit"),
 			});
+			// Allowing the `parent` property to be read from evicted commits spares readers from having to check `wasTrimmed` in order to safely find the root commit.
+			delete commit.parent;
+			commit.wasTrimmed = true;
 		}
 
 		// Dropping the parent field removes (transitively) all references to the evicted commits so they can be garbage collected.
 		delete newTrunkBase.parent;
+		newTrunkBase.wasTrimmed = true;
 		this.trunkBase = newTrunkBase;
 
 		this._events.emit("ancestryTrimmed", trimmedRevisions);

--- a/packages/dds/tree/src/shared-tree-core/editManager.ts
+++ b/packages/dds/tree/src/shared-tree-core/editManager.ts
@@ -136,6 +136,7 @@ export class EditManager<
 			revision: rootRevision,
 			change: changeFamily.rebaser.compose([]),
 			customMetadata: undefined,
+			wasTrimmed: true,
 		};
 
 		if (logger !== undefined) {
@@ -373,12 +374,15 @@ export class EditManager<
 			Reflect.defineProperty(commit, "customMetadata", {
 				get: () => fail("Should not access 'customMetadata' property of an evicted commit"),
 			});
-			// Allowing the `parent` property to be read from evicted commits spares readers from having to check `wasTrimmed` in order to safely find the root commit.
-			delete commit.parent;
+			Reflect.defineProperty(commit, "parent", {
+				get: () =>
+					assert(false, 0xa60 /* Should not access 'parent' property of an evicted commit */),
+			});
 			commit.wasTrimmed = true;
 		}
 
-		// Dropping the parent field removes (transitively) all references to the evicted commits so they can be garbage collected.
+		// Dropping the parent field (transitively) removes references to the evicted commits so they can be garbage collected.
+		// Allowing the `parent` property to be read from the trunk base (despite it being a trimmed commit) spares readers from having to check `wasTrimmed` in order to safely find the root commit.
 		delete newTrunkBase.parent;
 		newTrunkBase.wasTrimmed = true;
 		this.trunkBase = newTrunkBase;

--- a/packages/dds/tree/src/shared-tree/history.ts
+++ b/packages/dds/tree/src/shared-tree/history.ts
@@ -28,11 +28,12 @@ class LazyTreeBranchCommitMetadata implements TreeBranchCommitMetadata {
 	 */
 	private readonly snapshot: {
 		readonly revision: SessionSpaceCompressedId;
+		readonly parent: GraphCommit<SharedTreeChange> | undefined;
 		readonly customMetadata: CustomMetadataTree | undefined;
 	};
 	private parentCache?: {
-		readonly prior: GraphCommit<SharedTreeChange>;
-		readonly cached: TreeBranchCommitMetadata;
+		readonly prior: GraphCommit<SharedTreeChange> | undefined;
+		readonly cached: TreeBranchCommitMetadata | undefined;
 	};
 
 	public constructor(
@@ -42,6 +43,7 @@ class LazyTreeBranchCommitMetadata implements TreeBranchCommitMetadata {
 		assert(commit.revision !== "root", "Cannot construct metadata for the root commit");
 		this.snapshot = {
 			revision: commit.revision,
+			parent: commit.parent,
 			customMetadata: commit.customMetadata,
 		};
 	}
@@ -59,16 +61,19 @@ class LazyTreeBranchCommitMetadata implements TreeBranchCommitMetadata {
 	}
 
 	public getParent(): TreeBranchCommitMetadata | undefined {
-		// The parent of the commit may change over time due to trunk trimming.
-		if (this.commit.parent !== this.parentCache?.prior) {
-			const { parent } = this.commit;
-			this.parentCache =
-				parent === undefined || parent.revision === "root"
-					? undefined
-					: {
-							prior: parent,
-							cached: new LazyTreeBranchCommitMetadata(parent, this.idCompressor),
-						};
+		if (this.commit.wasTrimmed) {
+			delete this.parentCache;
+			return undefined;
+		}
+		const parent = this.snapshot.parent;
+		if (parent !== this.parentCache?.prior) {
+			this.parentCache = {
+				prior: parent,
+				cached:
+					parent === undefined || parent.wasTrimmed || parent.revision === "root"
+						? undefined
+						: new LazyTreeBranchCommitMetadata(parent, this.idCompressor),
+			};
 		}
 		return this.parentCache?.cached;
 	}

--- a/packages/dds/tree/src/shared-tree/history.ts
+++ b/packages/dds/tree/src/shared-tree/history.ts
@@ -4,12 +4,16 @@
  */
 
 import { assert } from "@fluidframework/core-utils/internal";
-import type { IIdCompressor } from "@fluidframework/id-compressor";
+import type { IIdCompressor, SessionSpaceCompressedId } from "@fluidframework/id-compressor";
 
 import type { GraphCommit, CustomMetadataTree } from "../core/index.js";
 import { flattenCustomMetadata } from "../core/index.js";
 import { BranchCommitCounter, type SharedTreeBranch } from "../shared-tree-core/index.js";
-import type { TreeBranchCommitMetadata, TreeBranchHistory } from "../simple-tree/index.js";
+import type {
+	CommitRevision,
+	TreeBranchCommitMetadata,
+	TreeBranchHistory,
+} from "../simple-tree/index.js";
 import type { JsonCompatibleReadOnlyObject } from "../util/index.js";
 
 import type { SharedTreeChange } from "./sharedTreeChangeTypes.js";
@@ -19,7 +23,13 @@ import type { SharedTreeEditBuilder } from "./sharedTreeEditBuilder.js";
  * A lazily constructed implementation of {@link TreeBranchCommitMetadata} that wraps a {@link GraphCommit}.
  */
 class LazyTreeBranchCommitMetadata implements TreeBranchCommitMetadata {
-	public readonly revision: string;
+	/**
+	 * Holds a copy of data that may become inaccessible when the commit is trimmed.
+	 */
+	private readonly snapshot: {
+		readonly revision: SessionSpaceCompressedId;
+		readonly customMetadata: CustomMetadataTree | undefined;
+	};
 	private parentCache?: {
 		readonly prior: GraphCommit<SharedTreeChange>;
 		readonly cached: TreeBranchCommitMetadata;
@@ -30,15 +40,22 @@ class LazyTreeBranchCommitMetadata implements TreeBranchCommitMetadata {
 		private readonly idCompressor: IIdCompressor,
 	) {
 		assert(commit.revision !== "root", "Cannot construct metadata for the root commit");
-		this.revision = idCompressor.decompress(commit.revision);
+		this.snapshot = {
+			revision: commit.revision,
+			customMetadata: commit.customMetadata,
+		};
+	}
+
+	public get revision(): CommitRevision {
+		return this.idCompressor.decompress(this.snapshot.revision);
 	}
 
 	public get custom(): JsonCompatibleReadOnlyObject | undefined {
-		return flattenCustomMetadata(this.commit.customMetadata);
+		return flattenCustomMetadata(this.snapshot.customMetadata);
 	}
 
 	public get customTree(): CustomMetadataTree | undefined {
-		return this.commit.customMetadata;
+		return this.snapshot.customMetadata;
 	}
 
 	public getParent(): TreeBranchCommitMetadata | undefined {

--- a/packages/dds/tree/src/shared-tree/history.ts
+++ b/packages/dds/tree/src/shared-tree/history.ts
@@ -70,7 +70,7 @@ class LazyTreeBranchCommitMetadata implements TreeBranchCommitMetadata {
 			this.parentCache = {
 				prior: parent,
 				cached:
-					parent === undefined || parent.wasTrimmed || parent.revision === "root"
+					parent === undefined || parent.wasTrimmed
 						? undefined
 						: new LazyTreeBranchCommitMetadata(parent, this.idCompressor),
 			};

--- a/packages/dds/tree/src/shared-tree/treeCheckout.ts
+++ b/packages/dds/tree/src/shared-tree/treeCheckout.ts
@@ -413,6 +413,7 @@ export function createTreeCheckout(
 				change: changeFamily.rebaser.compose([]),
 				revision: "root",
 				customMetadata: undefined,
+				wasTrimmed: true,
 			},
 			changeFamily,
 			() => idCompressor.generateCompressedId(),

--- a/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/sharedTree.spec.ts
@@ -85,6 +85,7 @@ import {
 	type SimpleTreeSchema,
 	FieldKind,
 	type SimpleLeafNodeSchema,
+	type TreeBranchCommitMetadata,
 } from "../../simple-tree/index.js";
 import {
 	handleSchema,
@@ -974,90 +975,185 @@ describe("SharedTree", () => {
 		assert.deepEqual([...view2.root], ["A", "B", "C"]);
 	});
 
-	it("has bounded memory growth in EditManager", () => {
-		const provider = new TestTreeProviderLite(2);
-		const viewInit = provider.trees[0].viewWith(
-			new TreeViewConfiguration({
-				schema: StringArray,
-				enableSchemaValidation,
-			}),
-		);
-		viewInit.initialize([]);
-		viewInit.dispose();
-		provider.synchronizeMessages();
+	describe("Trunk Trimming", () => {
+		it("has bounded memory growth in EditManager", () => {
+			const provider = new TestTreeProviderLite(2);
+			const viewInit = provider.trees[0].viewWith(
+				new TreeViewConfiguration({
+					schema: StringArray,
+					enableSchemaValidation,
+				}),
+			);
+			viewInit.initialize([]);
+			viewInit.dispose();
+			provider.synchronizeMessages();
 
-		const [view1, view2] = provider.trees.map((t) =>
-			t.viewWith(new TreeViewConfiguration({ schema: StringArray, enableSchemaValidation })),
-		);
+			const [view1, view2] = provider.trees.map((t) =>
+				t.viewWith(new TreeViewConfiguration({ schema: StringArray, enableSchemaValidation })),
+			);
 
-		// Make some arbitrary number of edits
-		for (let i = 0; i < 10; ++i) {
+			// Make some arbitrary number of edits
+			for (let i = 0; i < 10; ++i) {
+				view1.root.insertAtStart("");
+			}
+
+			provider.synchronizeMessages();
+
+			assert.equal(provider.trees[0].kernel.checkout.branchHistory.length, 10);
+			assert.equal(provider.trees[1].kernel.checkout.branchHistory.length, 10);
+
+			// These two edits will have ref numbers that correspond to the last of the above edits
 			view1.root.insertAtStart("");
+			view2.root.insertAtStart("");
+
+			// This synchronization point should ensure that both trees see the edits with the higher ref numbers.
+			provider.synchronizeMessages();
+
+			assert.equal(provider.trees[0].kernel.checkout.branchHistory.length, 2);
+			assert.equal(provider.trees[1].kernel.checkout.branchHistory.length, 2);
+		});
+
+		/**
+		 * Gets all commits reachable from the given commit, including the commit itself.
+		 * Order: most recent commit first.
+		 */
+		function getHistory(
+			commit: TreeBranchCommitMetadata | undefined,
+		): TreeBranchCommitMetadata[] {
+			const history: TreeBranchCommitMetadata[] = [];
+			let currentCommit = commit;
+			while (currentCommit !== undefined) {
+				history.push(currentCommit);
+				currentCommit = currentCommit.getParent();
+			}
+			return history;
 		}
 
-		provider.synchronizeMessages();
-
-		assert.equal(provider.trees[0].kernel.checkout.branchHistory.length, 10);
-		assert.equal(provider.trees[1].kernel.checkout.branchHistory.length, 10);
-
-		// These two edit will have ref numbers that correspond to the last of the above edits
-		view1.root.insertAtStart("");
-		view2.root.insertAtStart("");
-
-		// This synchronization point should ensure that both trees see the edits with the higher ref numbers.
-		provider.synchronizeMessages();
-
-		assert.equal(provider.trees[0].kernel.checkout.branchHistory.length, 2);
-		assert.equal(provider.trees[1].kernel.checkout.branchHistory.length, 2);
-	});
-
-	// This covers in-memory retention only. See the "retainHistory persistence" suite below for the
-	// summary round-trip behavior.
-	it("does not evict trunk commits when retainHistory is enabled", () => {
-		const provider = new TestTreeProviderLite(
-			2,
-			configuredSharedTree({
-				jsonValidator: FormatValidatorBasic,
-				retainHistory: true,
-			}).getFactory(),
-		);
-		const viewInit = provider.trees[0].viewWith(
-			new TreeViewConfiguration({
-				schema: StringArray,
-				enableSchemaValidation,
-			}),
-		);
-		viewInit.initialize([]);
-		viewInit.dispose();
-		provider.synchronizeMessages();
-
-		const priorEditCount = provider.trees[0].kernel.checkout.branchHistory.length;
-		assert.equal(provider.trees[1].kernel.checkout.branchHistory.length, priorEditCount);
-
-		const [view1, view2] = provider.trees.map((t) =>
-			t.viewWith(new TreeViewConfiguration({ schema: StringArray, enableSchemaValidation })),
-		);
-
-		const sequencedEditCount = 10;
-		for (let i = 0; i < sequencedEditCount; ++i) {
-			view1.root.insertAtStart("");
+		/**
+		 * Checks that all properties of the given commit are safe to read.
+		 * @remarks
+		 * This function recursively checks all ancestor commits.
+		 */
+		function checkHistorySafety(commit: TreeBranchCommitMetadata): void {
+			assert.doesNotThrow(() => commit.revision);
+			assert.doesNotThrow(() => commit.custom);
+			assert.doesNotThrow(() => commit.customTree);
+			assert.doesNotThrow(() => commit.getParent());
+			const parent = commit.getParent();
+			if (parent !== undefined) {
+				checkHistorySafety(parent);
+			}
 		}
 
-		provider.synchronizeMessages();
+		it("branch history remains safe to read after trunk trimming", () => {
+			const provider = new TestTreeProviderLite(2);
+			const viewInit = provider.trees[0].viewWith(
+				new TreeViewConfiguration({
+					schema: StringArray,
+					enableSchemaValidation,
+				}),
+			);
+			viewInit.initialize([]);
+			viewInit.dispose();
+			provider.synchronizeMessages();
 
-		// These two edits will have ref numbers that correspond to the last of the above edits
-		view1.root.insertAtStart("");
-		view2.root.insertAtStart("");
+			const [view1, view2] = provider.trees.map((t) =>
+				asAlpha(
+					t.viewWith(
+						new TreeViewConfiguration({ schema: StringArray, enableSchemaValidation }),
+					),
+				),
+			);
 
-		// This synchronization point should ensure that both trees see the edits with the higher ref numbers,
-		// and would normally cause the earlier commits to be evicted from the trunk.
-		provider.synchronizeMessages();
+			// Make some arbitrary number of edits
+			view1.root.insertAtStart("A");
+			view1.root.insertAtStart("B");
+			view1.root.insertAtStart("C");
 
-		// All of the edits (plus the two additional ones) should still be present on the trunk since
-		// retainHistory prevents trunk commits from ever being trimmed.
-		const expectedCount = priorEditCount + sequencedEditCount + 2;
-		assert.equal(provider.trees[0].kernel.checkout.branchHistory.length, expectedCount);
-		assert.equal(provider.trees[1].kernel.checkout.branchHistory.length, expectedCount);
+			provider.synchronizeMessages();
+
+			// These two edits will have ref numbers that correspond to the last of the above edits
+			view1.root.insertAtStart("D1");
+			view2.root.insertAtStart("D2");
+
+			assert.equal(provider.trees[0].kernel.checkout.branchHistory.length, 4);
+			assert.equal(provider.trees[1].kernel.checkout.branchHistory.length, 4);
+
+			// Capture all commit metadata objects reachable before trimming
+			const view1HistoryBeforeTrimming = getHistory(view1.branchHistory.getHead());
+			const view2HistoryBeforeTrimming = getHistory(view2.branchHistory.getHead());
+
+			// This synchronization point should ensure that both trees see the edits with the higher ref numbers.
+			provider.synchronizeMessages();
+			// Test-check: trimming should have occurred
+			assert.equal(provider.trees[0].kernel.checkout.branchHistory.length, 2);
+			assert.equal(provider.trees[1].kernel.checkout.branchHistory.length, 2);
+
+			// Check that the newly reachable history post-trimming is safe to read
+			checkHistorySafety(
+				view1.branchHistory.getHead() ?? assert.fail("Expected view1 to have a head commit"),
+			);
+			checkHistorySafety(
+				view2.branchHistory.getHead() ?? assert.fail("Expected view2 to have a head commit"),
+			);
+
+			// For each commit metadata object that might have been produced prior to trimming, check that it is still safe to read.
+			for (const commit of view1HistoryBeforeTrimming) {
+				checkHistorySafety(commit);
+			}
+			for (const commit of view2HistoryBeforeTrimming) {
+				checkHistorySafety(commit);
+			}
+		});
+
+		// This covers in-memory retention only. See the "retainHistory persistence" suite below for the
+		// summary round-trip behavior.
+		it("does not evict trunk commits when retainHistory is enabled", () => {
+			const provider = new TestTreeProviderLite(
+				2,
+				configuredSharedTree({
+					jsonValidator: FormatValidatorBasic,
+					retainHistory: true,
+				}).getFactory(),
+			);
+			const viewInit = provider.trees[0].viewWith(
+				new TreeViewConfiguration({
+					schema: StringArray,
+					enableSchemaValidation,
+				}),
+			);
+			viewInit.initialize([]);
+			viewInit.dispose();
+			provider.synchronizeMessages();
+
+			const priorEditCount = provider.trees[0].kernel.checkout.branchHistory.length;
+			assert.equal(provider.trees[1].kernel.checkout.branchHistory.length, priorEditCount);
+
+			const [view1, view2] = provider.trees.map((t) =>
+				t.viewWith(new TreeViewConfiguration({ schema: StringArray, enableSchemaValidation })),
+			);
+
+			const sequencedEditCount = 10;
+			for (let i = 0; i < sequencedEditCount; ++i) {
+				view1.root.insertAtStart("");
+			}
+
+			provider.synchronizeMessages();
+
+			// These two edits will have ref numbers that correspond to the last of the above edits
+			view1.root.insertAtStart("");
+			view2.root.insertAtStart("");
+
+			// This synchronization point should ensure that both trees see the edits with the higher ref numbers,
+			// and would normally cause the earlier commits to be evicted from the trunk.
+			provider.synchronizeMessages();
+
+			// All of the edits (plus the two additional ones) should still be present on the trunk since
+			// retainHistory prevents trunk commits from ever being trimmed.
+			const expectedCount = priorEditCount + sequencedEditCount + 2;
+			assert.equal(provider.trees[0].kernel.checkout.branchHistory.length, expectedCount);
+			assert.equal(provider.trees[1].kernel.checkout.branchHistory.length, expectedCount);
+		});
 	});
 
 	describe("Persists retained history", () => {

--- a/packages/dds/tree/src/test/simple-tree/api/history.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/history.spec.ts
@@ -52,6 +52,7 @@ function createBranch(branchTrimmer?: Listenable<BranchTrimmingEvents>): BranchT
 			change: changeFamily.rebaser.compose([]),
 			revision: "root",
 			customMetadata: undefined,
+			wasTrimmed: true,
 		},
 		changeFamily,
 		mintRevisionTag,


### PR DESCRIPTION
## Description

Fixes a bug where accessing commit metadata for a trimmed commit would assert (0xa5e, 0xa5f, 0xa60, or 0xd36).

This PR also introduces an explicit `wasTrimmed` flag on `GraphCommit` to make the code clearer and debugging easier.

## Breaking Changes

None