### PR TITLE
[release/3.0] fix(tree): Default includeAlreadyEnabledUpgrades to false

### DIFF
--- a/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
+++ b/packages/dds/tree/src/shared-tree/schematizingTreeView.ts
@@ -322,7 +322,7 @@ export class SchematizingSimpleTreeView<
 
 	private get effectiveUpgradePolicy(): StagedSchemaUpgradePolicy {
 		const configuredPolicy = this.stagedUpgradePolicy;
-		if (configuredPolicy.includeAlreadyEnabledUpgrades === false) {
+		if (configuredPolicy.includeAlreadyEnabledUpgrades !== true) {
 			return configuredPolicy;
 		}
 		const enabledUpgrades = this.currentEnabledUpgrades;

--- a/packages/dds/tree/src/simple-tree/api/schemaCompatibilityTester.ts
+++ b/packages/dds/tree/src/simple-tree/api/schemaCompatibilityTester.ts
@@ -141,7 +141,8 @@ export function checkSchemaCompatibility(
 	// The public API surface assumes defaultSchemaPolicy
 	const policy = defaultSchemaPolicy;
 	const configuredPolicy = resolveStoredSchemaGenerationOptions(stagedSchemaUpgrades);
-	const includeAlreadyEnabledUpgrades = configuredPolicy.includeAlreadyEnabledUpgrades ?? true;
+	const includeAlreadyEnabledUpgrades =
+		configuredPolicy.includeAlreadyEnabledUpgrades ?? false;
 
 	// Collect upgrade locations during the discrepancy walk (single pass).
 	const totalLocations = new Map<SchemaUpgrade, number>();

--- a/packages/dds/tree/src/simple-tree/api/tree.ts
+++ b/packages/dds/tree/src/simple-tree/api/tree.ts
@@ -722,9 +722,8 @@ export interface TreeView<in out TSchema extends ImplicitFieldSchema> extends ID
 	 *
 	 * When using {@link TreeViewConfigurationAlpha} with a {@link ITreeViewConfigurationAlpha.stagedUpgradePolicy},
 	 * staged schema upgrades matching the configured policy are included in the target stored schema.
-	 * Staged upgrades that are already enabled in the document are also included by default. Set
-	 * {@link (StagedSchemaUpgradePolicy:interface).includeAlreadyEnabledUpgrades} to `false` when
-	 * creating the policy to only include staged upgrades selected explicitly by the policy.
+	 * Set {@link (StagedSchemaUpgradePolicy:interface).includeAlreadyEnabledUpgrades} to `true` to
+	 * also include staged upgrades that are already enabled in the document.
 	 *
 	 * @example Enabling a staged allowed type for documents, selected by a feature flag
 	 *

--- a/packages/dds/tree/src/simple-tree/core/toStored.ts
+++ b/packages/dds/tree/src/simple-tree/core/toStored.ts
@@ -15,7 +15,7 @@ export interface StagedSchemaUpgradePolicy {
 	 * Whether schema upgrades should include staged upgrades that are already enabled in the
 	 * document's stored schema.
 	 *
-	 * @defaultValue `true`
+	 * @defaultValue `false`
 	 */
 	readonly includeAlreadyEnabledUpgrades?: boolean;
 

--- a/packages/dds/tree/src/test/simple-tree/api/schemaCompatibilityTester.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/schemaCompatibilityTester.spec.ts
@@ -45,9 +45,10 @@ function expectCompatibility(
 	> & {
 		enabledUpgrades?: ReadonlyMap<SchemaUpgrade, StagedUpgradeStatus>;
 	},
+	stagedSchemaUpgrades?: Parameters<typeof checkSchemaCompatibility>[2],
 ) {
 	const viewSchema = new TreeViewConfigurationAlpha({ schema: view });
-	const compatibility = checkSchemaCompatibility(viewSchema, stored);
+	const compatibility = checkSchemaCompatibility(viewSchema, stored, stagedSchemaUpgrades);
 	const { discrepancies, ...compatibilityWithoutDiscrepancies } = compatibility;
 	assert.deepEqual(compatibilityWithoutDiscrepancies, {
 		enabledUpgrades: new Map(),
@@ -642,7 +643,7 @@ describe("checkSchemaCompatibility", () => {
 				);
 			});
 
-			it("clients with staged schema preserve already enabled upgrades", () => {
+			it("clients with staged schema can preserve already enabled upgrades", () => {
 				const stagedString = SchemaFactoryAlpha.staged(SchemaFactoryAlpha.string);
 				const upgrade = stagedString.metadata.stagedSchemaUpgrade;
 				assert(upgrade !== undefined);
@@ -662,6 +663,10 @@ describe("checkSchemaCompatibility", () => {
 						canUpgrade: true,
 						isEquivalent: true,
 						enabledUpgrades: new Map([[upgrade, "enabled"]]),
+					},
+					{
+						...StagedSchemaUpgradePolicy.restrictive,
+						includeAlreadyEnabledUpgrades: true,
 					},
 				);
 			});

--- a/packages/dds/tree/src/test/simple-tree/api/snapshotCompatibilityChecker.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/snapshotCompatibilityChecker.spec.ts
@@ -174,6 +174,10 @@ describe("snapshotCompatibilityChecker", () => {
 
 		// The current schema's string schema is supported by the old schema's staged string schema
 		assert.equal(forwardsCompatibilityStatus.canView, true);
+
+		const combinedCompatibility = getCompatibility(currentViewSchema, oldViewSchema);
+		assert.equal(combinedCompatibility.currentViewOfSnapshotDocument.isEquivalent, false);
+		assert.equal(combinedCompatibility.snapshotViewOfCurrentDocument.isEquivalent, false);
 	});
 
 	it("SnapshotFileSystem", () => {

--- a/packages/dds/tree/src/test/simple-tree/api/stagedSchemaUpgrade.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/stagedSchemaUpgrade.spec.ts
@@ -234,7 +234,7 @@ describe("staged allowed type upgrade", () => {
 		assert.equal(viewMigrated.root, "test");
 	});
 
-	it("includes an already enabled allowed type in upgradeSchema by default", () => {
+	it("excludes an already enabled allowed type from upgradeSchema by default", () => {
 		const provider = new TestTreeProviderLite(3);
 		const [treeBase, treeEnabled, treeDefault] = provider.trees;
 
@@ -255,8 +255,11 @@ describe("staged allowed type upgrade", () => {
 		const viewDefault = treeDefault.viewWith(
 			new TreeViewConfigurationAlpha({ schema: schemaWithStagedType }),
 		);
-		assert.equal(viewDefault.compatibility.canUpgrade, true);
-		assert.doesNotThrow(() => viewDefault.upgradeSchema());
+		assert.equal(viewDefault.compatibility.canUpgrade, false);
+		assert.throws(
+			() => viewDefault.upgradeSchema(),
+			/cannot be upgraded to the requested schema/,
+		);
 	});
 
 	it("using independent view user apis", () => {
@@ -543,7 +546,7 @@ describe("staged optional upgrade", () => {
 		assert.equal(viewOptional.root, undefined);
 	});
 
-	it("includes an already enabled upgrade in upgradeSchema by default", () => {
+	it("excludes an already enabled upgrade from upgradeSchema by default", () => {
 		const provider = new TestTreeProviderLite(3);
 		const [treeRequired, treeStaged, treeOptional] = provider.trees;
 
@@ -564,15 +567,18 @@ describe("staged optional upgrade", () => {
 		viewStaged.dispose();
 		provider.synchronizeMessages();
 
-		// A new view without the upgrade token preserves the enabled upgrade.
+		// A new view without the upgrade token excludes the enabled upgrade.
 		const viewStagedDefault = treeOptional.viewWith(
 			new TreeViewConfigurationAlpha({ schema: stagedOptionalSchema }),
 		);
-		assert.equal(viewStagedDefault.compatibility.canUpgrade, true);
-		assert.doesNotThrow(() => viewStagedDefault.upgradeSchema());
+		assert.equal(viewStagedDefault.compatibility.canUpgrade, false);
+		assert.throws(
+			() => viewStagedDefault.upgradeSchema(),
+			/cannot be upgraded to the requested schema/,
+		);
 	});
 
-	it("can exclude already enabled upgrades from upgradeSchema", () => {
+	it("can include already enabled upgrades in upgradeSchema", () => {
 		const provider = new TestTreeProviderLite(3);
 		const [treeRequired, treeStaged, treeOptional] = provider.trees;
 
@@ -592,20 +598,17 @@ describe("staged optional upgrade", () => {
 		viewStaged.dispose();
 		provider.synchronizeMessages();
 
-		const viewStagedNarrow = treeOptional.viewWith(
+		const viewStagedPreserving = treeOptional.viewWith(
 			new TreeViewConfigurationAlpha({
 				schema: stagedOptionalSchema,
 				stagedUpgradePolicy: {
-					includeAlreadyEnabledUpgrades: false,
+					includeAlreadyEnabledUpgrades: true,
 					...StagedSchemaUpgradePolicy.enabledStagedUpgrades(),
 				},
 			}),
 		);
-		assert.equal(viewStagedNarrow.compatibility.canUpgrade, false);
-		assert.throws(
-			() => viewStagedNarrow.upgradeSchema(),
-			/cannot be upgraded to the requested schema/,
-		);
+		assert.equal(viewStagedPreserving.compatibility.canUpgrade, true);
+		assert.doesNotThrow(() => viewStagedPreserving.upgradeSchema());
 	});
 
 	it("checks compatibility through staged optional rollout", () => {
@@ -672,11 +675,11 @@ describe("staged optional upgrade", () => {
 			isEquivalent: true,
 		});
 
-		// stagedOptionalSchema preserves the already enabled optional upgrade by default.
+		// stagedOptionalSchema excludes the already enabled optional upgrade by default.
 		expectCompatibility(stagedOptionalSchema, {
 			canView: true,
-			canUpgrade: true,
-			isEquivalent: true,
+			canUpgrade: false,
+			isEquivalent: false,
 			enabledUpgrades: new Map([[optionalUpgrade, "enabled"]]),
 		});
 


### PR DESCRIPTION
The updates that #28165 and its backports made to compatibility checking can cause issues for non-alpha users of SharedTree, specifically assert code `0xcd3`. Switching the default of the newly introduced option from `true` to `false` (what this PR does) makes those issues off by default (and can only be "opted into" using alpha APIs)

PR for same change into main: #28180 
