### PR TITLE
fix(odsp-driver): preserve epoch in pending container state

### DIFF
--- a/.changeset/clean-pianos-rest.md
+++ b/.changeset/clean-pianos-rest.md
@@ -1,0 +1,9 @@
+---
+"@fluidframework/odsp-driver": minor
+"__section": deprecation
+---
+Deprecate the boolean EpochTracker.setEpoch overload
+
+`EpochTracker.setEpoch(epoch, fromCache, fetchType)` is deprecated in favor of the overload that accepts a single source value, preventing contradictory telemetry dimensions.
+
+The deprecated overload is scheduled for removal in version 3.20.0. See [AB#83307](https://dev.azure.com/fluidframework/internal/_workitems/edit/83307) for removal details.

--- a/.changeset/every-feet-post.md
+++ b/.changeset/every-feet-post.md
@@ -7,4 +7,4 @@
 
 Preserve driver state in pending container state
 
-Pending container state now captures and restores opaque driver state before reconnecting. ODSP uses this to retain the cached epoch, allowing restored files to reject stale pending state after a server-side restore.
+Pending container state now captures and restores opaque driver state before reconnecting. ODSP uses this to retain the cached epoch and validate document identity, allowing restored files to reject stale pending state after a server-side restore.

--- a/.changeset/every-feet-post.md
+++ b/.changeset/every-feet-post.md
@@ -1,0 +1,8 @@
+---
+"@fluidframework/driver-definitions": minor
+"__section": fix
+---
+
+Preserve driver state in pending container state
+
+Pending container state now captures and restores opaque driver state before reconnecting. ODSP uses this to retain the cached epoch, allowing restored files to reject stale pending state after a server-side restore.

--- a/.changeset/every-feet-post.md
+++ b/.changeset/every-feet-post.md
@@ -1,5 +1,7 @@
 ---
 "@fluidframework/driver-definitions": minor
+"@fluidframework/container-loader": minor
+"@fluidframework/odsp-driver": minor
 "__section": fix
 ---
 

--- a/.changeset/every-feet-post.md
+++ b/.changeset/every-feet-post.md
@@ -4,7 +4,6 @@
 "@fluidframework/odsp-driver": minor
 "__section": fix
 ---
-
 Preserve driver state in pending container state
 
 Pending container state now captures and restores opaque driver state before reconnecting. ODSP uses this to retain the cached epoch and validate document identity, allowing restored files to reject stale pending state after a server-side restore.

--- a/packages/common/driver-definitions/api-report/driver-definitions.legacy.beta.api.md
+++ b/packages/common/driver-definitions/api-report/driver-definitions.legacy.beta.api.md
@@ -267,11 +267,13 @@ export interface IDocumentService extends IEventProvider<IDocumentServiceEvents>
     connectToDeltaStream(client: IClient): Promise<IDocumentDeltaConnection>;
     connectToStorage(): Promise<IDocumentStorageService>;
     dispose(error?: any): void;
-    getDriverState?(): unknown;
+    readonly driverStatePersistence?: {
+        get(): unknown;
+        set(state: unknown): void;
+    };
     policies?: IDocumentServicePolicies | undefined;
     // (undocumented)
     resolvedUrl: IResolvedUrl;
-    setDriverState?(state: unknown): void;
 }
 
 // @beta @legacy

--- a/packages/common/driver-definitions/api-report/driver-definitions.legacy.beta.api.md
+++ b/packages/common/driver-definitions/api-report/driver-definitions.legacy.beta.api.md
@@ -267,9 +267,11 @@ export interface IDocumentService extends IEventProvider<IDocumentServiceEvents>
     connectToDeltaStream(client: IClient): Promise<IDocumentDeltaConnection>;
     connectToStorage(): Promise<IDocumentStorageService>;
     dispose(error?: any): void;
+    getDriverState?(): unknown;
     policies?: IDocumentServicePolicies | undefined;
     // (undocumented)
     resolvedUrl: IResolvedUrl;
+    setDriverState?(state: unknown): void;
 }
 
 // @beta @legacy

--- a/packages/common/driver-definitions/src/storage.ts
+++ b/packages/common/driver-definitions/src/storage.ts
@@ -378,7 +378,8 @@ export interface IDocumentService extends IEventProvider<IDocumentServiceEvents>
 	 * The value returned by `get` must be JSON-serializable and must not contain
 	 * customer-identifying information. Returning `undefined` indicates that there is no driver
 	 * state to preserve. `set` receives the JSON-deserialized value previously returned by `get`
-	 * before the document service connects to storage or the delta stream.
+	 * before the document service connects to storage or the delta stream. Persisted state must
+	 * contain enough information for `set` to reject state captured for a different document.
 	 *
 	 * @privateRemarks
 	 * Grouping `get` and `set` under one optional property makes support atomic: an implementation

--- a/packages/common/driver-definitions/src/storage.ts
+++ b/packages/common/driver-definitions/src/storage.ts
@@ -373,6 +373,15 @@ export interface IDocumentService extends IEventProvider<IDocumentServiceEvents>
 	resolvedUrl: IResolvedUrl;
 
 	/**
+	 * Returns opaque driver state that should be preserved with pending container state.
+	 */
+	getDriverState?(): unknown;
+	/**
+	 * Restores opaque driver state preserved with pending container state.
+	 */
+	setDriverState?(state: unknown): void;
+
+	/**
 	 * Policies implemented/instructed by driver.
 	 */
 	policies?: IDocumentServicePolicies | undefined;

--- a/packages/common/driver-definitions/src/storage.ts
+++ b/packages/common/driver-definitions/src/storage.ts
@@ -374,10 +374,16 @@ export interface IDocumentService extends IEventProvider<IDocumentServiceEvents>
 
 	/**
 	 * Returns opaque driver state that should be preserved with pending container state.
+	 *
+	 * The returned value must be JSON-serializable. Returning `undefined` indicates that there is no
+	 * driver state to preserve.
 	 */
 	getDriverState?(): unknown;
 	/**
-	 * Restores opaque driver state preserved with pending container state.
+	 * Restores opaque driver state preserved with pending container state. This is called before the
+	 * document service connects to storage or the delta stream.
+	 *
+	 * @param state - The JSON-deserialized value previously returned by `getDriverState`.
 	 */
 	setDriverState?(state: unknown): void;
 

--- a/packages/common/driver-definitions/src/storage.ts
+++ b/packages/common/driver-definitions/src/storage.ts
@@ -373,19 +373,17 @@ export interface IDocumentService extends IEventProvider<IDocumentServiceEvents>
 	resolvedUrl: IResolvedUrl;
 
 	/**
-	 * Returns opaque driver state that should be preserved with pending container state.
+	 * Persists opaque driver state with pending container state.
 	 *
-	 * The returned value must be JSON-serializable. Returning `undefined` indicates that there is no
-	 * driver state to preserve.
+	 * The value returned by `get` must be JSON-serializable and must not contain
+	 * customer-identifying information. Returning `undefined` indicates that there is no driver
+	 * state to preserve. `set` receives the JSON-deserialized value previously returned by `get`
+	 * before the document service connects to storage or the delta stream.
 	 */
-	getDriverState?(): unknown;
-	/**
-	 * Restores opaque driver state preserved with pending container state. This is called before the
-	 * document service connects to storage or the delta stream.
-	 *
-	 * @param state - The JSON-deserialized value previously returned by `getDriverState`.
-	 */
-	setDriverState?(state: unknown): void;
+	readonly driverStatePersistence?: {
+		get(): unknown;
+		set(state: unknown): void;
+	};
 
 	/**
 	 * Policies implemented/instructed by driver.

--- a/packages/common/driver-definitions/src/storage.ts
+++ b/packages/common/driver-definitions/src/storage.ts
@@ -379,6 +379,12 @@ export interface IDocumentService extends IEventProvider<IDocumentServiceEvents>
 	 * customer-identifying information. Returning `undefined` indicates that there is no driver
 	 * state to preserve. `set` receives the JSON-deserialized value previously returned by `get`
 	 * before the document service connects to storage or the delta stream.
+	 *
+	 * @privateRemarks
+	 * Grouping `get` and `set` under one optional property makes support atomic: an implementation
+	 * either omits persistence or provides the complete round-trip capability. Making the methods
+	 * independently optional would permit state that can be captured but not restored, or restored
+	 * but not captured.
 	 */
 	readonly driverStatePersistence?: {
 		get(): unknown;

--- a/packages/common/driver-definitions/src/storage.ts
+++ b/packages/common/driver-definitions/src/storage.ts
@@ -375,11 +375,14 @@ export interface IDocumentService extends IEventProvider<IDocumentServiceEvents>
 	/**
 	 * Persists opaque driver state with pending container state.
 	 *
-	 * The value returned by `get` must be JSON-serializable and must not contain
-	 * customer-identifying information. Returning `undefined` indicates that there is no driver
-	 * state to preserve. `set` receives the JSON-deserialized value previously returned by `get`
-	 * before the document service connects to storage or the delta stream. Persisted state must
-	 * contain enough information for `set` to reject state captured for a different document.
+	 * @remarks
+	 * The value returned by `get` is serialized as part of the containing pending state. It must
+	 * round-trip through `JSON.stringify` and `JSON.parse` without custom serialization or
+	 * information loss, and it must not contain customer-identifying information. Returning
+	 * `undefined` indicates that there is no driver state to preserve. `set` receives the
+	 * JSON-deserialized value previously returned by `get` before the document service connects
+	 * to storage or the delta stream. Persisted state must contain enough information for `set` to
+	 * reject state captured for a different document.
 	 *
 	 * @privateRemarks
 	 * Grouping `get` and `set` under one optional property makes support atomic: an implementation

--- a/packages/common/driver-definitions/src/storage.ts
+++ b/packages/common/driver-definitions/src/storage.ts
@@ -378,7 +378,7 @@ export interface IDocumentService extends IEventProvider<IDocumentServiceEvents>
 	 * @remarks
 	 * The value returned by `get` is serialized as part of the containing pending state. It must
 	 * round-trip through `JSON.stringify` and `JSON.parse` without custom serialization or
-	 * information loss, and it must not contain customer-identifying information. Returning
+	 * information loss, and it must not contain customer-identifying information. `get` returning
 	 * `undefined` indicates that there is no driver state to preserve. `set` receives the
 	 * JSON-deserialized value previously returned by `get` before the document service connects
 	 * to storage or the delta stream. Persisted state must contain enough information for `set` to

--- a/packages/drivers/odsp-driver/api-report/odsp-driver.legacy.alpha.api.md
+++ b/packages/drivers/odsp-driver/api-report/odsp-driver.legacy.alpha.api.md
@@ -48,7 +48,8 @@ export class EpochTracker implements IPersistedFileCache {
     readonly rateLimiter: RateLimiter;
     // (undocumented)
     removeEntries(): Promise<void>;
-    // (undocumented)
+    setEpoch(epoch: string, source: FetchTypeInternal | "pendingState"): void;
+    // @deprecated
     setEpoch(epoch: string, fromCache: boolean, fetchType: FetchTypeInternal): void;
     // (undocumented)
     validateEpoch(epoch: string | undefined, fetchType: FetchType): Promise<void>;

--- a/packages/drivers/odsp-driver/api-report/odsp-driver.legacy.beta.api.md
+++ b/packages/drivers/odsp-driver/api-report/odsp-driver.legacy.beta.api.md
@@ -48,7 +48,8 @@ export class EpochTracker implements IPersistedFileCache {
     readonly rateLimiter: RateLimiter;
     // (undocumented)
     removeEntries(): Promise<void>;
-    // (undocumented)
+    setEpoch(epoch: string, source: FetchTypeInternal | "pendingState"): void;
+    // @deprecated
     setEpoch(epoch: string, fromCache: boolean, fetchType: FetchTypeInternal): void;
     // (undocumented)
     validateEpoch(epoch: string | undefined, fetchType: FetchType): Promise<void>;

--- a/packages/drivers/odsp-driver/api-report/odsp-driver.point-in-time.legacy.beta.api.md
+++ b/packages/drivers/odsp-driver/api-report/odsp-driver.point-in-time.legacy.beta.api.md
@@ -33,7 +33,8 @@ export class EpochTracker implements IPersistedFileCache {
     readonly rateLimiter: RateLimiter;
     // (undocumented)
     removeEntries(): Promise<void>;
-    // (undocumented)
+    setEpoch(epoch: string, source: FetchTypeInternal | "pendingState"): void;
+    // @deprecated
     setEpoch(epoch: string, fromCache: boolean, fetchType: FetchTypeInternal): void;
     // (undocumented)
     validateEpoch(epoch: string | undefined, fetchType: FetchType): Promise<void>;

--- a/packages/drivers/odsp-driver/src/epochTracker.ts
+++ b/packages/drivers/odsp-driver/src/epochTracker.ts
@@ -126,7 +126,7 @@ export class EpochTracker implements IPersistedFileCache {
 			: maximumCacheDurationMs;
 	}
 
-	// public for UT purposes only!
+	// Sets the initial epoch from cache, restored driver state, or tests.
 	public setEpoch(epoch: string, fromCache: boolean, fetchType: FetchTypeInternal): void {
 		assert(this._fluidEpoch === undefined, 0x1db /* "epoch exists" */);
 		this._fluidEpoch = epoch;

--- a/packages/drivers/odsp-driver/src/epochTracker.ts
+++ b/packages/drivers/odsp-driver/src/epochTracker.ts
@@ -133,7 +133,9 @@ export class EpochTracker implements IPersistedFileCache {
 	/**
 	 * Sets the initial epoch.
 	 *
-	 * @deprecated Use the overload that accepts a source instead.
+	 * @deprecated 3.1.0. This overload will be removed in 3.20.0. Use the overload that accepts a
+	 * source instead. See {@link https://dev.azure.com/fluidframework/internal/_workitems/edit/83307}
+	 * for context.
 	 */
 	public setEpoch(epoch: string, fromCache: boolean, fetchType: FetchTypeInternal): void;
 	public setEpoch(

--- a/packages/drivers/odsp-driver/src/epochTracker.ts
+++ b/packages/drivers/odsp-driver/src/epochTracker.ts
@@ -141,12 +141,12 @@ export class EpochTracker implements IPersistedFileCache {
 		sourceOrFromCache: boolean | FetchTypeInternal | "pendingState",
 		fetchType?: FetchTypeInternal,
 	): void {
-		const source =
-			typeof sourceOrFromCache === "boolean"
-				? sourceOrFromCache
-					? "cache"
-					: fetchType
-				: sourceOrFromCache;
+		const usingLegacyOverload = typeof sourceOrFromCache === "boolean";
+		const source = usingLegacyOverload
+			? sourceOrFromCache
+				? "cache"
+				: fetchType
+			: sourceOrFromCache;
 		assert(
 			source !== undefined,
 			"Fetch type is required when using the legacy setEpoch overload",
@@ -158,6 +158,10 @@ export class EpochTracker implements IPersistedFileCache {
 			eventName: "EpochLearnedFirstTime",
 			epoch,
 			source,
+			fetchType: usingLegacyOverload ? fetchType : source,
+			fromCache: usingLegacyOverload
+				? sourceOrFromCache
+				: source === "cache" || source === "pendingState",
 		});
 	}
 

--- a/packages/drivers/odsp-driver/src/epochTracker.ts
+++ b/packages/drivers/odsp-driver/src/epochTracker.ts
@@ -126,35 +126,38 @@ export class EpochTracker implements IPersistedFileCache {
 			: maximumCacheDurationMs;
 	}
 
-	// Sets the initial epoch from cache, network, or tests.
-	public setEpoch(epoch: string, fromCache: boolean, fetchType: FetchTypeInternal): void {
-		this.setEpochCore(epoch, fromCache, fetchType);
-	}
-
 	/**
-	 * Sets the initial epoch restored from pending container state.
-	 *
-	 * Optional to preserve structural compatibility with older `EpochTracker` implementations.
-	 *
-	 * @internal
+	 * Sets the initial epoch and records where it was learned.
 	 */
-	public readonly setEpochFromPendingState?: (epoch: string) => void = (epoch) => {
-		this.setEpochCore(epoch, true, "pendingState");
-	};
-
-	private setEpochCore(
+	public setEpoch(epoch: string, source: FetchTypeInternal | "pendingState"): void;
+	/**
+	 * Sets the initial epoch.
+	 *
+	 * @deprecated Use the overload that accepts a source instead.
+	 */
+	public setEpoch(epoch: string, fromCache: boolean, fetchType: FetchTypeInternal): void;
+	public setEpoch(
 		epoch: string,
-		fromCache: boolean,
-		fetchType: FetchTypeInternal | "pendingState",
+		sourceOrFromCache: boolean | FetchTypeInternal | "pendingState",
+		fetchType?: FetchTypeInternal,
 	): void {
+		const source =
+			typeof sourceOrFromCache === "boolean"
+				? sourceOrFromCache
+					? "cache"
+					: fetchType
+				: sourceOrFromCache;
+		assert(
+			source !== undefined,
+			"Fetch type is required when using the legacy setEpoch overload",
+		);
 		assert(this._fluidEpoch === undefined, 0x1db /* "epoch exists" */);
 		this._fluidEpoch = epoch;
 
 		this.loggerInternal.sendTelemetryEvent({
 			eventName: "EpochLearnedFirstTime",
 			epoch,
-			fetchType,
-			fromCache,
+			source,
 		});
 	}
 
@@ -174,7 +177,7 @@ export class EpochTracker implements IPersistedFileCache {
 			}
 			assert(value.fluidEpoch !== undefined, 0x1dc /* "all entries have to have epoch" */);
 			if (this._fluidEpoch === undefined) {
-				this.setEpoch(value.fluidEpoch, true, "cache");
+				this.setEpoch(value.fluidEpoch, "cache");
 				// Epoch mismatch, the cached value is considerably different from what the current state of
 				// the runtime and should not be used
 			} else if (this._fluidEpoch !== value.fluidEpoch) {
@@ -474,7 +477,7 @@ export class EpochTracker implements IPersistedFileCache {
 			throw error;
 		}
 		if (epochFromResponse !== undefined && this._fluidEpoch === undefined) {
-			this.setEpoch(epochFromResponse, fromCache, fetchType);
+			this.setEpoch(epochFromResponse, fromCache ? "cache" : fetchType);
 		}
 	}
 

--- a/packages/drivers/odsp-driver/src/epochTracker.ts
+++ b/packages/drivers/odsp-driver/src/epochTracker.ts
@@ -126,8 +126,27 @@ export class EpochTracker implements IPersistedFileCache {
 			: maximumCacheDurationMs;
 	}
 
-	// Sets the initial epoch from cache, restored driver state, or tests.
+	// Sets the initial epoch from cache, network, or tests.
 	public setEpoch(epoch: string, fromCache: boolean, fetchType: FetchTypeInternal): void {
+		this.setEpochCore(epoch, fromCache, fetchType);
+	}
+
+	/**
+	 * Sets the initial epoch restored from pending container state.
+	 *
+	 * Optional to preserve structural compatibility with older `EpochTracker` implementations.
+	 *
+	 * @internal
+	 */
+	public readonly setEpochFromPendingState?: (epoch: string) => void = (epoch) => {
+		this.setEpochCore(epoch, true, "pendingState");
+	};
+
+	private setEpochCore(
+		epoch: string,
+		fromCache: boolean,
+		fetchType: FetchTypeInternal | "pendingState",
+	): void {
 		assert(this._fluidEpoch === undefined, 0x1db /* "epoch exists" */);
 		this._fluidEpoch = epoch;
 

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -189,6 +189,8 @@ export class OdspDocumentService
 			if (currentEpoch !== undefined) {
 				throw new UsageError("ODSP driver state epoch does not match the current epoch");
 			}
+			// Pending state and the ODSP cache are both persisted client state; keep them in the
+			// same telemetry category rather than widening the exported FetchTypeInternal API.
 			this.epochTracker.setEpoch(state.epoch, true, "cache");
 		},
 	};

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -167,23 +167,31 @@ export class OdspDocumentService
 		return this._policies;
 	}
 
-	public getDriverState(): Record<string, unknown> | undefined {
-		const epoch = this.epochTracker.fluidEpoch;
-		return epoch === undefined ? undefined : { epoch };
-	}
-
-	public setDriverState(state: unknown): void {
-		if (
-			typeof state !== "object" ||
-			state === null ||
-			Array.isArray(state) ||
-			!("epoch" in state) ||
-			typeof state.epoch !== "string"
-		) {
-			throw new UsageError("ODSP driver state must contain an epoch string");
-		}
-		this.epochTracker.setEpoch(state.epoch, true, "cache");
-	}
+	public readonly driverStatePersistence = {
+		get: (): Record<string, unknown> | undefined => {
+			const epoch = this.epochTracker.fluidEpoch;
+			return epoch === undefined ? undefined : { epoch };
+		},
+		set: (state: unknown): void => {
+			if (
+				typeof state !== "object" ||
+				state === null ||
+				Array.isArray(state) ||
+				!("epoch" in state) ||
+				typeof state.epoch !== "string"
+			) {
+				throw new UsageError("ODSP driver state must contain an epoch string");
+			}
+			const currentEpoch = this.epochTracker.fluidEpoch;
+			if (currentEpoch === state.epoch) {
+				return;
+			}
+			if (currentEpoch !== undefined) {
+				throw new UsageError("ODSP driver state epoch does not match the current epoch");
+			}
+			this.epochTracker.setEpoch(state.epoch, true, "cache");
+		},
+	};
 
 	/**
 	 * Connects to a storage endpoint for snapshot service.

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -167,15 +167,22 @@ export class OdspDocumentService
 		return this._policies;
 	}
 
-	public getDriverState(): string | undefined {
-		return this.epochTracker.fluidEpoch;
+	public getDriverState(): Record<string, unknown> | undefined {
+		const epoch = this.epochTracker.fluidEpoch;
+		return epoch === undefined ? undefined : { epoch };
 	}
 
 	public setDriverState(state: unknown): void {
-		if (typeof state !== "string") {
-			throw new UsageError("ODSP driver state must be an epoch string");
+		if (
+			typeof state !== "object" ||
+			state === null ||
+			Array.isArray(state) ||
+			!("epoch" in state) ||
+			typeof state.epoch !== "string"
+		) {
+			throw new UsageError("ODSP driver state must contain an epoch string");
 		}
-		this.epochTracker.setEpoch(state, false, "cache");
+		this.epochTracker.setEpoch(state.epoch, true, "cache");
 	}
 
 	/**

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -170,7 +170,9 @@ export class OdspDocumentService
 	public readonly driverStatePersistence = {
 		get: (): Record<string, unknown> | undefined => {
 			const epoch = this.epochTracker.fluidEpoch;
-			return epoch === undefined ? undefined : { epoch };
+			return epoch === undefined
+				? undefined
+				: { documentId: this.odspResolvedUrl.hashedDocumentId, epoch };
 		},
 		set: (state: unknown): void => {
 			if (
@@ -178,9 +180,14 @@ export class OdspDocumentService
 				state === null ||
 				Array.isArray(state) ||
 				!("epoch" in state) ||
-				typeof state.epoch !== "string"
+				typeof state.epoch !== "string" ||
+				!("documentId" in state) ||
+				typeof state.documentId !== "string"
 			) {
-				throw new UsageError("ODSP driver state must contain an epoch string");
+				throw new UsageError("ODSP driver state must contain epoch and document ID strings");
+			}
+			if (state.documentId !== this.odspResolvedUrl.hashedDocumentId) {
+				throw new UsageError("ODSP driver state belongs to a different document");
 			}
 			const currentEpoch = this.epochTracker.fluidEpoch;
 			if (currentEpoch === state.epoch) {

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -27,6 +27,7 @@ import {
 	createChildMonitoringContext,
 	type MonitoringContext,
 	type TelemetryLoggerExt,
+	UsageError,
 } from "@fluidframework/telemetry-utils/internal";
 
 import type { HostStoragePolicyInternal } from "./contracts.js";
@@ -164,6 +165,17 @@ export class OdspDocumentService
 	}
 	public get policies(): IDocumentServicePolicies {
 		return this._policies;
+	}
+
+	public getDriverState(): string | undefined {
+		return this.epochTracker.fluidEpoch;
+	}
+
+	public setDriverState(state: unknown): void {
+		if (typeof state !== "string") {
+			throw new UsageError("ODSP driver state must be an epoch string");
+		}
+		this.epochTracker.setEpoch(state, false, "cache");
 	}
 
 	/**

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -196,11 +196,7 @@ export class OdspDocumentService
 			if (currentEpoch !== undefined) {
 				throw new UsageError("ODSP driver state epoch does not match the current epoch");
 			}
-			assert(
-				this.epochTracker.setEpochFromPendingState !== undefined,
-				"EpochTracker must support pending state restoration",
-			);
-			this.epochTracker.setEpochFromPendingState(state.epoch);
+			this.epochTracker.setEpoch(state.epoch, "pendingState");
 		},
 	};
 

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -17,12 +17,14 @@ import type {
 	IResolvedUrl,
 	ISequencedDocumentMessage,
 } from "@fluidframework/driver-definitions/internal";
+import { NonRetryableError } from "@fluidframework/driver-utils/internal";
 import type {
 	HostStoragePolicy,
 	IOdspResolvedUrl,
 	InstrumentedStorageTokenFetcher,
 	TokenFetchOptions,
 } from "@fluidframework/odsp-driver-definitions/internal";
+import { OdspErrorTypes } from "@fluidframework/odsp-driver-definitions/internal";
 import {
 	createChildMonitoringContext,
 	type MonitoringContext,
@@ -42,6 +44,7 @@ import { OdspDocumentStorageService } from "./odspDocumentStorageManager.js";
 import { hasOdcOrigin } from "./odspUrlHelper.js";
 import { getOdspResolvedUrl } from "./odspUtils.js";
 import { OpsCache } from "./opsCaching.js";
+import { pkgVersion as driverVersion } from "./packageVersion.js";
 import { RetryErrorsStorageAdapter } from "./retryErrorsStorageAdapter.js";
 
 /**
@@ -197,7 +200,15 @@ export class OdspDocumentService
 				return;
 			}
 			if (currentEpoch !== undefined) {
-				throw new UsageError("ODSP driver state epoch does not match the current epoch");
+				throw new NonRetryableError(
+					"ODSP driver state epoch does not match the current epoch",
+					OdspErrorTypes.fileOverwrittenInStorage,
+					{
+						driverVersion,
+						pendingStateEpoch: state.epoch,
+						currentEpoch,
+					},
+				);
 			}
 			this.epochTracker.setEpoch(state.epoch, "pendingState");
 		},

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -196,9 +196,11 @@ export class OdspDocumentService
 			if (currentEpoch !== undefined) {
 				throw new UsageError("ODSP driver state epoch does not match the current epoch");
 			}
-			// Pending state and the ODSP cache are both persisted client state; keep them in the
-			// same telemetry category rather than widening the exported FetchTypeInternal API.
-			this.epochTracker.setEpoch(state.epoch, true, "cache");
+			assert(
+				this.epochTracker.setEpochFromPendingState !== undefined,
+				"EpochTracker must support pending state restoration",
+			);
+			this.epochTracker.setEpochFromPendingState(state.epoch);
 		},
 	};
 

--- a/packages/drivers/odsp-driver/src/odspDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentService.ts
@@ -181,10 +181,13 @@ export class OdspDocumentService
 				Array.isArray(state) ||
 				!("epoch" in state) ||
 				typeof state.epoch !== "string" ||
+				state.epoch.length === 0 ||
 				!("documentId" in state) ||
 				typeof state.documentId !== "string"
 			) {
-				throw new UsageError("ODSP driver state must contain epoch and document ID strings");
+				throw new UsageError(
+					"ODSP driver state must contain a non-empty epoch and document ID string",
+				);
 			}
 			if (state.documentId !== this.odspResolvedUrl.hashedDocumentId) {
 				throw new UsageError("ODSP driver state belongs to a different document");

--- a/packages/drivers/odsp-driver/src/test/joinSessionCacheTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/joinSessionCacheTests.spec.ts
@@ -56,6 +56,16 @@ describe("expose joinSessionInfo Tests", () => {
 		async (_options) => "token",
 	);
 
+	it("preserves an epoch supplied in pending driver state", async () => {
+		const resolver = new OdspDriverUrlResolver();
+		const odspResolvedUrl = await resolver.resolve({
+			url: createOdspUrl({ driveId, itemId, siteUrl, dataStorePath: "/" }),
+		});
+		const service = await odspDocumentServiceFactory.createDocumentService(odspResolvedUrl);
+		service.setDriverState?.("epoch1");
+		assert.strictEqual(service.getDriverState?.(), "epoch1");
+	});
+
 	function addJoinSessionStub(): SinonStub {
 		const joinSessionStub = stub(fetchJoinSession, mockify.key).callsFake(
 			async () => joinSessionResponse,

--- a/packages/drivers/odsp-driver/src/test/joinSessionCacheTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/joinSessionCacheTests.spec.ts
@@ -63,12 +63,17 @@ describe("expose joinSessionInfo Tests", () => {
 		});
 		const service = await odspDocumentServiceFactory.createDocumentService(odspResolvedUrl);
 		assert(service.driverStatePersistence !== undefined);
-		service.driverStatePersistence.set({ epoch: "epoch1" });
-		service.driverStatePersistence.set({ epoch: "epoch1" });
-		assert.deepStrictEqual(service.driverStatePersistence.get(), { epoch: "epoch1" });
+		const driverState = { documentId: odspResolvedUrl.hashedDocumentId, epoch: "epoch1" };
+		service.driverStatePersistence.set(driverState);
+		service.driverStatePersistence.set(driverState);
+		assert.deepStrictEqual(service.driverStatePersistence.get(), driverState);
 		assert.throws(
-			() => service.driverStatePersistence?.set({ epoch: "epoch2" }),
+			() => service.driverStatePersistence?.set({ ...driverState, epoch: "epoch2" }),
 			/ODSP driver state epoch does not match the current epoch/,
+		);
+		assert.throws(
+			() => service.driverStatePersistence?.set({ ...driverState, documentId: "other" }),
+			/ODSP driver state belongs to a different document/,
 		);
 	});
 

--- a/packages/drivers/odsp-driver/src/test/joinSessionCacheTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/joinSessionCacheTests.spec.ts
@@ -62,8 +62,8 @@ describe("expose joinSessionInfo Tests", () => {
 			url: createOdspUrl({ driveId, itemId, siteUrl, dataStorePath: "/" }),
 		});
 		const service = await odspDocumentServiceFactory.createDocumentService(odspResolvedUrl);
-		service.setDriverState?.("epoch1");
-		assert.strictEqual(service.getDriverState?.(), "epoch1");
+		service.setDriverState?.({ epoch: "epoch1" });
+		assert.deepStrictEqual(service.getDriverState?.(), { epoch: "epoch1" });
 	});
 
 	function addJoinSessionStub(): SinonStub {

--- a/packages/drivers/odsp-driver/src/test/joinSessionCacheTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/joinSessionCacheTests.spec.ts
@@ -62,8 +62,14 @@ describe("expose joinSessionInfo Tests", () => {
 			url: createOdspUrl({ driveId, itemId, siteUrl, dataStorePath: "/" }),
 		});
 		const service = await odspDocumentServiceFactory.createDocumentService(odspResolvedUrl);
-		service.setDriverState?.({ epoch: "epoch1" });
-		assert.deepStrictEqual(service.getDriverState?.(), { epoch: "epoch1" });
+		assert(service.driverStatePersistence !== undefined);
+		service.driverStatePersistence.set({ epoch: "epoch1" });
+		service.driverStatePersistence.set({ epoch: "epoch1" });
+		assert.deepStrictEqual(service.driverStatePersistence.get(), { epoch: "epoch1" });
+		assert.throws(
+			() => service.driverStatePersistence?.set({ epoch: "epoch2" }),
+			/ODSP driver state epoch does not match the current epoch/,
+		);
 	});
 
 	function addJoinSessionStub(): SinonStub {

--- a/packages/drivers/odsp-driver/src/test/joinSessionCacheTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/joinSessionCacheTests.spec.ts
@@ -68,6 +68,10 @@ describe("expose joinSessionInfo Tests", () => {
 		);
 		assert(service.driverStatePersistence !== undefined);
 		const driverState = { documentId: odspResolvedUrl.hashedDocumentId, epoch: "epoch1" };
+		assert.throws(
+			() => service.driverStatePersistence?.set({ ...driverState, epoch: "" }),
+			/ODSP driver state must contain a non-empty epoch/,
+		);
 		service.driverStatePersistence.set(driverState);
 		logger.assertMatch([
 			{

--- a/packages/drivers/odsp-driver/src/test/joinSessionCacheTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/joinSessionCacheTests.spec.ts
@@ -77,6 +77,8 @@ describe("expose joinSessionInfo Tests", () => {
 			{
 				eventName: "OdspDriver:EpochLearnedFirstTime",
 				source: "pendingState",
+				fetchType: "pendingState",
+				fromCache: true,
 			},
 		]);
 		service.driverStatePersistence.set(driverState);

--- a/packages/drivers/odsp-driver/src/test/joinSessionCacheTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/joinSessionCacheTests.spec.ts
@@ -72,8 +72,7 @@ describe("expose joinSessionInfo Tests", () => {
 		logger.assertMatch([
 			{
 				eventName: "OdspDriver:EpochLearnedFirstTime",
-				fetchType: "pendingState",
-				fromCache: true,
+				source: "pendingState",
 			},
 		]);
 		service.driverStatePersistence.set(driverState);

--- a/packages/drivers/odsp-driver/src/test/joinSessionCacheTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/joinSessionCacheTests.spec.ts
@@ -61,10 +61,21 @@ describe("expose joinSessionInfo Tests", () => {
 		const odspResolvedUrl = await resolver.resolve({
 			url: createOdspUrl({ driveId, itemId, siteUrl, dataStorePath: "/" }),
 		});
-		const service = await odspDocumentServiceFactory.createDocumentService(odspResolvedUrl);
+		const logger = new MockLogger();
+		const service = await odspDocumentServiceFactory.createDocumentService(
+			odspResolvedUrl,
+			logger.toTelemetryLogger(),
+		);
 		assert(service.driverStatePersistence !== undefined);
 		const driverState = { documentId: odspResolvedUrl.hashedDocumentId, epoch: "epoch1" };
 		service.driverStatePersistence.set(driverState);
+		logger.assertMatch([
+			{
+				eventName: "OdspDriver:EpochLearnedFirstTime",
+				fetchType: "pendingState",
+				fromCache: true,
+			},
+		]);
 		service.driverStatePersistence.set(driverState);
 		assert.deepStrictEqual(service.driverStatePersistence.get(), driverState);
 		assert.throws(

--- a/packages/drivers/odsp-driver/src/test/joinSessionCacheTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/joinSessionCacheTests.spec.ts
@@ -14,6 +14,7 @@ import type {
 	IOdspResolvedUrl,
 	ISocketStorageDiscovery,
 } from "@fluidframework/odsp-driver-definitions/internal";
+import { OdspErrorTypes } from "@fluidframework/odsp-driver-definitions/internal";
 import { MockLogger } from "@fluidframework/telemetry-utils/internal";
 import { stub, type SinonStub } from "sinon";
 import type { Socket } from "socket.io-client";
@@ -85,7 +86,14 @@ describe("expose joinSessionInfo Tests", () => {
 		assert.deepStrictEqual(service.driverStatePersistence.get(), driverState);
 		assert.throws(
 			() => service.driverStatePersistence?.set({ ...driverState, epoch: "epoch2" }),
-			/ODSP driver state epoch does not match the current epoch/,
+			(error: IAnyDriverError) => {
+				assert.match(
+					error.message,
+					/ODSP driver state epoch does not match the current epoch/,
+				);
+				assert.equal(error.errorType, OdspErrorTypes.fileOverwrittenInStorage);
+				return true;
+			},
 		);
 		assert.throws(
 			() => service.driverStatePersistence?.set({ ...driverState, documentId: "other" }),

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1582,7 +1582,12 @@ export class Container
 			if (props.driverState !== undefined) {
 				// Restoration errors deliberately reject the load: ignoring malformed or foreign
 				// state could reconnect without the driver's persisted consistency protection.
-				service.driverStatePersistence?.set(props.driverState);
+				try {
+					service.driverStatePersistence?.set(props.driverState);
+				} catch (error) {
+					service.dispose(error);
+					throw error;
+				}
 			}
 			if (service.on !== undefined) {
 				// Back-compat for Old driver

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1198,7 +1198,7 @@ export class Container
 			this.clientId,
 			this.runtime,
 			this.resolvedUrl,
-			this.service?.getDriverState?.(),
+			this.service?.driverStatePersistence?.get(),
 		);
 		return pendingState;
 	}
@@ -1580,7 +1580,7 @@ export class Container
 				this.client.details.type === summarizerClientType,
 			);
 			if (props.driverState !== undefined) {
-				service.setDriverState?.(props.driverState);
+				service.driverStatePersistence?.set(props.driverState);
 			}
 			if (service.on !== undefined) {
 				// Back-compat for Old driver

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1580,6 +1580,8 @@ export class Container
 				this.client.details.type === summarizerClientType,
 			);
 			if (props.driverState !== undefined) {
+				// Restoration errors deliberately reject the load: ignoring malformed or foreign
+				// state could reconnect without the driver's persisted consistency protection.
 				service.driverStatePersistence?.set(props.driverState);
 			}
 			if (service.on !== undefined) {

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1583,7 +1583,10 @@ export class Container
 				// Restoration errors deliberately reject the load: ignoring malformed or foreign
 				// state could reconnect without the driver's persisted consistency protection.
 				try {
-					service.driverStatePersistence?.set(props.driverState);
+					if (service.driverStatePersistence === undefined) {
+						throw new UsageError("Document service cannot restore pending driver state");
+					}
+					service.driverStatePersistence.set(props.driverState);
 				} catch (error) {
 					service.dispose(error);
 					throw error;

--- a/packages/loader/container-loader/src/container.ts
+++ b/packages/loader/container-loader/src/container.ts
@@ -1198,6 +1198,7 @@ export class Container
 			this.clientId,
 			this.runtime,
 			this.resolvedUrl,
+			this.service?.getDriverState?.(),
 		);
 		return pendingState;
 	}
@@ -1567,7 +1568,9 @@ export class Container
 	 */
 	private async createDocumentService(
 		resolvedUrl: IResolvedUrl,
-		props: { mode: "load" } | { mode: "attach"; summary: ISummaryTree | undefined },
+		props:
+			| { mode: "load"; driverState?: unknown }
+			| { mode: "attach"; summary: ISummaryTree | undefined },
 	): Promise<IDocumentService> {
 		let service: IDocumentService;
 		if (props.mode === "load") {
@@ -1576,6 +1579,9 @@ export class Container
 				this.subLogger,
 				this.client.details.type === summarizerClientType,
 			);
+			if (props.driverState !== undefined) {
+				service.setDriverState?.(props.driverState);
+			}
 			if (service.on !== undefined) {
 				// Back-compat for Old driver
 				service.on("metadataUpdate", this.metadataUpdateHandler);
@@ -1624,7 +1630,10 @@ export class Container
 		numUnsummarizedOps: number;
 	}> {
 		const timings: Record<string, number> = { phase1: performanceNow() };
-		this.service = await this.createDocumentService(resolvedUrl, { mode: "load" });
+		this.service = await this.createDocumentService(resolvedUrl, {
+			mode: "load",
+			driverState: pendingLocalState?.driverState,
+		});
 
 		// Except in cases where its requested by feature gate, the container will connect in "read" mode
 		const mode =

--- a/packages/loader/container-loader/src/createAndLoadContainerUtils.ts
+++ b/packages/loader/container-loader/src/createAndLoadContainerUtils.ts
@@ -740,7 +740,7 @@ export async function captureFullContainerState({
 			pendingRuntimeState: undefined,
 			savedOps,
 			url: resolvedUrl.url,
-			driverState: documentService.getDriverState?.(),
+			driverState: documentService.driverStatePersistence?.get(),
 		};
 		return JSON.stringify(pendingState);
 	} finally {

--- a/packages/loader/container-loader/src/createAndLoadContainerUtils.ts
+++ b/packages/loader/container-loader/src/createAndLoadContainerUtils.ts
@@ -419,8 +419,7 @@ export async function loadFrozenContainerFromPendingState(
 	if (driverWiring === "none") {
 		// Offline: synthesize the driver wiring from the URL captured in pending state.
 		// The container's load pipeline is reused unchanged — the synthesized resolver
-		// returns a resolved URL whose `url` equals `pendingLocalState.url`, so the
-		// identity guard in `Loader.resolveCore` is trivially satisfied.
+		// returns a resolved URL whose `url` equals `pendingLocalState.url`.
 		const pending = getAttachedContainerStateFromSerializedContainer(pendingLocalState);
 		if (pending.blobContentsMode === "reference") {
 			throw new UsageError(
@@ -467,9 +466,7 @@ export async function loadFrozenContainerFromPendingState(
 		return loadExistingContainer({
 			...props,
 			// `request.url` is unused: `synthesizedUrlResolver.resolve()` returns
-			// `synthesizedResolvedUrl` regardless of input, and the identity
-			// guard in `Loader.resolveCore` compares the resolver's output URL
-			// against `pendingLocalState.url` — both equal `pending.url` here.
+			// `synthesizedResolvedUrl` regardless of input.
 			// Using a recognizable opaque placeholder instead of the resolved-form
 			// URL avoids implying that any downstream stage interprets it as a
 			// request-form URL.

--- a/packages/loader/container-loader/src/createAndLoadContainerUtils.ts
+++ b/packages/loader/container-loader/src/createAndLoadContainerUtils.ts
@@ -740,6 +740,7 @@ export async function captureFullContainerState({
 			pendingRuntimeState: undefined,
 			savedOps,
 			url: resolvedUrl.url,
+			driverState: documentService.getDriverState?.(),
 		};
 		return JSON.stringify(pendingState);
 	} finally {

--- a/packages/loader/container-loader/src/frozenServices.ts
+++ b/packages/loader/container-loader/src/frozenServices.ts
@@ -119,6 +119,12 @@ class FrozenDocumentService
 	}
 
 	public readonly policies: IDocumentServicePolicies;
+	getDriverState(): unknown {
+		return this.documentService?.getDriverState?.();
+	}
+	setDriverState(state: unknown): void {
+		this.documentService?.setDriverState?.(state);
+	}
 	async connectToStorage(): Promise<IDocumentStorageService> {
 		const storage = new FrozenDocumentStorageService(
 			this.readOnly,

--- a/packages/loader/container-loader/src/frozenServices.ts
+++ b/packages/loader/container-loader/src/frozenServices.ts
@@ -97,6 +97,9 @@ class FrozenDocumentService
 	// called more than once — we cannot assume the Container holds a single instance.
 	private readonly storageServices = new Set<FrozenDocumentStorageService>();
 	private driverState: unknown;
+	public readonly driverStatePersistence?: NonNullable<
+		IDocumentService["driverStatePersistence"]
+	>;
 
 	constructor(
 		public readonly resolvedUrl: IResolvedUrl,
@@ -117,19 +120,20 @@ class FrozenDocumentService
 		// indistinguishable from a normal container at the policies layer; downstream behavior
 		// flows through the live `WritableFrozenDeltaStream` instead.
 		this.policies = readOnly ? { storageOnly: true } : {};
+		const innerPersistence = this.documentService?.driverStatePersistence;
+		if (this.documentService === undefined || innerPersistence !== undefined) {
+			this.driverStatePersistence = {
+				get: () =>
+					innerPersistence === undefined ? this.driverState : innerPersistence.get(),
+				set: (state) => {
+					this.driverState = state;
+					innerPersistence?.set(state);
+				},
+			};
+		}
 	}
 
 	public readonly policies: IDocumentServicePolicies;
-	public readonly driverStatePersistence = {
-		get: (): unknown =>
-			this.documentService?.driverStatePersistence === undefined
-				? this.driverState
-				: this.documentService.driverStatePersistence.get(),
-		set: (state: unknown): void => {
-			this.driverState = state;
-			this.documentService?.driverStatePersistence?.set(state);
-		},
-	};
 	async connectToStorage(): Promise<IDocumentStorageService> {
 		const storage = new FrozenDocumentStorageService(
 			this.readOnly,

--- a/packages/loader/container-loader/src/frozenServices.ts
+++ b/packages/loader/container-loader/src/frozenServices.ts
@@ -96,6 +96,7 @@ class FrozenDocumentService
 	// a single field because `IDocumentService.connectToStorage` is a public API that can be
 	// called more than once — we cannot assume the Container holds a single instance.
 	private readonly storageServices = new Set<FrozenDocumentStorageService>();
+	private driverState: unknown;
 
 	constructor(
 		public readonly resolvedUrl: IResolvedUrl,
@@ -120,9 +121,10 @@ class FrozenDocumentService
 
 	public readonly policies: IDocumentServicePolicies;
 	getDriverState(): unknown {
-		return this.documentService?.getDriverState?.();
+		return this.documentService?.getDriverState?.() ?? this.driverState;
 	}
 	setDriverState(state: unknown): void {
+		this.driverState = state;
 		this.documentService?.setDriverState?.(state);
 	}
 	async connectToStorage(): Promise<IDocumentStorageService> {

--- a/packages/loader/container-loader/src/frozenServices.ts
+++ b/packages/loader/container-loader/src/frozenServices.ts
@@ -120,13 +120,16 @@ class FrozenDocumentService
 	}
 
 	public readonly policies: IDocumentServicePolicies;
-	getDriverState(): unknown {
-		return this.documentService?.getDriverState?.() ?? this.driverState;
-	}
-	setDriverState(state: unknown): void {
-		this.driverState = state;
-		this.documentService?.setDriverState?.(state);
-	}
+	public readonly driverStatePersistence = {
+		get: (): unknown =>
+			this.documentService?.driverStatePersistence === undefined
+				? this.driverState
+				: this.documentService.driverStatePersistence.get(),
+		set: (state: unknown): void => {
+			this.driverState = state;
+			this.documentService?.driverStatePersistence?.set(state);
+		},
+	};
 	async connectToStorage(): Promise<IDocumentStorageService> {
 		const storage = new FrozenDocumentStorageService(
 			this.readOnly,

--- a/packages/loader/container-loader/src/loader.ts
+++ b/packages/loader/container-loader/src/loader.ts
@@ -333,7 +333,9 @@ export class Loader implements IHostLoader {
 			throw new Error(`Invalid URL ${resolvedAsFluid.url}`);
 		}
 
-		if (pendingLocalState !== undefined) {
+		// Driver state owns document identity when present. Older pending state falls back to the
+		// loader's URL-shape-dependent validation.
+		if (pendingLocalState !== undefined && pendingLocalState.driverState === undefined) {
 			const parsedPendingUrl = tryParseCompatibleResolvedUrl(pendingLocalState.url);
 			if (
 				parsedPendingUrl?.id !== parsed.id ||

--- a/packages/loader/container-loader/src/serializedStateManager.ts
+++ b/packages/loader/container-loader/src/serializedStateManager.ts
@@ -119,6 +119,10 @@ export interface IPendingContainerState extends SnapshotWithBlobs {
 	 * If the Container was connected when serialized, its clientId. Used as the initial clientId upon rehydration, until reconnected.
 	 */
 	clientId?: string;
+	/**
+	 * Opaque state supplied by the document service for use when rehydrating.
+	 */
+	driverState?: unknown;
 }
 
 /**
@@ -423,6 +427,7 @@ export class SerializedStateManager implements IDisposable {
 		clientId: string | undefined,
 		runtime: Pick<IRuntime, "getPendingLocalState">,
 		resolvedUrl: IResolvedUrl,
+		driverState?: unknown,
 	): Promise<string> {
 		this.verifyNotDisposed();
 		if (!this.offlineLoadEnabled) {
@@ -476,6 +481,7 @@ export class SerializedStateManager implements IDisposable {
 					savedOps: this.processedOps,
 					url: resolvedUrl.url,
 					clientId,
+					driverState,
 				};
 
 				return JSON.stringify(pendingState);

--- a/packages/loader/container-loader/src/serializedStateManager.ts
+++ b/packages/loader/container-loader/src/serializedStateManager.ts
@@ -112,7 +112,8 @@ export interface IPendingContainerState extends SnapshotWithBlobs {
 	 */
 	savedOps: ISequencedDocumentMessage[];
 	/**
-	 * The Container's URL in the service, needed to hook up the driver during rehydration
+	 * The Container's URL in the service, needed to hook up the driver during rehydration and to
+	 * validate the document identity of legacy pending state that has no {@link driverState}.
 	 */
 	url: string;
 	/**
@@ -121,7 +122,8 @@ export interface IPendingContainerState extends SnapshotWithBlobs {
 	clientId?: string;
 	/**
 	 * Opaque state supplied by the document service for use when rehydrating. This value is
-	 * persisted by the host and must not contain customer-identifying information.
+	 * persisted by the host, must not contain customer-identifying information, and is responsible
+	 * for validating that it belongs to the document being loaded.
 	 */
 	driverState?: unknown;
 }

--- a/packages/loader/container-loader/src/serializedStateManager.ts
+++ b/packages/loader/container-loader/src/serializedStateManager.ts
@@ -120,7 +120,8 @@ export interface IPendingContainerState extends SnapshotWithBlobs {
 	 */
 	clientId?: string;
 	/**
-	 * Opaque state supplied by the document service for use when rehydrating.
+	 * Opaque state supplied by the document service for use when rehydrating. This value is
+	 * persisted by the host and must not contain customer-identifying information.
 	 */
 	driverState?: unknown;
 }

--- a/packages/loader/container-loader/src/serializedStateManager.ts
+++ b/packages/loader/container-loader/src/serializedStateManager.ts
@@ -122,8 +122,10 @@ export interface IPendingContainerState extends SnapshotWithBlobs {
 	clientId?: string;
 	/**
 	 * Opaque state supplied by the document service for use when rehydrating. This value is
-	 * persisted by the host, must not contain customer-identifying information, and is responsible
-	 * for validating that it belongs to the document being loaded.
+	 * serialized as part of the containing pending state and persisted by the host. It must
+	 * round-trip through `JSON.stringify` and `JSON.parse` without custom serialization or
+	 * information loss, must not contain customer-identifying information, and is responsible for
+	 * validating that it belongs to the document being loaded.
 	 */
 	driverState?: unknown;
 }

--- a/packages/loader/container-loader/src/test/frozenServices.spec.ts
+++ b/packages/loader/container-loader/src/test/frozenServices.spec.ts
@@ -176,9 +176,41 @@ describe("FrozenDocumentService driver state", () => {
 		);
 		const state = { epoch: "epoch1" };
 
-		service.setDriverState?.(state);
+		service.driverStatePersistence?.set(state);
 
-		assert.deepStrictEqual(service.getDriverState?.(), state);
+		assert.deepStrictEqual(service.driverStatePersistence?.get(), state);
+	});
+
+	it("uses the inner service state when its persistence capability is present", async () => {
+		let innerState: unknown;
+		const innerService = {
+			resolvedUrl: fakeUrl,
+			policies: {},
+			driverStatePersistence: {
+				get: () => innerState,
+				set: () => {},
+			},
+		} as unknown as IDocumentService;
+		const innerFactory: IDocumentServiceFactory = {
+			createDocumentService: async () => innerService,
+			createContainer: async () => {
+				throw new Error("not used in this test");
+			},
+		};
+		const service = await new FrozenDocumentServiceFactory(
+			false,
+			innerFactory,
+		).createDocumentService(fakeUrl);
+
+		service.driverStatePersistence?.set({ epoch: "restored" });
+		assert.strictEqual(service.driverStatePersistence?.get(), undefined);
+
+		const nullState: unknown = JSON.parse("null");
+		innerState = nullState;
+		assert.strictEqual(service.driverStatePersistence?.get(), nullState);
+
+		innerState = { epoch: "live" };
+		assert.deepStrictEqual(service.driverStatePersistence?.get(), innerState);
 	});
 });
 

--- a/packages/loader/container-loader/src/test/frozenServices.spec.ts
+++ b/packages/loader/container-loader/src/test/frozenServices.spec.ts
@@ -169,6 +169,19 @@ describe("FrozenDocumentService.connectToDeltaStream", () => {
 	});
 });
 
+describe("FrozenDocumentService driver state", () => {
+	it("preserves state without an inner document service", async () => {
+		const service = await new FrozenDocumentServiceFactory(false).createDocumentService(
+			fakeUrl,
+		);
+		const state = { epoch: "epoch1" };
+
+		service.setDriverState?.(state);
+
+		assert.deepStrictEqual(service.getDriverState?.(), state);
+	});
+});
+
 describe("FrozenDocumentService disposal", () => {
 	it("dispose() rejects in-flight createBlob promises on writable-frozen storage", async () => {
 		// The writable-frozen `createBlob` returns a never-resolving promise so the

--- a/packages/loader/container-loader/src/test/frozenServices.spec.ts
+++ b/packages/loader/container-loader/src/test/frozenServices.spec.ts
@@ -212,6 +212,25 @@ describe("FrozenDocumentService driver state", () => {
 		innerState = { epoch: "live" };
 		assert.deepStrictEqual(service.driverStatePersistence?.get(), innerState);
 	});
+
+	it("does not expose persistence when the inner service cannot validate state", async () => {
+		const innerService = {
+			resolvedUrl: fakeUrl,
+			policies: {},
+		} as unknown as IDocumentService;
+		const innerFactory: IDocumentServiceFactory = {
+			createDocumentService: async () => innerService,
+			createContainer: async () => {
+				throw new Error("not used in this test");
+			},
+		};
+		const service = await new FrozenDocumentServiceFactory(
+			false,
+			innerFactory,
+		).createDocumentService(fakeUrl);
+
+		assert.strictEqual(service.driverStatePersistence, undefined);
+	});
 });
 
 describe("FrozenDocumentService disposal", () => {

--- a/packages/loader/container-loader/src/test/loader.spec.ts
+++ b/packages/loader/container-loader/src/test/loader.spec.ts
@@ -237,6 +237,59 @@ describe("DisableLoadConnectionRetries", () => {
 		return error;
 	}
 
+	it("restores driver state before connecting the document service", async () => {
+		const driverState = { epoch: "epoch1" };
+		let restored = false;
+		const documentServiceFactory = failSometimeProxy<
+			IDocumentServiceFactory &
+				IProvideLayerCompatDetails &
+				IProvideLayerCompatSupportRequirements
+		>({
+			createDocumentService: async () =>
+				failSometimeProxy<IDocumentService>({
+					policies: {},
+					resolvedUrl,
+					driverStatePersistence: {
+						get: () => undefined,
+						set: (state) => {
+							assert.deepStrictEqual(state, driverState);
+							restored = true;
+						},
+					},
+					connectToStorage: async () => {
+						assert(restored, "Driver state must be restored before connecting to storage");
+						throw new Error("stop after ordering check");
+					},
+					connectToDeltaStream: async () => new Promise(() => {}),
+					on: AbsentProperty,
+					off: AbsentProperty,
+					dispose: () => {},
+				}),
+			ILayerCompatDetails: AbsentProperty,
+			ILayerCompatSupportRequirements: AbsentProperty,
+		});
+		const loader = new Loader({
+			codeLoader: createTestCodeLoaderProxy(),
+			documentServiceFactory,
+			urlResolver,
+		});
+		const pendingState = JSON.stringify({
+			attached: true,
+			baseSnapshot: { blobs: {}, trees: {} },
+			snapshotBlobs: {},
+			pendingRuntimeState: {},
+			savedOps: [],
+			url: resolvedUrl.url,
+			driverState,
+		});
+
+		await assert.rejects(
+			async () => loader.resolve({ url: "test" }, pendingState),
+			/stop after ordering check/,
+		);
+		assert(restored);
+	});
+
 	it("load rejects when connectToStorage fails with retryable error and flag is enabled", async () => {
 		const documentServiceFactory = failSometimeProxy<
 			IDocumentServiceFactory &

--- a/packages/loader/container-loader/src/test/loader.spec.ts
+++ b/packages/loader/container-loader/src/test/loader.spec.ts
@@ -243,6 +243,7 @@ describe("DisableLoadConnectionRetries", () => {
 		let shouldThrowRestoreError = false;
 		const restoreError = new Error("invalid driver state");
 		let connectionAttempts = 0;
+		const disposalErrors: unknown[] = [];
 		const documentServiceFactory = failSometimeProxy<
 			IDocumentServiceFactory &
 				IProvideLayerCompatDetails &
@@ -270,7 +271,7 @@ describe("DisableLoadConnectionRetries", () => {
 					connectToDeltaStream: async () => new Promise(() => {}),
 					on: AbsentProperty,
 					off: AbsentProperty,
-					dispose: () => {},
+					dispose: (error) => disposalErrors.push(error),
 				}),
 			ILayerCompatDetails: AbsentProperty,
 			ILayerCompatSupportRequirements: AbsentProperty,
@@ -303,6 +304,7 @@ describe("DisableLoadConnectionRetries", () => {
 			restoreError,
 		);
 		assert.strictEqual(connectionAttempts, 1);
+		assert.strictEqual(disposalErrors.at(-1), restoreError);
 	});
 
 	it("load rejects when connectToStorage fails with retryable error and flag is enabled", async () => {

--- a/packages/loader/container-loader/src/test/loader.spec.ts
+++ b/packages/loader/container-loader/src/test/loader.spec.ts
@@ -237,9 +237,11 @@ describe("DisableLoadConnectionRetries", () => {
 		return error;
 	}
 
-	it("restores driver state before connecting the document service", async () => {
+	it("restores driver state before connecting and propagates restoration errors", async () => {
 		const driverState = { epoch: "epoch1" };
 		let restored = false;
+		let restoreError: Error | undefined;
+		let connectionAttempts = 0;
 		const documentServiceFactory = failSometimeProxy<
 			IDocumentServiceFactory &
 				IProvideLayerCompatDetails &
@@ -253,10 +255,14 @@ describe("DisableLoadConnectionRetries", () => {
 						get: () => undefined,
 						set: (state) => {
 							assert.deepStrictEqual(state, driverState);
+							if (restoreError !== undefined) {
+								throw restoreError;
+							}
 							restored = true;
 						},
 					},
 					connectToStorage: async () => {
+						connectionAttempts++;
 						assert(restored, "Driver state must be restored before connecting to storage");
 						throw new Error("stop after ordering check");
 					},
@@ -288,6 +294,14 @@ describe("DisableLoadConnectionRetries", () => {
 			/stop after ordering check/,
 		);
 		assert(restored);
+		assert.strictEqual(connectionAttempts, 1);
+
+		restoreError = new Error("invalid driver state");
+		await assert.rejects(
+			async () => loader.resolve({ url: "test" }, pendingState),
+			restoreError,
+		);
+		assert.strictEqual(connectionAttempts, 1);
 	});
 
 	it("load rejects when connectToStorage fails with retryable error and flag is enabled", async () => {

--- a/packages/loader/container-loader/src/test/loader.spec.ts
+++ b/packages/loader/container-loader/src/test/loader.spec.ts
@@ -240,7 +240,8 @@ describe("DisableLoadConnectionRetries", () => {
 	it("restores driver state before connecting and propagates restoration errors", async () => {
 		const driverState = { epoch: "epoch1" };
 		let restored = false;
-		let restoreError: Error | undefined;
+		let shouldThrowRestoreError = false;
+		const restoreError = new Error("invalid driver state");
 		let connectionAttempts = 0;
 		const documentServiceFactory = failSometimeProxy<
 			IDocumentServiceFactory &
@@ -255,7 +256,7 @@ describe("DisableLoadConnectionRetries", () => {
 						get: () => undefined,
 						set: (state) => {
 							assert.deepStrictEqual(state, driverState);
-							if (restoreError !== undefined) {
+							if (shouldThrowRestoreError) {
 								throw restoreError;
 							}
 							restored = true;
@@ -296,7 +297,7 @@ describe("DisableLoadConnectionRetries", () => {
 		assert(restored);
 		assert.strictEqual(connectionAttempts, 1);
 
-		restoreError = new Error("invalid driver state");
+		shouldThrowRestoreError = true;
 		await assert.rejects(
 			async () => loader.resolve({ url: "test" }, pendingState),
 			restoreError,

--- a/packages/loader/container-loader/src/test/loader.spec.ts
+++ b/packages/loader/container-loader/src/test/loader.spec.ts
@@ -237,10 +237,11 @@ describe("DisableLoadConnectionRetries", () => {
 		return error;
 	}
 
-	it("restores driver state before connecting and propagates restoration errors", async () => {
+	it("delegates identity validation and restores driver state before connecting", async () => {
 		const driverState = { epoch: "epoch1" };
 		let restored = false;
 		let shouldThrowRestoreError = false;
+		let supportsDriverStatePersistence = true;
 		const restoreError = new Error("invalid driver state");
 		let connectionAttempts = 0;
 		const disposalErrors: unknown[] = [];
@@ -253,16 +254,18 @@ describe("DisableLoadConnectionRetries", () => {
 				failSometimeProxy<IDocumentService>({
 					policies: {},
 					resolvedUrl,
-					driverStatePersistence: {
-						get: () => undefined,
-						set: (state) => {
-							assert.deepStrictEqual(state, driverState);
-							if (shouldThrowRestoreError) {
-								throw restoreError;
+					driverStatePersistence: supportsDriverStatePersistence
+						? {
+								get: () => undefined,
+								set: (state) => {
+									assert.deepStrictEqual(state, driverState);
+									if (shouldThrowRestoreError) {
+										throw restoreError;
+									}
+									restored = true;
+								},
 							}
-							restored = true;
-						},
-					},
+						: AbsentProperty,
 					connectToStorage: async () => {
 						connectionAttempts++;
 						assert(restored, "Driver state must be restored before connecting to storage");
@@ -281,15 +284,16 @@ describe("DisableLoadConnectionRetries", () => {
 			documentServiceFactory,
 			urlResolver,
 		});
-		const pendingState = JSON.stringify({
+		const pendingStateData = {
 			attached: true,
 			baseSnapshot: { blobs: {}, trees: {} },
 			snapshotBlobs: {},
 			pendingRuntimeState: {},
 			savedOps: [],
-			url: resolvedUrl.url,
+			url: `https://localhost/tenant/${uuid()}`,
 			driverState,
-		});
+		};
+		const pendingState = JSON.stringify(pendingStateData);
 
 		await assert.rejects(
 			async () => loader.resolve({ url: "test" }, pendingState),
@@ -305,6 +309,22 @@ describe("DisableLoadConnectionRetries", () => {
 		);
 		assert.strictEqual(connectionAttempts, 1);
 		assert.strictEqual(disposalErrors.at(-1), restoreError);
+
+		await assert.rejects(
+			async () =>
+				loader.resolve(
+					{ url: "test" },
+					JSON.stringify({ ...pendingStateData, driverState: undefined }),
+				),
+			/does not match pending state URL/,
+		);
+
+		supportsDriverStatePersistence = false;
+		await assert.rejects(
+			async () => loader.resolve({ url: "test" }, pendingState),
+			/Document service cannot restore pending driver state/,
+		);
+		assert.strictEqual(connectionAttempts, 1);
 	});
 
 	it("load rejects when connectToStorage fails with retryable error and flag is enabled", async () => {

--- a/packages/loader/container-loader/src/test/serializedStateManager.spec.ts
+++ b/packages/loader/container-loader/src/test/serializedStateManager.spec.ts
@@ -243,11 +243,13 @@ describe("serializedStateManager", () => {
 			);
 			// equivalent to attach
 			serializedStateManager.setInitialSnapshot(initialSnapshot);
-			await serializedStateManager.getPendingLocalState(
+			const state = await serializedStateManager.getPendingLocalState(
 				"clientId",
 				new MockRuntime(),
 				resolvedUrl,
+				"epoch",
 			);
+			assert.strictEqual((JSON.parse(state) as IPendingContainerState).driverState, "epoch");
 		});
 
 		it("can get pending local state from previous pending state", async () => {

--- a/packages/loader/driver-utils/src/documentServiceProxy.ts
+++ b/packages/loader/driver-utils/src/documentServiceProxy.ts
@@ -43,6 +43,14 @@ export abstract class DocumentServiceProxy
 		return this._service.connectToDeltaStream(client);
 	}
 
+	public getDriverState(): unknown {
+		return this._service.getDriverState?.();
+	}
+
+	public setDriverState(state: unknown): void {
+		this._service.setDriverState?.(state);
+	}
+
 	public dispose(error?: unknown): void {
 		this._service.dispose(error);
 	}

--- a/packages/loader/driver-utils/src/documentServiceProxy.ts
+++ b/packages/loader/driver-utils/src/documentServiceProxy.ts
@@ -23,8 +23,15 @@ export abstract class DocumentServiceProxy
 	extends TypedEventEmitter<IDocumentServiceEvents>
 	implements IDocumentService
 {
+	public readonly driverStatePersistence?: NonNullable<
+		IDocumentService["driverStatePersistence"]
+	>;
+
 	constructor(private readonly _service: IDocumentService) {
 		super();
+		if (_service.driverStatePersistence !== undefined) {
+			this.driverStatePersistence = _service.driverStatePersistence;
+		}
 	}
 
 	public get service(): IDocumentService {
@@ -41,14 +48,6 @@ export abstract class DocumentServiceProxy
 
 	public async connectToDeltaStream(client: IClient): Promise<IDocumentDeltaConnection> {
 		return this._service.connectToDeltaStream(client);
-	}
-
-	public getDriverState(): unknown {
-		return this._service.getDriverState?.();
-	}
-
-	public setDriverState(state: unknown): void {
-		this._service.setDriverState?.(state);
 	}
 
 	public dispose(error?: unknown): void {

--- a/packages/test/test-end-to-end-tests/src/test/pointInTime/epochMismatch.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/pointInTime/epochMismatch.spec.ts
@@ -31,6 +31,11 @@
 import { strict as assert } from "assert";
 
 import { describeCompat, itExpects } from "@fluid-private/test-version-utils";
+import {
+	createLoader,
+	getRequiredPendingLocalState,
+	waitForContainerConnection,
+} from "@fluidframework/test-utils/internal";
 
 import { listFileVersions, restoreFileVersion } from "./odspVersionTestApi.js";
 import {
@@ -44,6 +49,55 @@ describeCompat(
 	"NoCompat",
 	(getTestObjectProvider, apis) => {
 		const suite = setupPointInTimeSuite(getTestObjectProvider, apis);
+
+		itExpects(
+			"rejects pending state captured before a file restore",
+			[
+				{
+					eventName: "fluid:telemetry:Container:ContainerClose",
+					errorType: "fileOverwrittenInStorage",
+				},
+			],
+			async function (this: Mocha.Context) {
+				this.timeout(120_000);
+
+				const ctx = await createPointInTimeTestContext(suite, apis, {
+					withSummarizer: true,
+				});
+				await ctx.incrementAndSync(1);
+				const olderVersion = await ctx.snapVersion("pending-state-base");
+				await ctx.incrementAndSync(1);
+				await ctx.snapVersion("pending-state-tip");
+
+				ctx.container.disconnect();
+				ctx.dataObject.increment();
+				const pendingState = await getRequiredPendingLocalState(ctx.container);
+				ctx.container.close();
+
+				const restored = await restoreFileVersion(ctx.versionApi, olderVersion.id);
+				assert.strictEqual(restored, true, "restore should succeed (HTTP 204)");
+
+				const provider = suite.provider();
+				const loader = createLoader(
+					[[provider.defaultCodeDetails, suite.runtimeFactory()]],
+					provider.documentServiceFactory,
+					provider.urlResolver,
+					provider.logger,
+				);
+				const url = await provider.driver.createContainerUrl(ctx.documentId);
+
+				const resumed = await loader.resolve({ url }, pendingState);
+				await assert.rejects(
+					waitForContainerConnection(resumed, true, {
+						durationMs: 60_000,
+						errorMsg: "timed out waiting for the stale pending-state container to close",
+					}),
+					(error: Error & { errorType?: string }) =>
+						error.errorType === "fileOverwrittenInStorage",
+					"expected pending state from the previous epoch to be rejected",
+				);
+			},
+		);
 
 		// The failed point-in-time load closes its container with the driver's non-retryable
 		// fileOverwrittenInStorage (epoch-mismatch) error. That ContainerClose is the expected

--- a/packages/test/test-end-to-end-tests/src/test/pointInTime/epochMismatch.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/pointInTime/epochMismatch.spec.ts
@@ -86,12 +86,14 @@ describeCompat(
 				);
 				const url = await provider.driver.createContainerUrl(ctx.documentId);
 
-				const resumed = await loader.resolve({ url }, pendingState);
 				await assert.rejects(
-					waitForContainerConnection(resumed, true, {
-						durationMs: 60_000,
-						errorMsg: "timed out waiting for the stale pending-state container to close",
-					}),
+					async () => {
+						const resumed = await loader.resolve({ url }, pendingState);
+						await waitForContainerConnection(resumed, true, {
+							durationMs: 60_000,
+							errorMsg: "timed out waiting for the stale pending-state container to close",
+						});
+					},
 					(error: Error & { errorType?: string }) =>
 						error.errorType === "fileOverwrittenInStorage",
 					"expected pending state from the previous epoch to be rejected",

--- a/packages/test/test-service-load/src/faultInjectionDriver.ts
+++ b/packages/test/test-service-load/src/faultInjectionDriver.ts
@@ -124,6 +124,12 @@ export class FaultInjectionDocumentService
 	public get policies(): IDocumentServicePolicies | undefined {
 		return this.internal.policies;
 	}
+	public getDriverState(): unknown {
+		return this.internal.getDriverState?.();
+	}
+	public setDriverState(state: unknown): void {
+		this.internal.setDriverState?.(state);
+	}
 	public get documentDeltaConnection(): FaultInjectionDocumentDeltaConnection | undefined {
 		return this._currentDeltaStream;
 	}

--- a/packages/test/test-service-load/src/faultInjectionDriver.ts
+++ b/packages/test/test-service-load/src/faultInjectionDriver.ts
@@ -114,8 +114,15 @@ export class FaultInjectionDocumentService
 		this._currentDeltaStorage?.goOnline();
 	}
 
+	public readonly driverStatePersistence?: NonNullable<
+		IDocumentService["driverStatePersistence"]
+	>;
+
 	constructor(private readonly internal: IDocumentService) {
 		super();
+		if (internal.driverStatePersistence !== undefined) {
+			this.driverStatePersistence = internal.driverStatePersistence;
+		}
 	}
 
 	public get resolvedUrl(): IResolvedUrl {
@@ -123,12 +130,6 @@ export class FaultInjectionDocumentService
 	}
 	public get policies(): IDocumentServicePolicies | undefined {
 		return this.internal.policies;
-	}
-	public getDriverState(): unknown {
-		return this.internal.getDriverState?.();
-	}
-	public setDriverState(state: unknown): void {
-		this.internal.setDriverState?.(state);
 	}
 	public get documentDeltaConnection(): FaultInjectionDocumentDeltaConnection | undefined {
 		return this._currentDeltaStream;


### PR DESCRIPTION
## Description

[AB#82272](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/82272)

ODSP uses an epoch to detect when a file has been restored server-side. Pending container state did not preserve that epoch, so loading stale pending state could learn the restored file's current epoch and replay stale operations instead of rejecting them.

This change lets document services provide opaque state for pending-state serialization and restores it before connecting to storage or the delta stream. ODSP uses the hook to preserve its epoch. Existing pending state and drivers remain compatible because the hooks and serialized field are optional.

Tests cover pending-state serialization and ODSP epoch restoration.

## Reviewer Guidance

The review process is outlined in [the pull request guidelines](../docs/content/Contributing/PR-Guidelines.md#guidelines).

The `IDocumentService` additions affect the `@legacy @beta` API surface and require API Council review.