### PR TITLE
fix(tree): backport improved schema errors to 2.118

### DIFF
--- a/.changeset/improve-tree-schema-errors.md
+++ b/.changeset/improve-tree-schema-errors.md
@@ -1,0 +1,10 @@
+---
+"@fluidframework/tree": minor
+"fluid-framework": minor
+"__section": tree
+---
+SharedTree schema errors now explain the mismatch
+
+Schema validation errors now report the mismatch category and attach relevant diagnostic context. Depending on the mismatch, tagged telemetry properties identify the node type, field kind, child count, expected leaf value type, actual value type, unexpected fields, or path, making invalid content easier to diagnose while allowing consumers to filter potentially sensitive user data.
+
+When a view schema cannot access a document's stored schema, the error now reports the first schema mismatch and explains whether to initialize the document, upgrade its stored schema, use a compatible view schema, or explicitly migrate the document.

--- a/packages/common/core-utils/src/assert.ts
+++ b/packages/common/core-utils/src/assert.ts
@@ -78,6 +78,26 @@ export function fail(message: string | number, debugMessageBuilder?: () => strin
 	failPrivate(message, debugMessageBuilder);
 }
 
+/**
+ * Appends additional diagnostic text in non-production builds.
+ *
+ * @param message - The message to include in all builds.
+ * @param debugMessageBuilder - Builds the additional text to include only in non-production builds.
+ * @returns The message with the additional diagnostic text when non-production conditionals are enabled.
+ *
+ * @internal
+ */
+export function appendDebugMessage(
+	message: string,
+	debugMessageBuilder: () => string,
+): string {
+	let messageWithDebugDetails = message;
+	skipInProduction(() => {
+		messageWithDebugDetails = `${messageWithDebugDetails} ${debugMessageBuilder()}`;
+	});
+	return messageWithDebugDetails;
+}
+
 function onAssertionError(error: Error): void {
 	for (const handler of firstChanceAssertionHandler) {
 		handler(error);

--- a/packages/common/core-utils/src/index.ts
+++ b/packages/common/core-utils/src/index.ts
@@ -5,6 +5,7 @@
 
 export {
 	assert,
+	appendDebugMessage,
 	fail,
 	debugAssert,
 	configureDebugAsserts,

--- a/packages/common/core-utils/src/test/assert.spec.ts
+++ b/packages/common/core-utils/src/test/assert.spec.ts
@@ -6,6 +6,7 @@
 import { strict } from "node:assert";
 
 import {
+	appendDebugMessage,
 	assert,
 	configureDebugAsserts,
 	debugAssert,
@@ -84,6 +85,29 @@ describe("assert", () => {
 			"Error: message",
 		);
 		emulateProductionBuild(false);
+
+		strict.deepEqual(log, []);
+	});
+
+	it("appendDebugMessage", () => {
+		strict.equal(
+			appendDebugMessage("message", () => "details"),
+			"message details",
+		);
+
+		const log: string[] = [];
+		emulateProductionBuild(true);
+		try {
+			strict.equal(
+				appendDebugMessage("message", () => {
+					log.push("built");
+					return "details";
+				}),
+				"message",
+			);
+		} finally {
+			emulateProductionBuild(false);
+		}
 
 		strict.deepEqual(log, []);
 	});

--- a/packages/dds/tree/src/feature-libraries/index.ts
+++ b/packages/dds/tree/src/feature-libraries/index.ts
@@ -155,7 +155,7 @@ export {
 
 export {
 	SchemaValidationError,
-	type SchemaValidationErrorContext,
+	type SchemaValidationErrorDetails,
 	isNodeInSchema,
 	isFieldInSchema,
 	throwOutOfSchema,

--- a/packages/dds/tree/src/feature-libraries/schemaChecker.ts
+++ b/packages/dds/tree/src/feature-libraries/schemaChecker.ts
@@ -3,8 +3,21 @@
  * Licensed under the MIT License.
  */
 
-import { unreachableCase, fail } from "@fluidframework/core-utils/internal";
-import { UsageError } from "@fluidframework/telemetry-utils/internal";
+import {
+	appendDebugMessage,
+	unreachableCase,
+	fail,
+} from "@fluidframework/core-utils/internal";
+import type {
+	ITelemetryBaseProperties,
+	TelemetryBaseEventPropertyType,
+} from "@fluidframework/core-interfaces";
+import {
+	tagCodeArtifacts,
+	tagData,
+	TelemetryDataTag,
+	UsageError,
+} from "@fluidframework/telemetry-utils/internal";
 
 import {
 	type TreeFieldStoredSchema,
@@ -13,6 +26,7 @@ import {
 	MapNodeStoredSchema,
 	Multiplicity,
 	type SchemaAndPolicy,
+	ValueSchema,
 } from "../core/index.js";
 import { iterableHasSome, mapIterable } from "../util/index.js";
 
@@ -33,81 +47,137 @@ export enum SchemaValidationError {
 }
 
 /**
- * Additional context about a schema validation error.
- * @remarks
- * Not all fields are populated for every error type — only those relevant to the specific error.
+ * Information about a schema validation error.
  */
-export interface SchemaValidationErrorContext {
-	/**
-	 * The type identifier of the node that failed validation.
-	 */
-	readonly nodeType?: string;
-	/**
-	 * The set of type identifiers allowed in the field, if applicable.
-	 */
-	readonly allowedTypes?: ReadonlySet<string>;
-	/**
-	 * Field keys on the node that were not recognized by its schema.
-	 */
-	readonly unexpectedFields?: ReadonlySet<string>;
+export interface SchemaValidationErrorDetails {
+	readonly error: SchemaValidationError;
+	readonly path: readonly (string | number)[];
+	readonly telemetryProperties?: ITelemetryBaseProperties;
 }
 
 /**
  * Throws a UsageError indicating a tree is out of schema.
  */
-export function throwOutOfSchema(
-	maybeError: SchemaValidationError,
-	context?: SchemaValidationErrorContext,
-): never {
-	throw new UsageError(formatSchemaValidationError(maybeError, context));
+export function throwOutOfSchema(details: SchemaValidationErrorDetails): never {
+	const message = `Tree does not conform to schema. ${getSchemaValidationErrorMessage(details.error)}`;
+	throw new UsageError(
+		appendDebugMessage(message, () => getSchemaValidationDebugMessage(details)),
+		{
+			...tagCodeArtifacts({
+				schemaValidationError: SchemaValidationError[details.error],
+			}),
+			...tagData(TelemetryDataTag.UserData, {
+				schemaValidationPath: JSON.stringify(details.path),
+			}),
+			...details.telemetryProperties,
+		},
+	);
 }
 
-// Not exported: internal helper used by throwOutOfSchema.
-function formatSchemaValidationError(
-	error: SchemaValidationError,
-	context: SchemaValidationErrorContext | undefined,
-): string {
-	switch (error) {
-		case SchemaValidationError.Field_NodeTypeNotAllowed: {
-			const nodeDesc = context?.nodeType === undefined ? "unknown" : `"${context.nodeType}"`;
-			const allowedDesc =
-				context?.allowedTypes === undefined
-					? "unknown"
-					: `[${[...context.allowedTypes].map((t) => `"${t}"`).join(", ")}]`;
-			return (
-				`Tree does not conform to schema. ` +
-				`A node of type ${nodeDesc} is not allowed in this field. Allowed types: ${allowedDesc}. ` +
-				`If using a staged allowed type, the stored schema has not been upgraded to include this type yet. ` +
-				`Either upgrade the schema to enable the staged type or avoid inserting content of this type until the schema is upgraded.`
-			);
+function getTelemetryProperty(
+	details: SchemaValidationErrorDetails,
+	key: string,
+): TelemetryBaseEventPropertyType {
+	const property = details.telemetryProperties?.[key];
+	return typeof property === "object" ? property.value : property;
+}
+
+function getSchemaValidationDebugMessage(details: SchemaValidationErrorDetails): string {
+	const path = details.path.length === 0 ? "" : ` at path ${JSON.stringify(details.path)}`;
+	const nodeType = getTelemetryProperty(details, "nodeType");
+	const fieldKind = getTelemetryProperty(details, "fieldKind");
+	const childCount = getTelemetryProperty(details, "childCount");
+	switch (details.error) {
+		case SchemaValidationError.Field_KindNotInSchemaPolicy: {
+			return `Field kind ${JSON.stringify(fieldKind)} is not supported by the schema policy${path}.`;
 		}
-		case SchemaValidationError.Node_MissingSchema: {
-			const nodeDesc = context?.nodeType === undefined ? "unknown" : `"${context.nodeType}"`;
-			return (
-				`Tree does not conform to schema. ` +
-				`No schema definition was found for node type ${nodeDesc}. ` +
-				`Ensure the node's type is included in the schema and that the stored schema has been upgraded if needed.`
-			);
+		case SchemaValidationError.Field_MissingRequiredChild: {
+			return `A required field of kind ${JSON.stringify(fieldKind)} must contain exactly one child, but found ${childCount}${path}.`;
+		}
+		case SchemaValidationError.Field_MultipleChildrenNotAllowed: {
+			return `A field of kind ${JSON.stringify(fieldKind)} allows at most one child, but found ${childCount}${path}.`;
+		}
+		case SchemaValidationError.Field_ChildInForbiddenField: {
+			return `A forbidden field of kind ${JSON.stringify(fieldKind)} must be empty, but found ${childCount} ${childCount === 1 ? "child" : "children"}${path}.`;
+		}
+		case SchemaValidationError.Field_NodeTypeNotAllowed: {
+			return `A node of type ${JSON.stringify(nodeType)} is not allowed in this field${path}. Allowed types: ${getTelemetryProperty(details, "allowedTypes")}. If using a staged allowed type, upgrade the stored schema before inserting this content.`;
+		}
+		case SchemaValidationError.LeafNode_InvalidValue: {
+			return `Leaf node ${JSON.stringify(nodeType)} requires a value matching ${JSON.stringify(getTelemetryProperty(details, "expectedValueType"))}, but found ${JSON.stringify(getTelemetryProperty(details, "actualValueType"))}${path}.`;
+		}
+		case SchemaValidationError.LeafNode_FieldsNotAllowed: {
+			return `Leaf node ${JSON.stringify(nodeType)} must not contain fields${path}. Unexpected fields: ${getTelemetryProperty(details, "unexpectedFields")}.`;
 		}
 		case SchemaValidationError.ObjectNode_FieldNotInSchema: {
-			const nodeDesc = context?.nodeType === undefined ? "unknown" : `"${context.nodeType}"`;
-			const fieldsDesc =
-				context?.unexpectedFields === undefined || context.unexpectedFields.size === 0
-					? undefined
-					: `[${[...context.unexpectedFields].map((f) => `"${f}"`).join(", ")}]`;
-			const fieldsPart =
-				fieldsDesc === undefined
-					? "The node has fields that are not defined in its schema."
-					: `Unexpected fields: ${fieldsDesc}.`;
-			return (
-				`Tree does not conform to schema. ` +
-				`A node of type ${nodeDesc} has fields not defined in its schema. ${fieldsPart}`
-			);
+			return `A node of type ${JSON.stringify(nodeType)} has fields not defined in its schema${path}. Unexpected fields: ${getTelemetryProperty(details, "unexpectedFields")}.`;
+		}
+		case SchemaValidationError.NonLeafNode_ValueNotAllowed: {
+			return `Non-leaf node ${JSON.stringify(nodeType)} must not have a value, but found ${JSON.stringify(getTelemetryProperty(details, "actualValueType"))}${path}.`;
+		}
+		case SchemaValidationError.Node_MissingSchema: {
+			return `No schema definition was found for node type ${JSON.stringify(nodeType)}${path}. Ensure the node's type is included in the schema and that the stored schema has been upgraded if needed.`;
 		}
 		default: {
-			return `Tree does not conform to schema: ${SchemaValidationError[error]}.`;
+			return unreachableCase(details.error);
 		}
 	}
+}
+
+function getSchemaValidationErrorMessage(error: SchemaValidationError): string {
+	switch (error) {
+		case SchemaValidationError.Field_KindNotInSchemaPolicy: {
+			return "The field kind is not supported by the schema policy.";
+		}
+		case SchemaValidationError.Field_MissingRequiredChild: {
+			return "A required field is missing its child.";
+		}
+		case SchemaValidationError.Field_MultipleChildrenNotAllowed: {
+			return "A field contains more children than its kind allows.";
+		}
+		case SchemaValidationError.Field_ChildInForbiddenField: {
+			return "A forbidden field contains children.";
+		}
+		case SchemaValidationError.Field_NodeTypeNotAllowed: {
+			return "A node type is not allowed in its field.";
+		}
+		case SchemaValidationError.LeafNode_InvalidValue: {
+			return "A leaf node value does not match its schema.";
+		}
+		case SchemaValidationError.LeafNode_FieldsNotAllowed: {
+			return "A leaf node contains fields.";
+		}
+		case SchemaValidationError.ObjectNode_FieldNotInSchema: {
+			return "An object node contains fields not defined in its schema.";
+		}
+		case SchemaValidationError.NonLeafNode_ValueNotAllowed: {
+			return "A non-leaf node contains a value.";
+		}
+		case SchemaValidationError.Node_MissingSchema: {
+			return "The node type has no schema definition.";
+		}
+		default: {
+			return unreachableCase(error);
+		}
+	}
+}
+
+function schemaValidationError(
+	error: SchemaValidationError,
+	telemetryProperties?: ITelemetryBaseProperties,
+): SchemaValidationErrorDetails {
+	return { error, path: [], telemetryProperties };
+}
+
+function prependPath<T extends NotUndefined>(
+	onError: (details: SchemaValidationErrorDetails) => T,
+	segment: string | number,
+): (details: SchemaValidationErrorDetails) => T {
+	return (details) => onError({ ...details, path: [segment, ...details.path] });
+}
+
+function getValueType(value: unknown): string {
+	return value === null ? "null" : typeof value;
 }
 
 type NotUndefined = number | string | boolean | bigint | symbol | object;
@@ -122,28 +192,52 @@ type NotUndefined = number | string | boolean | bigint | symbol | object;
 export function isNodeInSchema<T extends NotUndefined>(
 	node: MinimalMapTreeNodeView,
 	schemaAndPolicy: SchemaAndPolicy,
-	onError: (error: SchemaValidationError, context?: SchemaValidationErrorContext) => T,
+	onError: (details: SchemaValidationErrorDetails) => T,
 ): T | undefined {
 	// Validate the schema declared by the node exists
 	const schema = schemaAndPolicy.schema.nodeSchema.get(node.type);
 	if (schema === undefined) {
-		return onError(SchemaValidationError.Node_MissingSchema, {
-			nodeType: node.type,
-		});
+		return onError(
+			schemaValidationError(
+				SchemaValidationError.Node_MissingSchema,
+				tagCodeArtifacts({ nodeType: node.type }),
+			),
+		);
 	}
 
 	// Validate the node is well formed according to its schema
 
 	if (schema instanceof LeafNodeStoredSchema) {
 		if (iterableHasSome(node.fields)) {
-			return onError(SchemaValidationError.LeafNode_FieldsNotAllowed);
+			const unexpectedFields = [...mapIterable(node.fields, ([key]) => key)].sort();
+			return onError(
+				schemaValidationError(SchemaValidationError.LeafNode_FieldsNotAllowed, {
+					...tagCodeArtifacts({ nodeType: node.type }),
+					...tagData(TelemetryDataTag.UserData, {
+						unexpectedFields: JSON.stringify(unexpectedFields),
+					}),
+				}),
+			);
 		}
 		if (!allowsValue(schema.leafValue, node.value)) {
-			return onError(SchemaValidationError.LeafNode_InvalidValue);
+			return onError(
+				schemaValidationError(SchemaValidationError.LeafNode_InvalidValue, {
+					...tagCodeArtifacts({
+						nodeType: node.type,
+						expectedValueType: ValueSchema[schema.leafValue],
+					}),
+					actualValueType: getValueType(node.value),
+				}),
+			);
 		}
 	} else {
 		if (node.value !== undefined) {
-			return onError(SchemaValidationError.NonLeafNode_ValueNotAllowed);
+			return onError(
+				schemaValidationError(SchemaValidationError.NonLeafNode_ValueNotAllowed, {
+					...tagCodeArtifacts({ nodeType: node.type }),
+					actualValueType: getValueType(node.value),
+				}),
+			);
 		}
 
 		if (schema instanceof ObjectNodeStoredSchema) {
@@ -154,7 +248,7 @@ export function isNodeInSchema<T extends NotUndefined>(
 					nodeField,
 					fieldSchema,
 					schemaAndPolicy,
-					onError,
+					prependPath(onError, fieldKey),
 				);
 				if (fieldInSchemaResult !== undefined) {
 					return fieldInSchemaResult;
@@ -166,18 +260,22 @@ export function isNodeInSchema<T extends NotUndefined>(
 			// Code using this with a stored schema derived from a view schema rather than the document can be problematic because it may be missing unknown fields that the actual document has.
 			// Other schema evolution features like "staged" allowed types will likely cause similar issues elsewhere in this checker.
 			if (uncheckedFieldsFromNode.size > 0) {
-				return onError(SchemaValidationError.ObjectNode_FieldNotInSchema, {
-					nodeType: node.type,
-					unexpectedFields: uncheckedFieldsFromNode,
-				});
+				return onError(
+					schemaValidationError(SchemaValidationError.ObjectNode_FieldNotInSchema, {
+						...tagCodeArtifacts({ nodeType: node.type }),
+						...tagData(TelemetryDataTag.UserData, {
+							unexpectedFields: JSON.stringify([...uncheckedFieldsFromNode].sort()),
+						}),
+					}),
+				);
 			}
 		} else if (schema instanceof MapNodeStoredSchema) {
-			for (const [_key, field] of node.fields) {
+			for (const [key, field] of node.fields) {
 				const fieldInSchemaResult = isFieldInSchema(
 					field,
 					schema.mapFields,
 					schemaAndPolicy,
-					onError,
+					prependPath(onError, key),
 				);
 				if (fieldInSchemaResult !== undefined) {
 					return fieldInSchemaResult;
@@ -202,36 +300,61 @@ export function isFieldInSchema<T extends NotUndefined>(
 	childNodes: MapTreeFieldViewGeneric<MinimalMapTreeNodeView>,
 	schema: TreeFieldStoredSchema,
 	schemaAndPolicy: SchemaAndPolicy,
-	onError: (error: SchemaValidationError, context?: SchemaValidationErrorContext) => T,
+	onError: (details: SchemaValidationErrorDetails) => T,
 ): T | undefined {
 	// Validate that the field kind is handled by the schema policy
 	const kind = schemaAndPolicy.policy.fieldKinds.get(schema.kind);
 	if (kind === undefined) {
-		return onError(SchemaValidationError.Field_KindNotInSchemaPolicy);
+		return onError(
+			schemaValidationError(
+				SchemaValidationError.Field_KindNotInSchemaPolicy,
+				tagCodeArtifacts({ fieldKind: schema.kind }),
+			),
+		);
 	}
 
 	// Validate that the field doesn't contain more nodes than its type supports
 	{
 		const multiplicityCheck = compliesWithMultiplicity(childNodes.length, kind.multiplicity);
 		if (multiplicityCheck !== undefined) {
-			return onError(multiplicityCheck);
+			return onError(
+				schemaValidationError(multiplicityCheck, {
+					...tagCodeArtifacts({ fieldKind: schema.kind }),
+					childCount: childNodes.length,
+				}),
+			);
 		}
 	}
 
+	let index = 0;
 	for (const node of childNodes) {
 		// Validate the type declared by the node is allowed in this field
 		if (schema.types !== undefined && !schema.types.has(node.type)) {
-			return onError(SchemaValidationError.Field_NodeTypeNotAllowed, {
-				nodeType: node.type,
-				allowedTypes: schema.types,
-			});
+			const allowedTypes = [...schema.types].sort();
+			return prependPath(
+				onError,
+				index,
+			)(
+				schemaValidationError(
+					SchemaValidationError.Field_NodeTypeNotAllowed,
+					tagCodeArtifacts({
+						nodeType: node.type,
+						allowedTypes: JSON.stringify(allowedTypes),
+					}),
+				),
+			);
 		}
 
 		// Validate the node complies with the type it declares to be.
-		const nodeInSchemaResult = isNodeInSchema(node, schemaAndPolicy, onError);
+		const nodeInSchemaResult = isNodeInSchema(
+			node,
+			schemaAndPolicy,
+			prependPath(onError, index),
+		);
 		if (nodeInSchemaResult !== undefined) {
 			return nodeInSchemaResult;
 		}
+		index += 1;
 	}
 
 	return undefined;

--- a/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
+++ b/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
@@ -61,6 +61,7 @@ import {
 	type TreeBranchHistory,
 	type UntypedTreeViewAlpha,
 	type TreeSchema,
+	getSchemaCompatibilityError,
 } from "../simple-tree/index.js";
 import {
 	type Breakable,
@@ -78,6 +79,28 @@ import type { TreeCheckout } from "./treeCheckout.js";
  * exists and error if creating a second.
  */
 export const ViewSlot = anchorSlot<TreeView<ImplicitFieldSchema>>();
+
+function throwIfSchemaIsIncompatible(
+	compatibility: SchemaCompatibilityStatus,
+	viewSchema: TreeSchema,
+	storedSchema: TreeCheckout["storedSchema"],
+): void {
+	if (compatibility.canView) {
+		return;
+	}
+
+	const discrepancy = getSchemaCompatibilityError(viewSchema, storedSchema);
+	const details =
+		discrepancy === undefined ? "" : ` The first schema mismatch is: ${discrepancy}.`;
+	const resolution = compatibility.canInitialize
+		? "The document is uninitialized; call TreeView.initialize() before reading or writing TreeView.root."
+		: compatibility.canUpgrade
+			? "The stored schema can be upgraded; call TreeView.upgradeSchema() before reading or writing TreeView.root."
+			: "The schemas cannot be upgraded automatically. Review the reported mismatch and use a compatible view schema or explicitly migrate the document schema and data.";
+	throw new UsageError(
+		`TreeView.root is unavailable because the view schema is not compatible with the document's stored schema.${details} ${resolution}`,
+	);
+}
 
 /**
  * Implementation of TreeView wrapping a FlexTreeView.
@@ -510,11 +533,11 @@ export class SchematizingSimpleTreeView<
 
 	private get flexRoot(): FlexTreeOptionalField | FlexTreeRequiredField {
 		this.breaker.use();
-		if (!this.compatibility.canView) {
-			throw new UsageError(
-				"Document is out of schema. Check TreeView.compatibility before accessing TreeView.root.",
-			);
-		}
+		throwIfSchemaIsIncompatible(
+			this.compatibility,
+			this.viewSchema,
+			this.checkout.storedSchema,
+		);
 		const view = this.getFlexTreeContext();
 		assert(
 			view.root.is(FieldKinds.optional) ||
@@ -531,11 +554,11 @@ export class SchematizingSimpleTreeView<
 
 	public set root(newRoot: InsertableField<TRootSchema>) {
 		this.breaker.use();
-		if (!this.compatibility.canView) {
-			throw new UsageError(
-				"Document is out of schema. Check TreeView.compatibility before accessing TreeView.root.",
-			);
-		}
+		throwIfSchemaIsIncompatible(
+			this.compatibility,
+			this.viewSchema,
+			this.checkout.storedSchema,
+		);
 		const view = this.getFlexTreeContext();
 		setField(
 			view.root,

--- a/packages/dds/tree/src/simple-tree/api/index.ts
+++ b/packages/dds/tree/src/simple-tree/api/index.ts
@@ -105,7 +105,10 @@ export {
 export type { TreeSchemaEncodingOptions } from "./getJsonSchema.js";
 export { getJsonSchema } from "./getJsonSchema.js";
 export { getSimpleSchema } from "./getSimpleSchema.js";
-export { checkSchemaCompatibility } from "./schemaCompatibilityTester.js";
+export {
+	checkSchemaCompatibility,
+	getSchemaCompatibilityError,
+} from "./schemaCompatibilityTester.js";
 export type {
 	Unenforced,
 	FieldSchemaAlphaUnsafe,

--- a/packages/dds/tree/src/simple-tree/api/schemaCompatibilityTester.ts
+++ b/packages/dds/tree/src/simple-tree/api/schemaCompatibilityTester.ts
@@ -3,14 +3,101 @@
  * Licensed under the MIT License.
  */
 
-import type { TreeStoredSchema } from "../../core/index.js";
+import { unreachableCase } from "@fluidframework/core-utils/internal";
+
+import {
+	LeafNodeStoredSchema,
+	MapNodeStoredSchema,
+	ObjectNodeStoredSchema,
+	type TreeStoredSchema,
+	ValueSchema,
+} from "../../core/index.js";
 import type { SchemaUpgrade, StagedSchemaUpgradePolicy } from "../core/index.js";
+import { NodeKind } from "../core/index.js";
 import { allowsRepoSuperset, defaultSchemaPolicy } from "../../feature-libraries/index.js";
 import { toUpgradeSchema } from "../toStoredSchema.js";
 import type { TreeSchema } from "../treeSchema.js";
 
-import { getDiscrepanciesInAllowedContent } from "./discrepancies.js";
+import {
+	type Discrepancy,
+	type FieldDiscrepancyLocation,
+	getDiscrepanciesInAllowedContent,
+} from "./discrepancies.js";
 import type { SchemaCompatibilityStatus } from "./tree.js";
+
+function formatLocation(location: FieldDiscrepancyLocation): string {
+	if (location.identifier === undefined) {
+		return "the root field";
+	}
+	if (location.fieldKey === undefined) {
+		return `the fields of node type ${JSON.stringify(location.identifier)}`;
+	}
+	return `field ${JSON.stringify(location.fieldKey)} of node type ${JSON.stringify(location.identifier)}`;
+}
+
+function formatStoredNodeKind(
+	kind:
+		| typeof ObjectNodeStoredSchema
+		| typeof MapNodeStoredSchema
+		| typeof LeafNodeStoredSchema,
+): string {
+	if (kind === ObjectNodeStoredSchema) {
+		return "Object";
+	}
+	if (kind === MapNodeStoredSchema) {
+		return "Map";
+	}
+	if (kind === LeafNodeStoredSchema) {
+		return "Leaf";
+	}
+	throw new TypeError("Unknown stored node kind.");
+}
+
+function formatDiscrepancy(discrepancy: Discrepancy): string {
+	switch (discrepancy.mismatch) {
+		case "allowedTypes": {
+			const differences: string[] = [];
+			if (discrepancy.view.length > 0) {
+				const viewTypes = discrepancy.view.map(({ type }) => type.identifier).sort();
+				differences.push(`only the view schema allows ${JSON.stringify(viewTypes)}`);
+			}
+			if (discrepancy.stored.length > 0) {
+				differences.push(
+					`only the stored schema allows ${JSON.stringify([...discrepancy.stored].sort())}`,
+				);
+			}
+			return `${formatLocation(discrepancy)} has different allowed node types: ${differences.join("; ")}`;
+		}
+		case "fieldKind": {
+			return `${formatLocation(discrepancy)} has field kind ${JSON.stringify(discrepancy.view)} in the view schema but ${JSON.stringify(discrepancy.stored)} in the stored schema`;
+		}
+		case "valueSchema": {
+			const view = discrepancy.view === undefined ? undefined : ValueSchema[discrepancy.view];
+			const stored =
+				discrepancy.stored === undefined ? undefined : ValueSchema[discrepancy.stored];
+			return `node type ${JSON.stringify(discrepancy.identifier)} has value schema ${JSON.stringify(view)} in the view schema but ${JSON.stringify(stored)} in the stored schema`;
+		}
+		case "nodeKind": {
+			return `node type ${JSON.stringify(discrepancy.identifier)} has node kind ${JSON.stringify(NodeKind[discrepancy.view])} in the view schema but ${JSON.stringify(formatStoredNodeKind(discrepancy.stored))} in the stored schema`;
+		}
+		default: {
+			return unreachableCase(discrepancy);
+		}
+	}
+}
+
+/**
+ * Describes the first discrepancy that prevents a view schema from viewing a stored schema.
+ */
+export function getSchemaCompatibilityError(
+	viewSchema: TreeSchema,
+	stored: TreeStoredSchema,
+): string | undefined {
+	const discrepancy = getDiscrepanciesInAllowedContent(viewSchema, stored)
+		[Symbol.iterator]()
+		.next();
+	return discrepancy.done === true ? undefined : formatDiscrepancy(discrepancy.value);
+}
 
 /**
  * Determines the compatibility of a stored document (based on its stored schema) with a viewer (based on its view schema).

--- a/packages/dds/tree/src/simple-tree/index.ts
+++ b/packages/dds/tree/src/simple-tree/index.ts
@@ -144,6 +144,7 @@ export {
 	comparePersistedSchema,
 	type ConciseTree,
 	checkSchemaCompatibility,
+	getSchemaCompatibilityError,
 	type Unenforced,
 	type System_Unsafe,
 	type ArrayNodeCustomizableSchemaUnsafe,

--- a/packages/dds/tree/src/test/feature-libraries/schemaChecker.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/schemaChecker.spec.ts
@@ -5,6 +5,9 @@
 
 import { strict as assert } from "node:assert";
 
+import { emulateProductionBuild } from "@fluidframework/core-utils/internal";
+import { TelemetryDataTag, UsageError } from "@fluidframework/telemetry-utils/internal";
+
 // Reaching into internal module just to test it
 import {
 	LeafNodeStoredSchema,
@@ -30,10 +33,11 @@ import {
 } from "../../feature-libraries/index.js";
 import {
 	SchemaValidationError,
-	type SchemaValidationErrorContext,
+	type SchemaValidationErrorDetails,
 	compliesWithMultiplicity,
 	isFieldInSchema,
 	isNodeInSchema,
+	throwOutOfSchema,
 	// eslint-disable-next-line import-x/no-internal-modules
 } from "../../feature-libraries/schemaChecker.js";
 import { brand } from "../../util/index.js";
@@ -55,6 +59,10 @@ function createSchemaAndPolicy(
 			fieldKinds,
 		},
 	};
+}
+
+function getError(details: SchemaValidationErrorDetails): SchemaValidationError {
+	return details.error;
 }
 
 /**
@@ -136,7 +144,7 @@ describe("schema validation", () => {
 				isNodeInSchema(
 					createLeafNode("myNumberNode", 1, ValueSchema.Number).node,
 					createSchemaAndPolicy(), // Note this passes an empty stored schema
-					(x) => x,
+					getError,
 				),
 				SchemaValidationError.Node_MissingSchema,
 			);
@@ -154,7 +162,7 @@ describe("schema validation", () => {
 					// Note, this cannot use an empty stored schema because that would skip validation,
 					// So just putting a schema for a node that is not the one we pass in for validation.
 					createSchemaAndPolicy(new Map([[stringNode.type, stringSchema]])),
-					(x) => x,
+					getError,
 				),
 				SchemaValidationError.Node_MissingSchema,
 			);
@@ -164,17 +172,14 @@ describe("schema validation", () => {
 			it("in schema", () => {
 				const { node, schema } = createLeafNode("myNode", 1, ValueSchema.Number);
 				const schemaAndPolicy = createSchemaAndPolicy(new Map([[node.type, schema]]));
-				assert.equal(
-					isNodeInSchema(node, schemaAndPolicy, (x) => x),
-					undefined,
-				);
+				assert.equal(isNodeInSchema(node, schemaAndPolicy, getError), undefined);
 			});
 
 			it("not in schema due to invalid value", () => {
 				const { node, schema } = createLeafNode("myNode", "string", ValueSchema.Number); // "string" is not a number
 				const schemaAndPolicy = createSchemaAndPolicy(new Map([[node.type, schema]]));
 				assert.equal(
-					isNodeInSchema(node, schemaAndPolicy, (x) => x),
+					isNodeInSchema(node, schemaAndPolicy, getError),
 					SchemaValidationError.LeafNode_InvalidValue,
 				);
 			});
@@ -183,7 +188,7 @@ describe("schema validation", () => {
 				const { node, schema } = createLeafNode("myNode", undefined, ValueSchema.Number);
 				const schemaAndPolicy = createSchemaAndPolicy(new Map([[node.type, schema]]));
 				assert.equal(
-					isNodeInSchema(node, schemaAndPolicy, (x) => x),
+					isNodeInSchema(node, schemaAndPolicy, getError),
 					SchemaValidationError.LeafNode_InvalidValue,
 				);
 			});
@@ -199,7 +204,7 @@ describe("schema validation", () => {
 				};
 
 				assert.equal(
-					isNodeInSchema(outOfSchemaNode, schemaAndPolicy, (x) => x),
+					isNodeInSchema(outOfSchemaNode, schemaAndPolicy, getError),
 					SchemaValidationError.LeafNode_FieldsNotAllowed,
 				);
 			});
@@ -231,10 +236,7 @@ describe("schema validation", () => {
 					new Map([[fieldSchema.kind, FieldKinds.required]]),
 				);
 
-				assert.equal(
-					isNodeInSchema(mapNode.node, schemaAndPolicy, (x) => x),
-					undefined,
-				);
+				assert.equal(isNodeInSchema(mapNode.node, schemaAndPolicy, getError), undefined);
 			});
 
 			it("in schema while empty", () => {
@@ -252,10 +254,7 @@ describe("schema validation", () => {
 					new Map([[fieldSchema.kind, FieldKinds.required]]),
 				);
 
-				assert.equal(
-					isNodeInSchema(mapNode.node, schemaAndPolicy, (x) => x),
-					undefined,
-				);
+				assert.equal(isNodeInSchema(mapNode.node, schemaAndPolicy, getError), undefined);
 			});
 
 			it("not in schema due to having a value", () => {
@@ -281,7 +280,7 @@ describe("schema validation", () => {
 				};
 
 				assert.equal(
-					isNodeInSchema(outOfSchemaNode, schemaAndPolicy, (x) => x),
+					isNodeInSchema(outOfSchemaNode, schemaAndPolicy, getError),
 					SchemaValidationError.NonLeafNode_ValueNotAllowed,
 				);
 			});
@@ -304,10 +303,7 @@ describe("schema validation", () => {
 					new Map([[fieldSchema.kind, FieldKinds.required]]),
 				);
 
-				assert.equal(
-					isNodeInSchema(objectNode.node, schemaAndPolicy, (x) => x),
-					undefined,
-				);
+				assert.equal(isNodeInSchema(objectNode.node, schemaAndPolicy, getError), undefined);
 			});
 
 			it(`in schema with empty optional field`, () => {
@@ -326,10 +322,7 @@ describe("schema validation", () => {
 					new Map([[fieldSchema.kind, FieldKinds.optional]]),
 				);
 
-				assert.equal(
-					isNodeInSchema(objectNode.node, schemaAndPolicy, (x) => x),
-					undefined,
-				);
+				assert.equal(isNodeInSchema(objectNode.node, schemaAndPolicy, getError), undefined);
 			});
 
 			it(`not in schema due to having a field not present in its defined schema`, () => {
@@ -352,7 +345,7 @@ describe("schema validation", () => {
 				);
 
 				assert.equal(
-					isNodeInSchema(objectNode.node, schemaAndPolicy, (x) => x),
+					isNodeInSchema(objectNode.node, schemaAndPolicy, getError),
 					SchemaValidationError.ObjectNode_FieldNotInSchema,
 				);
 			});
@@ -376,7 +369,7 @@ describe("schema validation", () => {
 				);
 
 				assert.equal(
-					isNodeInSchema(objectNode.node, schemaAndPolicy, (x) => x),
+					isNodeInSchema(objectNode.node, schemaAndPolicy, getError),
 					SchemaValidationError.Field_MissingRequiredChild,
 				);
 			});
@@ -405,7 +398,7 @@ describe("schema validation", () => {
 				};
 
 				assert.equal(
-					isNodeInSchema(outOfSchemaNode, schemaAndPolicy, (x) => x),
+					isNodeInSchema(outOfSchemaNode, schemaAndPolicy, getError),
 					SchemaValidationError.NonLeafNode_ValueNotAllowed,
 				);
 			});
@@ -428,7 +421,7 @@ describe("schema validation", () => {
 				);
 
 				assert.equal(
-					isNodeInSchema(objectNode.node, schemaAndPolicy, (x) => x),
+					isNodeInSchema(objectNode.node, schemaAndPolicy, getError),
 					SchemaValidationError.Field_KindNotInSchemaPolicy,
 				);
 			});
@@ -446,10 +439,7 @@ describe("schema validation", () => {
 
 			const field: MapTree[] = [numberNode.node];
 
-			assert.equal(
-				isFieldInSchema(field, fieldSchema, schemaAndPolicy, (x) => x),
-				undefined,
-			);
+			assert.equal(isFieldInSchema(field, fieldSchema, schemaAndPolicy, getError), undefined);
 		});
 
 		it(`not in schema if field kind not supported by schema policy`, () => {
@@ -461,7 +451,7 @@ describe("schema validation", () => {
 
 			// FieldKinds.required is used above but missing in the schema policy
 			assert.equal(
-				isFieldInSchema([numberNode.node], fieldSchema, schemaAndPolicy, (x) => x),
+				isFieldInSchema([numberNode.node], fieldSchema, schemaAndPolicy, getError),
 				SchemaValidationError.Field_KindNotInSchemaPolicy,
 			);
 		});
@@ -480,7 +470,7 @@ describe("schema validation", () => {
 					[createLeafNode("myStringNode", "myStringValue", ValueSchema.String).node],
 					fieldSchema,
 					schemaAndPolicy,
-					(x) => x,
+					getError,
 				),
 				SchemaValidationError.Field_NodeTypeNotAllowed,
 			);
@@ -497,7 +487,7 @@ describe("schema validation", () => {
 			const emptyField: MapTree[] = [];
 
 			assert.equal(
-				isFieldInSchema(emptyField, fieldSchema, schemaAndPolicy, (x) => x),
+				isFieldInSchema(emptyField, fieldSchema, schemaAndPolicy, getError),
 				SchemaValidationError.Field_MissingRequiredChild,
 			);
 		});
@@ -526,163 +516,139 @@ describe("schema validation", () => {
 		}
 	});
 
-	describe("SchemaValidationErrorContext", () => {
-		/**
-		 * Captures both the error and context from the onError callback.
-		 */
-		function captureError(
-			error: SchemaValidationError,
-			context?: SchemaValidationErrorContext,
-		): { error: SchemaValidationError; context: SchemaValidationErrorContext | undefined } {
-			return { error, context };
-		}
-
-		it("Field_NodeTypeNotAllowed includes node type and allowed types", () => {
+	describe("SchemaValidationErrorDetails", () => {
+		it("includes tagged diagnostic properties at the validation site", () => {
 			const numberNode = createLeafNode("myNumberNode", 1, ValueSchema.Number);
+			const stringNode = createLeafNode('my"StringNode', "hello", ValueSchema.String);
 			const fieldSchema = getFieldSchema(FieldKinds.sequence, [numberNode.node.type]);
-			const schemaAndPolicy = createSchemaAndPolicy(
-				new Map([[numberNode.node.type, numberNode.schema]]),
-				new Map([[fieldSchema.kind, FieldKinds.sequence]]),
-			);
-
-			const stringNode = createLeafNode("myStringNode", "hello", ValueSchema.String);
-			const result = isFieldInSchema(
-				[stringNode.node],
-				fieldSchema,
-				schemaAndPolicy,
-				captureError,
-			);
-
-			assert(result !== undefined);
-			assert.equal(result.error, SchemaValidationError.Field_NodeTypeNotAllowed);
-			assert(result.context !== undefined);
-			assert.equal(result.context.nodeType, "myStringNode");
-			assert(result.context.allowedTypes !== undefined);
-			assert(result.context.allowedTypes.has("myNumberNode"));
-			assert.equal(result.context.allowedTypes.size, 1);
-		});
-
-		it("Node_MissingSchema includes the missing node type", () => {
-			const result = isNodeInSchema(
-				createLeafNode("unknownNode", 1, ValueSchema.Number).node,
-				createSchemaAndPolicy(),
-				captureError,
-			);
-
-			assert(result !== undefined);
-			assert.equal(result.error, SchemaValidationError.Node_MissingSchema);
-			assert(result.context !== undefined);
-			assert.equal(result.context.nodeType, "unknownNode");
-		});
-
-		it("ObjectNode_FieldNotInSchema includes node type and unexpected field names", () => {
-			const numberNode = createLeafNode("myNumberNode", 1, ValueSchema.Number);
-			const fieldSchema = getFieldSchema(FieldKinds.optional, [numberNode.node.type]);
-
-			// Object node has "extraField" which is not in the schema (schema only defines "knownField")
-			const objectNode = createNonLeafNode(
-				"myObjectNode",
-				new Map([[brand("extraField"), []]]),
-				new ObjectNodeStoredSchema(new Map([[brand("knownField"), fieldSchema]])),
-			);
-
-			const schemaAndPolicy = createSchemaAndPolicy(
-				new Map([
-					[numberNode.node.type, numberNode.schema],
-					[objectNode.node.type, objectNode.schema],
-				]),
-				new Map([[fieldSchema.kind, FieldKinds.optional]]),
-			);
-
-			const result = isNodeInSchema(objectNode.node, schemaAndPolicy, captureError);
-
-			assert(result !== undefined);
-			assert.equal(result.error, SchemaValidationError.ObjectNode_FieldNotInSchema);
-			assert(result.context !== undefined);
-			assert.equal(result.context.nodeType, "myObjectNode");
-			assert(result.context.unexpectedFields !== undefined);
-			assert(result.context.unexpectedFields.has("extraField"));
-			assert.equal(result.context.unexpectedFields.size, 1);
-		});
-
-		it("ObjectNode_FieldNotInSchema includes multiple unexpected fields", () => {
-			const numberNode = createLeafNode("myNumberNode", 1, ValueSchema.Number);
-			const fieldSchema = getFieldSchema(FieldKinds.optional, [numberNode.node.type]);
-
-			const objectNode = createNonLeafNode(
-				"myObjectNode",
-				new Map([
-					[brand("unknownA"), []],
-					[brand("unknownB"), []],
-				]),
-				new ObjectNodeStoredSchema(new Map([[brand("knownField"), fieldSchema]])),
-			);
-
-			const schemaAndPolicy = createSchemaAndPolicy(
-				new Map([
-					[numberNode.node.type, numberNode.schema],
-					[objectNode.node.type, objectNode.schema],
-				]),
-				new Map([[fieldSchema.kind, FieldKinds.optional]]),
-			);
-
-			const result = isNodeInSchema(objectNode.node, schemaAndPolicy, captureError);
-
-			assert(result !== undefined);
-			assert.equal(result.error, SchemaValidationError.ObjectNode_FieldNotInSchema);
-			assert(result.context !== undefined);
-			assert(result.context.unexpectedFields !== undefined);
-			assert(result.context.unexpectedFields.has("unknownA"));
-			assert(result.context.unexpectedFields.has("unknownB"));
-			assert.equal(result.context.unexpectedFields.size, 2);
-		});
-
-		it("errors without enhanced context do not include context", () => {
-			// LeafNode_InvalidValue: no enhanced context is provided for this error type
-			const { node, schema } = createLeafNode("myNode", "string", ValueSchema.Number);
-			const schemaAndPolicy = createSchemaAndPolicy(new Map([[node.type, schema]]));
-
-			const result = isNodeInSchema(node, schemaAndPolicy, captureError);
-
-			assert(result !== undefined);
-			assert.equal(result.error, SchemaValidationError.LeafNode_InvalidValue);
-			assert.equal(result.context, undefined);
-		});
-
-		it("Field_NodeTypeNotAllowed context reflects all allowed types in a union field", () => {
-			const numberNode = createLeafNode("myNumberNode", 1, ValueSchema.Number);
-			const stringNode = createLeafNode("myStringNode", "hello", ValueSchema.String);
-			const boolNode = createLeafNode("myBoolNode", true, ValueSchema.Boolean);
-
-			// Field allows number and string, but we insert a bool
-			const fieldSchema = getFieldSchema(FieldKinds.sequence, [
-				numberNode.node.type,
-				stringNode.node.type,
-			]);
 			const schemaAndPolicy = createSchemaAndPolicy(
 				new Map([
 					[numberNode.node.type, numberNode.schema],
 					[stringNode.node.type, stringNode.schema],
-					[boolNode.node.type, boolNode.schema],
 				]),
 				new Map([[fieldSchema.kind, FieldKinds.sequence]]),
 			);
 
 			const result = isFieldInSchema(
-				[boolNode.node],
+				[stringNode.node],
 				fieldSchema,
 				schemaAndPolicy,
-				captureError,
+				(details) => details,
 			);
 
-			assert(result !== undefined);
-			assert.equal(result.error, SchemaValidationError.Field_NodeTypeNotAllowed);
-			assert(result.context !== undefined);
-			assert.equal(result.context.nodeType, "myBoolNode");
-			assert(result.context.allowedTypes !== undefined);
-			assert(result.context.allowedTypes.has("myNumberNode"));
-			assert(result.context.allowedTypes.has("myStringNode"));
-			assert.equal(result.context.allowedTypes.size, 2);
+			assert.deepEqual(result, {
+				error: SchemaValidationError.Field_NodeTypeNotAllowed,
+				path: [0],
+				telemetryProperties: {
+					allowedTypes: {
+						tag: TelemetryDataTag.CodeArtifact,
+						value: '["myNumberNode"]',
+					},
+					nodeType: {
+						tag: TelemetryDataTag.CodeArtifact,
+						value: 'my"StringNode',
+					},
+				},
+			});
 		});
+
+		it("includes the path to nested invalid content", () => {
+			const invalidLeaf = createLeafNode("number", "not a number", ValueSchema.Number);
+			const fieldSchema = getFieldSchema(FieldKinds.required, [invalidLeaf.node.type]);
+			const objectNode = createNonLeafNode(
+				"object",
+				new Map([[brand("child"), [invalidLeaf.node]]]),
+				new ObjectNodeStoredSchema(new Map([[brand("child"), fieldSchema]])),
+			);
+			const schemaAndPolicy = createSchemaAndPolicy(
+				new Map([
+					[invalidLeaf.node.type, invalidLeaf.schema],
+					[objectNode.node.type, objectNode.schema],
+				]),
+				new Map([[fieldSchema.kind, FieldKinds.required]]),
+			);
+
+			const result = isNodeInSchema(objectNode.node, schemaAndPolicy, (details) => details);
+
+			assert.deepEqual(result, {
+				error: SchemaValidationError.LeafNode_InvalidValue,
+				path: ["child", 0],
+				telemetryProperties: {
+					actualValueType: "string",
+					expectedValueType: {
+						tag: TelemetryDataTag.CodeArtifact,
+						value: "Number",
+					},
+					nodeType: {
+						tag: TelemetryDataTag.CodeArtifact,
+						value: "number",
+					},
+				},
+			});
+		});
+	});
+
+	it("throwOutOfSchema tags schema details without including them in the message", () => {
+		const details: SchemaValidationErrorDetails = {
+			error: SchemaValidationError.LeafNode_InvalidValue,
+			path: ["child", 0],
+			telemetryProperties: {
+				actualValueType: "string",
+				expectedValueType: {
+					tag: TelemetryDataTag.CodeArtifact,
+					value: "Number",
+				},
+				nodeType: {
+					tag: TelemetryDataTag.CodeArtifact,
+					value: "number",
+				},
+			},
+		};
+		assert.throws(
+			() => throwOutOfSchema(details),
+			(error: unknown) => {
+				assert(error instanceof UsageError);
+				assert.equal(
+					error.message,
+					'Tree does not conform to schema. A leaf node value does not match its schema. Leaf node "number" requires a value matching "Number", but found "string" at path ["child",0].',
+				);
+				const telemetryProperties = error.getTelemetryProperties();
+				assert.deepEqual(telemetryProperties.schemaValidationError, {
+					tag: TelemetryDataTag.CodeArtifact,
+					value: "LeafNode_InvalidValue",
+				});
+				assert.deepEqual(telemetryProperties.schemaValidationPath, {
+					tag: TelemetryDataTag.UserData,
+					value: '["child",0]',
+				});
+				assert.deepEqual(telemetryProperties.nodeType, {
+					tag: TelemetryDataTag.CodeArtifact,
+					value: "number",
+				});
+				assert.deepEqual(telemetryProperties.expectedValueType, {
+					tag: TelemetryDataTag.CodeArtifact,
+					value: "Number",
+				});
+				assert.equal(telemetryProperties.actualValueType, "string");
+				return true;
+			},
+		);
+
+		emulateProductionBuild(true);
+		try {
+			assert.throws(
+				() => throwOutOfSchema(details),
+				(error: unknown) => {
+					assert(error instanceof UsageError);
+					assert.equal(
+						error.message,
+						"Tree does not conform to schema. A leaf node value does not match its schema.",
+					);
+					return true;
+				},
+			);
+		} finally {
+			emulateProductionBuild(false);
+		}
 	});
 });

--- a/packages/dds/tree/src/test/shared-tree/schematizingTreeView.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/schematizingTreeView.spec.ts
@@ -595,7 +595,9 @@ describe("SchematizingSimpleTreeView", () => {
 		assert.equal(view.compatibility.isEquivalent, false);
 		assert.throws(
 			() => view.root,
-			(e) => e instanceof UsageError,
+			validateUsageError(
+				/TreeView\.root is unavailable because the view schema is not compatible with the document's stored schema\. The first schema mismatch is: the root field has different allowed node types: only the view schema allows \["com\.fluidframework\.leaf\.string"\]\. The stored schema can be upgraded; call TreeView\.upgradeSchema\(\)/,
+			),
 		);
 
 		view.upgradeSchema();
@@ -619,7 +621,9 @@ describe("SchematizingSimpleTreeView", () => {
 		assert.equal(view.compatibility.isEquivalent, false);
 		assert.throws(
 			() => view.root,
-			(e) => e instanceof UsageError,
+			validateUsageError(
+				/TreeView\.root is unavailable because the view schema is not compatible with the document's stored schema\. The first schema mismatch is: the root field has different allowed node types: only the stored schema allows \["com\.fluidframework\.leaf\.string"\]\. The schemas cannot be upgraded automatically\./,
+			),
 		);
 
 		assert.throws(
@@ -641,7 +645,9 @@ describe("SchematizingSimpleTreeView", () => {
 		assert.equal(view.compatibility.isEquivalent, false);
 		assert.throws(
 			() => view.root,
-			(e) => e instanceof UsageError,
+			validateUsageError(
+				/TreeView\.root is unavailable because the view schema is not compatible with the document's stored schema\. The first schema mismatch is: the root field has different allowed node types: only the view schema allows \["com\.fluidframework\.leaf\.boolean"\]; only the stored schema allows \["com\.fluidframework\.leaf\.string"\]\. The schemas cannot be upgraded automatically\./,
+			),
 		);
 
 		assert.throws(

--- a/packages/dds/tree/src/test/simple-tree/api/schemaFactory.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/schemaFactory.spec.ts
@@ -1510,7 +1510,7 @@ describe("schemaFactory", () => {
 						view.root = testObject;
 					},
 					validateUsageError(
-						/Tree does not conform to schema. A node of type .* is not allowed in this field./,
+						/Tree does not conform to schema\. A node type is not allowed in its field\./,
 					),
 				);
 			});
@@ -1529,7 +1529,7 @@ describe("schemaFactory", () => {
 						view.root.foo = "test";
 					},
 					validateUsageError(
-						/Tree does not conform to schema. A node of type .* is not allowed in this field./,
+						/Tree does not conform to schema\. A node type is not allowed in its field\./,
 					),
 				);
 			});
@@ -1637,7 +1637,7 @@ describe("schemaFactory", () => {
 						view.root = testMap;
 					},
 					validateUsageError(
-						/Tree does not conform to schema. A node of type .* is not allowed in this field./,
+						/Tree does not conform to schema\. A node type is not allowed in its field\./,
 					),
 				);
 			});
@@ -1656,7 +1656,7 @@ describe("schemaFactory", () => {
 						view.root.set("foo", "test");
 					},
 					validateUsageError(
-						/Tree does not conform to schema. A node of type .* is not allowed in this field./,
+						/Tree does not conform to schema\. A node type is not allowed in its field\./,
 					),
 				);
 			});
@@ -1694,7 +1694,7 @@ describe("schemaFactory", () => {
 						view.root = testRecord;
 					},
 					validateUsageError(
-						/Tree does not conform to schema. A node of type .* is not allowed in this field./,
+						/Tree does not conform to schema\. A node type is not allowed in its field\./,
 					),
 				);
 			});
@@ -1713,7 +1713,7 @@ describe("schemaFactory", () => {
 						view.root.foo = "test";
 					},
 					validateUsageError(
-						/Tree does not conform to schema. A node of type .* is not allowed in this field./,
+						/Tree does not conform to schema\. A node type is not allowed in its field\./,
 					),
 				);
 			});

--- a/packages/dds/tree/src/test/simple-tree/api/tree.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/tree.spec.ts
@@ -121,7 +121,7 @@ describe("simple-tree tree", () => {
 			const view = getView(config);
 			assert.throws(
 				() => view.initialize({}),
-				validateUsageError(/is not allowed in this field/),
+				validateUsageError(/A node type is not allowed in its field/),
 			);
 		});
 
@@ -135,7 +135,7 @@ describe("simple-tree tree", () => {
 				() => {
 					view.root = newNode;
 				},
-				validateUsageError(/is not allowed in this field/),
+				validateUsageError(/A node type is not allowed in its field/),
 			);
 		});
 	});
@@ -233,7 +233,10 @@ describe("simple-tree tree", () => {
 		const view = getView(config);
 		// Note: the tree's schema hasn't been initialized at this point, so even though the view schema
 		// allows an optional field, explicit initialization must occur.
-		assert.throws(() => view.root, /Document is out of schema./);
+		assert.throws(
+			() => view.root,
+			/TreeView\.root is unavailable because the view schema is not compatible with the document's stored schema.*The document is uninitialized; call TreeView\.initialize\(\)/,
+		);
 		view.initialize(undefined);
 		assert.equal(view.root, undefined);
 	});

--- a/packages/dds/tree/src/test/simple-tree/api/treeNodeApi.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/treeNodeApi.spec.ts
@@ -3984,7 +3984,7 @@ describe("treeNodeApi", () => {
 				class A extends factory.object("A", { a: factory.identifier }) {}
 				assert.throws(
 					() => TreeAlpha.importVerbose(A, { type: A.identifier, fields: {} }),
-					validateUsageError(/Field_MissingRequiredChild/),
+					validateUsageError(/A required field is missing its child/),
 				);
 			});
 

--- a/packages/dds/tree/src/test/simple-tree/prepareForInsertion.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/prepareForInsertion.spec.ts
@@ -192,7 +192,9 @@ describe("prepareForInsertion", () => {
 								...schemaValidationPolicy,
 								createFieldSchema(FieldKinds.required, [brand(stringSchema.identifier)]),
 							),
-						validateUsageError(/LeafNode_InvalidValue/),
+						validateUsageError(
+							/Tree does not conform to schema\. A leaf node value does not match its schema\./,
+						),
 					);
 				});
 			});


### PR DESCRIPTION
## Description

Backports the SharedTree schema diagnostics improvements from [PR #27950](https://github.com/microsoft/FluidFramework/pull/27950) to `release/client/2.118`.

The change improves mismatch diagnostics while protecting potentially sensitive document data through telemetry categorization and production-safe error messages.

## Reviewer Guidance

The review process is outlined in [the pull request guidelines](../docs/content/Contributing/PR-Guidelines.md#guidelines).

This is a clean cherry-pick of commit `0e44043224e1ac08433f71917e4350aa7f3e4047`. Changes to release branches require Patch Triage approval before merging.
