### PR TITLE
docs(container-definitions): correct dirty and saved event transitions

### DIFF
--- a/.changeset/correct-dirty-saved-event-docs.md
+++ b/.changeset/correct-dirty-saved-event-docs.md
@@ -1,0 +1,7 @@
+---
+"@fluidframework/container-definitions": minor
+"__section": fix
+---
+Correct dirty and saved event transition documentation
+
+The `IContainerEvents` documentation now correctly states that the `"dirty"` event represents `isDirty` changing from `false` to `true`, while the `"saved"` event represents it changing from `true` to `false`.

--- a/packages/common/container-definitions/src/loader.ts
+++ b/packages/common/container-definitions/src/loader.ts
@@ -237,7 +237,7 @@ export interface IContainerEvents extends IEvent {
 
 	/**
 	 * Emitted upon the first local change while the Container is in the "saved" state.
-	 * That is, when {@link IContainer.isDirty} transitions from `true` to `false`.
+	 * That is, when {@link IContainer.isDirty} transitions from `false` to `true`.
 	 *
 	 * @remarks Listener parameters:
 	 *
@@ -249,7 +249,7 @@ export interface IContainerEvents extends IEvent {
 
 	/**
 	 * Emitted when all local changes/edits have been acknowledged by the service.
-	 * I.e., when {@link IContainer.isDirty} transitions from `false` to `true`.
+	 * I.e., when {@link IContainer.isDirty} transitions from `true` to `false`.
 	 *
 	 * @remarks Listener parameters:
 	 *


### PR DESCRIPTION
## Description

Correct the `IContainerEvents` documentation for the `"dirty"` and `"saved"` events.

The documentation previously described the state transitions in reverse: it said `"dirty"` represented `isDirty` changing from `true` to `false`, and `"saved"` represented `false` to `true`. The runtime emits `"dirty"` when `isDirty` becomes `true` and `"saved"` when it becomes `false`.