### PR TITLE
feat(tree): preserve enabled staged schema upgrades

### DIFF
--- a/.changeset/frank-yaks-watch.md
+++ b/.changeset/frank-yaks-watch.md
@@ -5,10 +5,10 @@
 ---
 Preserve enabled staged schema upgrades by default
 
-`TreeView.upgradeSchema()` now includes staged schema upgrades that are already enabled in the document, even when the view's staged upgrade policy does not select them.
+[`TreeView.upgradeSchema()`](https://fluidframework.com/docs/api/tree/treeview-interface#upgradeschema-method) now includes staged schema upgrades that are already enabled in the document, even when the view's staged upgrade policy does not select them.
 This prevents a schema upgrade from accidentally attempting to narrow stored schema enabled by another client.
 
-Set `includeAlreadyEnabledUpgrades` to `false` when creating the staged upgrade policy to require upgrades to be selected explicitly:
+Set [`includeAlreadyEnabledUpgrades`](https://fluidframework.com/docs/api/tree/stagedschemaupgradepolicy-interface#includealreadyenabledupgrades-property) to `false` when creating the staged upgrade policy to require upgrades to be selected explicitly:
 
 ```typescript
 const config = new TreeViewConfigurationAlpha({

--- a/.changeset/frank-yaks-watch.md
+++ b/.changeset/frank-yaks-watch.md
@@ -1,0 +1,21 @@
+---
+"@fluidframework/tree": minor
+"fluid-framework": minor
+"__section": tree
+---
+Preserve enabled staged schema upgrades by default
+
+`TreeView.upgradeSchema()` now includes staged schema upgrades that are already enabled in the document, even when the view's staged upgrade policy does not select them.
+This prevents a schema upgrade from accidentally attempting to narrow stored schema enabled by another client.
+
+Set `includeAlreadyEnabledUpgrades` to `false` when creating the staged upgrade policy to require upgrades to be selected explicitly:
+
+```typescript
+const config = new TreeViewConfigurationAlpha({
+	schema: AppSchema,
+	stagedUpgradePolicy: {
+		includeAlreadyEnabledUpgrades: false,
+		...StagedSchemaUpgradePolicy.enabledStagedUpgrades(myUpgrade),
+	},
+});
+```

--- a/packages/dds/tree/api-report/tree.alpha.api.md
+++ b/packages/dds/tree/api-report/tree.alpha.api.md
@@ -1522,6 +1522,7 @@ export interface SnapshotSchemaCompatibilityOptions {
 
 // @alpha @input
 export interface StagedSchemaUpgradePolicy {
+    readonly includeAlreadyEnabledUpgrades?: boolean;
     includeStaged(upgrade: SchemaUpgrade): boolean;
     includeStagedOptional(upgrade: SchemaUpgrade): boolean;
 }

--- a/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
+++ b/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
@@ -301,7 +301,7 @@ export class SchematizingSimpleTreeView<
 	public upgradeSchema(): void {
 		this.ensureUndisposed();
 
-		const newSchema = toUpgradeSchema(this.viewSchema.root, this.stagedUpgradePolicy);
+		const newSchema = toUpgradeSchema(this.viewSchema.root, this.effectiveUpgradePolicy);
 		const storedSchema = this.checkout.storedSchema.clone();
 		if (!allowsRepoSuperset(defaultSchemaPolicy, storedSchema, newSchema)) {
 			throw new UsageError(
@@ -321,6 +321,25 @@ export class SchematizingSimpleTreeView<
 			this.failDisposed();
 		}
 		return this.currentEnabledUpgrades.get(upgrade) ?? "disabled";
+	}
+
+	private get effectiveUpgradePolicy(): StagedSchemaUpgradePolicy {
+		const configuredPolicy = this.stagedUpgradePolicy;
+		if (configuredPolicy.includeAlreadyEnabledUpgrades === false) {
+			return configuredPolicy;
+		}
+		const enabledUpgrades = this.currentEnabledUpgrades;
+		assert(
+			enabledUpgrades !== undefined,
+			"Enabled upgrades must be available for an active view",
+		);
+
+		return {
+			includeStaged: (upgrade) =>
+				configuredPolicy.includeStaged(upgrade) || enabledUpgrades.has(upgrade),
+			includeStagedOptional: (upgrade) =>
+				configuredPolicy.includeStagedOptional(upgrade) || enabledUpgrades.has(upgrade),
+		};
 	}
 
 	/**

--- a/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
+++ b/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
@@ -333,6 +333,9 @@ export class SchematizingSimpleTreeView<
 			enabledUpgrades !== undefined,
 			"Enabled upgrades must be available for an active view",
 		);
+		if (enabledUpgrades.size === 0) {
+			return configuredPolicy;
+		}
 
 		return {
 			includeStaged: (upgrade) =>

--- a/packages/dds/tree/src/simple-tree/api/schemaCompatibilityTester.ts
+++ b/packages/dds/tree/src/simple-tree/api/schemaCompatibilityTester.ts
@@ -14,7 +14,7 @@ import {
 import type { SchemaUpgrade, StagedSchemaUpgradePolicy } from "../core/index.js";
 import { NodeKind } from "../core/index.js";
 import { allowsRepoSuperset, defaultSchemaPolicy } from "../../feature-libraries/index.js";
-import { toUpgradeSchema } from "../toStoredSchema.js";
+import { resolveStoredSchemaGenerationOptions, toUpgradeSchema } from "../toStoredSchema.js";
 import type { TreeSchema } from "../treeSchema.js";
 
 import {
@@ -131,6 +131,8 @@ export function checkSchemaCompatibility(
 } {
 	// The public API surface assumes defaultSchemaPolicy
 	const policy = defaultSchemaPolicy;
+	const configuredPolicy = resolveStoredSchemaGenerationOptions(stagedSchemaUpgrades);
+	const includeAlreadyEnabledUpgrades = configuredPolicy.includeAlreadyEnabledUpgrades ?? true;
 
 	// Collect upgrade locations during the discrepancy walk (single pass).
 	const totalLocations = new Map<SchemaUpgrade, number>();
@@ -167,7 +169,11 @@ export function checkSchemaCompatibility(
 		break;
 	}
 
-	const wouldUpgradeTo = toUpgradeSchema(viewSchema.root, stagedSchemaUpgrades);
+	const enabledUpgrades = computeUpgradeStatuses(totalLocations, enabledLocations);
+	const upgradePolicy = includeAlreadyEnabledUpgrades
+		? includeEnabledUpgrades(configuredPolicy, enabledUpgrades)
+		: configuredPolicy;
+	const wouldUpgradeTo = toUpgradeSchema(viewSchema.root, upgradePolicy);
 
 	const canUpgrade = allowsRepoSuperset(policy, stored, wouldUpgradeTo);
 
@@ -176,13 +182,23 @@ export function checkSchemaCompatibility(
 	const isEquivalent =
 		canView && canUpgrade && allowsRepoSuperset(policy, wouldUpgradeTo, stored);
 
-	const enabledUpgrades = computeUpgradeStatuses(totalLocations, enabledLocations);
-
 	return {
 		canView,
 		canUpgrade,
 		isEquivalent,
 		enabledUpgrades,
+	};
+}
+
+function includeEnabledUpgrades(
+	configuredPolicy: StagedSchemaUpgradePolicy,
+	enabledUpgrades: ReadonlyMap<SchemaUpgrade, StagedUpgradeStatus>,
+): StagedSchemaUpgradePolicy {
+	return {
+		includeStaged: (upgrade) =>
+			configuredPolicy.includeStaged(upgrade) || enabledUpgrades.has(upgrade),
+		includeStagedOptional: (upgrade) =>
+			configuredPolicy.includeStagedOptional(upgrade) || enabledUpgrades.has(upgrade),
 	};
 }
 

--- a/packages/dds/tree/src/simple-tree/api/schemaCompatibilityTester.ts
+++ b/packages/dds/tree/src/simple-tree/api/schemaCompatibilityTester.ts
@@ -194,6 +194,9 @@ function includeEnabledUpgrades(
 	configuredPolicy: StagedSchemaUpgradePolicy,
 	enabledUpgrades: ReadonlyMap<SchemaUpgrade, StagedUpgradeStatus>,
 ): StagedSchemaUpgradePolicy {
+	if (enabledUpgrades.size === 0) {
+		return configuredPolicy;
+	}
 	return {
 		includeStaged: (upgrade) =>
 			configuredPolicy.includeStaged(upgrade) || enabledUpgrades.has(upgrade),

--- a/packages/dds/tree/src/simple-tree/api/tree.ts
+++ b/packages/dds/tree/src/simple-tree/api/tree.ts
@@ -722,9 +722,9 @@ export interface TreeView<in out TSchema extends ImplicitFieldSchema> extends ID
 	 *
 	 * When using {@link TreeViewConfigurationAlpha} with a {@link ITreeViewConfigurationAlpha.stagedUpgradePolicy},
 	 * staged schema upgrades matching the configured policy are included in the target stored schema.
-	 * Once a staged schema upgrade has been enabled in a document's stored schema, loading that document
-	 * with a view that does not include equivalent staged members in its construction-time policy will cause
-	 * `upgradeSchema` to throw a `UsageError` because the requested target would narrow the stored schema.
+	 * Staged upgrades that are already enabled in the document are also included by default. Set
+	 * {@link (StagedSchemaUpgradePolicy:interface).includeAlreadyEnabledUpgrades} to `false` when
+	 * creating the policy to only include staged upgrades selected explicitly by the policy.
 	 *
 	 * @example Enabling a staged allowed type for documents, selected by a feature flag
 	 *
@@ -829,10 +829,6 @@ export interface TreeViewAlpha<
 	 * Only valid to call when this view's {@link SchemaCompatibilityStatus.canInitialize} is true.
 	 *
 	 * Enables staged schema upgrades declared by {@link ITreeViewConfigurationAlpha.stagedUpgradePolicy} when generating the initial stored schema.
-	 * Once a staged schema upgrade has been enabled in a document's stored schema, loading that document
-	 * with a view that does not include equivalent staged members in its construction-time policy will cause
-	 * a subsequent `upgradeSchema` call to throw a `UsageError` because the stored schema already contains
-	 * the upgraded members and the new target would narrow it.
 	 *
 	 * Applications should typically call this function before attaching a `SharedTree`.
 	 * @param content - The content to initialize the tree with.

--- a/packages/dds/tree/src/simple-tree/core/toStored.ts
+++ b/packages/dds/tree/src/simple-tree/core/toStored.ts
@@ -12,6 +12,14 @@ import type { SchemaUpgrade } from "./allowedTypes.js";
  */
 export interface StagedSchemaUpgradePolicy {
 	/**
+	 * Whether schema upgrades should include staged upgrades that are already enabled in the
+	 * document's stored schema.
+	 *
+	 * @defaultValue `true`
+	 */
+	readonly includeAlreadyEnabledUpgrades?: boolean;
+
+	/**
 	 * Determines whether to include staged allowed types in the resulting stored schema.
 	 * @remarks
 	 * Due to caching, the behavior of this function must be pure.

--- a/packages/dds/tree/src/test/simple-tree/api/schemaCompatibilityTester.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/schemaCompatibilityTester.spec.ts
@@ -50,8 +50,7 @@ function expectCompatibility(
 		...expected,
 	});
 
-	// This does not include staged allowed types.
-	const viewStored = toUpgradeSchema(view);
+	const viewStored = toUpgradeSchema(view, compatibility.enabledUpgrades.keys());
 
 	// if it says upgradable, deriving a stored schema from the view schema gives one thats a superset of the old stored schema
 	if (compatibility.canUpgrade) {
@@ -595,7 +594,7 @@ describe("checkSchemaCompatibility", () => {
 				);
 			});
 
-			it("clients with staged schema allow viewing but not upgrading after upgrade", () => {
+			it("clients with staged schema preserve already enabled upgrades", () => {
 				const stagedString = SchemaFactoryAlpha.staged(SchemaFactoryAlpha.string);
 				const upgrade = stagedString.metadata.stagedSchemaUpgrade;
 				assert(upgrade !== undefined);
@@ -612,8 +611,8 @@ describe("checkSchemaCompatibility", () => {
 					{ view: Compatible1, stored: toUpgradeSchema(Compatible2) },
 					{
 						canView: true,
-						canUpgrade: false,
-						isEquivalent: false,
+						canUpgrade: true,
+						isEquivalent: true,
 						enabledUpgrades: new Map([[upgrade, "enabled"]]),
 					},
 				);

--- a/packages/dds/tree/src/test/simple-tree/api/stagedSchemaUpgrade.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/stagedSchemaUpgrade.spec.ts
@@ -234,6 +234,31 @@ describe("staged allowed type upgrade", () => {
 		assert.equal(viewMigrated.root, "test");
 	});
 
+	it("includes an already enabled allowed type in upgradeSchema by default", () => {
+		const provider = new TestTreeProviderLite(3);
+		const [treeBase, treeEnabled, treeDefault] = provider.trees;
+
+		const viewBase = treeBase.viewWith(new TreeViewConfiguration({ schema: baseSchema }));
+		viewBase.initialize(5);
+		provider.synchronizeMessages();
+
+		const viewEnabled = treeEnabled.viewWith(
+			new TreeViewConfigurationAlpha({
+				schema: schemaWithStagedType,
+				stagedUpgradePolicy: StagedSchemaUpgradePolicy.enabledStagedUpgrades(stringUpgrade),
+			}),
+		);
+		viewEnabled.upgradeSchema();
+		viewEnabled.dispose();
+		provider.synchronizeMessages();
+
+		const viewDefault = treeDefault.viewWith(
+			new TreeViewConfigurationAlpha({ schema: schemaWithStagedType }),
+		);
+		assert.equal(viewDefault.compatibility.canUpgrade, true);
+		assert.doesNotThrow(() => viewDefault.upgradeSchema());
+	});
+
 	it("using independent view user apis", () => {
 		// initialize with baseSchema
 		const configBase = new TreeViewConfigurationAlpha({
@@ -514,7 +539,7 @@ describe("staged optional upgrade", () => {
 		assert.equal(viewOptional.root, undefined);
 	});
 
-	it("throws when a view without upgrades tries to upgradeSchema on a document already upgraded by another view", () => {
+	it("includes an already enabled upgrade in upgradeSchema by default", () => {
 		const provider = new TestTreeProviderLite(3);
 		const [treeRequired, treeStaged, treeOptional] = provider.trees;
 
@@ -535,11 +560,44 @@ describe("staged optional upgrade", () => {
 		viewStaged.dispose();
 		provider.synchronizeMessages();
 
-		// A new view without the upgrade token cannot upgrade further — the stored schema already has the upgrade
-		// and the new target (without the token) would narrow it.
-		const viewStagedNarrow = treeOptional.viewWith(
+		// A new view without the upgrade token preserves the enabled upgrade.
+		const viewStagedDefault = treeOptional.viewWith(
 			new TreeViewConfigurationAlpha({ schema: stagedOptionalSchema }),
 		);
+		assert.equal(viewStagedDefault.compatibility.canUpgrade, true);
+		assert.doesNotThrow(() => viewStagedDefault.upgradeSchema());
+	});
+
+	it("can exclude already enabled upgrades from upgradeSchema", () => {
+		const provider = new TestTreeProviderLite(3);
+		const [treeRequired, treeStaged, treeOptional] = provider.trees;
+
+		const viewRequired = treeRequired.viewWith(
+			new TreeViewConfiguration({ schema: requiredSchema }),
+		);
+		viewRequired.initialize(5);
+		provider.synchronizeMessages();
+
+		const viewStaged = treeStaged.viewWith(
+			new TreeViewConfigurationAlpha({
+				schema: stagedOptionalSchema,
+				stagedUpgradePolicy: StagedSchemaUpgradePolicy.enabledStagedUpgrades(optionalUpgrade),
+			}),
+		);
+		viewStaged.upgradeSchema();
+		viewStaged.dispose();
+		provider.synchronizeMessages();
+
+		const viewStagedNarrow = treeOptional.viewWith(
+			new TreeViewConfigurationAlpha({
+				schema: stagedOptionalSchema,
+				stagedUpgradePolicy: {
+					includeAlreadyEnabledUpgrades: false,
+					...StagedSchemaUpgradePolicy.enabledStagedUpgrades(),
+				},
+			}),
+		);
+		assert.equal(viewStagedNarrow.compatibility.canUpgrade, false);
 		assert.throws(
 			() => viewStagedNarrow.upgradeSchema(),
 			/cannot be upgraded to the requested schema/,
@@ -606,12 +664,11 @@ describe("staged optional upgrade", () => {
 			isEquivalent: true,
 		});
 
-		// stagedOptionalSchema after full upgrade can view the optional stored schema, but its default
-		// upgrade target is required, which is no longer a valid upgrade from optional stored.
+		// stagedOptionalSchema preserves the already enabled optional upgrade by default.
 		expectCompatibility(stagedOptionalSchema, {
 			canView: true,
-			canUpgrade: false,
-			isEquivalent: false,
+			canUpgrade: true,
+			isEquivalent: true,
 			enabledUpgrades: new Map([[optionalUpgrade, "enabled"]]),
 		});
 

--- a/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
+++ b/packages/framework/fluid-framework/api-report/fluid-framework.alpha.api.md
@@ -2127,6 +2127,7 @@ export interface SnapshotSchemaCompatibilityOptions {
 
 // @alpha @input
 export interface StagedSchemaUpgradePolicy {
+    readonly includeAlreadyEnabledUpgrades?: boolean;
     includeStaged(upgrade: SchemaUpgrade): boolean;
     includeStagedOptional(upgrade: SchemaUpgrade): boolean;
 }


### PR DESCRIPTION
## Description

Updates `TreeView.upgradeSchema()` to include staged schema upgrades that are already enabled in the document by default. This prevents an upgrade from attempting to narrow stored schema when another client previously enabled a staged upgrade.

Applications that need to exclude previously enabled upgrades can compose an explicit opt-out into their staged upgrade policy:

```typescript
const stagedUpgradePolicy = {
	includeAlreadyEnabledUpgrades: false,
	...StagedSchemaUpgradePolicy.enabledStagedUpgrades(myUpgrade),
};
```

Adds coverage for staged allowed-type and staged-optional upgrades, including the explicit opt-out behavior.

## Reviewer Guidance

The review process is outlined in [the pull request guidelines](../docs/content/Contributing/PR-Guidelines.md#guidelines).

The customer-facing addition is `@alpha` and does not require API Council approval. Please focus on the policy composition and compatibility calculations.