### PR TITLE
Enable noUncheckedIndexedAccess for replay-driver

### DIFF
--- a/packages/drivers/replay-driver/eslint.config.mts
+++ b/packages/drivers/replay-driver/eslint.config.mts
@@ -10,7 +10,6 @@ const config: Linter.Config[] = [
 	...recommended,
 	{
 		rules: {
-			"@fluid-internal/fluid/no-unchecked-record-access": "warn",
 			"@rushstack/no-new-null": "off",
 			"@typescript-eslint/strict-boolean-expressions": "off",
 			"unicorn/no-null": "off",

--- a/packages/drivers/replay-driver/src/replayDocumentDeltaConnection.ts
+++ b/packages/drivers/replay-driver/src/replayDocumentDeltaConnection.ts
@@ -124,12 +124,15 @@ export class ReplayControllerStatic extends ReplayController {
 	): Promise<void> {
 		let current = this.skipToIndex(fetchedOps);
 
-		return new Promise((resolve) => {
+		return new Promise((resolve, reject) => {
 			const replayNextOps = (): void => {
 				// Emit the ops from replay to the end every "deltainterval" milliseconds
 				// to simulate the socket stream
-				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- scheduleNext() only schedules this callback while current < fetchedOps.length
-				const currentOp = fetchedOps[current]!;
+				const currentOp = fetchedOps[current];
+				if (currentOp === undefined) {
+					reject(new Error(`No op found at replay index ${current}`));
+					return;
+				}
 				const playbackOps = [currentOp];
 				let nextInterval = ReplayControllerStatic.DelayInterval;
 				current += 1;
@@ -140,8 +143,11 @@ export class ReplayControllerStatic extends ReplayController {
 						// Emit more ops that is in the ReplayResolution window
 
 						while (current < fetchedOps.length) {
-							// eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- the loop condition guarantees this index is in bounds
-							const op = fetchedOps[current]!;
+							const op = fetchedOps[current];
+							if (op === undefined) {
+								reject(new Error(`No op found at replay index ${current}`));
+								return;
+							}
 							if (op.timestamp === undefined) {
 								// Missing timestamp, just delay the standard amount of time
 								break;

--- a/packages/drivers/replay-driver/src/replayDocumentDeltaConnection.ts
+++ b/packages/drivers/replay-driver/src/replayDocumentDeltaConnection.ts
@@ -123,31 +123,25 @@ export class ReplayControllerStatic extends ReplayController {
 		fetchedOps: ISequencedDocumentMessage[],
 	): Promise<void> {
 		let current = this.skipToIndex(fetchedOps);
+		const remainingOps = fetchedOps.slice(current).values();
+		let nextOp = remainingOps.next();
 
-		return new Promise((resolve, reject) => {
-			const replayNextOps = (): void => {
+		return new Promise((resolve) => {
+			const replayNextOps = (currentOp: ISequencedDocumentMessage): void => {
 				// Emit the ops from replay to the end every "deltainterval" milliseconds
 				// to simulate the socket stream
-				const currentOp = fetchedOps[current];
-				if (currentOp === undefined) {
-					reject(new Error(`No op found at replay index ${current}`));
-					return;
-				}
 				const playbackOps = [currentOp];
 				let nextInterval = ReplayControllerStatic.DelayInterval;
 				current += 1;
+				nextOp = remainingOps.next();
 
 				if (this.unitIsTime === true) {
 					const currentTimeStamp = currentOp.timestamp;
 					if (currentTimeStamp !== undefined) {
 						// Emit more ops that is in the ReplayResolution window
 
-						while (current < fetchedOps.length) {
-							const op = fetchedOps[current];
-							if (op === undefined) {
-								reject(new Error(`No op found at replay index ${current}`));
-								return;
-							}
+						while (!nextOp.done) {
+							const op = nextOp.value;
 							if (op.timestamp === undefined) {
 								// Missing timestamp, just delay the standard amount of time
 								break;
@@ -167,6 +161,7 @@ export class ReplayControllerStatic extends ReplayController {
 							// The op is within the ReplayResolution emit it now
 							playbackOps.push(op);
 							current += 1;
+							nextOp = remainingOps.next();
 						}
 
 						if (
@@ -182,8 +177,9 @@ export class ReplayControllerStatic extends ReplayController {
 				emitter(playbackOps);
 			};
 			const scheduleNext = (nextInterval: number): void => {
-				if (nextInterval >= 0 && current < fetchedOps.length) {
-					setTimeout(replayNextOps, nextInterval);
+				if (nextInterval >= 0 && !nextOp.done) {
+					const opToPlay = nextOp.value;
+					setTimeout(() => replayNextOps(opToPlay), nextInterval);
 				} else {
 					this.replayCurrent += current;
 					resolve();

--- a/packages/drivers/replay-driver/src/replayDocumentDeltaConnection.ts
+++ b/packages/drivers/replay-driver/src/replayDocumentDeltaConnection.ts
@@ -128,7 +128,8 @@ export class ReplayControllerStatic extends ReplayController {
 			const replayNextOps = (): void => {
 				// Emit the ops from replay to the end every "deltainterval" milliseconds
 				// to simulate the socket stream
-				const currentOp = fetchedOps[current];
+				// eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- scheduleNext() only schedules this callback while current < fetchedOps.length
+				const currentOp = fetchedOps[current]!;
 				const playbackOps = [currentOp];
 				let nextInterval = ReplayControllerStatic.DelayInterval;
 				current += 1;
@@ -139,7 +140,8 @@ export class ReplayControllerStatic extends ReplayController {
 						// Emit more ops that is in the ReplayResolution window
 
 						while (current < fetchedOps.length) {
-							const op = fetchedOps[current];
+							// eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- the loop condition guarantees this index is in bounds
+							const op = fetchedOps[current]!;
 							if (op.timestamp === undefined) {
 								// Missing timestamp, just delay the standard amount of time
 								break;
@@ -335,7 +337,11 @@ export class ReplayDocumentDeltaConnection
 
 				const messages = result.value;
 				currentOp += messages.length;
-				done = controller.isDoneFetch(currentOp, messages[messages.length - 1].timestamp);
+				const lastMessage = messages.at(-1);
+				if (lastMessage === undefined) {
+					throw new Error("Delta storage returned an empty batch of messages");
+				}
+				done = controller.isDoneFetch(currentOp, lastMessage.timestamp);
 			} while (!done);
 
 			abortController.abort();

--- a/packages/drivers/replay-driver/src/replayDocumentDeltaConnection.ts
+++ b/packages/drivers/replay-driver/src/replayDocumentDeltaConnection.ts
@@ -123,25 +123,26 @@ export class ReplayControllerStatic extends ReplayController {
 		fetchedOps: ISequencedDocumentMessage[],
 	): Promise<void> {
 		let current = this.skipToIndex(fetchedOps);
-		const remainingOps = fetchedOps.slice(current).values();
-		let nextOp = remainingOps.next();
 
-		return new Promise((resolve) => {
+		return new Promise((resolve, reject) => {
 			const replayNextOps = (currentOp: ISequencedDocumentMessage): void => {
 				// Emit the ops from replay to the end every "deltainterval" milliseconds
 				// to simulate the socket stream
 				const playbackOps = [currentOp];
 				let nextInterval = ReplayControllerStatic.DelayInterval;
 				current += 1;
-				nextOp = remainingOps.next();
 
 				if (this.unitIsTime === true) {
 					const currentTimeStamp = currentOp.timestamp;
 					if (currentTimeStamp !== undefined) {
 						// Emit more ops that is in the ReplayResolution window
 
-						while (!nextOp.done) {
-							const op = nextOp.value;
+						while (current < fetchedOps.length) {
+							const op = fetchedOps[current];
+							if (op === undefined) {
+								reject(new Error(`No op found at replay index ${current}`));
+								return;
+							}
 							if (op.timestamp === undefined) {
 								// Missing timestamp, just delay the standard amount of time
 								break;
@@ -161,7 +162,6 @@ export class ReplayControllerStatic extends ReplayController {
 							// The op is within the ReplayResolution emit it now
 							playbackOps.push(op);
 							current += 1;
-							nextOp = remainingOps.next();
 						}
 
 						if (
@@ -177,13 +177,18 @@ export class ReplayControllerStatic extends ReplayController {
 				emitter(playbackOps);
 			};
 			const scheduleNext = (nextInterval: number): void => {
-				if (nextInterval >= 0 && !nextOp.done) {
-					const opToPlay = nextOp.value;
-					setTimeout(() => replayNextOps(opToPlay), nextInterval);
-				} else {
+				if (nextInterval < 0 || current >= fetchedOps.length) {
 					this.replayCurrent += current;
 					resolve();
+					return;
 				}
+
+				const currentOp = fetchedOps[current];
+				if (currentOp === undefined) {
+					reject(new Error(`No op found at replay index ${current}`));
+					return;
+				}
+				setTimeout(() => replayNextOps(currentOp), nextInterval);
 			};
 			scheduleNext(ReplayControllerStatic.DelayInterval);
 		});

--- a/packages/drivers/replay-driver/src/replayDocumentDeltaConnection.ts
+++ b/packages/drivers/replay-driver/src/replayDocumentDeltaConnection.ts
@@ -124,10 +124,14 @@ export class ReplayControllerStatic extends ReplayController {
 	): Promise<void> {
 		let current = this.skipToIndex(fetchedOps);
 
-		return new Promise((resolve, reject) => {
-			const replayNextOps = (currentOp: ISequencedDocumentMessage): void => {
+		return new Promise((resolve) => {
+			const replayNextOps = (): void => {
 				// Emit the ops from replay to the end every "deltainterval" milliseconds
 				// to simulate the socket stream
+				const currentOp = fetchedOps[current];
+				if (currentOp === undefined) {
+					throw new Error(`No op found at replay index ${current}`);
+				}
 				const playbackOps = [currentOp];
 				let nextInterval = ReplayControllerStatic.DelayInterval;
 				current += 1;
@@ -140,8 +144,7 @@ export class ReplayControllerStatic extends ReplayController {
 						while (current < fetchedOps.length) {
 							const op = fetchedOps[current];
 							if (op === undefined) {
-								reject(new Error(`No op found at replay index ${current}`));
-								return;
+								throw new Error(`No op found at replay index ${current}`);
 							}
 							if (op.timestamp === undefined) {
 								// Missing timestamp, just delay the standard amount of time
@@ -177,18 +180,12 @@ export class ReplayControllerStatic extends ReplayController {
 				emitter(playbackOps);
 			};
 			const scheduleNext = (nextInterval: number): void => {
-				if (nextInterval < 0 || current >= fetchedOps.length) {
+				if (nextInterval >= 0 && current < fetchedOps.length) {
+					setTimeout(replayNextOps, nextInterval);
+				} else {
 					this.replayCurrent += current;
 					resolve();
-					return;
 				}
-
-				const currentOp = fetchedOps[current];
-				if (currentOp === undefined) {
-					reject(new Error(`No op found at replay index ${current}`));
-					return;
-				}
-				setTimeout(() => replayNextOps(currentOp), nextInterval);
 			};
 			scheduleNext(ReplayControllerStatic.DelayInterval);
 		});
@@ -344,7 +341,7 @@ export class ReplayDocumentDeltaConnection
 
 				const messages = result.value;
 				currentOp += messages.length;
-				const lastMessage = messages.at(-1);
+				const lastMessage = messages[messages.length - 1];
 				if (lastMessage === undefined) {
 					throw new Error("Delta storage returned an empty batch of messages");
 				}

--- a/packages/drivers/replay-driver/src/replayDocumentDeltaConnection.ts
+++ b/packages/drivers/replay-driver/src/replayDocumentDeltaConnection.ts
@@ -124,13 +124,14 @@ export class ReplayControllerStatic extends ReplayController {
 	): Promise<void> {
 		let current = this.skipToIndex(fetchedOps);
 
-		return new Promise((resolve) => {
+		return new Promise((resolve, reject) => {
 			const replayNextOps = (): void => {
 				// Emit the ops from replay to the end every "deltainterval" milliseconds
 				// to simulate the socket stream
 				const currentOp = fetchedOps[current];
 				if (currentOp === undefined) {
-					throw new Error(`No op found at replay index ${current}`);
+					reject(new Error(`No op found at replay index ${current}`));
+					return;
 				}
 				const playbackOps = [currentOp];
 				let nextInterval = ReplayControllerStatic.DelayInterval;
@@ -144,7 +145,8 @@ export class ReplayControllerStatic extends ReplayController {
 						while (current < fetchedOps.length) {
 							const op = fetchedOps[current];
 							if (op === undefined) {
-								throw new Error(`No op found at replay index ${current}`);
+								reject(new Error(`No op found at replay index ${current}`));
+								return;
 							}
 							if (op.timestamp === undefined) {
 								// Missing timestamp, just delay the standard amount of time

--- a/packages/drivers/replay-driver/tsconfig.json
+++ b/packages/drivers/replay-driver/tsconfig.json
@@ -5,7 +5,5 @@
 	"compilerOptions": {
 		"rootDir": "./src",
 		"outDir": "./lib",
-		// TODO: AB#34164 Enable noUncheckedIndexedAccess for packages/drivers/replay-driver
-		"noUncheckedIndexedAccess": false,
 	},
 }


### PR DESCRIPTION
## Description

Enables the repository-default `noUncheckedIndexedAccess` TypeScript setting for `@fluidframework/replay-driver` by removing the package-level opt-out.

The replay scheduling logic now distinguishes normal end-of-array completion from an in-range missing operation. Valid operations are narrowed before being passed to the scheduled callback, while sparse or otherwise invalid message arrays fail explicitly instead of being treated as successful completion. The redundant `no-unchecked-record-access` ESLint override is also removed because that rule disables itself when `noUncheckedIndexedAccess` is enabled.
