### PR TITLE
docs(tree): seal schema discrepancy types

### DIFF
--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -1248,12 +1248,12 @@ export interface SchemaCompatibilityStatus {
     readonly isEquivalent: boolean;
 }
 
-// @beta
+// @beta @sealed
 export interface SchemaCompatibilityStatusBeta extends SchemaCompatibilityStatus {
     readonly discrepancies: readonly SchemaDiscrepancy[] | undefined;
 }
 
-// @beta
+// @beta @sealed
 export type SchemaDiscrepancy = {
     readonly mismatch: "allowedTypes";
     readonly location: "root" | {

--- a/packages/dds/tree/api-report/tree.beta.api.md
+++ b/packages/dds/tree/api-report/tree.beta.api.md
@@ -549,12 +549,12 @@ export interface SchemaCompatibilityStatus {
     readonly isEquivalent: boolean;
 }
 
-// @beta
+// @beta @sealed
 export interface SchemaCompatibilityStatusBeta extends SchemaCompatibilityStatus {
     readonly discrepancies: readonly SchemaDiscrepancy[] | undefined;
 }
 
-// @beta
+// @beta @sealed
 export type SchemaDiscrepancy = {
     readonly mismatch: "allowedTypes";
     readonly location: "root" | {

--- a/packages/dds/tree/api-report/tree.legacy.beta.api.md
+++ b/packages/dds/tree/api-report/tree.legacy.beta.api.md
@@ -552,12 +552,12 @@ export interface SchemaCompatibilityStatus {
     readonly isEquivalent: boolean;
 }
 
-// @beta
+// @beta @sealed
 export interface SchemaCompatibilityStatusBeta extends SchemaCompatibilityStatus {
     readonly discrepancies: readonly SchemaDiscrepancy[] | undefined;
 }
 
-// @beta
+// @beta @sealed
 export type SchemaDiscrepancy = {
     readonly mismatch: "allowedTypes";
     readonly location: "root" | {

--- a/packages/dds/tree/src/simple-tree/api/tree.ts
+++ b/packages/dds/tree/src/simple-tree/api/tree.ts
@@ -802,7 +802,7 @@ export interface TreeView<in out TSchema extends ImplicitFieldSchema> extends ID
  * @remarks
  * The `mismatch` property discriminates the different discrepancy shapes.
  *
- * @beta
+ * @sealed @beta
  */
 export type SchemaDiscrepancy =
 	| {
@@ -917,7 +917,7 @@ export type SchemaDiscrepancy =
 /**
  * {@link SchemaCompatibilityStatus} with additional beta APIs.
  *
- * @beta
+ * @sealed @beta
  */
 export interface SchemaCompatibilityStatusBeta extends SchemaCompatibilityStatus {
 	/**

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -1810,12 +1810,12 @@ export interface SchemaCompatibilityStatus {
     readonly isEquivalent: boolean;
 }
 
-// @beta
+// @beta @sealed
 export interface SchemaCompatibilityStatusBeta extends SchemaCompatibilityStatus {
     readonly discrepancies: readonly SchemaDiscrepancy[] | undefined;
 }
 
-// @beta
+// @beta @sealed
 export type SchemaDiscrepancy = {
     readonly mismatch: "allowedTypes";
     readonly location: "root" | {

--- a/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.beta.api.md
@@ -1037,12 +1037,12 @@ export interface SchemaCompatibilityStatus {
     readonly isEquivalent: boolean;
 }
 
-// @beta
+// @beta @sealed
 export interface SchemaCompatibilityStatusBeta extends SchemaCompatibilityStatus {
     readonly discrepancies: readonly SchemaDiscrepancy[] | undefined;
 }
 
-// @beta
+// @beta @sealed
 export type SchemaDiscrepancy = {
     readonly mismatch: "allowedTypes";
     readonly location: "root" | {

--- a/packages/framework/fluid-framework/api-report/fluid-framework.legacy.beta.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.legacy.beta.api.md
@@ -1327,12 +1327,12 @@ export interface SchemaCompatibilityStatus {
     readonly isEquivalent: boolean;
 }
 
-// @beta
+// @beta @sealed
 export interface SchemaCompatibilityStatusBeta extends SchemaCompatibilityStatus {
     readonly discrepancies: readonly SchemaDiscrepancy[] | undefined;
 }
 
-// @beta
+// @beta @sealed
 export type SchemaDiscrepancy = {
     readonly mismatch: "allowedTypes";
     readonly location: "root" | {


### PR DESCRIPTION
## Description

Marks `SchemaDiscrepancy` and `SchemaCompatibilityStatusBeta`, introduced in #28142, as sealed APIs. This communicates that consumers should use these types as returned rather than implementing or extending them.

Updates the `@fluidframework/tree` and `fluid-framework` API reports accordingly.

## Reviewer Guidance

The review process is outlined in [the pull request guidelines](../docs/content/Contributing/PR-Guidelines.md#guidelines).