### PR TITLE
test(external-data): Skip flaky test

### DIFF
--- a/examples/external-data/src/test/customerService.test.ts
+++ b/examples/external-data/src/test/customerService.test.ts
@@ -234,7 +234,8 @@ describe("mock-customer-service", () => {
 	});
 	/* eslint-enable @typescript-eslint/no-non-null-assertion */
 
-	it("register-session-url: Complete data flow", async function () {
+	// TODO: Skipped due to CI flakiness. Investigate, fix, and re-enable.
+	it.skip("register-session-url: Complete data flow", async function () {
 		// waitForCondition's internal timeout can exceed mocha's default per-test timeout;
 		// give this test enough headroom to let waitForCondition fail on its own terms.
 		this.timeout(10000);


### PR DESCRIPTION
This test has been failing pretty frequently in PR/CI.