### PR TITLE
fix(build-cli): preserve error exits in quiet mode

### DIFF
--- a/build-tools/packages/build-cli/src/commands/test-only-error.ts
+++ b/build-tools/packages/build-cli/src/commands/test-only-error.ts
@@ -1,0 +1,17 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { BaseCommand } from "../library/commands/base.js";
+
+/**
+ * A command that always fails so BaseCommand error handling can be tested through oclif.
+ */
+export default class TestOnlyErrorCommand extends BaseCommand<typeof TestOnlyErrorCommand> {
+	static readonly hidden = true;
+
+	public async run(): Promise<void> {
+		this.error("Intentional test error.", { exit: 1 });
+	}
+}

--- a/build-tools/packages/build-cli/src/library/commands/base.ts
+++ b/build-tools/packages/build-cli/src/library/commands/base.ts
@@ -263,19 +263,17 @@ export abstract class BaseCommand<T extends typeof Command>
 	 * This method overrides the oclif Command error method so we can do some formatting on the strings.
 	 */
 	public error(input: unknown, options?: unknown): void {
-		if (!this.suppressLogging) {
-			if (typeof input === "string") {
-				// Ignoring lint error because the typings here come from oclif and the options type oclif has is complex. It's
-				// not worth replicating in this call.
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
-				super.error(chalk.red(input), options as any);
-			}
-
+		if (typeof input === "string") {
 			// Ignoring lint error because the typings here come from oclif and the options type oclif has is complex. It's
 			// not worth replicating in this call.
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
-			return super.error(input as Error, options as any);
+			return super.error(chalk.red(input), options as any);
 		}
+
+		// Ignoring lint error because the typings here come from oclif and the options type oclif has is complex. It's
+		// not worth replicating in this call.
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
+		return super.error(input as Error, options as any);
 	}
 
 	/**

--- a/build-tools/packages/build-cli/src/test/commands/build-perf/check.test.ts
+++ b/build-tools/packages/build-cli/src/test/commands/build-perf/check.test.ts
@@ -98,32 +98,6 @@ describe("flub build-perf check", () => {
 		expect(error?.message).to.include("Thresholds exceeded");
 	});
 
-	it("fails under --quiet when average duration exceeds threshold", async () => {
-		const data = makeDataFile({
-			summary: { totalBuilds: 100, succeeded: 95, successRate: 95, avgDuration: 95 },
-		});
-		writeFileSync(path.join(tempDir, "public-data.json"), JSON.stringify(data));
-
-		const { error } = await runCommand(
-			[
-				"build-perf:check",
-				"--mode",
-				"public",
-				"--inputDir",
-				tempDir,
-				"--avgDurationThreshold",
-				"90",
-				"--changePeriodThreshold",
-				"15",
-				"--quiet",
-			],
-			{ root: import.meta.url },
-		);
-
-		expect(error?.oclif?.exit).to.equal(1);
-		expect(error?.message).to.include("Thresholds exceeded");
-	});
-
 	it("fails when period change exceeds threshold", async () => {
 		const data = makeDataFile({ change3Day: 20 });
 		writeFileSync(path.join(tempDir, "public-data.json"), JSON.stringify(data));

--- a/build-tools/packages/build-cli/src/test/commands/build-perf/check.test.ts
+++ b/build-tools/packages/build-cli/src/test/commands/build-perf/check.test.ts
@@ -98,6 +98,32 @@ describe("flub build-perf check", () => {
 		expect(error?.message).to.include("Thresholds exceeded");
 	});
 
+	it("fails under --quiet when average duration exceeds threshold", async () => {
+		const data = makeDataFile({
+			summary: { totalBuilds: 100, succeeded: 95, successRate: 95, avgDuration: 95 },
+		});
+		writeFileSync(path.join(tempDir, "public-data.json"), JSON.stringify(data));
+
+		const { error } = await runCommand(
+			[
+				"build-perf:check",
+				"--mode",
+				"public",
+				"--inputDir",
+				tempDir,
+				"--avgDurationThreshold",
+				"90",
+				"--changePeriodThreshold",
+				"15",
+				"--quiet",
+			],
+			{ root: import.meta.url },
+		);
+
+		expect(error?.oclif?.exit).to.equal(1);
+		expect(error?.message).to.include("Thresholds exceeded");
+	});
+
 	it("fails when period change exceeds threshold", async () => {
 		const data = makeDataFile({ change3Day: 20 });
 		writeFileSync(path.join(tempDir, "public-data.json"), JSON.stringify(data));

--- a/build-tools/packages/build-cli/src/test/commands/test-only-error.test.ts
+++ b/build-tools/packages/build-cli/src/test/commands/test-only-error.test.ts
@@ -1,0 +1,19 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { runCommand } from "@oclif/test";
+import { expect } from "chai";
+import { describe, it } from "mocha";
+
+describe("flub test-only-error", () => {
+	it("exits with an error under --quiet", async () => {
+		const { error } = await runCommand(["test-only-error", "--quiet"], {
+			root: import.meta.url,
+		});
+
+		expect(error?.oclif?.exit).to.equal(1);
+		expect(error?.message).to.include("Intentional test error.");
+	});
+});


### PR DESCRIPTION
## Description

Fixes [AB#74372](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/74372).

`BaseCommand.error()` previously skipped oclif's error handling when `--quiet` was set. As a result, fatal errors returned normally instead of throwing or applying the requested exit code, allowing commands to continue after a failure.

This change always delegates errors to oclif exactly once while retaining the existing string formatting. Other informational and warning output remains suppressed by `--quiet`.

A dedicated hidden test command immediately reports an intentional error with exit code 1. Its focused regression test invokes the command with `--quiet` and verifies that oclif still returns the expected error and exit code.

## Reviewer Guidance

The review process is outlined in [the pull request guidelines](../docs/content/Contributing/PR-Guidelines.md#guidelines).

Please confirm that fatal errors should preserve oclif's throw and exit behavior regardless of the logging verbosity setting.
