### PR TITLE
tree: Add changeset for transaction minimizer

### DIFF
--- a/.changeset/wicked-teams-go.md
+++ b/.changeset/wicked-teams-go.md
@@ -5,8 +5,9 @@
 ---
 Add the `minimize` transaction post-processor
 
-When calling `runTransaction` or `runTransactionAsync`, with `RunTransactionParamsAlpha.postProcessor` set to `minimize`,
-edits any newly created nodes which are removed by the transaction will be discarded.
+When calling `runTransaction` or `runTransactionAsync` on a [`TreeContextAlpha`](https://fluidframework.com/docs/api/fluid-framework/treecontextalpha-interface),
+with `RunTransactionParamsAlpha.postProcessor` set to [`minimize`](https://fluidframework.com/docs/api/fluid-framework/#minimize-variable),
+edits to any newly created nodes which are removed by the transaction will be discarded.
 Edits to removed nodes will also be discarded.
 This is intended to remove information from changes (which, for example, may have been made by an AI system)
 which cannot be easily inspected by a user looking at the effect of that change on the document.

--- a/.changeset/wicked-teams-go.md
+++ b/.changeset/wicked-teams-go.md
@@ -1,0 +1,16 @@
+---
+"@fluidframework/tree": minor
+"fluid-framework": minor
+"__section": tree
+---
+Add the `minimize` transaction post-processor
+
+When calling `runTransaction` or `runTransactionAsync`, with `RunTransactionParamsAlpha.postProcessor` set to `minimize`,
+edits any newly created nodes which are removed by the transaction will be discarded.
+Edits to removed nodes will also be discarded.
+This is intended to remove information from changes (which, for example, may have been made by an AI system)
+which cannot be easily inspected by a user looking at the effect of that change on the document.
+
+```typescript
+tree.runTransaction(() => { ... }, { postProcessor: minimize });
+```

--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -950,7 +950,7 @@ export const MapNodeSchema: {
     readonly [Symbol.hasInstance]: (value: TreeNodeSchema) => value is MapNodeSchema;
 };
 
-// @alpha @deprecated
+// @alpha
 export const minimize: TransactionPostProcessor;
 
 // @alpha

--- a/packages/dds/tree/src/shared-tree/transactionMinimize.ts
+++ b/packages/dds/tree/src/shared-tree/transactionMinimize.ts
@@ -65,6 +65,8 @@ function minimizeSharedTreeChange(
  * out to nothing. Minimizing the change reduces the size of the edit that is
  * submitted to (and stored by) the service without altering the observable
  * effect of the transaction.
+ * Minimization may discard edits to nodes which are removed by the transaction,
+ * which would cause an observable difference if those nodes are reattached by a concurrent edit.
  *
  * The current implementation is limited and is unable to guarantee that the
  * resulting change is fully minimized if multiple distinct edit groups are
@@ -73,11 +75,6 @@ function minimizeSharedTreeChange(
  * one or more schema changes and content edits on both sides. In such cases,
  * the implementation will throw a usage error:
  * "At most one edit group can be minimized..."
- *
- * @deprecated Note: minimization is not yet implemented. For now this is a
- * no-op that leaves the squashed change unchanged, so supplying it currently
- * has no observable effect beyond reserving the behavior. A real
- * implementation will be provided in a future change.
  *
  * @alpha
  */


### PR DESCRIPTION
## Description

Added a changeset for the addition of the `mimize` transaction post-processor, as well as updating a related doc comment.