### PR TITLE
fix(devtools-core): avoid self-import during CommonJS build

### DIFF
--- a/packages/tools/devtools/devtools-core/src/data-visualization/VisualSharedTreeTypes.ts
+++ b/packages/tools/devtools/devtools-core/src/data-visualization/VisualSharedTreeTypes.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import type { VisualChildNode } from "@fluidframework/devtools-core/internal";
+import type { VisualChildNode } from "./VisualTree.js";
 
 /**
  * Base visualizer for SharedTree.


### PR DESCRIPTION
## Description

Fix an intermittent CommonJS build race in `@fluidframework/devtools-core`. `VisualSharedTreeTypes.ts` imported `VisualChildNode` through the package's generated `/internal` entrypoint, which resolves to `lib/index.d.ts`. When the CommonJS compile ran before the concurrent ESM build produced that file, TypeScript failed with TS2307.

The issue reproduces deterministically by building workspace dependencies, cleaning only `devtools-core`, and running `build:cjs`. Importing the type directly from `./VisualTree.js` removes the generated-output dependency and allows the clean CommonJS build to succeed.

[AB#82524](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/82524)

## Reviewer Guidance

The review process is outlined in [the pull request guidelines](../docs/content/Contributing/PR-Guidelines.md#guidelines).

The generated type-compatibility test still intentionally imports the built `/alpha` entrypoint as a consumer. This change removes the only production-source self-import.