### PR TITLE
Close containers when self-join predates loaded state

### DIFF
--- a/.changeset/stale-joins-close.md
+++ b/.changeset/stale-joins-close.md
@@ -1,0 +1,8 @@
+---
+"@fluidframework/container-loader": minor
+"__section": fix
+---
+
+Close containers when the current connection's self-join predates the loaded state
+
+The loader now detects when a write connection's `ClientJoin` operation has a sequence number at or below the immutable sequence baseline captured for that connection. This incompatible-history condition closes the container with a non-retryable `fileOverwrittenInStorage` error instead of silently discarding the join as duplicate delivery.

--- a/.changeset/stale-joins-close.md
+++ b/.changeset/stale-joins-close.md
@@ -2,7 +2,6 @@
 "@fluidframework/container-loader": minor
 "__section": fix
 ---
-
 Close containers when the current connection's self-join predates the loaded state
 
 The loader now detects when a write connection's `ClientJoin` operation has a sequence number at or below the immutable sequence baseline captured for that connection. This incompatible-history condition closes the container with a non-retryable `fileOverwrittenInStorage` error instead of silently discarding the join as duplicate delivery.

--- a/packages/loader/container-loader/src/connectionManager.ts
+++ b/packages/loader/container-loader/src/connectionManager.ts
@@ -909,6 +909,8 @@ export class ConnectionManager implements IConnectionManager {
 		this.props.incomingOpHandler(
 			initialMessages,
 			this.connectFirstConnection ? "InitialOps" : "ReconnectOps",
+			connection.clientId,
+			connection.checkpointSequenceNumber,
 		);
 
 		this._connectionDetails = ConnectionManager.detailsFromConnection(connection, reason);
@@ -1193,7 +1195,13 @@ export class ConnectionManager implements IConnectionManager {
 		messagesArg: ISequencedDocumentMessage[],
 	): void => {
 		const messages = Array.isArray(messagesArg) ? messagesArg : [messagesArg];
-		this.props.incomingOpHandler(messages, "opHandler");
+		assert(this.connection !== undefined, "Received an op without an active connection");
+		this.props.incomingOpHandler(
+			messages,
+			"opHandler",
+			this.connection.clientId,
+			this.connection.checkpointSequenceNumber,
+		);
 	};
 
 	private readonly signalHandler = (signalsArg: ISignalMessage | ISignalMessage[]): void => {

--- a/packages/loader/container-loader/src/contracts.ts
+++ b/packages/loader/container-loader/src/contracts.ts
@@ -140,7 +140,12 @@ export interface IConnectionManagerFactoryArgs {
 	 * Called by connection manager for each incoming op. Some ops maybe delivered before
 	 * connectHandler is called (initial ops on socket connection)
 	 */
-	readonly incomingOpHandler: (messages: ISequencedDocumentMessage[], reason: string) => void;
+	readonly incomingOpHandler: (
+		messages: ISequencedDocumentMessage[],
+		reason: string,
+		clientId: string,
+		serviceCheckpointSequenceNumber: number | undefined,
+	) => void;
 
 	/**
 	 * Called by connection manager for each incoming signal.

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -231,6 +231,13 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 	 */
 	private serviceCheckpointSequenceNumber: number | undefined;
 	/**
+	 * Pre-enqueue baselines for joins accepted from storage while a stream connection is being
+	 * established. Its client ID is not known yet, and storage may deliver its join first.
+	 * Only newly accepted joins are recorded, so overlap cannot lower the loaded baseline.
+	 * Discarded when the connection is identified, cancelled, disconnected, or closed.
+	 */
+	private pendingConnectionJoinBaselines: Map<string, number> | undefined;
+	/**
 	 * Sequence state known before processing messages from the current connection.
 	 */
 	private connectionSequenceBaseline:
@@ -543,10 +550,12 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 	}
 
 	private cancelEstablishingConnection(reason: IConnectionStateChangeReason): void {
+		this.pendingConnectionJoinBaselines = undefined;
 		this.emit("cancelEstablishingConnection", reason);
 	}
 
 	private establishingConnection(reason: IConnectionStateChangeReason): void {
+		this.pendingConnectionJoinBaselines = new Map();
 		this.emit("establishingConnection", reason);
 	}
 
@@ -872,6 +881,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 	}
 
 	private clearQueues(): void {
+		this.pendingConnectionJoinBaselines = undefined;
 		this.closeAbortController.abort("DeltaManager is closed");
 
 		this._inbound.clear();
@@ -896,6 +906,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 	private disconnectHandler(reason: IConnectionStateChangeReason): void {
 		this.messageBuffer.length = 0;
 		this.connectionSequenceBaseline = undefined;
+		this.pendingConnectionJoinBaselines = undefined;
 		this.emit("disconnect", reason.text, reason.error);
 	}
 
@@ -1125,6 +1136,18 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 				}
 			} else if (message.sequenceNumber === this.lastQueuedSequenceNumber + 1) {
 				this.validateClientSequenceNumberConsistency(message);
+				if (this.pendingConnectionJoinBaselines !== undefined) {
+					const joiningClientId = this.getClientJoinId(message);
+					if (
+						joiningClientId !== undefined &&
+						!this.pendingConnectionJoinBaselines.has(joiningClientId)
+					) {
+						this.pendingConnectionJoinBaselines.set(
+							joiningClientId,
+							this.lastQueuedSequenceNumber,
+						);
+					}
+				}
 				this.lastQueuedSequenceNumber = message.sequenceNumber;
 				this.previouslyProcessedMessage = message;
 				this._inbound.push(message);
@@ -1142,6 +1165,8 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 
 	/**
 	 * Captures the immutable sequence baseline before this connection's first messages are enqueued.
+	 * If storage already delivered its join during connection setup, uses the baseline saved before
+	 * that join was accepted instead of a sequence number advanced by the same connection's history.
 	 */
 	private captureConnectionSequenceBaseline(
 		clientId: string,
@@ -1150,10 +1175,28 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 		if (this.connectionSequenceBaseline?.clientId !== clientId) {
 			this.connectionSequenceBaseline = {
 				clientId,
-				sequenceNumber: this.handler === undefined ? undefined : this.lastQueuedSequenceNumber,
+				sequenceNumber:
+					this.handler === undefined
+						? undefined
+						: (this.pendingConnectionJoinBaselines?.get(clientId) ??
+							this.lastQueuedSequenceNumber),
 			};
 		}
+		this.pendingConnectionJoinBaselines = undefined;
 		this.serviceCheckpointSequenceNumber = serviceCheckpointSequenceNumber;
+	}
+
+	/**
+	 * Reads only the embedded client ID from a ClientJoin system message.
+	 * Returns undefined for other messages or a join without a string client ID.
+	 */
+	private getClientJoinId(message: ISequencedDocumentMessage): string | undefined {
+		if (message.type !== MessageType.ClientJoin) {
+			return undefined;
+		}
+		const systemJoinMessage = message as ISequencedDocumentSystemMessage;
+		const join = JSON.parse(systemJoinMessage.data) as { clientId: unknown };
+		return typeof join.clientId === "string" ? join.clientId : undefined;
 	}
 
 	/**
@@ -1177,9 +1220,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 			return false;
 		}
 
-		const systemJoinMessage = message as ISequencedDocumentSystemMessage;
-		const join = JSON.parse(systemJoinMessage.data) as { clientId: unknown };
-		if (join.clientId !== baseline.clientId) {
+		if (this.getClientJoinId(message) !== baseline.clientId) {
 			return false;
 		}
 

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -212,6 +212,17 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 	private opsSize: number = 0;
 	private prevEnqueueMessagesReason: string | undefined;
 	private previouslyProcessedMessage: ISequencedDocumentMessage | undefined;
+	private loadedSequenceNumber: number | undefined;
+	private serviceCheckpointSequenceNumber: number | undefined;
+	/**
+	 * Sequence state known before processing messages from the current connection.
+	 */
+	private connectionSequenceBaseline:
+		| {
+				clientId: string;
+				sequenceNumber: number | undefined;
+		  }
+		| undefined;
 
 	// The sequence number we initially loaded from
 	// In case of reading from a snapshot or pending state, its value will be equal to
@@ -436,8 +447,14 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 			this.close(normalizeError(error));
 		});
 		const props: IConnectionManagerFactoryArgs = {
-			incomingOpHandler: (messages: ISequencedDocumentMessage[], reason: string) => {
+			incomingOpHandler: (
+				messages: ISequencedDocumentMessage[],
+				reason: string,
+				clientId: string,
+				serviceCheckpointSequenceNumber: number | undefined,
+			) => {
 				try {
+					this.captureConnectionSequenceBaseline(clientId, serviceCheckpointSequenceNumber);
 					this.enqueueMessages(messages, reason);
 				} catch (error) {
 					this.logger.sendErrorEvent({ eventName: "EnqueueMessages_Exception" }, error);
@@ -596,6 +613,17 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 		this.minSequenceNumber = minSequenceNumber;
 		this.lastQueuedSequenceNumber = lastProcessedSequenceNumber;
 		this.lastObservedSeqNumber = lastProcessedSequenceNumber;
+		this.loadedSequenceNumber = lastProcessedSequenceNumber;
+		const connectionSequenceBaseline = this.connectionSequenceBaseline;
+		if (
+			connectionSequenceBaseline !== undefined &&
+			connectionSequenceBaseline.sequenceNumber === undefined
+		) {
+			connectionSequenceBaseline.sequenceNumber = lastProcessedSequenceNumber;
+			if (this.pending.some((message) => this.validateSelfJoinSequenceNumber(message))) {
+				return;
+			}
+		}
 
 		// We will use same check in other places to make sure all the seq number above are set properly.
 		assert(
@@ -849,6 +877,7 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 
 	private disconnectHandler(reason: IConnectionStateChangeReason): void {
 		this.messageBuffer.length = 0;
+		this.connectionSequenceBaseline = undefined;
 		this.emit("disconnect", reason.text, reason.error);
 	}
 
@@ -1040,6 +1069,9 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 		);
 
 		for (const message of messages) {
+			if (this.validateSelfJoinSequenceNumber(message)) {
+				return;
+			}
 			// Check that the messages are arriving in the expected order
 			if (message.sequenceNumber <= this.lastQueuedSequenceNumber) {
 				// Validate that we do not have data loss, i.e. sequencing is reset and started again
@@ -1085,6 +1117,61 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 		// of prior ops. But if we have some out of order ops (this.pending), then reporting current reason
 		// becomes not accurate, as the gap existed before current batch, so we should just report "unknown".
 		this.prevEnqueueMessagesReason = this.pending.length > 0 ? "unknown" : reason;
+	}
+
+	/**
+	 * Captures the immutable sequence baseline before this connection's first messages are enqueued.
+	 */
+	private captureConnectionSequenceBaseline(
+		clientId: string,
+		serviceCheckpointSequenceNumber: number | undefined,
+	): void {
+		if (this.connectionSequenceBaseline?.clientId !== clientId) {
+			this.connectionSequenceBaseline = {
+				clientId,
+				sequenceNumber: this.handler === undefined ? undefined : this.lastQueuedSequenceNumber,
+			};
+		}
+		this.serviceCheckpointSequenceNumber = serviceCheckpointSequenceNumber;
+	}
+
+	/**
+	 * Closes when the current connection's self-join is incompatible with its captured baseline.
+	 */
+	private validateSelfJoinSequenceNumber(message: ISequencedDocumentMessage): boolean {
+		const baseline = this.connectionSequenceBaseline;
+		if (
+			baseline?.sequenceNumber === undefined ||
+			message.type !== MessageType.ClientJoin ||
+			message.sequenceNumber > baseline.sequenceNumber
+		) {
+			return false;
+		}
+
+		const systemJoinMessage = message as ISequencedDocumentSystemMessage;
+		const join = JSON.parse(systemJoinMessage.data) as { clientId: unknown };
+		if (join.clientId !== baseline.clientId) {
+			return false;
+		}
+
+		this.close(
+			new NonRetryableError(
+				"The current connection's self-join predates the client's pre-connection state",
+				DriverErrorTypes.fileOverwrittenInStorage,
+				{
+					clientId: baseline.clientId,
+					selfJoinSequenceNumber: message.sequenceNumber,
+					connectionSequenceBaseline: baseline.sequenceNumber,
+					snapshotSequenceNumber: this.initSequenceNumber,
+					loadedSequenceNumber: this.loadedSequenceNumber,
+					lastProcessedSequenceNumber: this.lastProcessedSequenceNumber,
+					lastQueuedSequenceNumber: this.lastQueuedSequenceNumber,
+					serviceCheckpointSequenceNumber: this.serviceCheckpointSequenceNumber,
+					driverVersion: undefined,
+				},
+			),
+		);
+		return true;
 	}
 
 	private processInboundMessage(message: ISequencedDocumentMessage): void {

--- a/packages/loader/container-loader/src/deltaManager.ts
+++ b/packages/loader/container-loader/src/deltaManager.ts
@@ -212,7 +212,23 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 	private opsSize: number = 0;
 	private prevEnqueueMessagesReason: string | undefined;
 	private previouslyProcessedMessage: ISequencedDocumentMessage | undefined;
+	/**
+	 * Sequence number already reflected in the loaded snapshot or restored state.
+	 * Set by attachOpHandler from lastProcessedSequenceNumber, which defaults to the snapshot
+	 * sequence number but may be higher for restored state. Undefined until initialization.
+	 *
+	 * Retained unchanged across message processing and reconnects for self-join error telemetry.
+	 * This is not the per-connection validation baseline, which may include subsequently queued ops.
+	 */
 	private loadedSequenceNumber: number | undefined;
+	/**
+	 * Driver-reported checkpoint for the most recently observed connection, before ConnectionManager
+	 * normalizes it using initial messages. Updated by incomingOpHandler, including for an empty
+	 * initial batch; undefined if the driver does not provide a checkpoint.
+	 *
+	 * Used only for self-join error telemetry. It may legitimately lag or reflect regressed service
+	 * history, so it neither determines the immutable connection baseline nor triggers closure.
+	 */
 	private serviceCheckpointSequenceNumber: number | undefined;
 	/**
 	 * Sequence state known before processing messages from the current connection.
@@ -620,6 +636,8 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 			connectionSequenceBaseline.sequenceNumber === undefined
 		) {
 			connectionSequenceBaseline.sequenceNumber = lastProcessedSequenceNumber;
+			// Connection messages may arrive before the loaded sequence state is known.
+			// Now that the baseline is available, reject incompatible buffered self-joins before replay.
 			if (this.pending.some((message) => this.validateSelfJoinSequenceNumber(message))) {
 				return;
 			}
@@ -1069,6 +1087,9 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 		);
 
 		for (const message of messages) {
+			// A newly assigned connection's self-join must follow the client's pre-connection state.
+			// Check before duplicate filtering can discard evidence of incompatible history. The
+			// immutable baseline still allows duplicate delivery of a valid join after later ops.
 			if (this.validateSelfJoinSequenceNumber(message)) {
 				return;
 			}
@@ -1137,6 +1158,14 @@ export class DeltaManager<TConnectionManager extends IConnectionManager>
 
 	/**
 	 * Closes when the current connection's self-join is incompatible with its captured baseline.
+	 *
+	 * @param message - An incoming or buffered sequenced message to inspect before duplicate
+	 * filtering. Only ClientJoin messages whose embedded client ID matches the current
+	 * connection's client ID are subject to this check.
+	 * @returns true if a matching self-join is at or below the immutable pre-connection baseline
+	 * and this method closes the DeltaManager; the caller must stop processing messages.
+	 * Returns false if no violation is detected, including when the baseline is not yet
+	 * initialized. A false result does not imply that the message is otherwise valid.
 	 */
 	private validateSelfJoinSequenceNumber(message: ISequencedDocumentMessage): boolean {
 		const baseline = this.connectionSequenceBaseline;

--- a/packages/loader/container-loader/src/test/deltaManager.spec.ts
+++ b/packages/loader/container-loader/src/test/deltaManager.spec.ts
@@ -12,15 +12,18 @@ import {
 } from "@fluid-private/test-loader-utils";
 import type { IClient } from "@fluidframework/driver-definitions";
 import {
+	DriverErrorTypes,
 	type IDocumentDeltaStorageService,
 	type IDocumentMessage,
 	MessageType,
 	type ISequencedDocumentMessage,
+	type ISequencedDocumentSystemMessage,
 	type IStream,
 	type IStreamResult,
 } from "@fluidframework/driver-definitions/internal";
 import {
 	createChildLogger,
+	isFluidError,
 	MockLogger,
 	type TelemetryLoggerExt,
 } from "@fluidframework/telemetry-utils/internal";
@@ -53,13 +56,26 @@ describe("Loader", () => {
 				reconnectAllowed = true,
 				dmLogger: TelemetryLoggerExt = logger,
 				deltaStorageFactory?: () => IDocumentDeltaStorageService,
+				sequenceState?: {
+					snapshotSequenceNumber?: number;
+					lastProcessedSequenceNumber?: number;
+					initialMessages?: ISequencedDocumentMessage[];
+					connectBeforeAttach?: boolean;
+					earlySocketMessages?: ISequencedDocumentMessage[];
+					clientIds?: string[];
+				},
 			): Promise<void> {
 				const service = new MockDocumentService(deltaStorageFactory, () => {
 					// Always create new connection, as reusing old closed connection
 					// Forces DM into infinite reconnection loop.
-					deltaConnection = new MockDocumentDeltaConnection("test", (messages) =>
-						emitter.emit(submitEvent, messages),
+					deltaConnection = new MockDocumentDeltaConnection(
+						sequenceState?.clientIds?.shift() ?? "test",
+						(messages) => emitter.emit(submitEvent, messages),
 					);
+					if (sequenceState !== undefined) {
+						Object.defineProperty(deltaConnection, "checkpointSequenceNumber", { value: 5 });
+					}
+					deltaConnection.initialMessages = sequenceState?.initialMessages ?? [];
 					return deltaConnection;
 				});
 				const client: Partial<IClient> = {
@@ -81,6 +97,9 @@ describe("Loader", () => {
 							props,
 						),
 				);
+				deltaManager.on("closed", (error: Error) => {
+					expectedError = error;
+				});
 
 				const noopHeuristic = new NoopHeuristic(expectedTimeout, noopCountFrequency);
 
@@ -89,15 +108,29 @@ describe("Loader", () => {
 					noopHeuristic.notifyMessageSent();
 				});
 
-				await deltaManager.attachOpHandler(0, 0, {
-					process: (message) => noopHeuristic.notifyMessageProcessed(message),
-					processSignal() {},
-				});
-
-				await new Promise((resolve) => {
-					deltaManager.on("connect", resolve);
-					deltaManager.connect({ reason: { text: "test" } });
-				});
+				const connect = async (): Promise<void> =>
+					new Promise((resolve) => {
+						deltaManager.once("connect", resolve);
+						deltaManager.once("closed", () => resolve());
+						deltaManager.connect({ reason: { text: "test" } });
+					});
+				if (sequenceState?.connectBeforeAttach === true) {
+					await connect();
+					deltaConnection.emitOp(docId, sequenceState.earlySocketMessages ?? []);
+				}
+				await deltaManager.attachOpHandler(
+					0,
+					sequenceState?.snapshotSequenceNumber ?? 0,
+					{
+						process: (message) => noopHeuristic.notifyMessageProcessed(message),
+						processSignal() {},
+					},
+					sequenceState?.connectBeforeAttach === true ? "all" : "none",
+					sequenceState?.lastProcessedSequenceNumber,
+				);
+				if (sequenceState?.connectBeforeAttach !== true) {
+					await connect();
+				}
 			}
 
 			// function to yield control in the Javascript event loop.
@@ -117,6 +150,25 @@ describe("Loader", () => {
 					sequenceNumber: seq++,
 					type,
 				} as unknown as ISequencedDocumentMessage;
+			}
+
+			function generateClientJoin(
+				clientId: string,
+				sequenceNumber: number,
+			): ISequencedDocumentSystemMessage {
+				return {
+					sequenceNumber,
+					minimumSequenceNumber: 0,
+					clientSequenceNumber: 1,
+					type: MessageType.ClientJoin,
+					// API uses null
+					// eslint-disable-next-line unicorn/no-null
+					clientId: null,
+					referenceSequenceNumber: 0,
+					timestamp: 1000,
+					contents: undefined,
+					data: JSON.stringify({ clientId }),
+				};
 			}
 
 			async function sendAndReceiveOps(count: number, type: MessageType): Promise<void> {
@@ -177,6 +229,135 @@ describe("Loader", () => {
 
 			after(() => {
 				clock.restore();
+			});
+
+			describe("Self-join sequence validation", () => {
+				it("closes when the current connection's self-join predates pending state", async () => {
+					await startDeltaManager(true, logger, undefined, {
+						lastProcessedSequenceNumber: 13,
+					});
+					deltaConnection.emitOp(docId, [generateClientJoin("test", 6)]);
+
+					assert(isFluidError(expectedError));
+					assert.strictEqual(
+						expectedError.errorType,
+						DriverErrorTypes.fileOverwrittenInStorage,
+					);
+					assert.strictEqual(deltaManager.disposed, true);
+					const telemetry = expectedError.getTelemetryProperties();
+					assert.strictEqual(telemetry.canRetry, false);
+					assert.strictEqual(telemetry.selfJoinSequenceNumber, 6);
+					assert.strictEqual(telemetry.connectionSequenceBaseline, 13);
+					assert.strictEqual(telemetry.clientId, "test");
+					assert.strictEqual(telemetry.snapshotSequenceNumber, 0);
+					assert.strictEqual(telemetry.loadedSequenceNumber, 13);
+					assert.strictEqual(telemetry.lastProcessedSequenceNumber, 13);
+					assert.strictEqual(telemetry.lastQueuedSequenceNumber, 13);
+					assert.strictEqual(telemetry.serviceCheckpointSequenceNumber, 5);
+				});
+
+				it("accepts a valid self-join and its duplicate after later operations", async () => {
+					await startDeltaManager(true, logger, undefined, {
+						lastProcessedSequenceNumber: 13,
+					});
+					const join = generateClientJoin("test", 14);
+					deltaConnection.emitOp(docId, [join]);
+					await yieldEventLoop();
+					assert.strictEqual(deltaManager.lastSequenceNumber, 14);
+					assert.strictEqual(expectedError, undefined);
+
+					deltaConnection.emitOp(docId, [{ ...generateOp(), sequenceNumber: 15 }]);
+					await yieldEventLoop();
+					deltaConnection.emitOp(docId, [join]);
+					await yieldEventLoop();
+					assert.strictEqual(deltaManager.lastSequenceNumber, 15);
+					assert.strictEqual(expectedError, undefined);
+					assert.strictEqual(deltaManager.disposed, false);
+				});
+
+				it("allows an older join for another client", async () => {
+					await startDeltaManager(true, logger, undefined, {
+						lastProcessedSequenceNumber: 13,
+					});
+					deltaConnection.emitOp(docId, [generateClientJoin("other", 6)]);
+					assert.strictEqual(expectedError, undefined);
+					assert.strictEqual(deltaManager.disposed, false);
+					assert.strictEqual(deltaManager.lastSequenceNumber, 13);
+				});
+
+				for (const source of ["initial", "socket"] as const) {
+					for (const state of ["pending", "snapshot"] as const) {
+						it(`uses ${state} state for ${source} messages delivered before attach`, async () => {
+							const messages = [generateClientJoin("test", 6)];
+							await startDeltaManager(true, logger, undefined, {
+								connectBeforeAttach: true,
+								lastProcessedSequenceNumber: state === "pending" ? 13 : undefined,
+								snapshotSequenceNumber: state === "snapshot" ? 13 : 0,
+								initialMessages: source === "initial" ? messages : [],
+								earlySocketMessages: source === "socket" ? messages : [],
+							});
+							assert(isFluidError(expectedError));
+							assert.strictEqual(
+								expectedError.errorType,
+								DriverErrorTypes.fileOverwrittenInStorage,
+							);
+							assert.strictEqual(
+								expectedError.getTelemetryProperties().connectionSequenceBaseline,
+								13,
+							);
+						});
+					}
+				}
+
+				it("rejects a self-join exactly at the baseline in initial messages", async () => {
+					await startDeltaManager(true, logger, undefined, {
+						lastProcessedSequenceNumber: 13,
+						initialMessages: [generateClientJoin("test", 13)],
+					});
+					assert(isFluidError(expectedError));
+					assert.strictEqual(
+						expectedError.errorType,
+						DriverErrorTypes.fileOverwrittenInStorage,
+					);
+					assert.strictEqual(
+						expectedError.getTelemetryProperties().serviceCheckpointSequenceNumber,
+						5,
+					);
+				});
+
+				for (const clientId of ["new-client", "test"]) {
+					it(`refreshes the baseline on reconnect with client ID '${clientId}'`, async () => {
+						await startDeltaManager(true, logger, undefined, {
+							lastProcessedSequenceNumber: 13,
+							clientIds: ["test", clientId],
+						});
+						deltaConnection.emitOp(docId, [
+							generateClientJoin("test", 14),
+							{ ...generateOp(), sequenceNumber: 15 },
+						]);
+						await yieldEventLoop();
+						const reconnectP = new Promise<void>((resolve) => {
+							deltaManager.once("connect", () => resolve());
+						});
+						deltaConnection.emitError({
+							errorType: DriverErrorTypes.genericError,
+							message: "Reconnect for test",
+							canRetry: true,
+						});
+						await reconnectP;
+						deltaConnection.emitOp(docId, [generateClientJoin(clientId, 14)]);
+						assert(isFluidError(expectedError));
+						assert.strictEqual(
+							expectedError.errorType,
+							DriverErrorTypes.fileOverwrittenInStorage,
+						);
+						assert.strictEqual(
+							expectedError.getTelemetryProperties().connectionSequenceBaseline,
+							15,
+						);
+						assert.strictEqual(expectedError.getTelemetryProperties().clientId, clientId);
+					});
+				}
 			});
 
 			describe("Update Minimum Sequence Number", () => {

--- a/packages/loader/container-loader/src/test/deltaManager.spec.ts
+++ b/packages/loader/container-loader/src/test/deltaManager.spec.ts
@@ -58,7 +58,7 @@ describe("Loader", () => {
 				deltaStorageFactory?: () => IDocumentDeltaStorageService,
 				sequenceState?: {
 					snapshotSequenceNumber?: number;
-					lastProcessedSequenceNumber?: number;
+					lastProcessedSequenceNumber?: number | undefined;
 					initialMessages?: ISequencedDocumentMessage[];
 					connectBeforeAttach?: boolean;
 					earlySocketMessages?: ISequencedDocumentMessage[];

--- a/packages/loader/container-loader/src/test/deltaManager.spec.ts
+++ b/packages/loader/container-loader/src/test/deltaManager.spec.ts
@@ -10,6 +10,7 @@ import {
 	MockDocumentDeltaConnection,
 	MockDocumentService,
 } from "@fluid-private/test-loader-utils";
+import { Deferred } from "@fluidframework/core-utils/internal";
 import type { IClient } from "@fluidframework/driver-definitions";
 import {
 	DriverErrorTypes,
@@ -63,6 +64,7 @@ describe("Loader", () => {
 					connectBeforeAttach?: boolean;
 					earlySocketMessages?: ISequencedDocumentMessage[];
 					clientIds?: string[];
+					beforeConnectionReturns?: () => Promise<void>;
 				},
 			): Promise<void> {
 				const service = new MockDocumentService(deltaStorageFactory, () => {
@@ -78,6 +80,15 @@ describe("Loader", () => {
 					deltaConnection.initialMessages = sequenceState?.initialMessages ?? [];
 					return deltaConnection;
 				});
+				const beforeConnectionReturns = sequenceState?.beforeConnectionReturns;
+				if (beforeConnectionReturns !== undefined) {
+					const connectToDeltaStream = service.connectToDeltaStream.bind(service);
+					service.connectToDeltaStream = async (connectingClient) => {
+						const connection = await connectToDeltaStream(connectingClient);
+						await beforeConnectionReturns();
+						return connection;
+					};
+				}
 				const client: Partial<IClient> = {
 					mode: "write",
 					details: { capabilities: { interactive: true } },
@@ -232,6 +243,53 @@ describe("Loader", () => {
 			});
 
 			describe("Self-join sequence validation", () => {
+				/**
+				 * Loads state at 13 and processes a storage batch before stream setup can finish.
+				 * The batch must end with a new operation above 13 so processing provides the barrier.
+				 */
+				async function startStorageFirstConnection(
+					messages: ISequencedDocumentMessage[],
+					initialMessages: ISequencedDocumentMessage[] = [],
+					clientIds: string[] = ["test"],
+				): Promise<void> {
+					const finalSequenceNumber = messages[messages.length - 1].sequenceNumber;
+					const connectionStarted = new Deferred<void>();
+					const storageProcessed = new Deferred<void>();
+					let storageRead = false;
+					await startDeltaManager(
+						true,
+						logger,
+						() => ({
+							fetchMessages: () => ({
+								read: async (): Promise<IStreamResult<ISequencedDocumentMessage[]>> => {
+									await connectionStarted.promise;
+									if (storageRead) {
+										return { done: true };
+									}
+									storageRead = true;
+									return { done: false, value: messages };
+								},
+							}),
+						}),
+						{
+							lastProcessedSequenceNumber: 13,
+							initialMessages,
+							clientIds,
+							beforeConnectionReturns: async () => {
+								// Sequence the batch through storage while stream setup is still
+								// awaiting its connection. Do not let socket delivery win this race.
+								deltaManager.on("op", (message) => {
+									if (message.sequenceNumber === finalSequenceNumber) {
+										storageProcessed.resolve();
+									}
+								});
+								connectionStarted.resolve();
+								await storageProcessed.promise;
+							},
+						},
+					);
+				}
+
 				it("closes when the current connection's self-join predates pending state", async () => {
 					await startDeltaManager(true, logger, undefined, {
 						lastProcessedSequenceNumber: 13,
@@ -286,6 +344,112 @@ describe("Loader", () => {
 				});
 
 				for (const source of ["initial", "socket"] as const) {
+					for (const advanceBeyondJoin of [false, true]) {
+						it(`accepts a storage-first self-join duplicated through ${source} messages (later ops: ${advanceBeyondJoin})`, async () => {
+							const join = generateClientJoin("test", 14);
+							const messages = advanceBeyondJoin
+								? [join, { ...generateOp(), sequenceNumber: 15 }]
+								: [join];
+							const finalSequenceNumber = advanceBeyondJoin ? 15 : 14;
+							await startStorageFirstConnection(messages, source === "initial" ? [join] : []);
+							assert.strictEqual(deltaManager.lastSequenceNumber, finalSequenceNumber);
+							if (source === "socket") {
+								deltaConnection.emitOp(docId, [join]);
+							}
+							const overlapError = expectedError;
+							assert.strictEqual(
+								overlapError,
+								undefined,
+								"Valid storage overlap must not close",
+							);
+							assert.strictEqual(deltaManager.disposed, false);
+
+							// Recognizing the valid duplicate must not allow an actually stale join.
+							deltaConnection.emitOp(docId, [generateClientJoin("test", 6)]);
+							assert(isFluidError(expectedError));
+							assert.strictEqual(
+								expectedError.errorType,
+								DriverErrorTypes.fileOverwrittenInStorage,
+							);
+							assert.strictEqual(
+								expectedError.getTelemetryProperties().connectionSequenceBaseline,
+								13,
+							);
+						});
+					}
+				}
+
+				it("selects the current client's pre-join baseline, not another client's or the latest storage sequence", async () => {
+					const join = generateClientJoin("test", 15);
+					await startStorageFirstConnection(
+						[generateClientJoin("other", 14), join, { ...generateOp(), sequenceNumber: 16 }],
+						[join],
+					);
+					assert.strictEqual(deltaManager.disposed, false);
+					assert.strictEqual(deltaManager.lastSequenceNumber, 16);
+					// The current join followed sequence 14, not the attempt's starting state at 13.
+					deltaConnection.emitOp(docId, [generateClientJoin("test", 14)]);
+					assert(isFluidError(expectedError));
+					assert.strictEqual(
+						expectedError.errorType,
+						DriverErrorTypes.fileOverwrittenInStorage,
+					);
+					assert.strictEqual(
+						expectedError.getTelemetryProperties().connectionSequenceBaseline,
+						14,
+					);
+				});
+
+				it("does not use an overlapping storage join to lower the baseline", async () => {
+					const join = generateClientJoin("test", 6);
+					await startStorageFirstConnection(
+						[join, { ...generateOp(), sequenceNumber: 14 }],
+						[join],
+					);
+					assert(isFluidError(expectedError));
+					assert.strictEqual(
+						expectedError.errorType,
+						DriverErrorTypes.fileOverwrittenInStorage,
+					);
+					assert.strictEqual(
+						expectedError.getTelemetryProperties().connectionSequenceBaseline,
+						14,
+					);
+					assert.strictEqual(expectedError.getTelemetryProperties().loadedSequenceNumber, 13);
+				});
+
+				for (const clientId of ["test", "other"]) {
+					it(`discards storage-first join baselines before reconnecting as '${clientId}'`, async () => {
+						const join = generateClientJoin("test", 15);
+						await startStorageFirstConnection(
+							[generateClientJoin("other", 14), join, { ...generateOp(), sequenceNumber: 16 }],
+							[],
+							["test", clientId],
+						);
+						deltaConnection.emitOp(docId, [join]);
+						assert.strictEqual(deltaManager.disposed, false);
+						const reconnected = new Deferred<void>();
+						deltaManager.once("connect", () => reconnected.resolve());
+						deltaConnection.emitError({
+							errorType: DriverErrorTypes.genericError,
+							message: "Reconnect after storage-first join",
+							canRetry: true,
+						});
+						await reconnected.promise;
+						deltaConnection.emitOp(docId, [generateClientJoin(clientId, 15)]);
+						assert(isFluidError(expectedError));
+						assert.strictEqual(
+							expectedError.errorType,
+							DriverErrorTypes.fileOverwrittenInStorage,
+						);
+						assert.strictEqual(
+							expectedError.getTelemetryProperties().connectionSequenceBaseline,
+							16,
+						);
+					});
+				}
+
+				for (const source of ["initial", "socket"] as const) {
 					for (const state of ["pending", "snapshot"] as const) {
 						it(`uses ${state} state for ${source} messages delivered before attach`, async () => {
 							const messages = [generateClientJoin("test", 6)];
@@ -305,6 +469,38 @@ describe("Loader", () => {
 								expectedError.getTelemetryProperties().connectionSequenceBaseline,
 								13,
 							);
+						});
+
+						it(`rejects a contiguous ${source} replay before attaching ${state} state`, async () => {
+							// Unlike the isolated join above, this replay could fill an inbound queue
+							// starting at zero. Before attachment, all of it must instead be buffered.
+							const messages = [
+								...Array.from({ length: 5 }, () => generateOp()),
+								generateClientJoin("test", 6),
+							];
+							await startDeltaManager(true, logger, undefined, {
+								connectBeforeAttach: true,
+								lastProcessedSequenceNumber: state === "pending" ? 13 : undefined,
+								snapshotSequenceNumber: state === "snapshot" ? 13 : 0,
+								initialMessages: source === "initial" ? messages : [],
+								earlySocketMessages: source === "socket" ? messages : [],
+							});
+							assert(isFluidError(expectedError));
+							assert.strictEqual(
+								expectedError.errorType,
+								DriverErrorTypes.fileOverwrittenInStorage,
+							);
+							assert.strictEqual(deltaManager.disposed, true);
+							const telemetry = expectedError.getTelemetryProperties();
+							assert.strictEqual(telemetry.canRetry, false);
+							assert.strictEqual(telemetry.selfJoinSequenceNumber, 6);
+							assert.strictEqual(telemetry.connectionSequenceBaseline, 13);
+							assert.strictEqual(telemetry.loadedSequenceNumber, 13);
+							assert.strictEqual(
+								telemetry.snapshotSequenceNumber,
+								state === "snapshot" ? 13 : 0,
+							);
+							assert.strictEqual(telemetry.serviceCheckpointSequenceNumber, 5);
 						});
 					}
 				}

--- a/packages/test/test-end-to-end-tests/src/test/container.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/container.spec.ts
@@ -31,6 +31,8 @@ import { IClient } from "@fluidframework/driver-definitions";
 import {
 	DriverErrorTypes,
 	IAnyDriverError,
+	type ISequencedDocumentSystemMessage,
+	MessageType,
 	ISnapshotTree,
 } from "@fluidframework/driver-definitions/internal";
 import {
@@ -44,7 +46,7 @@ import {
 	NonRetryableError,
 	RetryableError,
 } from "@fluidframework/driver-utils/internal";
-import { DataCorruptionError } from "@fluidframework/telemetry-utils/internal";
+import { DataCorruptionError, isFluidError } from "@fluidframework/telemetry-utils/internal";
 import {
 	ITestObjectProvider,
 	LoaderContainerTracker,
@@ -267,6 +269,105 @@ describeCompat("Container", "NoCompat", (getTestObjectProvider, apis) => {
 			container.dispose();
 		}
 	});
+
+	itExpects(
+		"closes a rehydrated container when its current self-join predates pending state",
+		[
+			{
+				eventName: "fluid:telemetry:Container:ContainerClose",
+				errorType: DriverErrorTypes.fileOverwrittenInStorage,
+				canRetry: false,
+			},
+		],
+		async () => {
+			const container = await createConnectedContainer();
+			const dataObject = (await container.getEntryPoint()) as ITestDataObject;
+			// Save real client state through sequence 13, then close the original container.
+			while (container.deltaManager.lastSequenceNumber < 13) {
+				dataObject._root.set("savedSequence", container.deltaManager.lastSequenceNumber);
+				await provider.ensureSynchronized();
+			}
+			assert.strictEqual(container.deltaManager.lastSequenceNumber, 13);
+			const savedValue = dataObject._root.get("savedSequence");
+			container.disconnect();
+			const pendingLocalState = await getRequiredPendingLocalState(container);
+			container.close();
+
+			// Restore that state without connecting yet. Replace only the delta connection so
+			// the test controls when the new client's self-join arrives.
+			const deltaConnection = new MockDocumentDeltaConnection("new-write-client");
+			const mockFactory = wrapObjectAndOverride<IDocumentServiceFactory>(
+				provider.documentServiceFactory,
+				{
+					createDocumentService: {
+						connectToDeltaStream: (_ds) => async () => deltaConnection,
+					},
+				},
+			);
+			const loader = provider.makeTestLoader({
+				loaderProps: { documentServiceFactory: mockFactory },
+			});
+			const rehydrated = await loader.resolve(
+				{
+					url: await provider.driver.createContainerUrl(provider.documentId),
+					headers: { [LoaderHeader.loadMode]: { deltaConnection: "none" } },
+				},
+				pendingLocalState,
+			);
+			loaderContainerTracker.addContainer(rehydrated);
+			try {
+				assert.strictEqual(rehydrated.deltaManager.lastSequenceNumber, 13);
+				const restoredDataObject = (await rehydrated.getEntryPoint()) as ITestDataObject;
+				assert.strictEqual(restoredDataObject._root.get("savedSequence"), savedValue);
+
+				let closeError: IErrorBase | undefined;
+				let becameConnected = false;
+				rehydrated.on("connected", () => {
+					becameConnected = true;
+				});
+				rehydrated.once("closed", (error) => {
+					closeError = error;
+				});
+
+				// Observe container events before starting the connection. The transport can
+				// connect, but the container must stay CatchingUp until it processes its self-join.
+				const connectedToStream = new Deferred<void>();
+				rehydrated.deltaManager.once("connect", () => connectedToStream.resolve());
+				rehydrated.connect();
+				await connectedToStream.promise;
+				assert.strictEqual(rehydrated.connectionState, ConnectionState.CatchingUp);
+
+				// Fake incompatible history: this newly assigned client's join is at sequence 6,
+				// before the saved baseline of 13. Ordinary duplicate filtering must not hide it.
+				const selfJoin: ISequencedDocumentSystemMessage = {
+					type: MessageType.ClientJoin,
+					// API uses null
+					// eslint-disable-next-line unicorn/no-null
+					clientId: null,
+					clientSequenceNumber: 1,
+					sequenceNumber: 6,
+					minimumSequenceNumber: 0,
+					referenceSequenceNumber: 0,
+					timestamp: 1000,
+					contents: undefined,
+					data: JSON.stringify({ clientId: deltaConnection.clientId }),
+				};
+				deltaConnection.emitOp(provider.documentId, [selfJoin]);
+
+				assert.strictEqual(rehydrated.closed, true, "Stale self-join must close immediately");
+				assert(isFluidError(closeError));
+				assert.strictEqual(closeError.errorType, DriverErrorTypes.fileOverwrittenInStorage);
+				assert.strictEqual(closeError.getTelemetryProperties().canRetry, false);
+				assert.strictEqual(closeError.getTelemetryProperties().connectionSequenceBaseline, 13);
+				assert.strictEqual(closeError.getTelemetryProperties().selfJoinSequenceNumber, 6);
+				assert.strictEqual(becameConnected, false, "Stale self-join must not connect");
+				assert.strictEqual(rehydrated.connectionState, ConnectionState.Disconnected);
+				assert.strictEqual(deltaConnection.disposed, true);
+			} finally {
+				rehydrated.dispose();
+			}
+		},
+	);
 
 	it("Close called on container", async () => {
 		const deltaConnection = new MockDocumentDeltaConnection("test");


### PR DESCRIPTION
## Description

A self-join for a newly assigned write connection cannot occur at or below the sequence state the client knew before processing that connection. DeltaManager previously discarded such a join as duplicate delivery, leaving the container waiting for a join it had already received.

Capture an immutable per-connection sequence baseline and reject matching ClientJoin messages at or below it with a non-retryable fileOverwrittenInStorage error, before duplicate filtering. Connections established before attachOpHandler use the eventual snapshot/restored sequence baseline. Normal overlap and duplicate delivery of valid joins remain unchanged.

This change targets main and can land before #28148. It does not include or depend on saved-anchor validation. Raw driver checkpoint telemetry is retained independently.

[AB#82433](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/82433)

## Breaking Changes

None.

## Reviewer Guidance

The review process is outlined in [the pull request guidelines](../docs/content/Contributing/PR-Guidelines.md#guidelines).

The primary regression initializes restored state through sequence 13 and delivers the current connection's join at sequence 6. It fails against main production and passes with this change.

Coverage includes initial and early socket delivery before attach, snapshot and pending-state initialization, equality at the baseline, valid duplicate delivery, other-client overlap, and fresh baselines on reconnect. The focused loader/connection suites pass 63 tests; pending-state/reconnect integration suites pass 52 tests.

Supersedes the stacked proposal in alexvy86/FluidFramework#8.