### PR TITLE
Validate pending state against service history

### DIFF
--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -338,6 +338,9 @@ export class ConnectionManager implements IConnectionManager {
 			serviceConfiguration: connection.serviceConfiguration,
 			version: connection.version,
 			reason,
+			...(connection.checkpointSequenceNumber === undefined
+				? {}
+				: { rawCheckpointSequenceNumber: connection.checkpointSequenceNumber }),
 		};
 	}
 

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -326,11 +326,12 @@ export class ConnectionManager implements IConnectionManager {
 	private static detailsFromConnection(
 		connection: IDocumentDeltaConnection,
 		reason: IConnectionStateChangeReason,
+		checkpointSequenceNumber: number | undefined,
 	): IConnectionDetailsInternal {
 		return {
 			claims: connection.claims,
 			clientId: connection.clientId,
-			checkpointSequenceNumber: connection.checkpointSequenceNumber,
+			checkpointSequenceNumber,
 			get initialClients(): ISignalClient[] {
 				return connection.initialClients;
 			},
@@ -340,7 +341,7 @@ export class ConnectionManager implements IConnectionManager {
 			reason,
 			...(connection.checkpointSequenceNumber === undefined
 				? {}
-				: { rawCheckpointSequenceNumber: connection.checkpointSequenceNumber }),
+				: { serviceCheckpointSequenceNumber: connection.checkpointSequenceNumber }),
 		};
 	}
 
@@ -914,8 +915,11 @@ export class ConnectionManager implements IConnectionManager {
 			this.connectFirstConnection ? "InitialOps" : "ReconnectOps",
 		);
 
-		this._connectionDetails = ConnectionManager.detailsFromConnection(connection, reason);
-		this._connectionDetails.checkpointSequenceNumber = checkpointSequenceNumber;
+		this._connectionDetails = ConnectionManager.detailsFromConnection(
+			connection,
+			reason,
+			checkpointSequenceNumber,
+		);
 		this.props.connectHandler(this._connectionDetails);
 
 		this.connectFirstConnection = false;

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -910,16 +910,18 @@ export class ConnectionManager implements IConnectionManager {
 			}
 		}
 
-		this.props.incomingOpHandler(
-			initialMessages,
-			this.connectFirstConnection ? "InitialOps" : "ReconnectOps",
-		);
-
-		this._connectionDetails = ConnectionManager.detailsFromConnection(
+		const connectionDetails = ConnectionManager.detailsFromConnection(
 			connection,
 			reason,
 			checkpointSequenceNumber,
 		);
+		this.props.incomingOpHandler(
+			initialMessages,
+			this.connectFirstConnection ? "InitialOps" : "ReconnectOps",
+			connectionDetails,
+		);
+
+		this._connectionDetails = connectionDetails;
 		this.props.connectHandler(this._connectionDetails);
 
 		this.connectFirstConnection = false;

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1388,12 +1388,11 @@ export class Container
 		} else if (this.attachState !== AttachState.Attached) {
 			throw new UsageError(`The Container is not attached and cannot be connected`);
 		} else if (!this.connected) {
-			// Note: no need to fetch ops as we do it preemptively as part of DeltaManager.attachOpHandler().
-			// If there is gap, we will learn about it once connected, but the gap should be small (if any),
-			// assuming that connect() is called quickly after initial container boot.
+			// Fetch only if a deltaConnection: "none" pending-state load deferred anchor validation.
+			// Otherwise attachOpHandler already fetched preemptively.
 			this.connectInternal({
 				reason: { text: "DocumentConnect" },
-				fetchOpsFromStorage: false,
+				fetchOpsFromStorage: this._deltaManager.hasPendingStateAnchor,
 			});
 		}
 	}

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1664,10 +1664,8 @@ export class Container
 		const baseSnapshotTree: ISnapshotTree | undefined = getSnapshotTree(baseSnapshot);
 		this._loadedFromVersion = version;
 
-		// If we saved ops, we will replay them and don't need DeltaManager to fetch them
-		const lastProcessedSequenceNumber =
-			pendingLocalState?.savedOps[pendingLocalState.savedOps.length - 1]?.sequenceNumber ??
-			attributes.sequenceNumber;
+		// Preserve the latest saved op so DeltaManager can validate the service history before replay.
+		const lastProcessedMessage = pendingLocalState?.savedOps.at(-1);
 		let opsBeforeReturnP: Promise<void> | undefined;
 
 		// Attach op handlers to finish initialization and be able to start processing ops
@@ -1679,7 +1677,7 @@ export class Container
 				this.attachDeltaManagerOpHandler(
 					attributes,
 					loadMode.deltaConnection === "none" ? "none" : "all",
-					lastProcessedSequenceNumber,
+					lastProcessedMessage,
 				);
 				break;
 			}
@@ -1688,7 +1686,7 @@ export class Container
 				opsBeforeReturnP = this.attachDeltaManagerOpHandler(
 					attributes,
 					loadMode.opsBeforeReturn,
-					lastProcessedSequenceNumber,
+					lastProcessedMessage,
 				);
 				break;
 			}
@@ -2127,7 +2125,7 @@ export class Container
 	private async attachDeltaManagerOpHandler(
 		attributes: IDocumentAttributes,
 		prefetchType?: "cached" | "all" | "none",
-		lastProcessedSequenceNumber?: number,
+		lastProcessedMessage?: ISequencedDocumentMessage,
 	): Promise<void> {
 		return this._deltaManager.attachOpHandler(
 			attributes.minimumSequenceNumber /* minimumSequenceNumber */,
@@ -2139,7 +2137,7 @@ export class Container
 				},
 			} /* handler to process incoming delta messages */,
 			prefetchType,
-			lastProcessedSequenceNumber,
+			lastProcessedMessage,
 		);
 	}
 

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1674,12 +1674,11 @@ export class Container
 			case undefined: {
 				// Pending-state loads validate the saved-op anchor asynchronously so rehydration
 				// does not wait for network access.
-				// eslint-disable-next-line @typescript-eslint/no-floating-promises
 				this.attachDeltaManagerOpHandler(
 					attributes,
 					loadMode.deltaConnection === "none" ? "none" : "all",
 					lastProcessedMessage,
-				);
+				).catch((error) => this.close(normalizeError(error)));
 				break;
 			}
 			case "cached":

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1672,7 +1672,8 @@ export class Container
 		// Kick off any ops fetching if required.
 		switch (loadMode.opsBeforeReturn) {
 			case undefined: {
-				// Start prefetch, but not set opsBeforeReturnP - boot is not blocked by it!
+				// Pending-state loads validate the saved-op anchor asynchronously so rehydration
+				// does not wait for network access.
 				// eslint-disable-next-line @typescript-eslint/no-floating-promises
 				this.attachDeltaManagerOpHandler(
 					attributes,

--- a/packages/loader/container-loader/src/contracts.ts
+++ b/packages/loader/container-loader/src/contracts.ts
@@ -42,6 +42,8 @@ export interface IConnectionDetailsInternal extends IConnectionDetails {
 	version: string;
 	initialClients: ISignalClient[];
 	reason: IConnectionStateChangeReason;
+	/** The checkpoint reported by the service before initial-message normalization. */
+	rawCheckpointSequenceNumber?: number;
 }
 
 /**

--- a/packages/loader/container-loader/src/contracts.ts
+++ b/packages/loader/container-loader/src/contracts.ts
@@ -43,7 +43,7 @@ export interface IConnectionDetailsInternal extends IConnectionDetails {
 	initialClients: ISignalClient[];
 	reason: IConnectionStateChangeReason;
 	/** The checkpoint reported by the service before initial-message normalization. */
-	rawCheckpointSequenceNumber?: number;
+	serviceCheckpointSequenceNumber?: number;
 }
 
 /**

--- a/packages/loader/container-loader/src/contracts.ts
+++ b/packages/loader/container-loader/src/contracts.ts
@@ -140,9 +140,15 @@ export interface IConnectionManager {
 export interface IConnectionManagerFactoryArgs {
 	/**
 	 * Called by connection manager for each incoming op. Some ops maybe delivered before
-	 * connectHandler is called (initial ops on socket connection)
+	 * connectHandler is called (initial ops on socket connection).
+	 * Connection details are supplied for initial ops so diagnostics use the current connection
+	 * before connectHandler runs. They are omitted for subsequent socket ops.
 	 */
-	readonly incomingOpHandler: (messages: ISequencedDocumentMessage[], reason: string) => void;
+	readonly incomingOpHandler: (
+		messages: ISequencedDocumentMessage[],
+		reason: string,
+		connection?: IConnectionDetailsInternal,
+	) => void;
 
 	/**
 	 * Called by connection manager for each incoming signal.

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -190,7 +190,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 	private lastObservedSeqNumber: number = 0;
 	private lastProcessedSequenceNumber: number = 0;
 	private lastProcessedMessage: ISequencedDocumentMessage | undefined;
-	private rawCheckpointSequenceNumber: number | undefined;
+	private serviceCheckpointSequenceNumber: number | undefined;
 
 	/**
 	 * Map of clientId to the last observed message from that client. This is used to validate
@@ -518,35 +518,14 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 		this.emit("establishingConnection", reason);
 	}
 
-	private logCheckpointSequenceNumberRegression(): void {
-		if (
-			this.rawCheckpointSequenceNumber === undefined ||
-			this.rawCheckpointSequenceNumber >= this.lastProcessedSequenceNumber
-		) {
-			return;
-		}
-
-		this.logger.sendTelemetryEvent({
-			eventName: "CheckpointSequenceNumberRegression",
-			...this.connectionManager.connectionProps,
-			...this.connectionManager.connectionVerboseProps,
-			checkpointSequenceNumber: this.rawCheckpointSequenceNumber,
-			lastProcessedSequenceNumber: this.lastProcessedSequenceNumber,
-			lastQueuedSequenceNumber: this.lastQueuedSequenceNumber,
-			lastObservedSequenceNumber: this.lastObservedSeqNumber,
-		});
-	}
-
 	private connectHandler(connection: IConnectionDetailsInternal): void {
 		this.refreshDelayInfo(this.deltaStreamDelayId);
 
 		const props = this.connectionManager.connectionVerboseProps;
 		props.connectionLastQueuedSequenceNumber = this.lastQueuedSequenceNumber;
 		props.connectionLastObservedSeqNumber = this.lastObservedSeqNumber;
-
 		const checkpointSequenceNumber = connection.checkpointSequenceNumber;
-		this.rawCheckpointSequenceNumber = connection.rawCheckpointSequenceNumber;
-		this.logCheckpointSequenceNumberRegression();
+		this.serviceCheckpointSequenceNumber = connection.serviceCheckpointSequenceNumber;
 		this._checkpointSequenceNumber = checkpointSequenceNumber;
 		if (checkpointSequenceNumber !== undefined) {
 			this.updateLatestKnownOpSeqNumber(checkpointSequenceNumber);
@@ -601,23 +580,25 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 	 * `"none"` does not initiate a fetch; `"all"` waits for all available missing ops from storage;
 	 * and `"cached"` waits only for cached ops before continuing the remaining storage fetch in the
 	 * background.
-	 * @param lastProcessedSequenceNumber - The latest sequence number already reflected in the
-	 * loaded state. It defaults to `snapshotSequenceNumber`. Offline loads may provide a later
-	 * sequence number so the DeltaManager skips downloading and processing ops already included in
-	 * that state.
+	 * @param lastProcessedMessage - The latest message already reflected in the loaded state.
+	 * Offline loads use it to skip already processed ops and validate that the service history has
+	 * not changed.
 	 */
 	public async attachOpHandler(
 		minSequenceNumber: number,
 		snapshotSequenceNumber: number,
 		handler: IDeltaHandlerStrategy,
 		prefetchType: "cached" | "all" | "none" = "none",
-		lastProcessedSequenceNumber: number = snapshotSequenceNumber,
+		lastProcessedMessage?: ISequencedDocumentMessage,
 	): Promise<void> {
+		const lastProcessedSequenceNumber =
+			lastProcessedMessage?.sequenceNumber ?? snapshotSequenceNumber;
 		this.initSequenceNumber = snapshotSequenceNumber;
 		this.lastProcessedSequenceNumber = lastProcessedSequenceNumber;
-		this.minSequenceNumber = minSequenceNumber;
+		this.minSequenceNumber = lastProcessedMessage?.minimumSequenceNumber ?? minSequenceNumber;
 		this.lastQueuedSequenceNumber = lastProcessedSequenceNumber;
 		this.lastObservedSeqNumber = lastProcessedSequenceNumber;
+		this.previouslyProcessedMessage = lastProcessedMessage;
 
 		// We will use same check in other places to make sure all the seq number above are set properly.
 		assert(
@@ -627,7 +608,6 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 		this.handler = handler;
 		// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
 		assert(!!this.handler, 0x0e3 /* "Newly set op handler is null/undefined!" */);
-		this.logCheckpointSequenceNumberRegression();
 
 		// There should be no pending fetch!
 		// This API is called right after attachOpHandler by Container.load().
@@ -1085,6 +1065,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 							{
 								clientId: this.connectionManager.clientId,
 								sequenceNumber: message.sequenceNumber,
+								serviceCheckpointSequenceNumber: this.serviceCheckpointSequenceNumber,
 								message1,
 								message2,
 								driverVersion: undefined,
@@ -1165,6 +1146,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 				message,
 				{
 					clientId: this.connectionManager.clientId,
+					serviceCheckpointSequenceNumber: this.serviceCheckpointSequenceNumber,
 				},
 			);
 		}

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -272,6 +272,13 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 	}
 
 	/**
+	 * Indicates whether pending-state history still needs validation against storage.
+	 */
+	public get hasPendingStateAnchor(): boolean {
+		return this.pendingStateAnchor !== undefined;
+	}
+
+	/**
 	 * Tells if  current connection has checkpoint information.
 	 * I.e. we know how far behind the client was at the time of establishing connection
 	 */
@@ -901,6 +908,10 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 		return `${m.clientId}-${m.type}-${m.minimumSequenceNumber}-${m.referenceSequenceNumber}-${m.timestamp}`;
 	}
 
+	private comparableMessageContents(m: ISequencedDocumentMessage): string | undefined {
+		return typeof m.contents === "string" ? m.contents : JSON.stringify(m.contents);
+	}
+
 	/**
 	 * Validates that the clientSequenceNumber for a given clientId is always increasing.
 	 * @param message - The message to validate.
@@ -1068,7 +1079,11 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 				if (previouslyObservedMessage?.sequenceNumber === message.sequenceNumber) {
 					const message1 = this.comparableMessagePayload(previouslyObservedMessage);
 					const message2 = this.comparableMessagePayload(message);
-					if (message1 !== message2) {
+					const contentsDiffer =
+						previouslyObservedMessage === this.pendingStateAnchor &&
+						this.comparableMessageContents(previouslyObservedMessage) !==
+							this.comparableMessageContents(message);
+					if (message1 !== message2 || contentsDiffer) {
 						const error = new NonRetryableError(
 							// This looks like a data corruption but the culprit was that the file was overwritten
 							// in storage.  See PR #5882.
@@ -1086,6 +1101,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 								serviceCheckpointSequenceNumber: this.serviceCheckpointSequenceNumber,
 								message1,
 								message2,
+								contentsDiffer,
 								driverVersion: undefined,
 							},
 						);

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -190,6 +190,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 	private lastObservedSeqNumber: number = 0;
 	private lastProcessedSequenceNumber: number = 0;
 	private lastProcessedMessage: ISequencedDocumentMessage | undefined;
+	private rawCheckpointSequenceNumber: number | undefined;
 
 	/**
 	 * Map of clientId to the last observed message from that client. This is used to validate
@@ -517,6 +518,25 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 		this.emit("establishingConnection", reason);
 	}
 
+	private logCheckpointSequenceNumberRegression(): void {
+		if (
+			this.rawCheckpointSequenceNumber === undefined ||
+			this.rawCheckpointSequenceNumber >= this.lastProcessedSequenceNumber
+		) {
+			return;
+		}
+
+		this.logger.sendTelemetryEvent({
+			eventName: "CheckpointSequenceNumberRegression",
+			...this.connectionManager.connectionProps,
+			...this.connectionManager.connectionVerboseProps,
+			checkpointSequenceNumber: this.rawCheckpointSequenceNumber,
+			lastProcessedSequenceNumber: this.lastProcessedSequenceNumber,
+			lastQueuedSequenceNumber: this.lastQueuedSequenceNumber,
+			lastObservedSequenceNumber: this.lastObservedSeqNumber,
+		});
+	}
+
 	private connectHandler(connection: IConnectionDetailsInternal): void {
 		this.refreshDelayInfo(this.deltaStreamDelayId);
 
@@ -525,20 +545,8 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 		props.connectionLastObservedSeqNumber = this.lastObservedSeqNumber;
 
 		const checkpointSequenceNumber = connection.checkpointSequenceNumber;
-		if (
-			checkpointSequenceNumber !== undefined &&
-			checkpointSequenceNumber < this.lastProcessedSequenceNumber
-		) {
-			this.logger.sendTelemetryEvent({
-				eventName: "CheckpointSequenceNumberRegression",
-				...this.connectionManager.connectionProps,
-				...props,
-				checkpointSequenceNumber,
-				lastProcessedSequenceNumber: this.lastProcessedSequenceNumber,
-				lastQueuedSequenceNumber: this.lastQueuedSequenceNumber,
-				lastObservedSequenceNumber: this.lastObservedSeqNumber,
-			});
-		}
+		this.rawCheckpointSequenceNumber = connection.rawCheckpointSequenceNumber;
+		this.logCheckpointSequenceNumberRegression();
 		this._checkpointSequenceNumber = checkpointSequenceNumber;
 		if (checkpointSequenceNumber !== undefined) {
 			this.updateLatestKnownOpSeqNumber(checkpointSequenceNumber);
@@ -619,6 +627,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 		this.handler = handler;
 		// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
 		assert(!!this.handler, 0x0e3 /* "Newly set op handler is null/undefined!" */);
+		this.logCheckpointSequenceNumberRegression();
 
 		// There should be no pending fetch!
 		// This API is called right after attachOpHandler by Container.load().

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -213,6 +213,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 	private opsSize: number = 0;
 	private prevEnqueueMessagesReason: string | undefined;
 	private previouslyProcessedMessage: ISequencedDocumentMessage | undefined;
+	private pendingStateAnchor: ISequencedDocumentMessage | undefined;
 
 	// The sequence number we initially loaded from
 	// In case of reading from a snapshot or pending state, its value will be equal to
@@ -591,6 +592,12 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 		prefetchType: "cached" | "all" | "none" = "none",
 		lastProcessedMessage?: ISequencedDocumentMessage,
 	): Promise<void> {
+		if (lastProcessedMessage !== undefined) {
+			assert(
+				lastProcessedMessage.minimumSequenceNumber >= minSequenceNumber,
+				"The last processed message's minimum sequence number is below the snapshot minimum sequence number",
+			);
+		}
 		const lastProcessedSequenceNumber =
 			lastProcessedMessage?.sequenceNumber ?? snapshotSequenceNumber;
 		this.initSequenceNumber = snapshotSequenceNumber;
@@ -599,6 +606,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 		this.lastQueuedSequenceNumber = lastProcessedSequenceNumber;
 		this.lastObservedSeqNumber = lastProcessedSequenceNumber;
 		this.previouslyProcessedMessage = lastProcessedMessage;
+		this.pendingStateAnchor = lastProcessedMessage;
 
 		// We will use same check in other places to make sure all the seq number above are set properly.
 		assert(
@@ -623,12 +631,18 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 			return;
 		}
 
+		let prefetchP: Promise<void> | undefined;
+		const cacheOnly = prefetchType === "cached";
+		if (prefetchType !== "none") {
+			// Capture the saved-op validation range before queued socket ops can advance it.
+			prefetchP = this.fetchMissingDeltasCore(`DocumentOpen_${prefetchType}`, cacheOnly);
+		}
+
 		this._inbound.resume();
 		this._inboundSignal.resume();
 
-		if (prefetchType !== "none") {
-			const cacheOnly = prefetchType === "cached";
-			await this.fetchMissingDeltasCore(`DocumentOpen_${prefetchType}`, cacheOnly);
+		if (prefetchP !== undefined) {
+			await prefetchP;
 
 			// Keep going with fetching ops from storage once we have all cached ops in.
 			// But do not block load and make this request async / not blocking this api.
@@ -1047,8 +1061,12 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 			if (message.sequenceNumber <= this.lastQueuedSequenceNumber) {
 				// Validate that we do not have data loss, i.e. sequencing is reset and started again
 				// with numbers that this client already observed before.
-				if (this.previouslyProcessedMessage?.sequenceNumber === message.sequenceNumber) {
-					const message1 = this.comparableMessagePayload(this.previouslyProcessedMessage);
+				const previouslyObservedMessage =
+					this.pendingStateAnchor?.sequenceNumber === message.sequenceNumber
+						? this.pendingStateAnchor
+						: this.previouslyProcessedMessage;
+				if (previouslyObservedMessage?.sequenceNumber === message.sequenceNumber) {
+					const message1 = this.comparableMessagePayload(previouslyObservedMessage);
 					const message2 = this.comparableMessagePayload(message);
 					if (message1 !== message2) {
 						const error = new NonRetryableError(
@@ -1072,6 +1090,9 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 							},
 						);
 						this.close(error);
+					}
+					if (previouslyObservedMessage === this.pendingStateAnchor) {
+						this.pendingStateAnchor = undefined;
 					}
 				}
 			} else if (message.sequenceNumber === this.lastQueuedSequenceNumber + 1) {

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -746,7 +746,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 			// Ops that are coming from this request should not cancel itself.
 			// This is useless for known ranges (to is defined) as it means request is over either way.
 			// And it will cancel unbound request too early, not allowing us to learn where the end of the file is.
-			if (!opsFromFetch && cancelFetch(op)) {
+			if (!opsFromFetch && this.pendingStateAnchor === undefined && cancelFetch(op)) {
 				controller.abort("DeltaManager getDeltas fetch cancelled");
 				this._inbound.off("push", opListener);
 			}

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -1265,7 +1265,8 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 		}
 
 		const pendingStateAnchor = cacheOnly ? undefined : this.pendingStateAnchor;
-		let refetchAfterUnvalidatedAnchor = false;
+		let fetchFrom: number | undefined;
+		let fetchCompleted = false;
 		try {
 			let from = this.lastQueuedSequenceNumber + 1;
 
@@ -1280,6 +1281,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 				assert(from > 1, 0x0f3 /* "not positive" */);
 				from--;
 			}
+			fetchFrom = from;
 
 			const fetchReason = `${reason}_fetch`;
 			this.fetchReason = fetchReason;
@@ -1294,23 +1296,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 				},
 				cacheOnly,
 			);
-			if (
-				pendingStateAnchor !== undefined &&
-				this.pendingStateAnchor === pendingStateAnchor &&
-				!this._closed
-			) {
-				this.logger.sendTelemetryEvent({
-					eventName: "PendingStateAnchorNotValidated",
-					sequenceNumber: pendingStateAnchor.sequenceNumber,
-					fetchFrom: from,
-					serviceCheckpointSequenceNumber: this.serviceCheckpointSequenceNumber,
-				});
-				this.pendingStateAnchor = undefined;
-				if (this.previouslyProcessedMessage === pendingStateAnchor) {
-					this.previouslyProcessedMessage = undefined;
-				}
-				refetchAfterUnvalidatedAnchor = true;
-			}
+			fetchCompleted = true;
 		} catch (error) {
 			this.logger.sendErrorEvent({ eventName: "GetDeltas_Exception" }, error);
 			this.close(normalizeError(error));
@@ -1318,7 +1304,23 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 			this.refreshDelayInfo(this.deltaStorageDelayId);
 			this.fetchReason = undefined;
 			this.processPendingOps(reason);
-			if (refetchAfterUnvalidatedAnchor && this.fetchReason === undefined) {
+			if (
+				fetchCompleted &&
+				pendingStateAnchor !== undefined &&
+				this.pendingStateAnchor === pendingStateAnchor &&
+				!this._closed &&
+				this.fetchReason === undefined
+			) {
+				this.logger.sendTelemetryEvent({
+					eventName: "PendingStateAnchorNotValidated",
+					sequenceNumber: pendingStateAnchor.sequenceNumber,
+					fetchFrom,
+					serviceCheckpointSequenceNumber: this.serviceCheckpointSequenceNumber,
+				});
+				this.pendingStateAnchor = undefined;
+				if (this.previouslyProcessedMessage === pendingStateAnchor) {
+					this.previouslyProcessedMessage = undefined;
+				}
 				this.fetchMissingDeltas("PendingStateAnchorNotValidated");
 			}
 		}

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -525,6 +525,20 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 		props.connectionLastObservedSeqNumber = this.lastObservedSeqNumber;
 
 		const checkpointSequenceNumber = connection.checkpointSequenceNumber;
+		if (
+			checkpointSequenceNumber !== undefined &&
+			checkpointSequenceNumber < this.lastProcessedSequenceNumber
+		) {
+			this.logger.sendTelemetryEvent({
+				eventName: "CheckpointSequenceNumberRegression",
+				...this.connectionManager.connectionProps,
+				...props,
+				checkpointSequenceNumber,
+				lastProcessedSequenceNumber: this.lastProcessedSequenceNumber,
+				lastQueuedSequenceNumber: this.lastQueuedSequenceNumber,
+				lastObservedSequenceNumber: this.lastObservedSeqNumber,
+			});
+		}
 		this._checkpointSequenceNumber = checkpointSequenceNumber;
 		if (checkpointSequenceNumber !== undefined) {
 			this.updateLatestKnownOpSeqNumber(checkpointSequenceNumber);

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -1264,6 +1264,8 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 			return;
 		}
 
+		const pendingStateAnchor = cacheOnly ? undefined : this.pendingStateAnchor;
+		let refetchAfterUnvalidatedAnchor = false;
 		try {
 			let from = this.lastQueuedSequenceNumber + 1;
 
@@ -1292,6 +1294,23 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 				},
 				cacheOnly,
 			);
+			if (
+				pendingStateAnchor !== undefined &&
+				this.pendingStateAnchor === pendingStateAnchor &&
+				!this._closed
+			) {
+				this.logger.sendTelemetryEvent({
+					eventName: "PendingStateAnchorNotValidated",
+					sequenceNumber: pendingStateAnchor.sequenceNumber,
+					fetchFrom: from,
+					serviceCheckpointSequenceNumber: this.serviceCheckpointSequenceNumber,
+				});
+				this.pendingStateAnchor = undefined;
+				if (this.previouslyProcessedMessage === pendingStateAnchor) {
+					this.previouslyProcessedMessage = undefined;
+				}
+				refetchAfterUnvalidatedAnchor = true;
+			}
 		} catch (error) {
 			this.logger.sendErrorEvent({ eventName: "GetDeltas_Exception" }, error);
 			this.close(normalizeError(error));
@@ -1299,6 +1318,9 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 			this.refreshDelayInfo(this.deltaStorageDelayId);
 			this.fetchReason = undefined;
 			this.processPendingOps(reason);
+			if (refetchAfterUnvalidatedAnchor && this.fetchReason === undefined) {
+				this.fetchMissingDeltas("PendingStateAnchorNotValidated");
+			}
 		}
 	}
 

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -909,7 +909,22 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 	}
 
 	private comparableMessageContents(m: ISequencedDocumentMessage): string | undefined {
-		return typeof m.contents === "string" ? m.contents : JSON.stringify(m.contents);
+		let contents = m.contents;
+		if (typeof contents === "string") {
+			const serializedContents = contents;
+			try {
+				contents = JSON.parse(contents) as unknown;
+			} catch {
+				return serializedContents;
+			}
+		}
+		return JSON.stringify(contents, (_key, value: unknown) =>
+			typeof value === "object" && value !== null && !Array.isArray(value)
+				? Object.fromEntries(
+						Object.entries(value).sort(([left], [right]) => left.localeCompare(right)),
+					)
+				: value,
+		);
 	}
 
 	/**

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -600,7 +600,10 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 	 * background.
 	 * @param lastProcessedMessage - The latest message already reflected in the loaded state.
 	 * Offline loads use it to skip already processed ops and validate that the service history has
-	 * not changed.
+	 * not changed. Local edits and inbound processing can continue during validation, but outbound
+	 * submissions wait for an anchor match or a completed non-cache fetch that cannot find it.
+	 * A mismatch closes the container without sending queued edits; hosts must capture pending
+	 * state before closure if they need it for recovery.
 	 */
 	public async attachOpHandler(
 		minSequenceNumber: number,
@@ -646,6 +649,15 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 
 		if (this._closed) {
 			return;
+		}
+
+		if (this.pendingStateAnchor !== undefined) {
+			// Hold submissions, not local edits or inbound catch-up, until history is checked.
+			// DeltaQueue counts pauses, so connection/reconnection and host pauses stay independent.
+			// On mismatch, close clears queued submissions without releasing this pause.
+			this.connectionManager.outbound
+				.pause()
+				.catch((error) => this.close(normalizeError(error)));
 		}
 
 		let prefetchP: Promise<void> | undefined;
@@ -1191,6 +1203,9 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 					}
 					if (previouslyObservedMessage === this.pendingStateAnchor) {
 						this.pendingStateAnchor = undefined;
+						if (!this._closed) {
+							this.connectionManager.outbound.resume();
+						}
 					}
 				}
 			} else if (message.sequenceNumber === this.lastQueuedSequenceNumber + 1) {
@@ -1400,6 +1415,8 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 					serviceCheckpointSequenceNumber: this.serviceCheckpointSequenceNumber,
 				});
 				this.pendingStateAnchor = undefined;
+				// Preserve the availability-first policy when retention removes the anchor.
+				this.connectionManager.outbound.resume();
 				if (this.previouslyProcessedMessage === pendingStateAnchor) {
 					this.previouslyProcessedMessage = undefined;
 				}

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -445,7 +445,17 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 			this.close(normalizeError(error));
 		});
 		const props: IConnectionManagerFactoryArgs = {
-			incomingOpHandler: (messages: ISequencedDocumentMessage[], reason: string) => {
+			incomingOpHandler: (
+				messages: ISequencedDocumentMessage[],
+				reason: string,
+				connection?: IConnectionDetailsInternal,
+			) => {
+				if (connection !== undefined) {
+					// Initial ops can fail anchor validation before connectHandler runs. Snapshot
+					// this connection's raw checkpoint first, including clearing a previous value
+					// when the service omits it. Do not change connect-event or catch-up ordering.
+					this.serviceCheckpointSequenceNumber = connection.serviceCheckpointSequenceNumber;
+				}
 				try {
 					this.enqueueMessages(messages, reason);
 				} catch (error) {

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -942,13 +942,30 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 	}
 
 	/**
+	 * Removes the loader's replay-only marker before comparing service metadata.
+	 * Container adds `savedOp` during offline replay, and re-stashing persists that marker.
+	 * It is not part of service history. Empty metadata and absent metadata are equivalent;
+	 * all other fields (including nested fields named `savedOp`) remain significant.
+	 */
+	private comparableMessageMetadata(metadata: unknown): string | undefined {
+		if (typeof metadata !== "object" || metadata === null || Array.isArray(metadata)) {
+			return this.comparableMessageProperty(metadata);
+		}
+		const entries = Object.entries(metadata).filter(([key]) => key !== "savedOp");
+		return entries.length === 0
+			? undefined
+			: this.comparableMessageProperty(Object.fromEntries(entries));
+	}
+
+	/**
 	 * Compares fields that identify or change the replay semantics of a pending-state anchor.
 	 *
 	 * `clientSequenceNumber` identifies the original submission; `contents`, `metadata`, and
 	 * `compression` determine runtime and batch interpretation; and `data` is the payload for
 	 * system messages. Service or diagnostic decorations such as `serverMetadata`, `origin`,
 	 * `traces`, and `expHash1` are intentionally omitted because they may be rewritten without
-	 * changing the operation replayed by the client.
+	 * changing the operation replayed by the client. Metadata excludes only the loader's
+	 * top-level `savedOp` replay marker, not service batch metadata.
 	 */
 	private pendingStateAnchorDifferences(
 		anchor: ISequencedDocumentMessage,
@@ -966,8 +983,8 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 				this.comparableMessageProperty(anchor.contents) !==
 				this.comparableMessageProperty(message.contents),
 			metadataDiffer:
-				this.comparableMessageProperty(anchor.metadata) !==
-				this.comparableMessageProperty(message.metadata),
+				this.comparableMessageMetadata(anchor.metadata) !==
+				this.comparableMessageMetadata(message.metadata),
 			compressionDiffer: anchor.compression !== message.compression,
 			dataDiffer: anchor.data !== message.data,
 		};

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -908,23 +908,59 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 		return `${m.clientId}-${m.type}-${m.minimumSequenceNumber}-${m.referenceSequenceNumber}-${m.timestamp}`;
 	}
 
-	private comparableMessageContents(m: ISequencedDocumentMessage): string | undefined {
-		let contents = m.contents;
-		if (typeof contents === "string") {
-			const serializedContents = contents;
+	/**
+	 * Canonicalizes JSON-compatible message fields that may be represented as either parsed values
+	 * or strings, or whose object keys may be ordered differently after serialization.
+	 */
+	private comparableMessageProperty(value: unknown): string | undefined {
+		let comparableValue = value;
+		if (typeof comparableValue === "string") {
+			const serializedValue = comparableValue;
 			try {
-				contents = JSON.parse(contents) as unknown;
+				comparableValue = JSON.parse(comparableValue) as unknown;
 			} catch {
-				return serializedContents;
+				return serializedValue;
 			}
 		}
-		return JSON.stringify(contents, (_key, value: unknown) =>
-			typeof value === "object" && value !== null && !Array.isArray(value)
+		return JSON.stringify(comparableValue, (_key, child: unknown) =>
+			typeof child === "object" && child !== null && !Array.isArray(child)
 				? Object.fromEntries(
-						Object.entries(value).sort(([left], [right]) => left.localeCompare(right)),
+						Object.entries(child).sort(([left], [right]) => left.localeCompare(right)),
 					)
-				: value,
+				: child,
 		);
+	}
+
+	/**
+	 * Compares fields that identify or change the replay semantics of a pending-state anchor.
+	 *
+	 * `clientSequenceNumber` identifies the original submission; `contents`, `metadata`, and
+	 * `compression` determine runtime and batch interpretation; and `data` is the payload for
+	 * system messages. Service or diagnostic decorations such as `serverMetadata`, `origin`,
+	 * `traces`, and `expHash1` are intentionally omitted because they may be rewritten without
+	 * changing the operation replayed by the client.
+	 */
+	private pendingStateAnchorDifferences(
+		anchor: ISequencedDocumentMessage,
+		message: ISequencedDocumentMessage,
+	): {
+		clientSequenceNumberDiffer: boolean;
+		contentsDiffer: boolean;
+		metadataDiffer: boolean;
+		compressionDiffer: boolean;
+		dataDiffer: boolean;
+	} {
+		return {
+			clientSequenceNumberDiffer: anchor.clientSequenceNumber !== message.clientSequenceNumber,
+			contentsDiffer:
+				this.comparableMessageProperty(anchor.contents) !==
+				this.comparableMessageProperty(message.contents),
+			metadataDiffer:
+				this.comparableMessageProperty(anchor.metadata) !==
+				this.comparableMessageProperty(message.metadata),
+			compressionDiffer: anchor.compression !== message.compression,
+			dataDiffer: anchor.data !== message.data,
+		};
 	}
 
 	/**
@@ -1094,11 +1130,15 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 				if (previouslyObservedMessage?.sequenceNumber === message.sequenceNumber) {
 					const message1 = this.comparableMessagePayload(previouslyObservedMessage);
 					const message2 = this.comparableMessagePayload(message);
-					const contentsDiffer =
-						previouslyObservedMessage === this.pendingStateAnchor &&
-						this.comparableMessageContents(previouslyObservedMessage) !==
-							this.comparableMessageContents(message);
-					if (message1 !== message2 || contentsDiffer) {
+					const anchorDifferences =
+						previouslyObservedMessage === this.pendingStateAnchor
+							? this.pendingStateAnchorDifferences(previouslyObservedMessage, message)
+							: undefined;
+					if (
+						message1 !== message2 ||
+						(anchorDifferences !== undefined &&
+							Object.values(anchorDifferences).includes(true))
+					) {
 						const error = new NonRetryableError(
 							// This looks like a data corruption but the culprit was that the file was overwritten
 							// in storage.  See PR #5882.
@@ -1116,7 +1156,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 								serviceCheckpointSequenceNumber: this.serviceCheckpointSequenceNumber,
 								message1,
 								message2,
-								contentsDiffer,
+								...anchorDifferences,
 								driverVersion: undefined,
 							},
 						);

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -933,6 +933,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 	/**
 	 * Canonicalizes JSON-compatible message fields that may be represented as either parsed values
 	 * or strings, or whose object keys may be ordered differently after serialization.
+	 * Order keys by UTF-16 code units, not locale collation, which can equate distinct keys.
 	 */
 	private comparableMessageProperty(value: unknown): string | undefined {
 		let comparableValue = value;
@@ -947,7 +948,9 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 		return JSON.stringify(comparableValue, (_key, child: unknown) =>
 			typeof child === "object" && child !== null && !Array.isArray(child)
 				? Object.fromEntries(
-						Object.entries(child).sort(([left], [right]) => left.localeCompare(right)),
+						Object.entries(child).sort(([left], [right]) =>
+							left < right ? -1 : left > right ? 1 : 0,
+						),
 					)
 				: child,
 		);

--- a/packages/loader/container-loader/src/test/deltaManager.spec.ts
+++ b/packages/loader/container-loader/src/test/deltaManager.spec.ts
@@ -226,6 +226,7 @@ describe("Loader", () => {
 					timestamp: savedOp.timestamp + 1,
 				};
 				let requestedFrom: number | undefined;
+				let fetchSignal: AbortSignal | undefined;
 				let read = false;
 				let releaseFetch: (() => void) | undefined;
 				const fetchReleasedP = new Promise<void>((resolve) => {
@@ -239,8 +240,9 @@ describe("Loader", () => {
 					true,
 					logger,
 					() => ({
-						fetchMessages: (from): IStream<ISequencedDocumentMessage[]> => {
+						fetchMessages: (from, _to, signal): IStream<ISequencedDocumentMessage[]> => {
 							requestedFrom = from;
+							fetchSignal = signal;
 							fetchStarted?.();
 							return {
 								read: async (): Promise<IStreamResult<ISequencedDocumentMessage[]>> => {
@@ -267,6 +269,16 @@ describe("Loader", () => {
 				deltaManager.on("closed", (error: Error) => {
 					expectedError = error;
 				});
+				deltaConnection.emitOp(docId, [
+					{
+						...initialMessage,
+						clientSequenceNumber: initialMessage.clientSequenceNumber + 1,
+						sequenceNumber: initialMessage.sequenceNumber + 1,
+						timestamp: initialMessage.timestamp + 1,
+					},
+				]);
+				await yieldEventLoop();
+				assert.strictEqual(fetchSignal?.aborted, false);
 				releaseFetch?.();
 				await loadP;
 				assert.strictEqual(requestedFrom, savedOp.sequenceNumber);

--- a/packages/loader/container-loader/src/test/deltaManager.spec.ts
+++ b/packages/loader/container-loader/src/test/deltaManager.spec.ts
@@ -351,6 +351,63 @@ describe("Loader", () => {
 				assert.strictEqual(expectedError, undefined);
 			});
 
+			it("continues fetching when the saved op is no longer available", async () => {
+				const savedOp = {
+					...generateOp(),
+					sequenceNumber: 13,
+					minimumSequenceNumber: 10,
+					timestamp: 1000,
+					referenceSequenceNumber: 12,
+				};
+				const continuingOp = {
+					...savedOp,
+					clientSequenceNumber: savedOp.clientSequenceNumber + 1,
+					sequenceNumber: savedOp.sequenceNumber + 1,
+					timestamp: savedOp.timestamp + 1,
+				};
+				const requestedFrom: number[] = [];
+				let fetchCompleted: (() => void) | undefined;
+				const fetchCompletedP = new Promise<void>((resolve) => {
+					fetchCompleted = resolve;
+				});
+
+				await startDeltaManager(
+					true,
+					logger,
+					() => ({
+						fetchMessages: (from): IStream<ISequencedDocumentMessage[]> => {
+							requestedFrom.push(from);
+							let read = false;
+							return {
+								read: async (): Promise<IStreamResult<ISequencedDocumentMessage[]>> => {
+									if (from === savedOp.sequenceNumber) {
+										return { done: true };
+									}
+									if (read) {
+										fetchCompleted?.();
+										return { done: true };
+									}
+									read = true;
+									return { done: false, value: [continuingOp] };
+								},
+							};
+						},
+					}),
+					5,
+					savedOp,
+					"all",
+				);
+				await fetchCompletedP;
+				await yieldEventLoop();
+
+				assert.deepStrictEqual(requestedFrom, [
+					savedOp.sequenceNumber,
+					savedOp.sequenceNumber + 1,
+				]);
+				assert.strictEqual(deltaManager.hasPendingStateAnchor, false);
+				assert.strictEqual(deltaManager.lastSequenceNumber, continuingOp.sequenceNumber);
+			});
+
 			it("uses the last saved op's minimum sequence number", async () => {
 				const savedOp = {
 					...generateOp(),

--- a/packages/loader/container-loader/src/test/deltaManager.spec.ts
+++ b/packages/loader/container-loader/src/test/deltaManager.spec.ts
@@ -408,6 +408,40 @@ describe("Loader", () => {
 				assert.strictEqual(deltaManager.lastSequenceNumber, continuingOp.sequenceNumber);
 			});
 
+			it("validates a buffered saved op when storage no longer has it", async () => {
+				const savedOp = {
+					...generateOp(),
+					sequenceNumber: 13,
+					minimumSequenceNumber: 10,
+					timestamp: 1000,
+					referenceSequenceNumber: 12,
+				};
+				const loadP = startDeltaManager(
+					true,
+					logger,
+					() => ({
+						fetchMessages: (): IStream<ISequencedDocumentMessage[]> => ({
+							read: async () => ({ done: true }),
+						}),
+					}),
+					5,
+					savedOp,
+					"all",
+					[{ ...savedOp, clientId: "restored-history-client" }],
+					true,
+				);
+				deltaManager.on("closed", (error: Error) => {
+					expectedError = error;
+				});
+				await loadP;
+
+				assert.match(
+					expectedError?.message ?? "",
+					/same sequenceNumber but different payloads/,
+				);
+				assert.strictEqual(deltaManager.hasPendingStateAnchor, false);
+			});
+
 			it("uses the last saved op's minimum sequence number", async () => {
 				const savedOp = {
 					...generateOp(),

--- a/packages/loader/container-loader/src/test/deltaManager.spec.ts
+++ b/packages/loader/container-loader/src/test/deltaManager.spec.ts
@@ -217,6 +217,7 @@ describe("Loader", () => {
 						minimumSequenceNumber: 10,
 						timestamp: 1000,
 						referenceSequenceNumber: 12,
+						contents: JSON.stringify({ value: "original" }),
 					}),
 				) as ISequencedDocumentMessage;
 				const initialMessage = {
@@ -253,7 +254,12 @@ describe("Loader", () => {
 									await fetchReleasedP;
 									return {
 										done: false,
-										value: [{ ...savedOp, clientId: "Different client" }],
+										value: [
+											{
+												...savedOp,
+												contents: JSON.stringify({ value: "restored" }),
+											},
+										],
 									};
 								},
 							};
@@ -292,6 +298,7 @@ describe("Loader", () => {
 					expectedError.getTelemetryProperties().serviceCheckpointSequenceNumber,
 					5,
 				);
+				assert.strictEqual(expectedError.getTelemetryProperties().contentsDiffer, true);
 			});
 
 			it("continues loading when the saved op matches service history", async () => {
@@ -302,6 +309,7 @@ describe("Loader", () => {
 						minimumSequenceNumber: 10,
 						timestamp: 1000,
 						referenceSequenceNumber: 12,
+						contents: { value: "same" },
 					}),
 				) as ISequencedDocumentMessage;
 				let read = false;
@@ -315,7 +323,10 @@ describe("Loader", () => {
 									return { done: true };
 								}
 								read = true;
-								return { done: false, value: [savedOp] };
+								return {
+									done: false,
+									value: [{ ...savedOp, contents: JSON.stringify(savedOp.contents) }],
+								};
 							},
 						}),
 					}),

--- a/packages/loader/container-loader/src/test/deltaManager.spec.ts
+++ b/packages/loader/container-loader/src/test/deltaManager.spec.ts
@@ -55,6 +55,8 @@ describe("Loader", () => {
 				deltaStorageFactory?: () => IDocumentDeltaStorageService,
 				checkpointSequenceNumber?: number,
 				lastProcessedSequenceNumber = 0,
+				initialMessages: ISequencedDocumentMessage[] = [],
+				connectBeforeAttach = false,
 			): Promise<void> {
 				const service = new MockDocumentService(deltaStorageFactory, () => {
 					// Always create new connection, as reusing old closed connection
@@ -69,6 +71,7 @@ describe("Loader", () => {
 							}
 						).checkpointSequenceNumber = checkpointSequenceNumber;
 					}
+					deltaConnection.initialMessages = initialMessages;
 					return deltaConnection;
 				});
 				const client: Partial<IClient> = {
@@ -98,6 +101,16 @@ describe("Loader", () => {
 					noopHeuristic.notifyMessageSent();
 				});
 
+				const connect = async (): Promise<void> =>
+					new Promise((resolve) => {
+						deltaManager.on("connect", resolve);
+						deltaManager.connect({ reason: { text: "test" } });
+					});
+
+				if (connectBeforeAttach) {
+					await connect();
+				}
+
 				await deltaManager.attachOpHandler(
 					0,
 					0,
@@ -109,10 +122,9 @@ describe("Loader", () => {
 					lastProcessedSequenceNumber,
 				);
 
-				await new Promise((resolve) => {
-					deltaManager.on("connect", resolve);
-					deltaManager.connect({ reason: { text: "test" } });
-				});
+				if (!connectBeforeAttach) {
+					await connect();
+				}
 			}
 
 			// function to yield control in the Javascript event loop.
@@ -194,20 +206,47 @@ describe("Loader", () => {
 				clock.restore();
 			});
 
-			it("logs a regressed checkpoint sequence number", async () => {
+			it("logs the raw checkpoint when initial messages normalize it", async () => {
 				const mockLogger = new MockLogger();
-				await startDeltaManager(true, mockLogger.toTelemetryLogger(), undefined, 5, 13);
+				const initialMessage = {
+					...generateOp(),
+					sequenceNumber: 14,
+				};
+				await startDeltaManager(true, mockLogger.toTelemetryLogger(), undefined, 5, 13, [
+					initialMessage,
+				]);
+
+				mockLogger.assertMatchAny([
+					{
+						eventName: "CheckpointSequenceNumberRegression",
+						checkpointSequenceNumber: 5,
+						lastProcessedSequenceNumber: 13,
+						lastQueuedSequenceNumber: 14,
+						lastObservedSequenceNumber: 14,
+						clientId: "test",
+						mode: "write",
+						socketDocumentId: "documentId",
+					},
+				]);
+			});
+
+			it("logs a regressed checkpoint after sequence tracking is initialized", async () => {
+				const mockLogger = new MockLogger();
+				await startDeltaManager(
+					true,
+					mockLogger.toTelemetryLogger(),
+					undefined,
+					5,
+					13,
+					undefined,
+					true,
+				);
 
 				mockLogger.assertMatch([
 					{
 						eventName: "CheckpointSequenceNumberRegression",
 						checkpointSequenceNumber: 5,
 						lastProcessedSequenceNumber: 13,
-						lastQueuedSequenceNumber: 13,
-						lastObservedSequenceNumber: 13,
-						clientId: "test",
-						mode: "write",
-						socketDocumentId: "documentId",
 					},
 				]);
 			});

--- a/packages/loader/container-loader/src/test/deltaManager.spec.ts
+++ b/packages/loader/container-loader/src/test/deltaManager.spec.ts
@@ -21,6 +21,7 @@ import {
 } from "@fluidframework/driver-definitions/internal";
 import {
 	createChildLogger,
+	isFluidError,
 	MockLogger,
 	type TelemetryLoggerExt,
 } from "@fluidframework/telemetry-utils/internal";
@@ -54,9 +55,8 @@ describe("Loader", () => {
 				dmLogger: TelemetryLoggerExt = logger,
 				deltaStorageFactory?: () => IDocumentDeltaStorageService,
 				checkpointSequenceNumber?: number,
-				lastProcessedSequenceNumber = 0,
-				initialMessages: ISequencedDocumentMessage[] = [],
-				connectBeforeAttach = false,
+				lastProcessedMessage?: ISequencedDocumentMessage,
+				prefetchType: "cached" | "all" | "none" = "none",
 			): Promise<void> {
 				const service = new MockDocumentService(deltaStorageFactory, () => {
 					// Always create new connection, as reusing old closed connection
@@ -71,7 +71,6 @@ describe("Loader", () => {
 							}
 						).checkpointSequenceNumber = checkpointSequenceNumber;
 					}
-					deltaConnection.initialMessages = initialMessages;
 					return deltaConnection;
 				});
 				const client: Partial<IClient> = {
@@ -107,10 +106,6 @@ describe("Loader", () => {
 						deltaManager.connect({ reason: { text: "test" } });
 					});
 
-				if (connectBeforeAttach) {
-					await connect();
-				}
-
 				await deltaManager.attachOpHandler(
 					0,
 					0,
@@ -118,13 +113,11 @@ describe("Loader", () => {
 						process: (message) => noopHeuristic.notifyMessageProcessed(message),
 						processSignal() {},
 					},
-					"none",
-					lastProcessedSequenceNumber,
+					prefetchType,
+					lastProcessedMessage,
 				);
 
-				if (!connectBeforeAttach) {
-					await connect();
-				}
+				await connect();
 			}
 
 			// function to yield control in the Javascript event loop.
@@ -133,6 +126,8 @@ describe("Loader", () => {
 					realSetTimeout(resolve, 0);
 				});
 			}
+
+			const assertNoExpectedError = (): void => assert.strictEqual(expectedError, undefined);
 
 			function generateOp(
 				type: MessageType = MessageType.Operation,
@@ -206,49 +201,93 @@ describe("Loader", () => {
 				clock.restore();
 			});
 
-			it("logs the raw checkpoint when initial messages normalize it", async () => {
-				const mockLogger = new MockLogger();
-				const initialMessage = {
+			it("validates the last saved op when loading pending state", async () => {
+				const savedOp = {
 					...generateOp(),
-					sequenceNumber: 14,
+					sequenceNumber: 13,
+					minimumSequenceNumber: 10,
+					timestamp: 1000,
+					referenceSequenceNumber: 12,
 				};
-				await startDeltaManager(true, mockLogger.toTelemetryLogger(), undefined, 5, 13, [
-					initialMessage,
-				]);
-
-				mockLogger.assertMatchAny([
-					{
-						eventName: "CheckpointSequenceNumberRegression",
-						checkpointSequenceNumber: 5,
-						lastProcessedSequenceNumber: 13,
-						lastQueuedSequenceNumber: 14,
-						lastObservedSequenceNumber: 14,
-						clientId: "test",
-						mode: "write",
-						socketDocumentId: "documentId",
-					},
-				]);
-			});
-
-			it("logs a regressed checkpoint after sequence tracking is initialized", async () => {
-				const mockLogger = new MockLogger();
+				let requestedFrom: number | undefined;
+				let read = false;
 				await startDeltaManager(
 					true,
-					mockLogger.toTelemetryLogger(),
-					undefined,
+					logger,
+					() => ({
+						fetchMessages: (from): IStream<ISequencedDocumentMessage[]> => {
+							requestedFrom = from;
+							return {
+								read: async (): Promise<IStreamResult<ISequencedDocumentMessage[]>> => {
+									if (read) {
+										return { done: true };
+									}
+									read = true;
+									return { done: false, value: [savedOp] };
+								},
+							};
+						},
+					}),
 					5,
-					13,
-					undefined,
-					true,
+					savedOp,
+					"all",
 				);
+				assert.strictEqual(requestedFrom, savedOp.sequenceNumber);
 
-				mockLogger.assertMatch([
+				deltaManager.on("closed", (error: Error) => {
+					expectedError = error;
+				});
+				const continuingOp = {
+					...savedOp,
+					clientSequenceNumber: savedOp.clientSequenceNumber + 1,
+					sequenceNumber: savedOp.sequenceNumber + 1,
+					timestamp: savedOp.timestamp + 1,
+				};
+				deltaConnection.emitOp(docId, [continuingOp]);
+				await yieldEventLoop();
+				assert.strictEqual(deltaManager.lastSequenceNumber, continuingOp.sequenceNumber);
+				assertNoExpectedError();
+
+				deltaConnection.emitOp(docId, [{ ...continuingOp, clientId: "Different client" }]);
+				assert.match(
+					expectedError?.message ?? "",
+					/same sequenceNumber but different payloads/,
+				);
+				assert(isFluidError(expectedError));
+				assert.strictEqual(
+					expectedError.getTelemetryProperties().serviceCheckpointSequenceNumber,
+					5,
+				);
+			});
+
+			it("uses the last saved op's minimum sequence number", async () => {
+				const savedOp = {
+					...generateOp(),
+					sequenceNumber: 13,
+					minimumSequenceNumber: 10,
+					timestamp: 1000,
+					referenceSequenceNumber: 12,
+				};
+				await startDeltaManager(true, logger, undefined, 5, savedOp);
+				deltaManager.on("closed", (error: Error) => {
+					expectedError = error;
+				});
+
+				deltaConnection.emitOp(docId, [
 					{
-						eventName: "CheckpointSequenceNumberRegression",
-						checkpointSequenceNumber: 5,
-						lastProcessedSequenceNumber: 13,
+						...generateOp(),
+						sequenceNumber: 14,
+						minimumSequenceNumber: 9,
 					},
 				]);
+				await yieldEventLoop();
+
+				assert.match(expectedError?.message ?? "", /Invalid MinimumSequenceNumber/);
+				assert(isFluidError(expectedError));
+				assert.strictEqual(
+					expectedError.getTelemetryProperties().serviceCheckpointSequenceNumber,
+					5,
+				);
 			});
 
 			describe("Update Minimum Sequence Number", () => {

--- a/packages/loader/container-loader/src/test/deltaManager.spec.ts
+++ b/packages/loader/container-loader/src/test/deltaManager.spec.ts
@@ -53,6 +53,8 @@ describe("Loader", () => {
 				reconnectAllowed = true,
 				dmLogger: TelemetryLoggerExt = logger,
 				deltaStorageFactory?: () => IDocumentDeltaStorageService,
+				checkpointSequenceNumber?: number,
+				lastProcessedSequenceNumber = 0,
 			): Promise<void> {
 				const service = new MockDocumentService(deltaStorageFactory, () => {
 					// Always create new connection, as reusing old closed connection
@@ -60,6 +62,13 @@ describe("Loader", () => {
 					deltaConnection = new MockDocumentDeltaConnection("test", (messages) =>
 						emitter.emit(submitEvent, messages),
 					);
+					if (checkpointSequenceNumber !== undefined) {
+						(
+							deltaConnection as MockDocumentDeltaConnection & {
+								checkpointSequenceNumber: number;
+							}
+						).checkpointSequenceNumber = checkpointSequenceNumber;
+					}
 					return deltaConnection;
 				});
 				const client: Partial<IClient> = {
@@ -89,10 +98,16 @@ describe("Loader", () => {
 					noopHeuristic.notifyMessageSent();
 				});
 
-				await deltaManager.attachOpHandler(0, 0, {
-					process: (message) => noopHeuristic.notifyMessageProcessed(message),
-					processSignal() {},
-				});
+				await deltaManager.attachOpHandler(
+					0,
+					0,
+					{
+						process: (message) => noopHeuristic.notifyMessageProcessed(message),
+						processSignal() {},
+					},
+					"none",
+					lastProcessedSequenceNumber,
+				);
 
 				await new Promise((resolve) => {
 					deltaManager.on("connect", resolve);
@@ -177,6 +192,24 @@ describe("Loader", () => {
 
 			after(() => {
 				clock.restore();
+			});
+
+			it("logs a regressed checkpoint sequence number", async () => {
+				const mockLogger = new MockLogger();
+				await startDeltaManager(true, mockLogger.toTelemetryLogger(), undefined, 5, 13);
+
+				mockLogger.assertMatch([
+					{
+						eventName: "CheckpointSequenceNumberRegression",
+						checkpointSequenceNumber: 5,
+						lastProcessedSequenceNumber: 13,
+						lastQueuedSequenceNumber: 13,
+						lastObservedSequenceNumber: 13,
+						clientId: "test",
+						mode: "write",
+						socketDocumentId: "documentId",
+					},
+				]);
 			});
 
 			describe("Update Minimum Sequence Number", () => {

--- a/packages/loader/container-loader/src/test/deltaManager.spec.ts
+++ b/packages/loader/container-loader/src/test/deltaManager.spec.ts
@@ -57,6 +57,9 @@ describe("Loader", () => {
 				checkpointSequenceNumber?: number,
 				lastProcessedMessage?: ISequencedDocumentMessage,
 				prefetchType: "cached" | "all" | "none" = "none",
+				initialMessages: ISequencedDocumentMessage[] = [],
+				connectBeforeAttach = false,
+				minimumSequenceNumber = 0,
 			): Promise<void> {
 				const service = new MockDocumentService(deltaStorageFactory, () => {
 					// Always create new connection, as reusing old closed connection
@@ -71,6 +74,7 @@ describe("Loader", () => {
 							}
 						).checkpointSequenceNumber = checkpointSequenceNumber;
 					}
+					deltaConnection.initialMessages = initialMessages;
 					return deltaConnection;
 				});
 				const client: Partial<IClient> = {
@@ -106,8 +110,12 @@ describe("Loader", () => {
 						deltaManager.connect({ reason: { text: "test" } });
 					});
 
+				if (connectBeforeAttach) {
+					await connect();
+				}
+
 				await deltaManager.attachOpHandler(
-					0,
+					minimumSequenceNumber,
 					0,
 					{
 						process: (message) => noopHeuristic.notifyMessageProcessed(message),
@@ -117,7 +125,9 @@ describe("Loader", () => {
 					lastProcessedMessage,
 				);
 
-				await connect();
+				if (!connectBeforeAttach) {
+					await connect();
+				}
 			}
 
 			// function to yield control in the Javascript event loop.
@@ -126,8 +136,6 @@ describe("Loader", () => {
 					realSetTimeout(resolve, 0);
 				});
 			}
-
-			const assertNoExpectedError = (): void => assert.strictEqual(expectedError, undefined);
 
 			function generateOp(
 				type: MessageType = MessageType.Operation,
@@ -201,29 +209,50 @@ describe("Loader", () => {
 				clock.restore();
 			});
 
-			it("validates the last saved op when loading pending state", async () => {
-				const savedOp = {
-					...generateOp(),
-					sequenceNumber: 13,
-					minimumSequenceNumber: 10,
-					timestamp: 1000,
-					referenceSequenceNumber: 12,
+			it("rejects a saved op that differs from service history", async () => {
+				const savedOp = JSON.parse(
+					JSON.stringify({
+						...generateOp(),
+						sequenceNumber: 13,
+						minimumSequenceNumber: 10,
+						timestamp: 1000,
+						referenceSequenceNumber: 12,
+					}),
+				) as ISequencedDocumentMessage;
+				const initialMessage = {
+					...savedOp,
+					clientSequenceNumber: savedOp.clientSequenceNumber + 1,
+					sequenceNumber: savedOp.sequenceNumber + 1,
+					timestamp: savedOp.timestamp + 1,
 				};
 				let requestedFrom: number | undefined;
 				let read = false;
-				await startDeltaManager(
+				let releaseFetch: (() => void) | undefined;
+				const fetchReleasedP = new Promise<void>((resolve) => {
+					releaseFetch = resolve;
+				});
+				let fetchStarted: (() => void) | undefined;
+				const fetchStartedP = new Promise<void>((resolve) => {
+					fetchStarted = resolve;
+				});
+				const loadP = startDeltaManager(
 					true,
 					logger,
 					() => ({
 						fetchMessages: (from): IStream<ISequencedDocumentMessage[]> => {
 							requestedFrom = from;
+							fetchStarted?.();
 							return {
 								read: async (): Promise<IStreamResult<ISequencedDocumentMessage[]>> => {
 									if (read) {
 										return { done: true };
 									}
 									read = true;
-									return { done: false, value: [savedOp] };
+									await fetchReleasedP;
+									return {
+										done: false,
+										value: [{ ...savedOp, clientId: "Different client" }],
+									};
 								},
 							};
 						},
@@ -231,24 +260,17 @@ describe("Loader", () => {
 					5,
 					savedOp,
 					"all",
+					[initialMessage],
+					true,
 				);
-				assert.strictEqual(requestedFrom, savedOp.sequenceNumber);
-
+				await fetchStartedP;
 				deltaManager.on("closed", (error: Error) => {
 					expectedError = error;
 				});
-				const continuingOp = {
-					...savedOp,
-					clientSequenceNumber: savedOp.clientSequenceNumber + 1,
-					sequenceNumber: savedOp.sequenceNumber + 1,
-					timestamp: savedOp.timestamp + 1,
-				};
-				deltaConnection.emitOp(docId, [continuingOp]);
-				await yieldEventLoop();
-				assert.strictEqual(deltaManager.lastSequenceNumber, continuingOp.sequenceNumber);
-				assertNoExpectedError();
+				releaseFetch?.();
+				await loadP;
+				assert.strictEqual(requestedFrom, savedOp.sequenceNumber);
 
-				deltaConnection.emitOp(docId, [{ ...continuingOp, clientId: "Different client" }]);
 				assert.match(
 					expectedError?.message ?? "",
 					/same sequenceNumber but different payloads/,
@@ -258,6 +280,52 @@ describe("Loader", () => {
 					expectedError.getTelemetryProperties().serviceCheckpointSequenceNumber,
 					5,
 				);
+			});
+
+			it("continues loading when the saved op matches service history", async () => {
+				const savedOp = JSON.parse(
+					JSON.stringify({
+						...generateOp(),
+						sequenceNumber: 13,
+						minimumSequenceNumber: 10,
+						timestamp: 1000,
+						referenceSequenceNumber: 12,
+					}),
+				) as ISequencedDocumentMessage;
+				let read = false;
+				await startDeltaManager(
+					true,
+					logger,
+					() => ({
+						fetchMessages: (): IStream<ISequencedDocumentMessage[]> => ({
+							read: async (): Promise<IStreamResult<ISequencedDocumentMessage[]>> => {
+								if (read) {
+									return { done: true };
+								}
+								read = true;
+								return { done: false, value: [savedOp] };
+							},
+						}),
+					}),
+					5,
+					savedOp,
+					"all",
+				);
+				deltaManager.on("closed", (error: Error) => {
+					expectedError = error;
+				});
+
+				const continuingOp = {
+					...savedOp,
+					clientSequenceNumber: savedOp.clientSequenceNumber + 1,
+					sequenceNumber: savedOp.sequenceNumber + 1,
+					timestamp: savedOp.timestamp + 1,
+				};
+				deltaConnection.emitOp(docId, [continuingOp]);
+				await yieldEventLoop();
+
+				assert.strictEqual(deltaManager.lastSequenceNumber, continuingOp.sequenceNumber);
+				assert.strictEqual(expectedError, undefined);
 			});
 
 			it("uses the last saved op's minimum sequence number", async () => {
@@ -287,6 +355,29 @@ describe("Loader", () => {
 				assert.strictEqual(
 					expectedError.getTelemetryProperties().serviceCheckpointSequenceNumber,
 					5,
+				);
+			});
+
+			it("rejects a saved-op MSN below the snapshot MSN", async () => {
+				const savedOp = {
+					...generateOp(),
+					sequenceNumber: 13,
+					minimumSequenceNumber: 9,
+				};
+
+				await assert.rejects(
+					startDeltaManager(
+						true,
+						logger,
+						undefined,
+						undefined,
+						savedOp,
+						"none",
+						[],
+						false,
+						10,
+					),
+					/The last processed message's minimum sequence number is below the snapshot minimum sequence number/,
 				);
 			});
 

--- a/packages/loader/container-loader/src/test/deltaManager.spec.ts
+++ b/packages/loader/container-loader/src/test/deltaManager.spec.ts
@@ -29,7 +29,7 @@ import {
 import { type SinonFakeTimers, useFakeTimers } from "sinon";
 
 import { ConnectionManager } from "../connectionManager.js";
-import type { IConnectionManagerFactoryArgs } from "../contracts.js";
+import { type IConnectionManagerFactoryArgs, ReconnectMode } from "../contracts.js";
 import { DeltaManager } from "../deltaManager.js";
 import { NoopHeuristic } from "../noopHeuristic.js";
 
@@ -209,6 +209,85 @@ describe("Loader", () => {
 			after(() => {
 				clock.restore();
 			});
+
+			for (const checkpoint of [7, undefined]) {
+				it(`reports the current raw checkpoint '${checkpoint}' for a conflicting reconnect anchor`, async () => {
+					const savedOp = {
+						...generateOp(),
+						sequenceNumber: 13,
+						minimumSequenceNumber: 10,
+						timestamp: 1000,
+						referenceSequenceNumber: 12,
+					};
+					let connectionCount = 0;
+					const service = new MockDocumentService(undefined, () => {
+						const reconnect = connectionCount++ > 0;
+						const rawCheckpoint = reconnect ? checkpoint : 5;
+						return Object.assign(new MockDocumentDeltaConnection("test"), {
+							...(rawCheckpoint === undefined
+								? {}
+								: { checkpointSequenceNumber: rawCheckpoint }),
+							initialMessages: reconnect
+								? [{ ...savedOp, clientId: "restored-history-client" }]
+								: [],
+						});
+					});
+					const client: Partial<IClient> = {
+						mode: "write",
+						details: { capabilities: { interactive: true } },
+					};
+					deltaManager = new DeltaManager<ConnectionManager>(
+						() => service,
+						logger,
+						() => false,
+						(props) =>
+							new ConnectionManager(
+								() => service,
+								() => false,
+								client as IClient,
+								true,
+								logger,
+								props,
+							),
+					);
+					await deltaManager.attachOpHandler(
+						0,
+						0,
+						{ process() {}, processSignal() {} },
+						"none",
+						savedOp,
+					);
+					const connected = new Deferred<void>();
+					deltaManager.once("connect", () => connected.resolve());
+					deltaManager.connect({
+						reason: { text: "first connection" },
+						fetchOpsFromStorage: false,
+					});
+					await connected.promise;
+					assert.strictEqual(deltaManager.hasPendingStateAnchor, true);
+					deltaManager.connectionManager.setAutoReconnect(ReconnectMode.Disabled, {
+						text: "test disconnect",
+					});
+					deltaManager.connectionManager.setAutoReconnect(ReconnectMode.Enabled, {
+						text: "test reconnect",
+					});
+					const closed = new Deferred<unknown>();
+					deltaManager.once("closed", (closeError) => closed.resolve(closeError));
+					deltaManager.connect({
+						reason: { text: "second connection" },
+						fetchOpsFromStorage: false,
+					});
+					const error = await closed.promise;
+
+					assert(isFluidError(error));
+					assert.match(error.message, /same sequenceNumber but different payloads/);
+					assert.strictEqual(
+						error.getTelemetryProperties().serviceCheckpointSequenceNumber,
+						checkpoint,
+					);
+					assert.strictEqual(connectionCount, 2);
+				});
+			}
 
 			it("rejects a saved op that differs from service history", async () => {
 				const savedOp = JSON.parse(

--- a/packages/loader/container-loader/src/test/deltaManager.spec.ts
+++ b/packages/loader/container-loader/src/test/deltaManager.spec.ts
@@ -464,6 +464,75 @@ describe("Loader", () => {
 				});
 			}
 
+			for (const field of ["contents", "metadata"] as const) {
+				for (const changedValues of [false, true]) {
+					it(`compares reordered Unicode keys in ${field} with changed values '${changedValues}'`, async () => {
+						// These distinct keys collate equally, but must retain separate values.
+						const savedOp = {
+							...generateOp(),
+							sequenceNumber: 13,
+							minimumSequenceNumber: 10,
+							[field]: { nested: { "\u00E9": 1, "e\u0301": 2 } },
+						};
+						const fetchStarted = new Deferred<void>();
+						const releaseFetch = new Deferred<void>();
+						let read = false;
+						const loadP = startDeltaManager(
+							true,
+							logger,
+							() => ({
+								fetchMessages: (): IStream<ISequencedDocumentMessage[]> => ({
+									read: async (): Promise<IStreamResult<ISequencedDocumentMessage[]>> => {
+										if (read) {
+											return { done: true };
+										}
+										read = true;
+										fetchStarted.resolve();
+										await releaseFetch.promise;
+										return {
+											done: false,
+											value: [
+												{
+													...savedOp,
+													[field]: JSON.stringify({
+														nested: {
+															"e\u0301": changedValues ? 1 : 2,
+															"\u00E9": changedValues ? 2 : 1,
+														},
+													}),
+												},
+											],
+										};
+									},
+								}),
+							}),
+							5,
+							savedOp,
+							"all",
+							[],
+							true,
+						);
+						await fetchStarted.promise;
+						deltaManager.on("closed", (error: Error) => {
+							expectedError = error;
+						});
+						releaseFetch.resolve();
+						await loadP;
+						assert.strictEqual(deltaManager.hasPendingStateAnchor, false);
+						if (changedValues) {
+							assert(isFluidError(expectedError));
+							assert.strictEqual(
+								expectedError.getTelemetryProperties()[`${field}Differ`],
+								true,
+							);
+						} else {
+							assert.strictEqual(expectedError, undefined);
+							assert.strictEqual(deltaManager.connectionManager.outbound.paused, false);
+						}
+					});
+				}
+			}
+
 			for (const serviceMetadata of [
 				undefined,
 				{},

--- a/packages/loader/container-loader/src/test/deltaManager.spec.ts
+++ b/packages/loader/container-loader/src/test/deltaManager.spec.ts
@@ -10,6 +10,7 @@ import {
 	MockDocumentDeltaConnection,
 	MockDocumentService,
 } from "@fluid-private/test-loader-utils";
+import { Deferred } from "@fluidframework/core-utils/internal";
 import type { IClient } from "@fluidframework/driver-definitions";
 import {
 	type IDocumentDeltaStorageService,
@@ -300,6 +301,84 @@ describe("Loader", () => {
 				);
 				assert.strictEqual(expectedError.getTelemetryProperties().contentsDiffer, true);
 			});
+
+			for (const { name, serviceValue, telemetryProperty } of [
+				{
+					name: "client sequence number",
+					serviceValue: { clientSequenceNumber: 99 },
+					telemetryProperty: "clientSequenceNumberDiffer",
+				},
+				{
+					name: "metadata",
+					serviceValue: { metadata: { batch: false } },
+					telemetryProperty: "metadataDiffer",
+				},
+				{
+					name: "compression",
+					serviceValue: { compression: "different" },
+					telemetryProperty: "compressionDiffer",
+				},
+				{
+					name: "system data",
+					serviceValue: { data: "different" },
+					telemetryProperty: "dataDiffer",
+				},
+			] as const) {
+				it(`rejects a saved op with different ${name}`, async () => {
+					const savedOp = {
+						...generateOp(),
+						sequenceNumber: 13,
+						minimumSequenceNumber: 10,
+						timestamp: 1000,
+						referenceSequenceNumber: 12,
+						contents: { value: "same" },
+						metadata: { batch: true },
+						compression: "lz4",
+						data: "same",
+					};
+					const fetchStarted = new Deferred<void>();
+					const releaseFetch = new Deferred<void>();
+					let read = false;
+					const loadP = startDeltaManager(
+						true,
+						logger,
+						() => ({
+							fetchMessages: (): IStream<ISequencedDocumentMessage[]> => ({
+								read: async (): Promise<IStreamResult<ISequencedDocumentMessage[]>> => {
+									if (read) {
+										return { done: true };
+									}
+									read = true;
+									fetchStarted.resolve();
+									await releaseFetch.promise;
+									return {
+										done: false,
+										value: [{ ...savedOp, ...serviceValue }],
+									};
+								},
+							}),
+						}),
+						5,
+						savedOp,
+						"all",
+						[],
+						true,
+					);
+					await fetchStarted.promise;
+					deltaManager.on("closed", (error: Error) => {
+						expectedError = error;
+					});
+					releaseFetch.resolve();
+					await loadP;
+
+					assert.match(
+						expectedError?.message ?? "",
+						/same sequenceNumber but different payloads/,
+					);
+					assert(isFluidError(expectedError));
+					assert.strictEqual(expectedError.getTelemetryProperties()[telemetryProperty], true);
+				});
+			}
 
 			it("continues loading when the saved op matches service history", async () => {
 				const savedOp = JSON.parse(

--- a/packages/loader/container-loader/src/test/deltaManager.spec.ts
+++ b/packages/loader/container-loader/src/test/deltaManager.spec.ts
@@ -309,7 +309,10 @@ describe("Loader", () => {
 						minimumSequenceNumber: 10,
 						timestamp: 1000,
 						referenceSequenceNumber: 12,
-						contents: { value: "same" },
+						contents: {
+							first: 1,
+							nested: { second: 2, third: 3 },
+						},
 					}),
 				) as ISequencedDocumentMessage;
 				let read = false;
@@ -325,7 +328,15 @@ describe("Loader", () => {
 								read = true;
 								return {
 									done: false,
-									value: [{ ...savedOp, contents: JSON.stringify(savedOp.contents) }],
+									value: [
+										{
+											...savedOp,
+											contents: JSON.stringify({
+												nested: { third: 3, second: 2 },
+												first: 1,
+											}),
+										},
+									],
 								};
 							},
 						}),

--- a/packages/loader/container-loader/src/test/deltaManager.spec.ts
+++ b/packages/loader/container-loader/src/test/deltaManager.spec.ts
@@ -389,7 +389,12 @@ describe("Loader", () => {
 				},
 				{
 					name: "metadata",
-					serviceValue: { metadata: { batch: false } },
+					serviceValue: { metadata: { batch: false, nested: { savedOp: true } } },
+					telemetryProperty: "metadataDiffer",
+				},
+				{
+					name: "nested savedOp metadata",
+					serviceValue: { metadata: { batch: true, nested: { savedOp: false } } },
 					telemetryProperty: "metadataDiffer",
 				},
 				{
@@ -411,7 +416,7 @@ describe("Loader", () => {
 						timestamp: 1000,
 						referenceSequenceNumber: 12,
 						contents: { value: "same" },
-						metadata: { batch: true },
+						metadata: { batch: true, nested: { savedOp: true }, savedOp: true },
 						compression: "lz4",
 						data: "same",
 					};
@@ -459,66 +464,76 @@ describe("Loader", () => {
 				});
 			}
 
-			it("continues loading when the saved op matches service history", async () => {
-				const savedOp = JSON.parse(
-					JSON.stringify({
-						...generateOp(),
-						sequenceNumber: 13,
-						minimumSequenceNumber: 10,
-						timestamp: 1000,
-						referenceSequenceNumber: 12,
-						contents: {
-							first: 1,
-							nested: { second: 2, third: 3 },
-						},
-					}),
-				) as ISequencedDocumentMessage;
-				let read = false;
-				await startDeltaManager(
-					true,
-					logger,
-					() => ({
-						fetchMessages: (): IStream<ISequencedDocumentMessage[]> => ({
-							read: async (): Promise<IStreamResult<ISequencedDocumentMessage[]>> => {
-								if (read) {
-									return { done: true };
-								}
-								read = true;
-								return {
-									done: false,
-									value: [
-										{
-											...savedOp,
-											contents: JSON.stringify({
-												nested: { third: 3, second: 2 },
-												first: 1,
-											}),
-										},
-									],
-								};
+			for (const serviceMetadata of [
+				undefined,
+				{},
+				{ batch: true, batchId: "same-batch", nested: { savedOp: true } },
+			]) {
+				it(`continues loading when the saved op matches service metadata '${JSON.stringify(serviceMetadata)}'`, async () => {
+					const savedOp = JSON.parse(
+						JSON.stringify({
+							...generateOp(),
+							sequenceNumber: 13,
+							minimumSequenceNumber: 10,
+							timestamp: 1000,
+							referenceSequenceNumber: 12,
+							metadata: { ...serviceMetadata, savedOp: true },
+							contents: {
+								first: 1,
+								nested: { second: 2, third: 3 },
 							},
 						}),
-					}),
-					5,
-					savedOp,
-					"all",
-				);
-				deltaManager.on("closed", (error: Error) => {
-					expectedError = error;
+					) as ISequencedDocumentMessage;
+					let read = false;
+					await startDeltaManager(
+						true,
+						logger,
+						() => ({
+							fetchMessages: (): IStream<ISequencedDocumentMessage[]> => ({
+								read: async (): Promise<IStreamResult<ISequencedDocumentMessage[]>> => {
+									if (read) {
+										return { done: true };
+									}
+									read = true;
+									return {
+										done: false,
+										value: [
+											{
+												...savedOp,
+												metadata: serviceMetadata,
+												contents: JSON.stringify({
+													nested: { third: 3, second: 2 },
+													first: 1,
+												}),
+											},
+										],
+									};
+								},
+							}),
+						}),
+						5,
+						savedOp,
+						"all",
+					);
+					assert.strictEqual(deltaManager.hasPendingStateAnchor, false);
+					assert.deepStrictEqual(savedOp.metadata, { ...serviceMetadata, savedOp: true });
+					deltaManager.on("closed", (error: Error) => {
+						expectedError = error;
+					});
+
+					const continuingOp = {
+						...savedOp,
+						clientSequenceNumber: savedOp.clientSequenceNumber + 1,
+						sequenceNumber: savedOp.sequenceNumber + 1,
+						timestamp: savedOp.timestamp + 1,
+					};
+					deltaConnection.emitOp(docId, [continuingOp]);
+					await yieldEventLoop();
+
+					assert.strictEqual(deltaManager.lastSequenceNumber, continuingOp.sequenceNumber);
+					assert.strictEqual(expectedError, undefined);
 				});
-
-				const continuingOp = {
-					...savedOp,
-					clientSequenceNumber: savedOp.clientSequenceNumber + 1,
-					sequenceNumber: savedOp.sequenceNumber + 1,
-					timestamp: savedOp.timestamp + 1,
-				};
-				deltaConnection.emitOp(docId, [continuingOp]);
-				await yieldEventLoop();
-
-				assert.strictEqual(deltaManager.lastSequenceNumber, continuingOp.sequenceNumber);
-				assert.strictEqual(expectedError, undefined);
-			});
+			}
 
 			it("continues fetching when the saved op is no longer available", async () => {
 				const savedOp = {

--- a/packages/test/local-server-tests/src/test/pendingStateHistoryValidation.spec.ts
+++ b/packages/test/local-server-tests/src/test/pendingStateHistoryValidation.spec.ts
@@ -1,0 +1,135 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "node:assert";
+
+import {
+	asLegacyAlpha,
+	createDetachedContainer,
+	loadExistingContainer,
+} from "@fluidframework/container-loader/internal";
+import type { IErrorBase } from "@fluidframework/core-interfaces/internal";
+import { Deferred } from "@fluidframework/core-utils/internal";
+import type {
+	IDocumentDeltaStorageService,
+	IDocumentService,
+	IDocumentServiceFactory,
+	ISequencedDocumentMessage,
+	IStream,
+} from "@fluidframework/driver-definitions/internal";
+import type { ISharedMap } from "@fluidframework/map/internal";
+import { LocalDeltaConnectionServer } from "@fluidframework/server-local-server";
+import {
+	getRequiredPendingLocalState,
+	type ITestFluidObject,
+	timeoutAwait,
+	timeoutPromise,
+} from "@fluidframework/test-utils/internal";
+
+import { createLoader } from "./utils.js";
+
+function delayMismatchedAnchor(
+	inner: IDocumentServiceFactory,
+	anchorSequenceNumber: number,
+	validationStarted: Deferred<void>,
+	releaseValidation: Deferred<void>,
+): IDocumentServiceFactory {
+	const wrapService = (service: IDocumentService): IDocumentService =>
+		new Proxy(service, {
+			get: (target, property, receiver) => {
+				if (property !== "connectToDeltaStorage") {
+					return Reflect.get(target, property, receiver) as unknown;
+				}
+				return async (): Promise<IDocumentDeltaStorageService> => {
+					const storage = await target.connectToDeltaStorage();
+					return {
+						fetchMessages: (...args): IStream<ISequencedDocumentMessage[]> => {
+							const stream = storage.fetchMessages(...args);
+							let firstRead = true;
+							return {
+								read: async () => {
+									const result = await stream.read();
+									if (!firstRead || result.done) {
+										return result;
+									}
+									firstRead = false;
+									assert.strictEqual(result.value[0]?.sequenceNumber, anchorSequenceNumber);
+									validationStarted.resolve();
+									await releaseValidation.promise;
+									return {
+										done: false,
+										value: [{ ...result.value[0], clientId: "restored-history-client" }],
+									};
+								},
+							};
+						},
+					};
+				};
+			},
+		});
+
+	return {
+		createContainer: async (...args) => wrapService(await inner.createContainer(...args)),
+		createDocumentService: async (...args) =>
+			wrapService(await inner.createDocumentService(...args)),
+	};
+}
+
+describe("Pending-state history validation", () => {
+	it("returns before validation completes and closes on a delayed mismatch", async () => {
+		const deltaConnectionServer = LocalDeltaConnectionServer.create();
+		const { codeDetails, loaderProps, urlResolver, codeLoader, documentServiceFactory } =
+			createLoader({ deltaConnectionServer });
+		const container = asLegacyAlpha(
+			await createDetachedContainer({ codeDetails, ...loaderProps }),
+		);
+		const entryPoint = (await container.getEntryPoint()) as ITestFluidObject;
+		const map = await entryPoint.getSharedObject<ISharedMap>("map");
+		map.set("before-attach", "value");
+		await container.attach(urlResolver.createCreateNewRequest("pending-history-validation"));
+		map.set("saved", "value");
+		if (container.isDirty) {
+			await timeoutPromise((resolve) => container.once("saved", () => resolve()));
+		}
+
+		const url = await container.getAbsoluteUrl("");
+		assert(url !== undefined, "Expected the attached container to have a URL");
+		container.disconnect();
+		const pendingLocalState = await getRequiredPendingLocalState(container);
+		container.close();
+
+		const pendingState = JSON.parse(pendingLocalState) as {
+			savedOps: ISequencedDocumentMessage[];
+		};
+		const anchor = pendingState.savedOps.at(-1);
+		assert(anchor !== undefined, "Expected pending state to contain a saved-op anchor");
+
+		const validationStarted = new Deferred<void>();
+		const releaseValidation = new Deferred<void>();
+		const loadP = loadExistingContainer({
+			codeLoader,
+			documentServiceFactory: delayMismatchedAnchor(
+				documentServiceFactory,
+				anchor.sequenceNumber,
+				validationStarted,
+				releaseValidation,
+			),
+			urlResolver,
+			request: { url },
+			pendingLocalState,
+		});
+
+		await timeoutAwait(validationStarted.promise);
+		const rehydrated = await timeoutAwait(loadP);
+		const closedP = new Promise<IErrorBase | undefined>((resolve) =>
+			rehydrated.once("closed", (error) => resolve(error)),
+		);
+		releaseValidation.resolve();
+
+		const error = await timeoutAwait(closedP);
+		assert.match(error?.message ?? "", /same sequenceNumber but different payloads/);
+		assert.strictEqual(rehydrated.closed, true);
+	});
+});

--- a/packages/test/local-server-tests/src/test/pendingStateHistoryValidation.spec.ts
+++ b/packages/test/local-server-tests/src/test/pendingStateHistoryValidation.spec.ts
@@ -10,6 +10,7 @@ import {
 	createDetachedContainer,
 	loadExistingContainer,
 } from "@fluidframework/container-loader/internal";
+import { LoaderHeader } from "@fluidframework/container-definitions/internal";
 import type { IErrorBase } from "@fluidframework/core-interfaces/internal";
 import { Deferred } from "@fluidframework/core-utils/internal";
 import type {
@@ -139,6 +140,41 @@ describe("Pending-state history validation", () => {
 		const closedP = new Promise<IErrorBase | undefined>((resolve) =>
 			rehydrated.once("closed", (closeError) => resolve(closeError)),
 		);
+		releaseValidation.resolve();
+
+		const error = await timeoutAwait(closedP);
+		assert.match(error?.message ?? "", /same sequenceNumber but different payloads/);
+		assert.strictEqual(rehydrated.closed, true);
+	});
+
+	it("validates pending state after a deferred connection", async () => {
+		const { codeLoader, documentServiceFactory, urlResolver, url, pendingLocalState, anchor } =
+			await createPendingState();
+		const validationStarted = new Deferred<void>();
+		const releaseValidation = new Deferred<void>();
+		const rehydrated = await timeoutAwait(
+			loadExistingContainer({
+				codeLoader,
+				documentServiceFactory: delayMismatchedAnchor(
+					documentServiceFactory,
+					anchor.sequenceNumber,
+					validationStarted,
+					releaseValidation,
+				),
+				urlResolver,
+				request: {
+					url,
+					headers: { [LoaderHeader.loadMode]: { deltaConnection: "none" } },
+				},
+				pendingLocalState,
+			}),
+		);
+		const closedP = new Promise<IErrorBase | undefined>((resolve) =>
+			rehydrated.once("closed", (closeError) => resolve(closeError)),
+		);
+
+		rehydrated.connect();
+		await timeoutAwait(validationStarted.promise);
 		releaseValidation.resolve();
 
 		const error = await timeoutAwait(closedP);

--- a/packages/test/local-server-tests/src/test/pendingStateHistoryValidation.spec.ts
+++ b/packages/test/local-server-tests/src/test/pendingStateHistoryValidation.spec.ts
@@ -124,7 +124,7 @@ describe("Pending-state history validation", () => {
 		await timeoutAwait(validationStarted.promise);
 		const rehydrated = await timeoutAwait(loadP);
 		const closedP = new Promise<IErrorBase | undefined>((resolve) =>
-			rehydrated.once("closed", (error) => resolve(error)),
+			rehydrated.once("closed", (closeError) => resolve(closeError)),
 		);
 		releaseValidation.resolve();
 

--- a/packages/test/local-server-tests/src/test/pendingStateHistoryValidation.spec.ts
+++ b/packages/test/local-server-tests/src/test/pendingStateHistoryValidation.spec.ts
@@ -77,34 +77,47 @@ function delayMismatchedAnchor(
 	};
 }
 
+async function createPendingState(): Promise<{
+	codeLoader: Parameters<typeof loadExistingContainer>[0]["codeLoader"];
+	documentServiceFactory: IDocumentServiceFactory;
+	urlResolver: Parameters<typeof loadExistingContainer>[0]["urlResolver"];
+	url: string;
+	pendingLocalState: string;
+	anchor: ISequencedDocumentMessage;
+}> {
+	const deltaConnectionServer = LocalDeltaConnectionServer.create();
+	const { codeDetails, loaderProps, urlResolver, codeLoader, documentServiceFactory } =
+		createLoader({ deltaConnectionServer });
+	const container = asLegacyAlpha(
+		await createDetachedContainer({ codeDetails, ...loaderProps }),
+	);
+	const entryPoint = (await container.getEntryPoint()) as ITestFluidObject;
+	const map = await entryPoint.getSharedObject<ISharedMap>("map");
+	map.set("before-attach", "value");
+	await container.attach(urlResolver.createCreateNewRequest("pending-history-validation"));
+	map.set("saved", "value");
+	if (container.isDirty) {
+		await timeoutPromise((resolve) => container.once("saved", () => resolve()));
+	}
+
+	const url = await container.getAbsoluteUrl("");
+	assert(url !== undefined, "Expected the attached container to have a URL");
+	container.disconnect();
+	const pendingLocalState = await getRequiredPendingLocalState(container);
+	container.close();
+
+	const pendingState = JSON.parse(pendingLocalState) as {
+		savedOps: ISequencedDocumentMessage[];
+	};
+	const anchor = pendingState.savedOps.at(-1);
+	assert(anchor !== undefined, "Expected pending state to contain a saved-op anchor");
+	return { codeLoader, documentServiceFactory, urlResolver, url, pendingLocalState, anchor };
+}
+
 describe("Pending-state history validation", () => {
 	it("returns before validation completes and closes on a delayed mismatch", async () => {
-		const deltaConnectionServer = LocalDeltaConnectionServer.create();
-		const { codeDetails, loaderProps, urlResolver, codeLoader, documentServiceFactory } =
-			createLoader({ deltaConnectionServer });
-		const container = asLegacyAlpha(
-			await createDetachedContainer({ codeDetails, ...loaderProps }),
-		);
-		const entryPoint = (await container.getEntryPoint()) as ITestFluidObject;
-		const map = await entryPoint.getSharedObject<ISharedMap>("map");
-		map.set("before-attach", "value");
-		await container.attach(urlResolver.createCreateNewRequest("pending-history-validation"));
-		map.set("saved", "value");
-		if (container.isDirty) {
-			await timeoutPromise((resolve) => container.once("saved", () => resolve()));
-		}
-
-		const url = await container.getAbsoluteUrl("");
-		assert(url !== undefined, "Expected the attached container to have a URL");
-		container.disconnect();
-		const pendingLocalState = await getRequiredPendingLocalState(container);
-		container.close();
-
-		const pendingState = JSON.parse(pendingLocalState) as {
-			savedOps: ISequencedDocumentMessage[];
-		};
-		const anchor = pendingState.savedOps.at(-1);
-		assert(anchor !== undefined, "Expected pending state to contain a saved-op anchor");
+		const { codeLoader, documentServiceFactory, urlResolver, url, pendingLocalState, anchor } =
+			await createPendingState();
 
 		const validationStarted = new Deferred<void>();
 		const releaseValidation = new Deferred<void>();
@@ -131,5 +144,41 @@ describe("Pending-state history validation", () => {
 		const error = await timeoutAwait(closedP);
 		assert.match(error?.message ?? "", /same sequenceNumber but different payloads/);
 		assert.strictEqual(rehydrated.closed, true);
+	});
+
+	it("rejects an invalid saved-op MSN without an unhandled rejection", async () => {
+		const { codeLoader, documentServiceFactory, urlResolver, url, pendingLocalState } =
+			await createPendingState();
+		const pendingState = JSON.parse(pendingLocalState) as {
+			savedOps: ISequencedDocumentMessage[];
+		};
+		const anchor = pendingState.savedOps.at(-1);
+		assert(anchor !== undefined, "Expected pending state to contain a saved-op anchor");
+		anchor.minimumSequenceNumber = -2;
+
+		const unhandledRejections: unknown[] = [];
+		const rejectionHandler = (reason: unknown): void => {
+			unhandledRejections.push(reason);
+		};
+		process.on("unhandledRejection", rejectionHandler);
+		try {
+			await assert.rejects(
+				timeoutAwait(
+					loadExistingContainer({
+						codeLoader,
+						documentServiceFactory,
+						urlResolver,
+						request: { url },
+						pendingLocalState: JSON.stringify(pendingState),
+					}),
+				),
+				/The last processed message's minimum sequence number is below the snapshot minimum sequence number/,
+			);
+			await new Promise<void>((resolve) => setImmediate(resolve));
+
+			assert.deepStrictEqual(unhandledRejections, []);
+		} finally {
+			process.off("unhandledRejection", rejectionHandler);
+		}
 	});
 });

--- a/packages/test/local-server-tests/src/test/pendingStateHistoryValidation.spec.ts
+++ b/packages/test/local-server-tests/src/test/pendingStateHistoryValidation.spec.ts
@@ -27,6 +27,8 @@ import {
 	type ITestFluidObject,
 	timeoutAwait,
 	timeoutPromise,
+	toIDeltaManagerFull,
+	waitForContainerConnection,
 } from "@fluidframework/test-utils/internal";
 
 import { createLoader } from "./utils.js";
@@ -41,8 +43,8 @@ import { createLoader } from "./utils.js";
  * @param releaseValidation - The intercepted read waits for this to resolve.
  * @param validationCompleted - Optionally resolved when the stream that returned the anchor ends.
  * This signals storage completion, not successful validation or container connection.
- * @param introduceMismatch - If true, changes only the returned anchor's client ID to simulate
- * overwritten history. If false, returns the service response unchanged.
+ * @param anchorBehavior - Preserves the response, changes the anchor's client ID to simulate
+ * overwritten history, or omits the anchor to simulate history retention.
  */
 function wrapAnchorValidation(
 	inner: IDocumentServiceFactory,
@@ -50,7 +52,7 @@ function wrapAnchorValidation(
 	validationStarted: Deferred<void>,
 	releaseValidation: Deferred<void>,
 	validationCompleted?: Deferred<void>,
-	introduceMismatch = true,
+	anchorBehavior: "preserve" | "change" | "omit" = "change",
 ): IDocumentServiceFactory {
 	// Shared across streams so only one read is intercepted, even if catch-up starts more fetches.
 	let anchorObserved = false;
@@ -82,8 +84,14 @@ function wrapAnchorValidation(
 				validatingFetch = true;
 				validationStarted.resolve();
 				await releaseValidation.promise;
-				if (!introduceMismatch) {
+				if (anchorBehavior === "preserve") {
 					return result;
+				}
+				if (anchorBehavior === "omit") {
+					return {
+						done: false,
+						value: result.value.filter((_, index) => index !== anchorIndex),
+					};
 				}
 				return {
 					done: false,
@@ -171,6 +179,152 @@ async function createPendingState(): Promise<{
 }
 
 describe("Pending-state history validation", () => {
+	for (const scenario of [
+		"match",
+		"mismatch",
+		"unavailable",
+		"reconnect",
+		"host-pause",
+	] as const) {
+		it(`holds host edits during blocked anchor validation: ${scenario}`, async () => {
+			const {
+				codeLoader,
+				documentServiceFactory,
+				urlResolver,
+				url,
+				pendingLocalState,
+				anchor,
+			} = await createPendingState();
+			const observer = await loadExistingContainer({
+				codeLoader,
+				documentServiceFactory,
+				urlResolver,
+				request: { url },
+			});
+			const validationStarted = new Deferred<void>();
+			const releaseValidation = new Deferred<void>();
+			const validationCompleted = new Deferred<void>();
+			const loadP = loadExistingContainer({
+				codeLoader,
+				documentServiceFactory: wrapAnchorValidation(
+					documentServiceFactory,
+					anchor.sequenceNumber,
+					validationStarted,
+					releaseValidation,
+					validationCompleted,
+					scenario === "mismatch"
+						? "change"
+						: scenario === "unavailable"
+							? "omit"
+							: "preserve",
+				),
+				urlResolver,
+				request: { url },
+				pendingLocalState,
+			});
+			await timeoutAwait(validationStarted.promise);
+			const rehydrated = asLegacyAlpha(await timeoutAwait(loadP));
+			const outbound = toIDeltaManagerFull(rehydrated.deltaManager).outbound;
+			try {
+				const entryPoint = (await rehydrated.getEntryPoint()) as ITestFluidObject;
+				const map = await entryPoint.getSharedObject<ISharedMap>("map");
+				const observerEntryPoint = (await observer.getEntryPoint()) as ITestFluidObject;
+				const observerMap = await observerEntryPoint.getSharedObject<ISharedMap>("map");
+				const observedEdit = new Deferred<void>();
+				const key = "edit-before-validation";
+				observerMap.on("valueChanged", (changed) => {
+					if (changed.key === key) {
+						observedEdit.resolve();
+					}
+				});
+				const closed = new Deferred<IErrorBase | undefined>();
+				rehydrated.once("closed", (error) => closed.resolve(error));
+
+				await waitForContainerConnection(rehydrated);
+				const queuedEdit = new Deferred<void>();
+				outbound.once("push", () => queuedEdit.resolve());
+				map.set(key, "host-value");
+				assert.strictEqual(rehydrated.isDirty, true);
+				const capturedState = await getRequiredPendingLocalState(rehydrated);
+				await timeoutAwait(queuedEdit.promise);
+
+				if (scenario === "reconnect") {
+					rehydrated.disconnect();
+					rehydrated.connect();
+					await waitForContainerConnection(rehydrated);
+				}
+				// Prove socket traffic progresses independently of the storage gate. The host
+				// edit has been queued, but must not reach the service even across reconnect.
+				const receivedBarrier = new Deferred<void>();
+				map.on("valueChanged", (changed) => {
+					if (changed.key === "inbound-barrier") {
+						receivedBarrier.resolve();
+					}
+				});
+				observerMap.set("inbound-barrier", true);
+				await timeoutAwait(receivedBarrier.promise);
+				assert.strictEqual(outbound.paused, true);
+				assert(outbound.length > 0);
+				assert.strictEqual(observerMap.has(key), false);
+				assert.strictEqual(rehydrated.isDirty, true);
+				assert.strictEqual(rehydrated.closed, false);
+				if (scenario === "host-pause") {
+					await outbound.pause();
+				}
+				releaseValidation.resolve();
+
+				if (scenario === "mismatch") {
+					const error = await timeoutAwait(closed.promise);
+					assert.strictEqual(error?.errorType, "fileOverwrittenInStorage");
+					assert.strictEqual(rehydrated.closed, true);
+					await assert.rejects(
+						rehydrated.getPendingLocalState(),
+						/Pending state cannot be retried if the container is closed or disposed/,
+					);
+					assert.strictEqual(outbound.length, 0);
+					assert.strictEqual(observerMap.has(key), false);
+				} else {
+					await timeoutAwait(validationCompleted.promise);
+					if (scenario === "host-pause") {
+						assert.strictEqual(outbound.paused, true);
+						assert.strictEqual(observerMap.has(key), false);
+						outbound.resume();
+					}
+					await timeoutAwait(observedEdit.promise);
+					if (rehydrated.isDirty) {
+						await timeoutPromise((resolve) => rehydrated.once("saved", () => resolve()));
+					}
+					assert.strictEqual(rehydrated.closed, false);
+					assert.strictEqual(observerMap.get(key), "host-value");
+				}
+
+				// Only a state capture made before closure is available for offline recovery.
+				// Reload it without a connection so storage cannot supply the edited value.
+				const recovered = await loadExistingContainer({
+					codeLoader,
+					documentServiceFactory,
+					urlResolver,
+					request: {
+						url,
+						headers: { [LoaderHeader.loadMode]: { deltaConnection: "none" } },
+					},
+					pendingLocalState: capturedState,
+				});
+				try {
+					const recoveredEntryPoint = (await recovered.getEntryPoint()) as ITestFluidObject;
+					const recoveredMap = await recoveredEntryPoint.getSharedObject<ISharedMap>("map");
+					assert.strictEqual(recoveredMap.get(key), "host-value");
+				} finally {
+					recovered.close();
+				}
+			} finally {
+				releaseValidation.resolve();
+				rehydrated.close();
+				observer.close();
+			}
+		});
+	}
+
 	it("remains usable after re-stashing offline state and validating unchanged service history", async () => {
 		const { codeLoader, documentServiceFactory, urlResolver, url, pendingLocalState, anchor } =
 			await createPendingState();
@@ -202,7 +356,7 @@ describe("Pending-state history validation", () => {
 					validationStarted,
 					releaseValidation,
 					validationCompleted,
-					false,
+					"preserve",
 				),
 				urlResolver,
 				request: {

--- a/packages/test/local-server-tests/src/test/pendingStateHistoryValidation.spec.ts
+++ b/packages/test/local-server-tests/src/test/pendingStateHistoryValidation.spec.ts
@@ -37,8 +37,9 @@ function wrapAnchorValidation(
 	validationStarted: Deferred<void>,
 	releaseValidation: Deferred<void>,
 	validationCompleted?: Deferred<void>,
-	matchingAnchor?: ISequencedDocumentMessage,
+	introduceMismatch = true,
 ): IDocumentServiceFactory {
+	let anchorObserved = false;
 	const wrapService = (service: IDocumentService): IDocumentService =>
 		new Proxy(service, {
 			get: (target, property, receiver) => {
@@ -50,31 +51,36 @@ function wrapAnchorValidation(
 					return {
 						fetchMessages: (...args): IStream<ISequencedDocumentMessage[]> => {
 							const stream = storage.fetchMessages(...args);
-							let firstRead = true;
+							let validatingFetch = false;
 							return {
 								read: async () => {
 									const result = await stream.read();
-									if (!firstRead || result.done) {
-										if (result.done) {
+									if (result.done) {
+										if (validatingFetch) {
 											validationCompleted?.resolve();
 										}
 										return result;
 									}
-									firstRead = false;
+									const anchorIndex = result.value.findIndex(
+										(message) => message.sequenceNumber === anchorSequenceNumber,
+									);
+									if (anchorObserved || anchorIndex === -1) {
+										return result;
+									}
+									anchorObserved = true;
+									validatingFetch = true;
 									validationStarted.resolve();
 									await releaseValidation.promise;
-									if (matchingAnchor !== undefined) {
-										return { done: false, value: [matchingAnchor] };
+									if (!introduceMismatch) {
+										return result;
 									}
-									assert.strictEqual(result.value[0]?.sequenceNumber, anchorSequenceNumber);
 									return {
 										done: false,
-										value: [
-											{
-												...result.value[0],
-												clientId: "restored-history-client",
-											},
-										],
+										value: result.value.map((message, index) =>
+											index === anchorIndex
+												? { ...message, clientId: "restored-history-client" }
+												: message,
+										),
 									};
 								},
 							};
@@ -129,9 +135,24 @@ async function createPendingState(): Promise<{
 }
 
 describe("Pending-state history validation", () => {
-	it("remains usable after validating unchanged pending state", async () => {
+	it("remains usable after re-stashing offline state and validating unchanged service history", async () => {
 		const { codeLoader, documentServiceFactory, urlResolver, url, pendingLocalState, anchor } =
 			await createPendingState();
+		const offline = asLegacyAlpha(
+			await loadExistingContainer({
+				codeLoader,
+				documentServiceFactory,
+				urlResolver,
+				request: {
+					url,
+					headers: { [LoaderHeader.loadMode]: { deltaConnection: "none" } },
+				},
+				pendingLocalState,
+			}),
+		);
+		// Re-stashing preserves the loader's savedOp replay marker, which is absent in storage.
+		const restashedState = await getRequiredPendingLocalState(offline);
+		offline.close();
 		const validationStarted = new Deferred<void>();
 		const releaseValidation = new Deferred<void>();
 		const validationCompleted = new Deferred<void>();
@@ -145,14 +166,14 @@ describe("Pending-state history validation", () => {
 					validationStarted,
 					releaseValidation,
 					validationCompleted,
-					anchor,
+					false,
 				),
 				urlResolver,
 				request: {
 					url,
 					headers: { [LoaderHeader.loadMode]: { deltaConnection: "none" } },
 				},
-				pendingLocalState,
+				pendingLocalState: restashedState,
 			}),
 		);
 
@@ -170,6 +191,9 @@ describe("Pending-state history validation", () => {
 		const entryPoint = (await rehydrated.getEntryPoint()) as ITestFluidObject;
 		const map = await entryPoint.getSharedObject<ISharedMap>("map");
 		map.set("after-validation", "value");
+		if (rehydrated.isDirty) {
+			await timeoutPromise((resolve) => rehydrated.once("saved", () => resolve()));
+		}
 		assert.strictEqual(map.get("after-validation"), "value");
 		assert.strictEqual(rehydrated.closed, false);
 		rehydrated.close();

--- a/packages/test/local-server-tests/src/test/pendingStateHistoryValidation.spec.ts
+++ b/packages/test/local-server-tests/src/test/pendingStateHistoryValidation.spec.ts
@@ -31,6 +31,19 @@ import {
 
 import { createLoader } from "./utils.js";
 
+/**
+ * Intercepts the first storage response containing the saved-op anchor so tests can control
+ * when history validation proceeds. Other messages, later fetches, and socket traffic pass through.
+ *
+ * @param inner - Factory backed by the real local service.
+ * @param anchorSequenceNumber - Sequence number of the final op in the saved pending state.
+ * @param validationStarted - Resolved when a storage read finds the anchor, before returning it.
+ * @param releaseValidation - The intercepted read waits for this to resolve.
+ * @param validationCompleted - Optionally resolved when the stream that returned the anchor ends.
+ * This signals storage completion, not successful validation or container connection.
+ * @param introduceMismatch - If true, changes only the returned anchor's client ID to simulate
+ * overwritten history. If false, returns the service response unchanged.
+ */
 function wrapAnchorValidation(
 	inner: IDocumentServiceFactory,
 	anchorSequenceNumber: number,
@@ -39,54 +52,69 @@ function wrapAnchorValidation(
 	validationCompleted?: Deferred<void>,
 	introduceMismatch = true,
 ): IDocumentServiceFactory {
+	// Shared across streams so only one read is intercepted, even if catch-up starts more fetches.
 	let anchorObserved = false;
+
+	/**
+	 * Delays the anchor-bearing response and optionally changes that anchor without dropping
+	 * other ops. Completion belongs to this stream, not to unrelated concurrent fetches.
+	 */
+	function wrapStream(
+		stream: IStream<ISequencedDocumentMessage[]>,
+	): IStream<ISequencedDocumentMessage[]> {
+		let validatingFetch = false;
+		return {
+			read: async () => {
+				const result = await stream.read();
+				if (result.done) {
+					if (validatingFetch) {
+						validationCompleted?.resolve();
+					}
+					return result;
+				}
+				const anchorIndex = result.value.findIndex(
+					(message) => message.sequenceNumber === anchorSequenceNumber,
+				);
+				if (anchorObserved || anchorIndex === -1) {
+					return result;
+				}
+				anchorObserved = true;
+				validatingFetch = true;
+				validationStarted.resolve();
+				await releaseValidation.promise;
+				if (!introduceMismatch) {
+					return result;
+				}
+				return {
+					done: false,
+					value: result.value.map((message, index) =>
+						index === anchorIndex
+							? { ...message, clientId: "restored-history-client" }
+							: message,
+					),
+				};
+			},
+		};
+	}
+
+	/** Wraps storage fetch streams while preserving their requested ranges and abort signals. */
+	async function connectToDeltaStorage(
+		service: IDocumentService,
+	): Promise<IDocumentDeltaStorageService> {
+		const storage = await service.connectToDeltaStorage();
+		return {
+			fetchMessages: (...args) => wrapStream(storage.fetchMessages(...args)),
+		};
+	}
+
+	/** Overrides only delta storage access; all other service operations remain unchanged. */
 	const wrapService = (service: IDocumentService): IDocumentService =>
 		new Proxy(service, {
 			get: (target, property, receiver) => {
 				if (property !== "connectToDeltaStorage") {
 					return Reflect.get(target, property, receiver) as unknown;
 				}
-				return async (): Promise<IDocumentDeltaStorageService> => {
-					const storage = await target.connectToDeltaStorage();
-					return {
-						fetchMessages: (...args): IStream<ISequencedDocumentMessage[]> => {
-							const stream = storage.fetchMessages(...args);
-							let validatingFetch = false;
-							return {
-								read: async () => {
-									const result = await stream.read();
-									if (result.done) {
-										if (validatingFetch) {
-											validationCompleted?.resolve();
-										}
-										return result;
-									}
-									const anchorIndex = result.value.findIndex(
-										(message) => message.sequenceNumber === anchorSequenceNumber,
-									);
-									if (anchorObserved || anchorIndex === -1) {
-										return result;
-									}
-									anchorObserved = true;
-									validatingFetch = true;
-									validationStarted.resolve();
-									await releaseValidation.promise;
-									if (!introduceMismatch) {
-										return result;
-									}
-									return {
-										done: false,
-										value: result.value.map((message, index) =>
-											index === anchorIndex
-												? { ...message, clientId: "restored-history-client" }
-												: message,
-										),
-									};
-								},
-							};
-						},
-					};
-				};
+				return async () => connectToDeltaStorage(target);
 			},
 		});
 
@@ -97,6 +125,14 @@ function wrapAnchorValidation(
 	};
 }
 
+/**
+ * Creates a local container, waits for an edit to be saved, then disconnects and captures its
+ * pending state before closing it. The saved ops include an anchor backed by unchanged service
+ * history, which tests can compare directly or deliberately corrupt in intercepted responses.
+ *
+ * @returns The serialized pending state, its final saved-op anchor, and the URL and loader
+ * dependencies needed to rehydrate the same document against the existing local service.
+ */
 async function createPendingState(): Promise<{
 	codeLoader: Parameters<typeof loadExistingContainer>[0]["codeLoader"];
 	documentServiceFactory: IDocumentServiceFactory;

--- a/packages/test/local-server-tests/src/test/pendingStateHistoryValidation.spec.ts
+++ b/packages/test/local-server-tests/src/test/pendingStateHistoryValidation.spec.ts
@@ -31,11 +31,13 @@ import {
 
 import { createLoader } from "./utils.js";
 
-function delayMismatchedAnchor(
+function wrapAnchorValidation(
 	inner: IDocumentServiceFactory,
 	anchorSequenceNumber: number,
 	validationStarted: Deferred<void>,
 	releaseValidation: Deferred<void>,
+	validationCompleted?: Deferred<void>,
+	matchingAnchor?: ISequencedDocumentMessage,
 ): IDocumentServiceFactory {
 	const wrapService = (service: IDocumentService): IDocumentService =>
 		new Proxy(service, {
@@ -53,15 +55,26 @@ function delayMismatchedAnchor(
 								read: async () => {
 									const result = await stream.read();
 									if (!firstRead || result.done) {
+										if (result.done) {
+											validationCompleted?.resolve();
+										}
 										return result;
 									}
 									firstRead = false;
-									assert.strictEqual(result.value[0]?.sequenceNumber, anchorSequenceNumber);
 									validationStarted.resolve();
 									await releaseValidation.promise;
+									if (matchingAnchor !== undefined) {
+										return { done: false, value: [matchingAnchor] };
+									}
+									assert.strictEqual(result.value[0]?.sequenceNumber, anchorSequenceNumber);
 									return {
 										done: false,
-										value: [{ ...result.value[0], clientId: "restored-history-client" }],
+										value: [
+											{
+												...result.value[0],
+												clientId: "restored-history-client",
+											},
+										],
 									};
 								},
 							};
@@ -116,6 +129,52 @@ async function createPendingState(): Promise<{
 }
 
 describe("Pending-state history validation", () => {
+	it("remains usable after validating unchanged pending state", async () => {
+		const { codeLoader, documentServiceFactory, urlResolver, url, pendingLocalState, anchor } =
+			await createPendingState();
+		const validationStarted = new Deferred<void>();
+		const releaseValidation = new Deferred<void>();
+		const validationCompleted = new Deferred<void>();
+		releaseValidation.resolve();
+		const rehydrated = await timeoutAwait(
+			loadExistingContainer({
+				codeLoader,
+				documentServiceFactory: wrapAnchorValidation(
+					documentServiceFactory,
+					anchor.sequenceNumber,
+					validationStarted,
+					releaseValidation,
+					validationCompleted,
+					anchor,
+				),
+				urlResolver,
+				request: {
+					url,
+					headers: { [LoaderHeader.loadMode]: { deltaConnection: "none" } },
+				},
+				pendingLocalState,
+			}),
+		);
+
+		const connectedP = new Promise<void>((resolve) =>
+			rehydrated.once("connected", () => resolve()),
+		);
+		let closeError: IErrorBase | undefined;
+		rehydrated.once("closed", (error) => {
+			closeError = error;
+		});
+		rehydrated.connect();
+		await Promise.all([timeoutAwait(validationCompleted.promise), timeoutAwait(connectedP)]);
+		await new Promise<void>((resolve) => setImmediate(resolve));
+		assert.strictEqual(rehydrated.closed, false, closeError?.message);
+		const entryPoint = (await rehydrated.getEntryPoint()) as ITestFluidObject;
+		const map = await entryPoint.getSharedObject<ISharedMap>("map");
+		map.set("after-validation", "value");
+		assert.strictEqual(map.get("after-validation"), "value");
+		assert.strictEqual(rehydrated.closed, false);
+		rehydrated.close();
+	});
+
 	it("returns before validation completes and closes on a delayed mismatch", async () => {
 		const { codeLoader, documentServiceFactory, urlResolver, url, pendingLocalState, anchor } =
 			await createPendingState();
@@ -124,7 +183,7 @@ describe("Pending-state history validation", () => {
 		const releaseValidation = new Deferred<void>();
 		const loadP = loadExistingContainer({
 			codeLoader,
-			documentServiceFactory: delayMismatchedAnchor(
+			documentServiceFactory: wrapAnchorValidation(
 				documentServiceFactory,
 				anchor.sequenceNumber,
 				validationStarted,
@@ -155,7 +214,7 @@ describe("Pending-state history validation", () => {
 		const rehydrated = await timeoutAwait(
 			loadExistingContainer({
 				codeLoader,
-				documentServiceFactory: delayMismatchedAnchor(
+				documentServiceFactory: wrapAnchorValidation(
 					documentServiceFactory,
 					anchor.sequenceNumber,
 					validationStarted,


### PR DESCRIPTION
## Description

Pending-state rehydration previously restored the last processed sequence number but discarded the corresponding saved message and its minimum sequence number. As a result, it could not use DeltaManager's existing overwritten-history validation and only validated future minimum sequence numbers against the older base snapshot.

Pass the last saved op into DeltaManager so it:

- re-fetches and compares that op with service history while independently holding outbound submissions;
- rejects a later op whose minimum sequence number moves backward; and
- includes the raw service checkpoint as diagnostic context only when either anomaly occurs.

This replaces the standalone checkpoint-regression telemetry because service checkpoints may legitimately lag and therefore are not independently actionable. The overlap validation remains deliberately asynchronous: pending-state rehydration does not wait for network access, and local editing and inbound processing can continue while outbound submissions are held.

### Validation policy and accepted limitation

This is a best-effort overwrite detector at the final saved-op boundary, not proof of identity for the complete service history:

- **Matching anchor:** release the validation-owned outbound pause and resume submissions.
- **Conflicting anchor:** close with `fileOverwrittenInStorage` without sending queued edits.
- **Anchor remains unvalidated after a completed non-cache fetch and buffered-op processing:** emit `PendingStateAnchorNotValidated`, release the validation-owned pause, and continue catch-up and submissions under an availability-first policy. Fetch errors do not take this continuation path.

An unavailable anchor is not proof that retention removed it or that history is unchanged. This policy intentionally accepts the residual risk that forward-divergent replacement history whose anchor is also unavailable may go undetected. Minimum-sequence-number, sequence-continuity, and client-sequence checks remain active, but do not establish history identity. Failing closed solely because the anchor is unavailable would also reject valid offline resumes; this change deliberately does not impose that stricter requirement.

A host needing pending state for recovery must capture it before closure; post-close capture remains unsupported. No automatic recovery or strict-mode option is introduced.

Tests cover matching and conflicting serialized saved-op anchors, Unicode key ordering, raw checkpoint normalization and connection ordering, malformed saved-op minimum sequence numbers, repeat offline rehydration, and edits during blocked validation. The production-path coverage verifies inbound progress, queued-edit suppression on mismatch, submission after a match or unavailable anchor, reconnects, independent host pauses, and offline recovery from state captured before closure.

[AB#82434](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/82434)

## Reviewer Guidance

The review process is outlined in [the pull request guidelines](../docs/content/Contributing/PR-Guidelines.md#guidelines).

Please focus on using the last persisted op as the rehydration baseline for overlap validation and minimum-sequence-number monotonicity, the independent outbound pause, and the explicitly accepted unavailable-anchor risk described above.