### PR TITLE
fix(test-version-utils): keep compatibility lockfiles npmjs-portable

### DIFF
--- a/packages/test/test-version-utils/README.md
+++ b/packages/test/test-version-utils/README.md
@@ -164,10 +164,15 @@ The script (`scripts/updateCompatVersions.ts`) does the following:
 3. Writes `compat-workspaces/generated-versions.cjs` with the resolved exact versions.
 4. Creates or updates per-version `package.json` files in `compat-workspaces/full/`.
 5. Removes version directories that are no longer needed.
-6. Runs `pnpm install --no-frozen-lockfile` in the workspace to regenerate the committed lockfile.
+6. Runs `pnpm install --no-frozen-lockfile` against `registry.npmjs.org` in the workspace to regenerate the committed
+   lockfile, then rejects any Microsoft-internal registry references in the generated file.
 
 Commit all files produced by the script: `generated-versions.cjs`, per-version `package.json` files, and
 `compat-workspaces/full/pnpm-lock.yaml`.
+
+The compatibility lockfile is an open-source artifact and must work for contributors who install directly from npmjs.
+The update script therefore ignores a developer's normal registry mirror for this one generation step. Internal mirrors
+remain supported for all other repository work.
 
 ### Adding pinned versions for specific tests
 

--- a/packages/test/test-version-utils/scripts/updateCompatVersions.ts
+++ b/packages/test/test-version-utils/scripts/updateCompatVersions.ts
@@ -21,7 +21,8 @@
  *   3. Writes `compat-workspaces/generated-versions.cjs` with the resolved exact versions.
  *   4. Creates or updates per-version `package.json` files in `compat-workspaces/full/`.
  *   5. Removes version directories that are no longer needed.
- *   6. Runs `pnpm install --no-frozen-lockfile` in the workspace to regenerate the lockfile.
+ *   6. Runs `pnpm install --no-frozen-lockfile` against npmjs in the workspace to regenerate the lockfile.
+ *      The generated lockfile is validated to reject registry metadata from internal mirrors.
  *   7. Regenerates the checkpoints table in `CompatibilityCheckpoints.md` from
  *      the single source of truth in `src/checkpoints.ts`.
  *
@@ -35,7 +36,7 @@
  *   The auto-generated table block in CompatibilityCheckpoints.md
  */
 
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import {
 	existsSync,
 	mkdirSync,
@@ -70,6 +71,7 @@ import {
 	getInWindowPriorCheckpoints,
 	injectCheckpointsTable,
 } from "../src/checkpoints.js";
+import { assertNoInternalRegistryReferences } from "../src/compatLockfile.js";
 
 // ---------------------------------------------------------------------------
 // Configuration
@@ -80,6 +82,8 @@ const pkgRoot = path.resolve(scriptDir, "..");
 const gitRoot = findGitRootSync(pkgRoot);
 const compatWorkspacesDir = path.join(pkgRoot, "compat-workspaces");
 const generatedVersionsCjsPath = path.join(compatWorkspacesDir, "generated-versions.cjs");
+const publicNpmRegistry = "https://registry.npmjs.org/";
+const pnpmCommand = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
 
 // ---------------------------------------------------------------------------
 // Version resolution
@@ -188,12 +192,23 @@ function removeStaleVersionDirs(workspaceDir: string, keepVersions: Set<string>)
 }
 
 function pnpmInstallWorkspace(workspaceDir: string): void {
-	console.log(`\nRunning pnpm install in ${path.relative(pkgRoot, workspaceDir)} ...`);
-	execSync(`pnpm install --no-frozen-lockfile`, {
-		cwd: workspaceDir,
-		env: { ...process.env, NODE_OPTIONS: "" },
-		stdio: "inherit",
-	});
+	console.log(
+		`\nRunning pnpm install against ${publicNpmRegistry} in ${path.relative(pkgRoot, workspaceDir)} ...`,
+	);
+	execFileSync(
+		pnpmCommand,
+		["install", "--no-frozen-lockfile", `--config.registry=${publicNpmRegistry}`],
+		{
+			cwd: workspaceDir,
+			env: { ...process.env, NODE_OPTIONS: "" },
+			// Windows cannot launch pnpm.cmd through execFileSync without a shell.
+			shell: process.platform === "win32",
+			stdio: "inherit",
+		},
+	);
+
+	const lockfilePath = path.join(workspaceDir, "pnpm-lock.yaml");
+	assertNoInternalRegistryReferences(readFileSync(lockfilePath, "utf8"), lockfilePath);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/test/test-version-utils/src/compatLockfile.ts
+++ b/packages/test/test-version-utils/src/compatLockfile.ts
@@ -1,0 +1,46 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+const internalRegistryMarkers = [
+	"packagefeedproxy.microsoft.io",
+	".pkgs.visualstudio.com/",
+	"pkgs.dev.azure.com/",
+	"dev.azure.com/",
+] as const;
+
+/**
+ * Finds references to Microsoft-internal package registries in a compatibility lockfile.
+ *
+ * @remarks
+ * The compatibility lockfile is committed to an open-source repository and must remain installable
+ * through the public npm registry. A developer may use an internal mirror for normal work, but its
+ * registry-specific metadata must not be persisted in this generated artifact.
+ */
+export function findInternalRegistryReferences(lockfile: string): readonly string[] {
+	return lockfile
+		.split(/\r?\n/)
+		.flatMap((line, index) =>
+			internalRegistryMarkers.some((marker) => line.includes(marker))
+				? [`line ${index + 1}: ${line.trim()}`]
+				: [],
+		);
+}
+
+/**
+ * Throws when a compatibility lockfile contains Microsoft-internal registry metadata.
+ */
+export function assertNoInternalRegistryReferences(
+	lockfile: string,
+	source = "compatibility lockfile",
+): void {
+	const references = findInternalRegistryReferences(lockfile);
+	if (references.length === 0) {
+		return;
+	}
+
+	throw new Error(
+		`${source} contains Microsoft-internal registry references. Regenerate it against https://registry.npmjs.org/ before committing:\n${references.join("\n")}`,
+	);
+}

--- a/packages/test/test-version-utils/src/test/compatLockfile.spec.ts
+++ b/packages/test/test-version-utils/src/test/compatLockfile.spec.ts
@@ -1,0 +1,49 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "node:assert";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+	assertNoInternalRegistryReferences,
+	findInternalRegistryReferences,
+} from "../compatLockfile.js";
+
+describe("compatibility lockfile registry", () => {
+	it("accepts public npm registry metadata", () => {
+		const lockfile =
+			"resolution: {integrity: sha512-example}\n" +
+			"tarball: https://registry.npmjs.org/example/-/example-1.0.0.tgz\n";
+
+		assert.doesNotThrow(() => assertNoInternalRegistryReferences(lockfile));
+		assert.deepStrictEqual(findInternalRegistryReferences(lockfile), []);
+	});
+
+	for (const registryUrl of [
+		"https://packagefeedproxy.microsoft.io/npm/example",
+		"https://ms-feed-2.pkgs.visualstudio.com/example",
+		"https://pkgs.dev.azure.com/example/_packaging/npm/npm/registry/example",
+		"https://dev.azure.com/example/_packaging/npm/npm/registry/example",
+	]) {
+		it(`rejects ${new URL(registryUrl).hostname}`, () => {
+			const lockfile = `resolution: {tarball: ${registryUrl}}\n`;
+
+			assert.throws(
+				() => assertNoInternalRegistryReferences(lockfile),
+				/microsoft-internal registry references.*line 1/is,
+			);
+		});
+	}
+
+	it("keeps the committed compatibility lockfile public-registry portable", () => {
+		const lockfilePath = fileURLToPath(
+			new URL("../../compat-workspaces/full/pnpm-lock.yaml", import.meta.url),
+		);
+		const lockfile = readFileSync(lockfilePath, "utf8");
+
+		assertNoInternalRegistryReferences(lockfile, lockfilePath);
+	});
+});


### PR DESCRIPTION
## Description

The committed compatibility-workspace lockfile was regenerated through an internal npm mirror in #28127, which persisted mirror-specific tarball URLs and caused pnpm 11's supply-chain validation to reject installs from `registry.npmjs.org`. #28132 repairs the current lockfile, but the generator still inherits each developer's registry configuration.

This change makes future regeneration deterministic:

- the nested `pnpm install` explicitly uses `registry.npmjs.org`;
- generation fails if Microsoft-internal registry URLs appear in the lockfile;
- tests cover known mirror URL shapes and scan the committed lockfile itself;
- the package README documents why this OSS artifact intentionally ignores a developer's normal mirror.

Internal mirrors remain supported for normal repository work; only generation of the committed public compatibility lockfile is pinned to npmjs.

## Reviewer Guidance

The review process is outlined in [the pull request guidelines](../docs/content/Contributing/PR-Guidelines.md#guidelines).

This is a draft to confirm whether generator-local enforcement is sufficient or whether the internal-registry scan should eventually move into a broader repository policy check.
