### PR TITLE
fix(build-cli): Test ADMONITION_REGEX and fix lost alert line breaks

### DIFF
--- a/build-tools/packages/build-cli/src/library/markdown.ts
+++ b/build-tools/packages/build-cli/src/library/markdown.ts
@@ -60,9 +60,15 @@ export function addHeadingLinks(): (tree: Node) => void {
  *
  * This regular expression matches patterns in the form of `[!WORD]` where WORD can be CAUTION, IMPORTANT, NOTE, TIP, or
  * WARNING. It ensures that the pattern is not followed by only whitespace characters until the end of the line.
- * Additionally, it captures any whitespace characters that follow the matched pattern.
+ * Additionally, it consumes any whitespace characters that follow the matched pattern, so those characters are part of
+ * the overall match even though they are not part of capture group 1.
+ *
+ * Exported for testing. Note that this regular expression is global, so `exec`/`test` mutate its `lastIndex`; copy it
+ * with `new RegExp(ADMONITION_REGEX)` before using those methods.
+ *
+ * @internal
  */
-const ADMONITION_REGEX = /(\[!(?:CAUTION|IMPORTANT|NOTE|TIP|WARNING)])(?!\s*$)\s*/gm;
+export const ADMONITION_REGEX = /(\[!(?:CAUTION|IMPORTANT|NOTE|TIP|WARNING)])(?!\s*$)\s*/gm;
 
 /**
  * A regular expression to remove single line breaks from text. This is used to remove extraneous line breaks in text

--- a/build-tools/packages/build-cli/src/library/markdown.ts
+++ b/build-tools/packages/build-cli/src/library/markdown.ts
@@ -85,7 +85,7 @@ export const ADMONITION_REGEX = /(\[!(?:CAUTION|IMPORTANT|NOTE|TIP|WARNING)])(?!
 const SOFT_BREAK_REGEX = /$[^$]/gms;
 
 /**
- * A regular expression that extracts an admonition title that sits at the very end of a string, ignoring any trailing
+ * A regular expression that matches a text node whose entire content is an admonition title, ignoring any trailing
  * whitespace.
  *
  * Capture group 1 is the admonition type/title, exactly as in {@link ADMONITION_REGEX}.
@@ -98,12 +98,14 @@ const SOFT_BREAK_REGEX = /$[^$]/gms;
  * the title ends up alone at the end of its own text node and {@link ADMONITION_REGEX} leaves it untouched. This
  * regular expression matches those titles so the caller can restore the line break the alert needs.
  *
- * Note that this regular expression is deliberately not multiline: `$` must mean the end of the whole string, not the
- * end of any line within it.
+ * The `^` anchor matters: GitHub only treats a blockquote as an alert when the title is the very first thing in it, so
+ * a title with text before it is ordinary prose and must not be split. Note also that this regular expression is
+ * deliberately not multiline, so `^` and `$` mean the start and end of the whole string rather than of any line
+ * within it.
  *
  * @internal
  */
-export const TRAILING_ADMONITION_REGEX = /(\[!(?:CAUTION|IMPORTANT|NOTE|TIP|WARNING)])\s*$/;
+export const TRAILING_ADMONITION_REGEX = /^(\[!(?:CAUTION|IMPORTANT|NOTE|TIP|WARNING)])\s*$/;
 
 /**
  * A remarkjs/unist plugin that strips soft line breaks. This is a workaround for GitHub's inconsistent markdown

--- a/build-tools/packages/build-cli/src/library/markdown.ts
+++ b/build-tools/packages/build-cli/src/library/markdown.ts
@@ -85,6 +85,27 @@ export const ADMONITION_REGEX = /(\[!(?:CAUTION|IMPORTANT|NOTE|TIP|WARNING)])(?!
 const SOFT_BREAK_REGEX = /$[^$]/gms;
 
 /**
+ * A regular expression that extracts an admonition title that sits at the very end of a string, ignoring any trailing
+ * whitespace.
+ *
+ * Capture group 1 is the admonition type/title, exactly as in {@link ADMONITION_REGEX}.
+ *
+ * @remarks
+ *
+ * {@link ADMONITION_REGEX} deliberately skips a title that is the only thing on its line, because such a title already
+ * has a line of its own. That check only sees a single text node, though. When an alert body starts with formatting -
+ * `**bold**`, a link, or inline code, for example - markdown parsers put the title and the body in sibling nodes, so
+ * the title ends up alone at the end of its own text node and {@link ADMONITION_REGEX} leaves it untouched. This
+ * regular expression matches those titles so the caller can restore the line break the alert needs.
+ *
+ * Note that this regular expression is deliberately not multiline: `$` must mean the end of the whole string, not the
+ * end of any line within it.
+ *
+ * @internal
+ */
+export const TRAILING_ADMONITION_REGEX = /(\[!(?:CAUTION|IMPORTANT|NOTE|TIP|WARNING)])\s*$/;
+
+/**
  * A remarkjs/unist plugin that strips soft line breaks. This is a workaround for GitHub's inconsistent markdown
  * rendering in GitHub Releases. According to CommonMark, Markdown paragraphs are denoted by two line breaks, and single
  * line breaks should be ignored. But in GitHub releases, single line breaks are rendered. This plugin removes the soft
@@ -99,10 +120,29 @@ export function stripSoftBreaks(): (tree: Node) => void {
 
 		// preserve GitHub admonitions; without this the line breaks in the alert are lost and it doesn't render correctly.
 		visit(tree, "blockquote", (node: Node) => {
-			visit(node, "text", (innerNode: { value: string }) => {
-				// If the text is an admonition title, split
-				innerNode.value = innerNode.value.replace(ADMONITION_REGEX, "$1\n");
-			});
+			visit(
+				node,
+				"text",
+				(
+					innerNode: { value: string },
+					index: number | undefined,
+					parent: Parent | undefined,
+				) => {
+					// If the text is an admonition title, split
+					innerNode.value = innerNode.value.replace(ADMONITION_REGEX, "$1\n");
+
+					if (index === undefined || parent === undefined) {
+						return;
+					}
+
+					const nextSibling = parent.children[index + 1];
+					// A title left at the end of this text node still needs its line break when the alert body continues in
+					// a sibling node. A `break` sibling is skipped because it already supplies the line break.
+					if (nextSibling !== undefined && nextSibling.type !== "break") {
+						innerNode.value = innerNode.value.replace(TRAILING_ADMONITION_REGEX, "$1\n");
+					}
+				},
+			);
 		});
 	};
 }

--- a/build-tools/packages/build-cli/src/test/library/markdown.test.ts
+++ b/build-tools/packages/build-cli/src/test/library/markdown.test.ts
@@ -1,0 +1,138 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "node:assert";
+
+import type { Root } from "mdast";
+import { describe, it } from "mocha";
+import { remark } from "remark";
+import remarkGfm from "remark-gfm";
+import { visit } from "unist-util-visit";
+
+import { ADMONITION_REGEX, stripSoftBreaks } from "../../library/markdown.js";
+
+/**
+ * The admonition types that GitHub supports, and that the regular expression is expected to recognize.
+ */
+const admonitionTypes = ["CAUTION", "IMPORTANT", "NOTE", "TIP", "WARNING"] as const;
+
+/**
+ * Applies {@link ADMONITION_REGEX} exactly the way `stripSoftBreaks` does, so these tests exercise the regular
+ * expression through its real usage instead of an approximation of it.
+ */
+function splitAdmonitionTitles(input: string): string {
+	return input.replace(ADMONITION_REGEX, "$1\n");
+}
+
+describe("ADMONITION_REGEX", () => {
+	describe("splits the title onto its own line when the body shares the line", () => {
+		for (const type of admonitionTypes) {
+			it(`[!${type}]`, () => {
+				assert.equal(splitAdmonitionTitles(`[!${type}] Body text.`), `[!${type}]\nBody text.`);
+			});
+		}
+	});
+
+	describe("leaves the title alone when it is the only thing on its line", () => {
+		const cases: [name: string, input: string][] = [
+			["at the end of the string", "[!NOTE]"],
+			["with only trailing whitespace at the end of the string", "[!NOTE]   "],
+			["followed by a line break", "[!NOTE]\nBody text."],
+			["followed by trailing spaces and a line break", "[!NOTE]  \nBody text."],
+			["followed by a CRLF line break", "[!NOTE]\r\nBody text."],
+			["followed by a blank line", "[!NOTE]\n\nBody text."],
+		];
+
+		for (const [name, input] of cases) {
+			it(name, () => {
+				assert.equal(splitAdmonitionTitles(input), input);
+			});
+		}
+	});
+
+	describe("consumes the whitespace between the title and the body", () => {
+		const cases: [name: string, input: string][] = [
+			["no whitespace", "[!NOTE]Body text."],
+			["a single space", "[!NOTE] Body text."],
+			["multiple spaces", "[!NOTE]     Body text."],
+			["a tab", "[!NOTE]\tBody text."],
+			["mixed spaces and tabs", "[!NOTE] \t  \tBody text."],
+		];
+
+		for (const [name, input] of cases) {
+			it(name, () => {
+				assert.equal(splitAdmonitionTitles(input), "[!NOTE]\nBody text.");
+			});
+		}
+	});
+
+	describe("ignores tokens that are not GitHub admonition titles", () => {
+		const cases: [name: string, input: string][] = [
+			["an unsupported admonition type", "[!DANGER] Body text."],
+			["a lowercase type", "[!note] Body text."],
+			["a mixed-case type", "[!Note] Body text."],
+			["a missing exclamation point", "[NOTE] Body text."],
+			["an unterminated title", "[!NOTE Body text."],
+			["a space after the exclamation point", "[! NOTE] Body text."],
+			["a space before the closing bracket", "[!NOTE ] Body text."],
+			["extra brackets around the type", "[![NOTE]] Body text."],
+		];
+
+		for (const [name, input] of cases) {
+			it(name, () => {
+				assert.equal(splitAdmonitionTitles(input), input);
+			});
+		}
+	});
+
+	it("splits every admonition title in a multi-line string", () => {
+		assert.equal(
+			splitAdmonitionTitles("[!NOTE] First body.\n[!TIP] Second body."),
+			"[!NOTE]\nFirst body.\n[!TIP]\nSecond body.",
+		);
+	});
+
+	it("puts the title in capture group 1 and the consumed whitespace in the full match", () => {
+		// ADMONITION_REGEX is global, so exec/test would mutate the shared instance's lastIndex. Copy it instead.
+		const match = new RegExp(ADMONITION_REGEX).exec("[!WARNING]  \tBody text.");
+
+		assert.notEqual(match, null);
+		assert.equal(match?.[1], "[!WARNING]");
+		assert.equal(match?.[0], "[!WARNING]  \t");
+	});
+});
+
+describe("stripSoftBreaks", () => {
+	/**
+	 * Parses markdown into an mdast tree, applies the `stripSoftBreaks` plugin to it, and returns the values of every
+	 * text node in the resulting tree, in document order.
+	 */
+	function stripAndCollectText(markdown: string): string[] {
+		const tree: Root = remark().use(remarkGfm).parse(markdown);
+		stripSoftBreaks()(tree);
+
+		const values: string[] = [];
+		visit(tree, "text", (node: { value: string }) => {
+			values.push(node.value);
+		});
+		return values;
+	}
+
+	it("keeps an admonition title on its own line while collapsing soft breaks in the body", () => {
+		// Without the admonition pass, the line break after the title would be collapsed into a space along with the
+		// rest of the body's soft breaks, and GitHub would stop rendering the blockquote as an alert.
+		assert.deepEqual(stripAndCollectText("> [!NOTE]\n> Body line one.\n> Body line two.\n"), [
+			"[!NOTE]\nBody line one. Body line two.",
+		]);
+	});
+
+	it("only splits admonition titles inside blockquotes", () => {
+		// The admonition pass only visits blockquote nodes, so an alert-looking token in an ordinary paragraph keeps
+		// the collapsed soft break and is not split back onto its own line.
+		assert.deepEqual(stripAndCollectText("[!NOTE]\nBody line one.\n"), [
+			"[!NOTE] Body line one.",
+		]);
+	});
+});

--- a/build-tools/packages/build-cli/src/test/library/markdown.test.ts
+++ b/build-tools/packages/build-cli/src/test/library/markdown.test.ts
@@ -116,13 +116,12 @@ describe("TRAILING_ADMONITION_REGEX", () => {
 		return input.replace(TRAILING_ADMONITION_REGEX, "$1\n");
 	}
 
-	describe("splits a title left at the end of the string", () => {
+	describe("splits a title that is the whole text node", () => {
 		const cases: [name: string, input: string][] = [
 			["with no trailing whitespace", "[!NOTE]"],
 			["with a trailing space", "[!NOTE] "],
 			["with trailing spaces", "[!NOTE]   "],
 			["with a trailing line break", "[!NOTE]\n"],
-			["after other content", "Leading text. [!NOTE] "],
 		];
 
 		for (const [name, input] of cases) {
@@ -139,6 +138,9 @@ describe("TRAILING_ADMONITION_REGEX", () => {
 	describe("leaves the string alone", () => {
 		const cases: [name: string, input: string][] = [
 			["when the title is followed by content", "[!NOTE] Body text."],
+			// GitHub only treats a blockquote as an alert when the title is the very first thing in it, so a title with
+			// text in front of it is ordinary prose and must not be split.
+			["when the title is preceded by content", "Leading text. [!NOTE] "],
 			["when there is no title", "Body text."],
 			["when the type is not supported", "[!DANGER] "],
 			["when the type is lowercase", "[!note] "],
@@ -151,10 +153,10 @@ describe("TRAILING_ADMONITION_REGEX", () => {
 		}
 	});
 
-	it("is not multiline, so a title at the end of an inner line is left alone", () => {
-		// The title here ends the first line, so the `m` flag would make `$` match right after it. Without that flag
-		// `$` means the end of the whole string, so the title is left alone.
-		const input = "Leading text. [!NOTE]\nBody text.";
+	it("is not multiline, so a title alone on the first line of a longer string is left alone", () => {
+		// With the `m` flag `^` and `$` would match the bounds of the first line and this would split. Without it they
+		// mean the bounds of the whole string, so the title is left alone.
+		const input = "[!NOTE]\nBody text.";
 		assert.equal(splitTrailingTitle(input), input);
 	});
 });
@@ -233,6 +235,16 @@ describe("stripSoftBreaks", () => {
 			"Regular quote with ",
 			"bold",
 			" text.",
+		]);
+	});
+
+	it("does not split a title that is preceded by text in the same blockquote", () => {
+		// GitHub only renders an alert when the title is the very first thing in the blockquote, so this blockquote is
+		// ordinary prose. Splitting it would push a line break into the middle of the author's sentence.
+		assert.deepEqual(stripAndCollectText("> Please read [!NOTE] **carefully**.\n"), [
+			"Please read [!NOTE] ",
+			"carefully",
+			".",
 		]);
 	});
 });

--- a/build-tools/packages/build-cli/src/test/library/markdown.test.ts
+++ b/build-tools/packages/build-cli/src/test/library/markdown.test.ts
@@ -11,7 +11,11 @@ import { remark } from "remark";
 import remarkGfm from "remark-gfm";
 import { visit } from "unist-util-visit";
 
-import { ADMONITION_REGEX, stripSoftBreaks } from "../../library/markdown.js";
+import {
+	ADMONITION_REGEX,
+	stripSoftBreaks,
+	TRAILING_ADMONITION_REGEX,
+} from "../../library/markdown.js";
 
 /**
  * The admonition types that GitHub supports, and that the regular expression is expected to recognize.
@@ -104,6 +108,54 @@ describe("ADMONITION_REGEX", () => {
 	});
 });
 
+describe("TRAILING_ADMONITION_REGEX", () => {
+	/**
+	 * Applies {@link TRAILING_ADMONITION_REGEX} the way `stripSoftBreaks` does.
+	 */
+	function splitTrailingTitle(input: string): string {
+		return input.replace(TRAILING_ADMONITION_REGEX, "$1\n");
+	}
+
+	describe("splits a title left at the end of the string", () => {
+		const cases: [name: string, input: string][] = [
+			["with no trailing whitespace", "[!NOTE]"],
+			["with a trailing space", "[!NOTE] "],
+			["with trailing spaces", "[!NOTE]   "],
+			["with a trailing line break", "[!NOTE]\n"],
+			["after other content", "Leading text. [!NOTE] "],
+		];
+
+		for (const [name, input] of cases) {
+			it(name, () => {
+				assert.equal(splitTrailingTitle(input), `${input.trimEnd()}\n`);
+			});
+		}
+	});
+
+	it("is idempotent, so an already-split title does not gain a second line break", () => {
+		assert.equal(splitTrailingTitle(splitTrailingTitle("[!NOTE] ")), "[!NOTE]\n");
+	});
+
+	describe("leaves the string alone", () => {
+		const cases: [name: string, input: string][] = [
+			["when the title is followed by content", "[!NOTE] Body text."],
+			["when there is no title", "Body text."],
+			["when the type is not supported", "[!DANGER] "],
+			["when the type is lowercase", "[!note] "],
+		];
+
+		for (const [name, input] of cases) {
+			it(name, () => {
+				assert.equal(splitTrailingTitle(input), input);
+			});
+		}
+	});
+
+	it("is not multiline, so a title at the end of an inner line is left alone", () => {
+		assert.equal(splitTrailingTitle("[!NOTE]\nBody text."), "[!NOTE]\nBody text.");
+	});
+});
+
 describe("stripSoftBreaks", () => {
 	/**
 	 * Parses markdown into an mdast tree, applies the `stripSoftBreaks` plugin to it, and returns the values of every
@@ -133,6 +185,51 @@ describe("stripSoftBreaks", () => {
 		// the collapsed soft break and is not split back onto its own line.
 		assert.deepEqual(stripAndCollectText("[!NOTE]\nBody line one.\n"), [
 			"[!NOTE] Body line one.",
+		]);
+	});
+
+	describe("keeps the title on its own line when the body starts with formatting", () => {
+		// Markdown parsers put the title and the body in sibling nodes when the body starts with anything other than
+		// plain text, which leaves the title alone at the end of its own text node. The title still needs its line
+		// break, otherwise the alert collapses onto one line and GitHub stops rendering it as an alert.
+		const cases: [name: string, markdown: string, expected: string[]][] = [
+			[
+				"bold text",
+				"> [!NOTE]\n> **Bold body** and more.\n",
+				["[!NOTE]\n", "Bold body", " and more."],
+			],
+			[
+				"a link",
+				"> [!TIP]\n> [a link](https://example.com) then text.\n",
+				["[!TIP]\n", "a link", " then text."],
+			],
+			["inline code", "> [!WARNING]\n> `code` first.\n", ["[!WARNING]\n", " first."]],
+		];
+
+		for (const [name, markdown, expected] of cases) {
+			it(name, () => {
+				assert.deepEqual(stripAndCollectText(markdown), expected);
+			});
+		}
+	});
+
+	it("does not add a line break to a title that has no body", () => {
+		assert.deepEqual(stripAndCollectText("> [!NOTE]\n"), ["[!NOTE]"]);
+	});
+
+	it("does not add a line break when a hard break already follows the title", () => {
+		// The two trailing spaces produce a `break` node, which already supplies the line break the alert needs.
+		assert.deepEqual(stripAndCollectText("> [!NOTE]  \n> **Bold body**\n"), [
+			"[!NOTE]",
+			"Bold body",
+		]);
+	});
+
+	it("leaves a blockquote that is not an admonition alone", () => {
+		assert.deepEqual(stripAndCollectText("> Regular quote with **bold** text.\n"), [
+			"Regular quote with ",
+			"bold",
+			" text.",
 		]);
 	});
 });

--- a/build-tools/packages/build-cli/src/test/library/markdown.test.ts
+++ b/build-tools/packages/build-cli/src/test/library/markdown.test.ts
@@ -152,7 +152,10 @@ describe("TRAILING_ADMONITION_REGEX", () => {
 	});
 
 	it("is not multiline, so a title at the end of an inner line is left alone", () => {
-		assert.equal(splitTrailingTitle("[!NOTE]\nBody text."), "[!NOTE]\nBody text.");
+		// The title here ends the first line, so the `m` flag would make `$` match right after it. Without that flag
+		// `$` means the end of the whole string, so the title is left alone.
+		const input = "Leading text. [!NOTE]\nBody text.";
+		assert.equal(splitTrailingTitle(input), input);
 	});
 });
 


### PR DESCRIPTION
## Description

[AB#15064](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/15064) asked for unit tests covering `ADMONITION_REGEX` in `build-tools/packages/build-cli/src/library/markdown.ts`, which had no coverage. Writing them surfaced a real defect in `stripSoftBreaks`, so this PR does both. The two concerns are kept in separate commits.

### Tests

`ADMONITION_REGEX` is now exported (marked `@internal`) so it can be tested directly. It is not reachable from the package entry point, so `build-cli.api.md` is unchanged.

Coverage includes all five supported admonition types, the "alone on its line" cases that must be left untouched, whitespace consumption between the title and the body, tokens that must not match, global/multiline behavior, and capture-group contents. Two AST-level tests exercise the regex through `stripSoftBreaks` on a real remark tree.

### Fix

`stripSoftBreaks` collapses single line breaks for GitHub Releases, then puts a GitHub alert title back on its own line so the alert still renders. That restore step only worked when the alert body was plain text.

When the body starts with formatting — `**bold**`, a link, or inline code — the parser puts the title and the body in sibling nodes, so the title ends up alone at the end of its own text node. `ADMONITION_REGEX` intentionally skips a title that is alone on its line, and it cannot see past the current node, so it skipped these too and the line break was lost:

```md
Before:
> \[!NOTE] **Bold body** and more.

After:
> \[!NOTE]
> **Bold body** and more.
```

The fix adds `TRAILING_ADMONITION_REGEX`, matching a title left at the end of a string, and applies it only when a following sibling node exists — so the line break is restored exactly when the body really does continue. Siblings that are `break` nodes are skipped because they already supply the line break.

### How this was verified

Serialized markdown output was diffed, current vs. fixed, through the real release-notes processor. Output is byte-identical for plain-text bodies, titles with no body, hard breaks, and blockquotes that are not alerts. Only the three previously broken cases change.

47 tests in `src/test/library/markdown.test.ts` pass. Across the full `build-cli` mocha suite the failure count is unchanged versus a baseline run of the same commit without these changes, so there are no regressions. `tsc`, `eslint`, and `biome` are clean.

