### PR TITLE
fix(tree): tag schema incompatibility details in telemetry

### DIFF
--- a/.changeset/improve-tree-schema-errors.md
+++ b/.changeset/improve-tree-schema-errors.md
@@ -7,4 +7,5 @@ SharedTree schema errors now explain the mismatch
 
 Schema validation errors now report the mismatch category and attach relevant diagnostic context. Depending on the mismatch, tagged telemetry properties identify the node type, field kind, child count, expected leaf value type, actual value type, unexpected fields, or path, making invalid content easier to diagnose while allowing consumers to filter potentially sensitive user data.
 
-When a view schema cannot access a document's stored schema, the error now reports the first schema mismatch and explains whether to initialize the document, upgrade its stored schema, use a compatible view schema, or explicitly migrate the document.
+When a view schema cannot access a document's stored schema, the error now explains whether to initialize the document, upgrade its stored schema, use a compatible view schema, or explicitly migrate the document.
+The first schema mismatch is attached as structured, schema-artifact-tagged telemetry.

--- a/.changeset/improve-tree-schema-errors.md
+++ b/.changeset/improve-tree-schema-errors.md
@@ -7,5 +7,4 @@ SharedTree schema errors now explain the mismatch
 
 Schema validation errors now report the mismatch category and attach relevant diagnostic context. Depending on the mismatch, tagged telemetry properties identify the node type, field kind, child count, expected leaf value type, actual value type, unexpected fields, or path, making invalid content easier to diagnose while allowing consumers to filter potentially sensitive user data.
 
-When a view schema cannot access a document's stored schema, the error now explains whether to initialize the document, upgrade its stored schema, use a compatible view schema, or explicitly migrate the document.
-The first schema mismatch is attached as structured, schema-artifact-tagged telemetry.
+When a view schema cannot access a document's stored schema, the error now reports the first schema mismatch and explains whether to initialize the document, upgrade its stored schema, use a compatible view schema, or explicitly migrate the document.

--- a/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
+++ b/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
@@ -10,7 +10,7 @@ import type {
 	Listenable,
 } from "@fluidframework/core-interfaces/internal";
 import { assert } from "@fluidframework/core-utils/internal";
-import { UsageError } from "@fluidframework/telemetry-utils/internal";
+import { tagSchemaArtifacts, UsageError } from "@fluidframework/telemetry-utils/internal";
 
 import { anchorSlot, rootFieldKey, type RevertToOptionsAlpha } from "../core/index.js";
 import {
@@ -63,7 +63,7 @@ import {
 	type TreeSchema,
 	type SchemaUpgrade,
 	type StagedUpgradeStatus,
-	getSchemaCompatibilityError,
+	getSchemaIncompatibilityDetails,
 } from "../simple-tree/index.js";
 import {
 	type Breakable,
@@ -91,16 +91,18 @@ function throwIfSchemaIsIncompatible(
 		return;
 	}
 
-	const discrepancy = getSchemaCompatibilityError(viewSchema, storedSchema);
-	const details =
-		discrepancy === undefined ? "" : ` The first schema mismatch is: ${discrepancy}.`;
+	const schemaIncompatibilityDetails = getSchemaIncompatibilityDetails(
+		viewSchema,
+		storedSchema,
+	);
 	const resolution = compatibility.canInitialize
 		? "The document is uninitialized; call TreeView.initialize() before reading or writing TreeView.root."
 		: compatibility.canUpgrade
 			? "The stored schema can be upgraded; call TreeView.upgradeSchema() before reading or writing TreeView.root."
-			: "The schemas cannot be upgraded automatically. Review the reported mismatch and use a compatible view schema or explicitly migrate the document schema and data.";
+			: "The schemas cannot be upgraded automatically. Use a compatible view schema or explicitly migrate the document schema and data.";
 	throw new UsageError(
-		`TreeView.root is unavailable because the view schema is not compatible with the document's stored schema.${details} ${resolution}`,
+		`TreeView.root is unavailable because the view schema is incompatible with the stored schema. ${resolution}`,
+		tagSchemaArtifacts({ schemaIncompatibilityDetails }),
 	);
 }
 

--- a/packages/dds/tree/src/simple-tree/api/index.ts
+++ b/packages/dds/tree/src/simple-tree/api/index.ts
@@ -107,7 +107,7 @@ export { getJsonSchema } from "./getJsonSchema.js";
 export { getSimpleSchema } from "./getSimpleSchema.js";
 export {
 	checkSchemaCompatibility,
-	getSchemaCompatibilityError,
+	getSchemaIncompatibilityDetails,
 } from "./schemaCompatibilityTester.js";
 export { type StagedUpgradeStatus } from "./schemaCompatibilityTester.js";
 export type {

--- a/packages/dds/tree/src/simple-tree/api/schemaCompatibilityTester.ts
+++ b/packages/dds/tree/src/simple-tree/api/schemaCompatibilityTester.ts
@@ -6,7 +6,6 @@
 import { unreachableCase } from "@fluidframework/core-utils/internal";
 
 import {
-	LeafNodeStoredSchema,
 	MapNodeStoredSchema,
 	ObjectNodeStoredSchema,
 	type TreeStoredSchema,
@@ -19,85 +18,72 @@ import { toUpgradeSchema } from "../toStoredSchema.js";
 import type { TreeSchema } from "../treeSchema.js";
 
 import {
-	type Discrepancy,
-	type FieldDiscrepancyLocation,
 	getDiscrepanciesInAllowedContent,
 	type UpgradeLocationCollector,
 } from "./discrepancies.js";
 import type { SchemaCompatibilityStatus } from "./tree.js";
 
-function formatLocation(location: FieldDiscrepancyLocation): string {
-	if (location.identifier === undefined) {
-		return "the root field";
-	}
-	if (location.fieldKey === undefined) {
-		return `the fields of node type ${JSON.stringify(location.identifier)}`;
-	}
-	return `field ${JSON.stringify(location.fieldKey)} of node type ${JSON.stringify(location.identifier)}`;
-}
-
-function formatStoredNodeKind(
-	kind:
-		| typeof ObjectNodeStoredSchema
-		| typeof MapNodeStoredSchema
-		| typeof LeafNodeStoredSchema,
-): string {
-	if (kind === ObjectNodeStoredSchema) {
-		return "Object";
-	}
-	if (kind === MapNodeStoredSchema) {
-		return "Map";
-	}
-	if (kind === LeafNodeStoredSchema) {
-		return "Leaf";
-	}
-	throw new TypeError("Unknown stored node kind.");
-}
-
-function formatDiscrepancy(discrepancy: Discrepancy): string {
-	switch (discrepancy.mismatch) {
-		case "allowedTypes": {
-			const differences: string[] = [];
-			if (discrepancy.view.length > 0) {
-				const viewTypes = discrepancy.view.map(({ type }) => type.identifier).sort();
-				differences.push(`only the view schema allows ${JSON.stringify(viewTypes)}`);
-			}
-			if (discrepancy.stored.length > 0) {
-				differences.push(
-					`only the stored schema allows ${JSON.stringify([...discrepancy.stored].sort())}`,
-				);
-			}
-			return `${formatLocation(discrepancy)} has different allowed node types: ${differences.join("; ")}`;
-		}
-		case "fieldKind": {
-			return `${formatLocation(discrepancy)} has field kind ${JSON.stringify(discrepancy.view)} in the view schema but ${JSON.stringify(discrepancy.stored)} in the stored schema`;
-		}
-		case "valueSchema": {
-			const view = discrepancy.view === undefined ? undefined : ValueSchema[discrepancy.view];
-			const stored =
-				discrepancy.stored === undefined ? undefined : ValueSchema[discrepancy.stored];
-			return `node type ${JSON.stringify(discrepancy.identifier)} has value schema ${JSON.stringify(view)} in the view schema but ${JSON.stringify(stored)} in the stored schema`;
-		}
-		case "nodeKind": {
-			return `node type ${JSON.stringify(discrepancy.identifier)} has node kind ${JSON.stringify(NodeKind[discrepancy.view])} in the view schema but ${JSON.stringify(formatStoredNodeKind(discrepancy.stored))} in the stored schema`;
-		}
-		default: {
-			return unreachableCase(discrepancy);
-		}
-	}
-}
-
 /**
- * Describes the first discrepancy that prevents a view schema from viewing a stored schema.
+ * Describes the first discrepancy that prevents a view schema from viewing a stored schema as a
+ * JSON object.
  */
-export function getSchemaCompatibilityError(
+export function getSchemaIncompatibilityDetails(
 	viewSchema: TreeSchema,
 	stored: TreeStoredSchema,
 ): string | undefined {
 	const discrepancy = getDiscrepanciesInAllowedContent(viewSchema, stored)
 		[Symbol.iterator]()
 		.next();
-	return discrepancy.done === true ? undefined : formatDiscrepancy(discrepancy.value);
+	if (discrepancy.done === true) {
+		return undefined;
+	}
+
+	const value = discrepancy.value;
+	switch (value.mismatch) {
+		case "allowedTypes": {
+			return JSON.stringify({
+				location: {
+					nodeType: value.identifier ?? null,
+					fieldKey: value.fieldKey ?? null,
+				},
+				view: value.view.map(({ type }) => type.identifier).sort(),
+				stored: [...value.stored].sort(),
+			});
+		}
+		case "fieldKind": {
+			return JSON.stringify({
+				location: {
+					nodeType: value.identifier ?? null,
+					fieldKey: value.fieldKey ?? null,
+				},
+				view: value.view,
+				stored: value.stored,
+			});
+		}
+		case "valueSchema": {
+			return JSON.stringify({
+				nodeType: value.identifier,
+				view: value.view === undefined ? null : ValueSchema[value.view],
+				stored: value.stored === undefined ? null : ValueSchema[value.stored],
+			});
+		}
+		case "nodeKind": {
+			const storedNodeKind =
+				value.stored === ObjectNodeStoredSchema
+					? "Object"
+					: value.stored === MapNodeStoredSchema
+						? "Map"
+						: "Leaf";
+			return JSON.stringify({
+				nodeType: value.identifier,
+				view: NodeKind[value.view],
+				stored: storedNodeKind,
+			});
+		}
+		default: {
+			return unreachableCase(value);
+		}
+	}
 }
 
 /**

--- a/packages/dds/tree/src/simple-tree/api/schemaCompatibilityTester.ts
+++ b/packages/dds/tree/src/simple-tree/api/schemaCompatibilityTester.ts
@@ -24,66 +24,73 @@ import {
 import type { SchemaCompatibilityStatus } from "./tree.js";
 
 /**
- * Describes the first discrepancy that prevents a view schema from viewing a stored schema as a
- * JSON-serialized object.
+ * Describes the discrepancies that prevent a view schema from viewing a stored schema as a
+ * JSON-serialized array.
  */
 export function getSchemaIncompatibilityDetails(
 	viewSchema: TreeSchema,
 	stored: TreeStoredSchema,
 ): string | undefined {
-	const discrepancy = getDiscrepanciesInAllowedContent(viewSchema, stored)
-		[Symbol.iterator]()
-		.next();
-	if (discrepancy.done === true) {
+	const discrepancies = [...getDiscrepanciesInAllowedContent(viewSchema, stored)];
+	if (discrepancies.length === 0) {
 		return undefined;
 	}
 
-	const value = discrepancy.value;
-	switch (value.mismatch) {
-		case "allowedTypes": {
-			return JSON.stringify({
-				location: {
-					nodeType: value.identifier ?? null,
-					fieldKey: value.fieldKey ?? null,
-				},
-				view: value.view.map(({ type }) => type.identifier).sort(),
-				stored: [...value.stored].sort(),
-			});
-		}
-		case "fieldKind": {
-			return JSON.stringify({
-				location: {
-					nodeType: value.identifier ?? null,
-					fieldKey: value.fieldKey ?? null,
-				},
-				view: value.view,
-				stored: value.stored,
-			});
-		}
-		case "valueSchema": {
-			return JSON.stringify({
-				nodeType: value.identifier,
-				view: value.view === undefined ? null : ValueSchema[value.view],
-				stored: value.stored === undefined ? null : ValueSchema[value.stored],
-			});
-		}
-		case "nodeKind": {
-			const storedNodeKind =
-				value.stored === ObjectNodeStoredSchema
-					? "Object"
-					: value.stored === MapNodeStoredSchema
-						? "Map"
-						: "Leaf";
-			return JSON.stringify({
-				nodeType: value.identifier,
-				view: NodeKind[value.view],
-				stored: storedNodeKind,
-			});
-		}
-		default: {
-			return unreachableCase(value);
-		}
-	}
+	return JSON.stringify(
+		discrepancies.map((value) => {
+			switch (value.mismatch) {
+				case "allowedTypes": {
+					return {
+						location:
+							value.identifier === undefined
+								? "root"
+								: {
+										nodeType: value.identifier,
+										fieldKey: value.fieldKey ?? null,
+									},
+						view: value.view.map(({ type }) => type.identifier).sort(),
+						stored: [...value.stored].sort(),
+					};
+				}
+				case "fieldKind": {
+					return {
+						location:
+							value.identifier === undefined
+								? "root"
+								: {
+										nodeType: value.identifier,
+										fieldKey: value.fieldKey ?? null,
+									},
+						view: value.view,
+						stored: value.stored,
+					};
+				}
+				case "valueSchema": {
+					return {
+						nodeType: value.identifier,
+						view: value.view === undefined ? null : ValueSchema[value.view],
+						stored: value.stored === undefined ? null : ValueSchema[value.stored],
+					};
+				}
+				case "nodeKind": {
+					const storedNodeKind =
+						value.stored === ObjectNodeStoredSchema
+							? "Object"
+							: value.stored === MapNodeStoredSchema
+								? "Map"
+								: "Leaf";
+					return {
+						nodeType: value.identifier,
+						view: NodeKind[value.view],
+						stored: storedNodeKind,
+					};
+				}
+				default: {
+					return unreachableCase(value);
+				}
+			}
+		}),
+	);
 }
 
 /**

--- a/packages/dds/tree/src/simple-tree/api/schemaCompatibilityTester.ts
+++ b/packages/dds/tree/src/simple-tree/api/schemaCompatibilityTester.ts
@@ -24,7 +24,7 @@ import {
 import type { SchemaCompatibilityStatus } from "./tree.js";
 
 /**
- * Describes the first discrepancy that prevents a view schema from viewing a stored schema as a
+ * Describes the first discrepancy that prevents a view schema from viewing a stored schema, as a
  * JSON object.
  */
 export function getSchemaIncompatibilityDetails(

--- a/packages/dds/tree/src/simple-tree/api/schemaCompatibilityTester.ts
+++ b/packages/dds/tree/src/simple-tree/api/schemaCompatibilityTester.ts
@@ -24,8 +24,8 @@ import {
 import type { SchemaCompatibilityStatus } from "./tree.js";
 
 /**
- * Describes the first discrepancy that prevents a view schema from viewing a stored schema, as a
- * JSON object.
+ * Describes the first discrepancy that prevents a view schema from viewing a stored schema as a
+ * JSON-serialized object.
  */
 export function getSchemaIncompatibilityDetails(
 	viewSchema: TreeSchema,

--- a/packages/dds/tree/src/simple-tree/index.ts
+++ b/packages/dds/tree/src/simple-tree/index.ts
@@ -143,7 +143,7 @@ export {
 	comparePersistedSchema,
 	type ConciseTree,
 	checkSchemaCompatibility,
-	getSchemaCompatibilityError,
+	getSchemaIncompatibilityDetails,
 	type Unenforced,
 	type System_Unsafe,
 	type ArrayNodeCustomizableSchemaUnsafe,

--- a/packages/dds/tree/src/test/shared-tree/schematizingTreeView.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/schematizingTreeView.spec.ts
@@ -603,11 +603,13 @@ describe("SchematizingSimpleTreeView", () => {
 				);
 				assert.deepEqual(error.getTelemetryProperties().schemaIncompatibilityDetails, {
 					tag: TelemetryDataTag.SchemaArtifact,
-					value: JSON.stringify({
-						location: { nodeType: null, fieldKey: null },
-						view: ["com.fluidframework.leaf.string"],
-						stored: [],
-					}),
+					value: JSON.stringify([
+						{
+							location: "root",
+							view: ["com.fluidframework.leaf.string"],
+							stored: [],
+						},
+					]),
 				});
 				return true;
 			},
@@ -642,11 +644,13 @@ describe("SchematizingSimpleTreeView", () => {
 				);
 				assert.deepEqual(error.getTelemetryProperties().schemaIncompatibilityDetails, {
 					tag: TelemetryDataTag.SchemaArtifact,
-					value: JSON.stringify({
-						location: { nodeType: null, fieldKey: null },
-						view: [],
-						stored: ["com.fluidframework.leaf.string"],
-					}),
+					value: JSON.stringify([
+						{
+							location: "root",
+							view: [],
+							stored: ["com.fluidframework.leaf.string"],
+						},
+					]),
 				});
 				return true;
 			},
@@ -677,11 +681,13 @@ describe("SchematizingSimpleTreeView", () => {
 			);
 			assert.deepEqual(error.getTelemetryProperties().schemaIncompatibilityDetails, {
 				tag: TelemetryDataTag.SchemaArtifact,
-				value: JSON.stringify({
-					location: { nodeType: null, fieldKey: null },
-					view: ["com.fluidframework.leaf.boolean"],
-					stored: ["com.fluidframework.leaf.string"],
-				}),
+				value: JSON.stringify([
+					{
+						location: "root",
+						view: ["com.fluidframework.leaf.boolean"],
+						stored: ["com.fluidframework.leaf.string"],
+					},
+				]),
 			});
 			return true;
 		};

--- a/packages/dds/tree/src/test/shared-tree/schematizingTreeView.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/schematizingTreeView.spec.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert, fail } from "node:assert";
 
-import { UsageError } from "@fluidframework/telemetry-utils/internal";
+import { TelemetryDataTag, UsageError } from "@fluidframework/telemetry-utils/internal";
 import { validateUsageError } from "@fluidframework/test-runtime-utils/internal";
 
 import { CommitKind, type RevertibleAlpha, type TransactionLabels } from "../../core/index.js";
@@ -595,9 +595,22 @@ describe("SchematizingSimpleTreeView", () => {
 		assert.equal(view.compatibility.isEquivalent, false);
 		assert.throws(
 			() => view.root,
-			validateUsageError(
-				/TreeView\.root is unavailable because the view schema is not compatible with the document's stored schema\. The first schema mismatch is: the root field has different allowed node types: only the view schema allows \["com\.fluidframework\.leaf\.string"\]\. The stored schema can be upgraded; call TreeView\.upgradeSchema\(\)/,
-			),
+			(error) => {
+				assert(error instanceof UsageError);
+				assert.equal(
+					error.message,
+					"TreeView.root is unavailable because the view schema is incompatible with the stored schema. The stored schema can be upgraded; call TreeView.upgradeSchema() before reading or writing TreeView.root.",
+				);
+				assert.deepEqual(error.getTelemetryProperties().schemaIncompatibilityDetails, {
+					tag: TelemetryDataTag.SchemaArtifact,
+					value: JSON.stringify({
+						location: { nodeType: null, fieldKey: null },
+						view: ["com.fluidframework.leaf.string"],
+						stored: [],
+					}),
+				});
+				return true;
+			},
 		);
 
 		view.upgradeSchema();
@@ -621,9 +634,22 @@ describe("SchematizingSimpleTreeView", () => {
 		assert.equal(view.compatibility.isEquivalent, false);
 		assert.throws(
 			() => view.root,
-			validateUsageError(
-				/TreeView\.root is unavailable because the view schema is not compatible with the document's stored schema\. The first schema mismatch is: the root field has different allowed node types: only the stored schema allows \["com\.fluidframework\.leaf\.string"\]\. The schemas cannot be upgraded automatically\./,
-			),
+			(error) => {
+				assert(error instanceof UsageError);
+				assert.equal(
+					error.message,
+					"TreeView.root is unavailable because the view schema is incompatible with the stored schema. The schemas cannot be upgraded automatically. Use a compatible view schema or explicitly migrate the document schema and data.",
+				);
+				assert.deepEqual(error.getTelemetryProperties().schemaIncompatibilityDetails, {
+					tag: TelemetryDataTag.SchemaArtifact,
+					value: JSON.stringify({
+						location: { nodeType: null, fieldKey: null },
+						view: [],
+						stored: ["com.fluidframework.leaf.string"],
+					}),
+				});
+				return true;
+			},
 		);
 
 		assert.throws(
@@ -645,9 +671,22 @@ describe("SchematizingSimpleTreeView", () => {
 		assert.equal(view.compatibility.isEquivalent, false);
 		assert.throws(
 			() => view.root,
-			validateUsageError(
-				/TreeView\.root is unavailable because the view schema is not compatible with the document's stored schema\. The first schema mismatch is: the root field has different allowed node types: only the view schema allows \["com\.fluidframework\.leaf\.boolean"\]; only the stored schema allows \["com\.fluidframework\.leaf\.string"\]\. The schemas cannot be upgraded automatically\./,
-			),
+			(error) => {
+				assert(error instanceof UsageError);
+				assert.equal(
+					error.message,
+					"TreeView.root is unavailable because the view schema is incompatible with the stored schema. The schemas cannot be upgraded automatically. Use a compatible view schema or explicitly migrate the document schema and data.",
+				);
+				assert.deepEqual(error.getTelemetryProperties().schemaIncompatibilityDetails, {
+					tag: TelemetryDataTag.SchemaArtifact,
+					value: JSON.stringify({
+						location: { nodeType: null, fieldKey: null },
+						view: ["com.fluidframework.leaf.boolean"],
+						stored: ["com.fluidframework.leaf.string"],
+					}),
+				});
+				return true;
+			},
 		);
 
 		assert.throws(

--- a/packages/dds/tree/src/test/shared-tree/schematizingTreeView.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/schematizingTreeView.spec.ts
@@ -669,25 +669,26 @@ describe("SchematizingSimpleTreeView", () => {
 		assert.equal(view.compatibility.canView, false);
 		assert.equal(view.compatibility.canUpgrade, false);
 		assert.equal(view.compatibility.isEquivalent, false);
-		assert.throws(
-			() => view.root,
-			(error) => {
-				assert(error instanceof UsageError);
-				assert.equal(
-					error.message,
-					"TreeView.root is unavailable because the view schema is incompatible with the stored schema. The schemas cannot be upgraded automatically. Use a compatible view schema or explicitly migrate the document schema and data.",
-				);
-				assert.deepEqual(error.getTelemetryProperties().schemaIncompatibilityDetails, {
-					tag: TelemetryDataTag.SchemaArtifact,
-					value: JSON.stringify({
-						location: { nodeType: null, fieldKey: null },
-						view: ["com.fluidframework.leaf.boolean"],
-						stored: ["com.fluidframework.leaf.string"],
-					}),
-				});
-				return true;
-			},
-		);
+		const validateIncompatibleSchemaError = (error: unknown): boolean => {
+			assert(error instanceof UsageError);
+			assert.equal(
+				error.message,
+				"TreeView.root is unavailable because the view schema is incompatible with the stored schema. The schemas cannot be upgraded automatically. Use a compatible view schema or explicitly migrate the document schema and data.",
+			);
+			assert.deepEqual(error.getTelemetryProperties().schemaIncompatibilityDetails, {
+				tag: TelemetryDataTag.SchemaArtifact,
+				value: JSON.stringify({
+					location: { nodeType: null, fieldKey: null },
+					view: ["com.fluidframework.leaf.boolean"],
+					stored: ["com.fluidframework.leaf.string"],
+				}),
+			});
+			return true;
+		};
+		assert.throws(() => view.root, validateIncompatibleSchemaError);
+		assert.throws(() => {
+			view.root = 7;
+		}, validateIncompatibleSchemaError);
 
 		assert.throws(
 			() => view.upgradeSchema(),

--- a/packages/dds/tree/src/test/simple-tree/api/schemaCompatibilityTester.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/schemaCompatibilityTester.spec.ts
@@ -76,28 +76,37 @@ describe("getSchemaIncompatibilityDetails", () => {
 		const schema = new TreeViewConfigurationAlpha({ schema: factory.string });
 		assert.equal(
 			getSchemaIncompatibilityDetails(schema, toUpgradeSchema(factory.number)),
-			JSON.stringify({
-				location: { nodeType: null, fieldKey: null },
-				view: [factory.string.identifier],
-				stored: [factory.number.identifier],
-			}),
+			JSON.stringify([
+				{
+					location: "root",
+					view: [factory.string.identifier],
+					stored: [factory.number.identifier],
+				},
+			]),
 		);
 	});
 
-	it("formats a field kind discrepancy", () => {
+	it("formats all discrepancies", () => {
 		const schema = new TreeViewConfigurationAlpha({
-			schema: factory.optional(factory.number),
+			schema: factory.optional(factory.string),
 		});
 		assert.equal(
 			getSchemaIncompatibilityDetails(
 				schema,
 				toUpgradeSchema(factory.required(factory.number)),
 			),
-			JSON.stringify({
-				location: { nodeType: null, fieldKey: null },
-				view: "Optional",
-				stored: "Value",
-			}),
+			JSON.stringify([
+				{
+					location: "root",
+					view: [factory.string.identifier],
+					stored: [factory.number.identifier],
+				},
+				{
+					location: "root",
+					view: "Optional",
+					stored: "Value",
+				},
+			]),
 		);
 	});
 
@@ -108,11 +117,13 @@ describe("getSchemaIncompatibilityDetails", () => {
 		const schema = new TreeViewConfigurationAlpha({ schema: viewLeaf });
 		assert.equal(
 			getSchemaIncompatibilityDetails(schema, toUpgradeSchema(storedLeaf)),
-			JSON.stringify({
-				nodeType: identifier,
-				view: "Number",
-				stored: "String",
-			}),
+			JSON.stringify([
+				{
+					nodeType: identifier,
+					view: "Number",
+					stored: "String",
+				},
+			]),
 		);
 	});
 
@@ -122,11 +133,13 @@ describe("getSchemaIncompatibilityDetails", () => {
 		const schema = new TreeViewConfigurationAlpha({ schema: ViewNode });
 		assert.equal(
 			getSchemaIncompatibilityDetails(schema, toUpgradeSchema(StoredNode)),
-			JSON.stringify({
-				nodeType: ViewNode.identifier,
-				view: "Object",
-				stored: "Map",
-			}),
+			JSON.stringify([
+				{
+					nodeType: ViewNode.identifier,
+					view: "Object",
+					stored: "Map",
+				},
+			]),
 		);
 	});
 });

--- a/packages/dds/tree/src/test/simple-tree/api/schemaCompatibilityTester.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/schemaCompatibilityTester.spec.ts
@@ -9,11 +9,14 @@ import {
 	EmptyKey,
 	storedEmptyFieldSchema,
 	type TreeStoredSchema,
+	ValueSchema,
 } from "../../../core/index.js";
 import { allowsRepoSuperset, defaultSchemaPolicy } from "../../../feature-libraries/index.js";
 // eslint-disable-next-line import-x/no-internal-modules
-import { checkSchemaCompatibility } from "../../../simple-tree/api/schemaCompatibilityTester.js";
+import { LeafNodeSchema } from "../../../simple-tree/leafNodeSchema.js";
 import {
+	checkSchemaCompatibility,
+	getSchemaIncompatibilityDetails,
 	type ImplicitFieldSchema,
 	type SchemaCompatibilityStatus,
 	type SchemaUpgrade,
@@ -59,6 +62,74 @@ function expectCompatibility(
 		assert.equal(allowsRepoSuperset(defaultSchemaPolicy, viewStored, stored), true);
 	}
 }
+
+describe("getSchemaIncompatibilityDetails", () => {
+	it("returns undefined for compatible schema", () => {
+		const schema = new TreeViewConfigurationAlpha({ schema: factory.number });
+		assert.equal(
+			getSchemaIncompatibilityDetails(schema, toUpgradeSchema(factory.number)),
+			undefined,
+		);
+	});
+
+	it("formats an allowed types discrepancy", () => {
+		const schema = new TreeViewConfigurationAlpha({ schema: factory.string });
+		assert.equal(
+			getSchemaIncompatibilityDetails(schema, toUpgradeSchema(factory.number)),
+			JSON.stringify({
+				location: { nodeType: null, fieldKey: null },
+				view: [factory.string.identifier],
+				stored: [factory.number.identifier],
+			}),
+		);
+	});
+
+	it("formats a field kind discrepancy", () => {
+		const schema = new TreeViewConfigurationAlpha({
+			schema: factory.optional(factory.number),
+		});
+		assert.equal(
+			getSchemaIncompatibilityDetails(
+				schema,
+				toUpgradeSchema(factory.required(factory.number)),
+			),
+			JSON.stringify({
+				location: { nodeType: null, fieldKey: null },
+				view: "Optional",
+				stored: "Value",
+			}),
+		);
+	});
+
+	it("formats a value schema discrepancy", () => {
+		const identifier = "valueSchema";
+		const viewLeaf = new LeafNodeSchema(identifier, ValueSchema.Number);
+		const storedLeaf = new LeafNodeSchema(identifier, ValueSchema.String);
+		const schema = new TreeViewConfigurationAlpha({ schema: viewLeaf });
+		assert.equal(
+			getSchemaIncompatibilityDetails(schema, toUpgradeSchema(storedLeaf)),
+			JSON.stringify({
+				nodeType: identifier,
+				view: "Number",
+				stored: "String",
+			}),
+		);
+	});
+
+	it("formats a node kind discrepancy", () => {
+		class ViewNode extends factory.object("nodeKind", {}) {}
+		class StoredNode extends factory.map("nodeKind", []) {}
+		const schema = new TreeViewConfigurationAlpha({ schema: ViewNode });
+		assert.equal(
+			getSchemaIncompatibilityDetails(schema, toUpgradeSchema(StoredNode)),
+			JSON.stringify({
+				nodeType: ViewNode.identifier,
+				view: "Object",
+				stored: "Map",
+			}),
+		);
+	});
+});
 
 describe("checkSchemaCompatibility", () => {
 	describe("function", () => {

--- a/packages/dds/tree/src/test/simple-tree/api/tree.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/tree.spec.ts
@@ -235,7 +235,7 @@ describe("simple-tree tree", () => {
 		// allows an optional field, explicit initialization must occur.
 		assert.throws(
 			() => view.root,
-			/TreeView\.root is unavailable because the view schema is not compatible with the document's stored schema.*The document is uninitialized; call TreeView\.initialize\(\)/,
+			/TreeView\.root is unavailable because the view schema is incompatible with the stored schema\. The document is uninitialized; call TreeView\.initialize\(\)/,
 		);
 		view.initialize(undefined);
 		assert.equal(view.root, undefined);


### PR DESCRIPTION
## Description

Simplifies the `TreeView.root` incompatible-schema `UsageError` so its message no longer embeds application-defined schema identifiers or field keys.

The incompatibilities are serialized as structured `schemaIncompatibilityDetails` telemetry and tagged as `SchemaArtifact`. The error continues to explain whether callers should initialize the document, upgrade its stored schema, use a compatible view schema, or migrate the schema and data.

Tests verify the stable messages and tagged telemetry details for upgradable and non-upgradable schemas.

## Reviewer Guidance

The review process is outlined in [the pull request guidelines](../docs/content/Contributing/PR-Guidelines.md#guidelines).

Please review the structured telemetry shape and confirm the schema-artifact classification is appropriate for all included values.