### PR TITLE
fix(tree): schema factory alpha static identifier default value

### DIFF
--- a/.changeset/static-identifier-defaults.md
+++ b/.changeset/static-identifier-defaults.md
@@ -3,6 +3,6 @@
 "fluid-framework": minor
 "__section": tree
 ---
-Static identifier fields now generate identifiers when omitted
+Fields defined with `SchemaFactoryAlpha.identifier()` now generate identifiers when omitted
 
-Fields defined with SchemaFactoryAlpha's static identifier method now correctly generate identifiers.
+Fields defined with [`SchemaFactoryAlpha.identifier()`](https://fluidframework.com/docs/api/tree/schemafactoryalpha-class#identifier-property) now correctly generate identifiers when omitted.

--- a/.changeset/static-identifier-defaults.md
+++ b/.changeset/static-identifier-defaults.md
@@ -5,5 +5,4 @@
 ---
 Static identifier fields now generate identifiers when omitted
 
-`SchemaFactoryAlpha.identifier()` now generates an identifier when an object is created without a value for the field.
-This behavior now matches `SchemaFactory.identifier` and prevents a schema compatibility error during object creation.
+Fields defined with SchemaFactoryAlpha's static identifier method now correctly generate identifiers.

--- a/.changeset/static-identifier-defaults.md
+++ b/.changeset/static-identifier-defaults.md
@@ -1,0 +1,9 @@
+---
+"@fluidframework/tree": minor
+"fluid-framework": minor
+"__section": tree
+---
+Static identifier fields now generate identifiers when omitted
+
+`SchemaFactoryAlpha.identifier()` now generates an identifier when an object is created without a value for the field.
+This behavior now matches `SchemaFactory.identifier` and prevents a schema compatibility error during object creation.

--- a/packages/dds/tree/src/simple-tree/api/identifierDefaultProvider.ts
+++ b/packages/dds/tree/src/simple-tree/api/identifierDefaultProvider.ts
@@ -1,0 +1,39 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import type { IIdCompressor } from "@fluidframework/id-compressor";
+import { createIdCompressor } from "@fluidframework/id-compressor/internal";
+
+import type { FlexTreeHydratedContextMinimal } from "../../feature-libraries/index.js";
+import type { UnhydratedFlexTreeNode } from "../core/index.js";
+import { type DefaultProvider, getDefaultProvider } from "../fieldSchema.js";
+import { stringSchema } from "../leafNodeSchema.js";
+import { unhydratedFlexTreeFromInsertable } from "../unhydratedFlexTreeFromInsertable.js";
+
+/**
+ * Used to allocate default identifiers for unhydrated nodes when no context is available.
+ * @remarks
+ * The identifiers allocated by this will never be compressed to Short Ids.
+ * Using this is only better than creating fully random V4 UUIDs because it reduces the entropy making it possible for things like text compression to work slightly better.
+ */
+const globalIdentifierAllocator: IIdCompressor = createIdCompressor();
+
+/**
+ * Provides identifiers using the tree's identifier compressor when available, or a global allocator otherwise.
+ */
+export const defaultIdentifierProvider: DefaultProvider = getDefaultProvider(
+	(context: FlexTreeHydratedContextMinimal | "UseGlobalContext"): UnhydratedFlexTreeNode[] => {
+		const id =
+			context === "UseGlobalContext"
+				? globalIdentifierAllocator.decompress(
+						globalIdentifierAllocator.generateCompressedId(),
+					)
+				: context.nodeKeyManager.stabilizeNodeIdentifier(
+						context.nodeKeyManager.generateLocalNodeIdentifier(),
+					);
+
+		return [unhydratedFlexTreeFromInsertable(id, stringSchema)];
+	},
+);

--- a/packages/dds/tree/src/simple-tree/api/schemaFactory.ts
+++ b/packages/dds/tree/src/simple-tree/api/schemaFactory.ts
@@ -4,13 +4,10 @@
  */
 
 import { assert, debugAssert, unreachableCase } from "@fluidframework/core-utils/internal";
-import type { IIdCompressor } from "@fluidframework/id-compressor";
-import { createIdCompressor } from "@fluidframework/id-compressor/internal";
 import { isFluidHandle } from "@fluidframework/runtime-utils/internal";
 import { UsageError } from "@fluidframework/telemetry-utils/internal";
 
 import type { TreeValue } from "../../core/index.js";
-import type { FlexTreeHydratedContextMinimal } from "../../feature-libraries/index.js";
 import {
 	type JsonCompatibleReadOnlyObject,
 	type RestrictiveStringRecord,
@@ -26,7 +23,6 @@ import type {
 	TreeNodeSchemaClass,
 	TreeNodeSchemaNonClass,
 	TreeNodeSchemaBoth,
-	UnhydratedFlexTreeNode,
 	NodeSchemaMetadata,
 	ImplicitAllowedTypes,
 	InsertableTreeNodeFromImplicitAllowedTypes,
@@ -39,8 +35,6 @@ import {
 	// eslint-disable-next-line unused-imports/no-unused-imports, @typescript-eslint/no-unused-vars
 	type FieldProps,
 	createFieldSchema,
-	type DefaultProvider,
-	getDefaultProvider,
 } from "../fieldSchema.js";
 import {
 	booleanSchema,
@@ -62,8 +56,8 @@ import {
 	type TreeMapNode,
 	type TreeObjectNode,
 } from "../node-kinds/index.js";
-import { unhydratedFlexTreeFromInsertable } from "../unhydratedFlexTreeFromInsertable.js";
 
+import { defaultIdentifierProvider } from "./identifierDefaultProvider.js";
 import { type SchemaStatics, schemaStatics } from "./schemaStatics.js";
 import type { System_Unsafe } from "./typesUnsafe.js";
 
@@ -767,22 +761,6 @@ export class SchemaFactory<
 	 * A node may have more than one identifier field (though note that this precludes the use of the {@link TreeNodeApi.shortId|Tree.shortId()} API).
 	 */
 	public get identifier(): FieldSchema<FieldKind.Identifier, typeof this.string> {
-		const defaultIdentifierProvider: DefaultProvider = getDefaultProvider(
-			(
-				context: FlexTreeHydratedContextMinimal | "UseGlobalContext",
-			): UnhydratedFlexTreeNode[] => {
-				const id =
-					context === "UseGlobalContext"
-						? globalIdentifierAllocator.decompress(
-								globalIdentifierAllocator.generateCompressedId(),
-							)
-						: context.nodeKeyManager.stabilizeNodeIdentifier(
-								context.nodeKeyManager.generateLocalNodeIdentifier(),
-							);
-
-				return [unhydratedFlexTreeFromInsertable(id, this.string)];
-			},
-		);
 		return createFieldSchema(FieldKind.Identifier, this.string, {
 			defaultProvider: defaultIdentifierProvider,
 		});
@@ -965,14 +943,6 @@ export function scoped<
 		factory.scope === undefined ? `${name}` : `${factory.scope}.${name}`
 	) as ScopedSchemaName<TScope, Name>;
 }
-
-/**
- * Used to allocate default identifiers for unhydrated nodes when no context is available.
- * @remarks
- * The identifiers allocated by this will never be compressed to Short Ids.
- * Using this is only better than creating fully random V4 UUIDs because it reduces the entropy making it possible for things like text compression to work slightly better.
- */
-const globalIdentifierAllocator: IIdCompressor = createIdCompressor();
 
 /**
  * Additional information to provide to Node Schema creation.

--- a/packages/dds/tree/src/simple-tree/api/schemaStatics.ts
+++ b/packages/dds/tree/src/simple-tree/api/schemaStatics.ts
@@ -25,6 +25,7 @@ import {
 	handleSchema,
 } from "../leafNodeSchema.js";
 
+import { defaultIdentifierProvider } from "./identifierDefaultProvider.js";
 import type { System_Unsafe, FieldSchemaAlphaUnsafe } from "./typesUnsafe.js";
 
 /**
@@ -257,7 +258,7 @@ export const schemaStatics = {
 		FieldPropsAlpha<TCustomMetadata>
 	> => {
 		return createFieldSchema(FieldKind.Identifier, stringSchema, {
-			defaultProvider: undefined,
+			defaultProvider: defaultIdentifierProvider,
 			...props,
 		});
 	},

--- a/packages/dds/tree/src/simple-tree/node-kinds/object/objectNode.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/object/objectNode.ts
@@ -764,23 +764,14 @@ function shallowCompatibilityTest(
 
 	// TODO#7441: Consider allowing data to be inserted which has keys that are extraneous/unknown to the schema (those keys are ignored)
 
-	let compatibility = CompatibilityLevel.Normal;
+	// If the schema has a required key which is not present in the input object, reject it.
 	for (const [fieldKey, fieldSchema] of schema.fields) {
-		if (getFieldProperty(data, fieldKey) !== undefined) {
-			continue;
-		}
-
-		if (fieldSchema.requiresValue) {
+		if (fieldSchema.requiresValue && getFieldProperty(data, fieldKey) === undefined) {
 			return CompatibilityLevel.None;
-		}
-
-		// Prefer a union type that does not need to generate an identifier.
-		if (fieldSchema.kind === FieldKind.Identifier) {
-			compatibility = CompatibilityLevel.Low;
 		}
 	}
 
-	return compatibility;
+	return CompatibilityLevel.Normal;
 }
 
 /**

--- a/packages/dds/tree/src/simple-tree/node-kinds/object/objectNode.ts
+++ b/packages/dds/tree/src/simple-tree/node-kinds/object/objectNode.ts
@@ -764,14 +764,23 @@ function shallowCompatibilityTest(
 
 	// TODO#7441: Consider allowing data to be inserted which has keys that are extraneous/unknown to the schema (those keys are ignored)
 
-	// If the schema has a required key which is not present in the input object, reject it.
+	let compatibility = CompatibilityLevel.Normal;
 	for (const [fieldKey, fieldSchema] of schema.fields) {
-		if (fieldSchema.requiresValue && getFieldProperty(data, fieldKey) === undefined) {
+		if (getFieldProperty(data, fieldKey) !== undefined) {
+			continue;
+		}
+
+		if (fieldSchema.requiresValue) {
 			return CompatibilityLevel.None;
+		}
+
+		// Prefer a union type that does not need to generate an identifier.
+		if (fieldSchema.kind === FieldKind.Identifier) {
+			compatibility = CompatibilityLevel.Low;
 		}
 	}
 
-	return CompatibilityLevel.Normal;
+	return compatibility;
 }
 
 /**

--- a/packages/dds/tree/src/test/simple-tree/api/simpleSchemaToJsonSchema.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/simpleSchemaToJsonSchema.spec.ts
@@ -434,7 +434,7 @@ describe("simpleSchemaToJsonSchema", () => {
 							description: "Unique identifier for the test object.",
 						},
 					},
-					required: ["bar", "id"],
+					required: ["bar"],
 					additionalProperties: false,
 				},
 				[numberSchema.identifier]: {
@@ -467,7 +467,7 @@ describe("simpleSchemaToJsonSchema", () => {
 			{
 				bar: "Hello World",
 			},
-			false,
+			true,
 		);
 		validator(
 			{
@@ -541,9 +541,7 @@ describe("simpleSchemaToJsonSchema", () => {
 					properties: {
 						id: { $ref: "#/$defs/com.fluidframework.leaf.string" },
 					},
-					// The identifier field is technically required, it just has a default provider.
-					// TODO: Support for generating schema for insertable content (concise tree with fields that have default providers as optional) is now implemented: refactor tests so it can be validated.
-					required: ["id"],
+					required: [],
 					additionalProperties: false,
 				},
 				"com.fluidframework.leaf.string": {

--- a/packages/dds/tree/src/test/simple-tree/node-kinds/object/objectNode.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/node-kinds/object/objectNode.spec.ts
@@ -839,24 +839,6 @@ describeHydration(
 			assert.notEqual(first, second);
 		});
 
-		it("prefers a union type that does not need an identifier default", () => {
-			const alphaSchemaFactory = new SchemaFactoryAlpha("AlphaUnionTest");
-			class WithId extends alphaSchemaFactory.object("WithId", {
-				value: alphaSchemaFactory.string,
-				id: SchemaFactoryAlpha.identifier(),
-			}) {}
-			class WithoutId extends alphaSchemaFactory.object("WithoutId", {
-				value: alphaSchemaFactory.string,
-			}) {}
-			class Root extends alphaSchemaFactory.object("Root", {
-				child: [WithId, WithoutId],
-			}) {}
-
-			const root = new Root({ child: { value: "hello" } });
-
-			assert(Tree.is(root.child, WithoutId));
-		});
-
 		it("unhydrated default identifier access via shortId returns UUID", () => {
 			class HasId extends schemaFactory.object("hasID", { id: schemaFactory.identifier }) {}
 			const newNode = new HasId({});

--- a/packages/dds/tree/src/test/simple-tree/node-kinds/object/objectNode.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/node-kinds/object/objectNode.spec.ts
@@ -825,6 +825,38 @@ describeHydration(
 			assert.notEqual(id, id2);
 		});
 
+		it("generates an identifier when SchemaFactoryAlpha.identifier is omitted", () => {
+			const alphaSchemaFactory = new SchemaFactoryAlpha("AlphaTest");
+			class HasId extends alphaSchemaFactory.object("hasID", {
+				id: SchemaFactoryAlpha.identifier(),
+			}) {}
+
+			const first = new HasId({}).id;
+			const second = new HasId({}).id;
+
+			assert(isStableId(first));
+			assert(isStableId(second));
+			assert.notEqual(first, second);
+		});
+
+		it("prefers a union type that does not need an identifier default", () => {
+			const alphaSchemaFactory = new SchemaFactoryAlpha("AlphaUnionTest");
+			class WithId extends alphaSchemaFactory.object("WithId", {
+				value: alphaSchemaFactory.string,
+				id: SchemaFactoryAlpha.identifier(),
+			}) {}
+			class WithoutId extends alphaSchemaFactory.object("WithoutId", {
+				value: alphaSchemaFactory.string,
+			}) {}
+			class Root extends alphaSchemaFactory.object("Root", {
+				child: [WithId, WithoutId],
+			}) {}
+
+			const root = new Root({ child: { value: "hello" } });
+
+			assert(Tree.is(root.child, WithoutId));
+		});
+
 		it("unhydrated default identifier access via shortId returns UUID", () => {
 			class HasId extends schemaFactory.object("hasID", { id: schemaFactory.identifier }) {}
 			const newNode = new HasId({});


### PR DESCRIPTION
## Description

`SchemaFactoryAlpha.identifier()` now generates an identifier when field value is omitted, matching `SchemaFactory.identifier()` behavior.