### PR TITLE
build(tree, fluid-framework): Add "rebuild" scripts

### DIFF
--- a/packages/dds/tree/package.json
+++ b/packages/dds/tree/package.json
@@ -84,6 +84,7 @@
 		"lint": "fluid-build . --task lint",
 		"lint:fix": "fluid-build . --task eslint:fix --task format",
 		"pack:tests": "tar -cf ./tree.test-files.tar ./src/test ./lib/test",
+		"rebuild": "npm run clean && npm run build",
 		"test": "npm run test:mocha",
 		"test:coverage": "c8 npm test",
 		"test:memory": "cross-env FLUID_TEST_PERF_MODE=1 mocha --fgrep @Memory --parallel --jobs 6",

--- a/packages/framework/fluid-framework/package.json
+++ b/packages/framework/fluid-framework/package.json
@@ -83,6 +83,7 @@
 		"format:biome": "biome check . --write",
 		"lint": "fluid-build . --task lint",
 		"lint:fix": "fluid-build . --task eslint:fix --task format",
+		"rebuild": "npm run clean && npm run build",
 		"typetests:gen": "flub generate typetests --dir . -v"
 	},
 	"dependencies": {


### PR DESCRIPTION
Add simple "rebuild" scripts as aliases for `npm run clean && npm run build` in packages where rebuild is often required to get correct API reports.