### PR TITLE
fix(build-cli): Preserve GitHub alerts correctly when stripping soft breaks

### DIFF
--- a/build-tools/packages/build-cli/src/library/markdown.ts
+++ b/build-tools/packages/build-cli/src/library/markdown.ts
@@ -49,22 +49,6 @@ export function addHeadingLinks(): (tree: Node) => void {
 }
 
 /**
- * A regular expression that extracts an admonition title from a string UNLESS the admonition title is the only thing on
- * the line.
- *
- * Capture group 1 is the admonition type/title (from the leading `[!` all the way to the trailing `]`).
- *
- * @remarks
- *
- * Description of the regular expression:
- *
- * This regular expression matches patterns in the form of `[!WORD]` where WORD can be CAUTION, IMPORTANT, NOTE, TIP, or
- * WARNING. It ensures that the pattern is not followed by only whitespace characters until the end of the line.
- * Additionally, it captures any whitespace characters that follow the matched pattern.
- */
-const ADMONITION_REGEX = /(\[!(?:CAUTION|IMPORTANT|NOTE|TIP|WARNING)])(?!\s*$)\s*/gm;
-
-/**
  * A regular expression to remove single line breaks from text. This is used to remove extraneous line breaks in text
  * nodes in markdown. This is useful because GitHub sometimes renders single line breaks, and sometimes it ignores them
  * like the CommonMark spec describes. Removing them ensures that markdown renders as expected across GitHub.
@@ -79,24 +63,102 @@ const ADMONITION_REGEX = /(\[!(?:CAUTION|IMPORTANT|NOTE|TIP|WARNING)])(?!\s*$)\s
 const SOFT_BREAK_REGEX = /$[^$]/gms;
 
 /**
+ * A regular expression that matches a GitHub alert marker at the start of a string, together with the rest of that
+ * line and the line break that ends it.
+ *
+ * Capture group 1 is the marker itself (from the leading `[!` all the way to the trailing `]`).
+ *
+ * @remarks
+ *
+ * GitHub renders a blockquote as an alert when its first paragraph begins with one of these markers and the marker is
+ * alone on its line. The match is deliberately case-insensitive, because GitHub accepts `[!note]` and `[!Note]` just
+ * as it accepts `[!NOTE]`. The alternation is written in lower case only to satisfy the `unicorn/better-regex` lint
+ * rule; with the `i` flag the case used in the pattern makes no difference.
+ *
+ * `[^\S\n]*` allows trailing spaces or tabs after the marker, which GitHub also allows, while stopping short of the
+ * line break so that the line break itself is part of the match and can be preserved.
+ */
+const ALERT_MARKER_REGEX = /^(\[!(?:caution|important|note|tip|warning)])[^\S\n]*\n/i;
+
+/**
+ * Returns the text node holding the alert marker of a GitHub alert, or `undefined` if the given node is not an alert.
+ *
+ * @remarks
+ *
+ * The rules mirror GitHub's own renderer:
+ *
+ * - The marker must be the very first thing in the blockquote's first paragraph. A marker that appears after other
+ * text, or in a later paragraph, does not make an alert.
+ * - The marker must be alone on its line, with the body starting on a following line.
+ * - Alerts cannot be nested inside other elements, so the blockquote must be at the top level of the document.
+ */
+function findAlertMarkerNode(
+	blockquote: Parent,
+	parent: Parent | undefined,
+): { value: string } | undefined {
+	// GitHub does not render alerts nested inside other elements, including inside another blockquote.
+	if (parent?.type !== "root") {
+		return undefined;
+	}
+
+	const firstBlock = blockquote.children[0];
+	if (firstBlock?.type !== "paragraph") {
+		return undefined;
+	}
+
+	const firstInline = (firstBlock as Parent).children[0] as { type: string; value?: string };
+	if (firstInline?.type !== "text" || firstInline.value === undefined) {
+		return undefined;
+	}
+
+	// A marker with no line break after it is either the whole blockquote, which GitHub does not treat as an alert
+	// because it has no body, or a marker with the body on its own line, which GitHub does not treat as an alert
+	// either. Neither case has a line break to preserve.
+	return ALERT_MARKER_REGEX.test(firstInline.value)
+		? (firstInline as { value: string })
+		: undefined;
+}
+
+/**
  * A remarkjs/unist plugin that strips soft line breaks. This is a workaround for GitHub's inconsistent markdown
  * rendering in GitHub Releases. According to CommonMark, Markdown paragraphs are denoted by two line breaks, and single
  * line breaks should be ignored. But in GitHub releases, single line breaks are rendered. This plugin removes the soft
  * line breaks so that the markdown is correctly rendered.
+ *
+ * @remarks
+ *
+ * GitHub alerts (`> [!NOTE]`) depend on the marker being alone on its line, so collapsing that particular line break
+ * would stop the alert from rendering. Alert blockquotes are therefore identified before any line breaks are removed,
+ * and the line break that ends the marker's line is kept.
  */
 export function stripSoftBreaks(): (tree: Node) => void {
 	return (tree: Node): void => {
-		// strip soft breaks
-		visit(tree, "text", (node: { value: string }) => {
-			node.value = node.value.replace(SOFT_BREAK_REGEX, " ");
-		});
+		// Identify alert markers up front. Once soft breaks have been stripped there is no way to tell a marker that
+		// was alone on its line from one the author wrote inline with the body, and only the former is an alert.
+		const alertMarkerNodes = new Set<{ value: string }>();
+		visit(
+			tree,
+			"blockquote",
+			(node: Parent, _index: number | undefined, parent: Parent | undefined) => {
+				const markerNode = findAlertMarkerNode(node, parent);
+				if (markerNode !== undefined) {
+					alertMarkerNodes.add(markerNode);
+				}
+			},
+		);
 
-		// preserve GitHub admonitions; without this the line breaks in the alert are lost and it doesn't render correctly.
-		visit(tree, "blockquote", (node: Node) => {
-			visit(node, "text", (innerNode: { value: string }) => {
-				// If the text is an admonition title, split
-				innerNode.value = innerNode.value.replace(ADMONITION_REGEX, "$1\n");
-			});
+		visit(tree, "text", (node: { value: string }) => {
+			if (alertMarkerNodes.has(node)) {
+				// Keep the marker and the line break that follows it, and strip soft breaks from the rest of the node.
+				const marker = ALERT_MARKER_REGEX.exec(node.value);
+				if (marker !== null) {
+					const body = node.value.slice(marker[0].length).replace(SOFT_BREAK_REGEX, " ");
+					node.value = `${marker[1]}\n${body}`;
+					return;
+				}
+			}
+
+			node.value = node.value.replace(SOFT_BREAK_REGEX, " ");
 		});
 	};
 }

--- a/build-tools/packages/build-cli/src/test/library/markdown.test.ts
+++ b/build-tools/packages/build-cli/src/test/library/markdown.test.ts
@@ -1,0 +1,167 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "node:assert";
+
+import { describe, it } from "mocha";
+import { remark } from "remark";
+import remarkGfm from "remark-gfm";
+
+import { stripSoftBreaks } from "../../library/markdown.js";
+
+/**
+ * Runs markdown through `stripSoftBreaks` the same way the release notes commands do, and returns the resulting
+ * markdown.
+ */
+function process(markdown: string): string {
+	return String(remark().use(remarkGfm).use(stripSoftBreaks).processSync(markdown));
+}
+
+/**
+ * The five alert types GitHub supports.
+ */
+const alertTypes = ["NOTE", "TIP", "IMPORTANT", "WARNING", "CAUTION"] as const;
+
+/**
+ * These tests describe what GitHub actually does, rather than what the current implementation does. Every expectation
+ * below was verified by rendering the markdown through GitHub's own renderer (`POST /markdown`) and checking whether
+ * the result carried a `markdown-alert` class.
+ *
+ * The rules that came out of that exercise:
+ *
+ * 1. An alert is a blockquote whose first paragraph begins with a `[!TYPE]` marker.
+ * 2. The marker must be the very first thing in the blockquote. Text in front of it means it is not an alert.
+ * 3. The marker must be alone on its line. Body content on the marker's line means it is not an alert.
+ * 4. Matching is case-insensitive: `[!note]` and `[!Note]` are alerts just like `[!NOTE]`.
+ * 5. Only NOTE, TIP, IMPORTANT, WARNING and CAUTION are alert types.
+ * 6. An alert needs a body. A marker on its own is just a blockquote.
+ * 7. Trailing whitespace after the marker is fine, as is a blank line between the marker and the body.
+ * 8. A backslash-escaped marker (`\[!NOTE]`) still renders as an alert, so the escaping that remark-stringify applies
+ * on output is harmless.
+ * 9. Nested blockquotes are not alerts, and neither is a marker outside a blockquote.
+ *
+ * `stripSoftBreaks` collapses single line breaks, which would otherwise pull the body up onto the marker's line and
+ * break rule 3. So the contract under test is: markdown that GitHub renders as an alert must still be rendered as an
+ * alert afterwards, and markdown that is not an alert must not be rewritten into something that looks like one.
+ */
+describe("stripSoftBreaks and GitHub alerts", () => {
+	describe("keeps the marker on its own line for every alert type", () => {
+		for (const type of alertTypes) {
+			it(type, () => {
+				assert.equal(
+					process(`> [!${type}]\n> Body line one.\n> Body line two.\n`),
+					`> \\[!${type}]\n> Body line one. Body line two.\n`,
+				);
+			});
+		}
+	});
+
+	describe("treats the marker case-insensitively, as GitHub does", () => {
+		const cases: [name: string, marker: string][] = [
+			["all lowercase", "[!note]"],
+			["capitalised", "[!Note]"],
+			["mixed case", "[!nOtE]"],
+			["lowercase tip", "[!tip]"],
+			["lowercase important", "[!important]"],
+			["lowercase warning", "[!warning]"],
+			["lowercase caution", "[!caution]"],
+		];
+
+		for (const [name, marker] of cases) {
+			it(name, () => {
+				assert.equal(
+					process(`> ${marker}\n> Body line one.\n> Body line two.\n`),
+					`> \\${marker}\n> Body line one. Body line two.\n`,
+				);
+			});
+		}
+	});
+
+	describe("keeps the marker on its own line when the body starts with formatting", () => {
+		const cases: [name: string, body: string, expected: string][] = [
+			["bold", "**Bold** and more.", "**Bold** and more."],
+			["emphasis", "_Emphasised_ and more.", "*Emphasised* and more."],
+			[
+				"a link",
+				"[a link](https://example.com) then text.",
+				"[a link](https://example.com) then text.",
+			],
+			["inline code", "`code` first.", "`code` first."],
+			["strikethrough", "~~struck~~ then text.", "~~struck~~ then text."],
+		];
+
+		for (const [name, body, expected] of cases) {
+			it(name, () => {
+				assert.equal(process(`> [!NOTE]\n> ${body}\n`), `> \\[!NOTE]\n> ${expected}\n`);
+			});
+		}
+	});
+
+	describe("does not rewrite markdown that GitHub does not treat as an alert", () => {
+		const cases: [name: string, input: string, expected: string][] = [
+			[
+				"marker preceded by text",
+				"> Please read [!NOTE] and continue.\n",
+				"> Please read \\[!NOTE] and continue.\n",
+			],
+			[
+				"marker preceded by text, body starts with formatting",
+				"> Please read [!NOTE] **carefully**.\n",
+				"> Please read \\[!NOTE] **carefully**.\n",
+			],
+			[
+				"marker with body already on its line",
+				"> [!NOTE] Body on the marker line.\n",
+				"> \\[!NOTE] Body on the marker line.\n",
+			],
+			["unsupported alert type", "> [!DANGER]\n> Body text.\n", "> \\[!DANGER] Body text.\n"],
+			["marker outside a blockquote", "[!NOTE]\nBody text.\n", "\\[!NOTE] Body text.\n"],
+		];
+
+		for (const [name, input, expected] of cases) {
+			it(name, () => {
+				assert.equal(process(input), expected);
+			});
+		}
+	});
+
+	it("does not split a marker that has no body, because that is not an alert", () => {
+		assert.equal(process("> [!NOTE]\n"), "> \\[!NOTE]\n");
+	});
+
+	it("keeps an alert whose body is separated by a blank line", () => {
+		// GitHub still renders this as an alert. The marker and body are separate paragraphs, so there is no soft break
+		// between them to lose in the first place.
+		assert.equal(process("> [!NOTE]\n>\n> Body text.\n"), "> \\[!NOTE]\n>\n> Body text.\n");
+	});
+
+	describe("does not treat a marker as an alert where GitHub would not", () => {
+		const cases: [name: string, input: string, expected: string][] = [
+			[
+				"inside a nested blockquote",
+				"> > [!NOTE]\n> > Body text.\n",
+				"> > \\[!NOTE] Body text.\n",
+			],
+			[
+				"in a paragraph other than the first",
+				"> Intro.\n>\n> [!NOTE]\n> Body text.\n",
+				"> Intro.\n>\n> \\[!NOTE] Body text.\n",
+			],
+		];
+
+		for (const [name, input, expected] of cases) {
+			it(name, () => {
+				assert.equal(process(input), expected);
+			});
+		}
+	});
+
+	it("leaves an ordinary blockquote alone apart from collapsing its soft breaks", () => {
+		assert.equal(
+			process("> Regular quote with **bold**.\n> A second line.\n"),
+			"> Regular quote with **bold**. A second line.\n",
+		);
+	});
+});

--- a/build-tools/packages/build-cli/src/test/library/markdown.test.ts
+++ b/build-tools/packages/build-cli/src/test/library/markdown.test.ts
@@ -5,17 +5,36 @@
 
 import { strict as assert } from "node:assert";
 
+import type { Root } from "mdast";
 import { describe, it } from "mocha";
 import { remark } from "remark";
 import remarkGfm from "remark-gfm";
+import { visit } from "unist-util-visit";
 
 import { stripSoftBreaks } from "../../library/markdown.js";
 
 /**
- * Runs markdown through `stripSoftBreaks` the same way the release notes commands do, and returns the resulting
- * markdown.
+ * Parses markdown, applies `stripSoftBreaks` to the tree, and returns the value of every text node in document order.
+ *
+ * Text node values are what the plugin actually edits, so they show its effect directly. A line break in a value means
+ * the text is still split across two lines; a space where the source had a line break means the soft break was
+ * collapsed.
  */
-function process(markdown: string): string {
+function strippedText(markdown: string): string[] {
+	const tree: Root = remark().use(remarkGfm).parse(markdown);
+	stripSoftBreaks()(tree);
+
+	const values: string[] = [];
+	visit(tree, "text", (node: { value: string }) => {
+		values.push(node.value);
+	});
+	return values;
+}
+
+/**
+ * Parses markdown, applies `stripSoftBreaks`, and serializes the result back to markdown.
+ */
+function strippedMarkdown(markdown: string): string {
 	return String(remark().use(remarkGfm).use(stripSoftBreaks).processSync(markdown));
 }
 
@@ -34,131 +53,143 @@ const alertTypes = ["NOTE", "TIP", "IMPORTANT", "WARNING", "CAUTION"] as const;
  * - The alert has a body. A marker on its own is just a blockquote.
  * - The blockquote is at the top level of the document, because alerts do not nest inside other elements.
  *
- * Trailing whitespace after the marker is allowed, as is a blank line between the marker and the body. A
- * backslash-escaped marker (`\[!NOTE]`) still renders as an alert, so the escaping that remark-stringify applies on
- * output does not affect any of this.
+ * Trailing whitespace after the marker is allowed, as is a blank line between the marker and the body.
  *
  * `stripSoftBreaks` collapses single line breaks, which would otherwise pull the body up onto the marker's line and
- * stop the alert from rendering. The contract these tests cover is therefore twofold: markdown that GitHub renders as
- * an alert must still render as one afterwards, and markdown that GitHub does not render as an alert must not be
- * rewritten into something that looks like one.
+ * stop the alert from rendering. So the contract is twofold: an alert must keep the line break that ends its marker,
+ * and anything that is not an alert must have its line breaks collapsed like any other text.
  */
 describe("stripSoftBreaks and GitHub alerts", () => {
-	describe("keeps the marker on its own line for every alert type", () => {
+	describe("keeps the line break after the marker, for every alert type", () => {
 		for (const type of alertTypes) {
 			it(type, () => {
-				assert.equal(
-					process(`> [!${type}]\n> Body line one.\n> Body line two.\n`),
-					`> \\[!${type}]\n> Body line one. Body line two.\n`,
-				);
+				assert.deepEqual(strippedText(`> [!${type}]\n> Line one.\n> Line two.\n`), [
+					`[!${type}]\nLine one. Line two.`,
+				]);
 			});
 		}
 	});
 
-	describe("treats the marker case-insensitively, as GitHub does", () => {
-		const cases: [name: string, marker: string][] = [
-			["all lowercase", "[!note]"],
-			["capitalised", "[!Note]"],
-			["mixed case", "[!nOtE]"],
-			["lowercase tip", "[!tip]"],
-			["lowercase important", "[!important]"],
-			["lowercase warning", "[!warning]"],
-			["lowercase caution", "[!caution]"],
-		];
+	describe("matches the marker case-insensitively, as GitHub does", () => {
+		const markers = ["[!note]", "[!Note]", "[!nOtE]", "[!tip]", "[!important]", "[!caution]"];
 
-		for (const [name, marker] of cases) {
-			it(name, () => {
-				assert.equal(
-					process(`> ${marker}\n> Body line one.\n> Body line two.\n`),
-					`> \\${marker}\n> Body line one. Body line two.\n`,
-				);
+		for (const marker of markers) {
+			it(marker, () => {
+				assert.deepEqual(strippedText(`> ${marker}\n> Line one.\n> Line two.\n`), [
+					`${marker}\nLine one. Line two.`,
+				]);
 			});
 		}
 	});
 
-	describe("keeps the marker on its own line when the body starts with formatting", () => {
-		const cases: [name: string, body: string, expected: string][] = [
-			["bold", "**Bold** and more.", "**Bold** and more."],
-			["emphasis", "_Emphasised_ and more.", "*Emphasised* and more."],
+	describe("keeps the line break when the body starts with formatting", () => {
+		// The marker and the body land in sibling nodes here, so the marker ends up alone in its own text node.
+		const cases: [name: string, body: string, expected: string[]][] = [
+			["bold", "**Bold** and more.", ["[!NOTE]\n", "Bold", " and more."]],
+			["emphasis", "_Emphasised_ and more.", ["[!NOTE]\n", "Emphasised", " and more."]],
 			[
 				"a link",
 				"[a link](https://example.com) then text.",
-				"[a link](https://example.com) then text.",
+				["[!NOTE]\n", "a link", " then text."],
 			],
-			["inline code", "`code` first.", "`code` first."],
-			["strikethrough", "~~struck~~ then text.", "~~struck~~ then text."],
+			["inline code", "`code` first.", ["[!NOTE]\n", " first."]],
+			["strikethrough", "~~struck~~ then text.", ["[!NOTE]\n", "struck", " then text."]],
 		];
 
 		for (const [name, body, expected] of cases) {
 			it(name, () => {
-				assert.equal(process(`> [!NOTE]\n> ${body}\n`), `> \\[!NOTE]\n> ${expected}\n`);
+				assert.deepEqual(strippedText(`> [!NOTE]\n> ${body}\n`), expected);
 			});
 		}
 	});
 
-	describe("does not rewrite markdown that GitHub does not treat as an alert", () => {
-		const cases: [name: string, input: string, expected: string][] = [
+	describe("collapses the line break instead, when the blockquote is not an alert", () => {
+		// Each input has a real line break after the marker. An alert would keep that break; these are not alerts, so
+		// it is collapsed to a space like any other soft break.
+		const cases: [name: string, input: string, expected: string[]][] = [
 			[
-				"marker preceded by text",
-				"> Please read [!NOTE] and continue.\n",
-				"> Please read \\[!NOTE] and continue.\n",
+				"the marker is preceded by text",
+				"> Please read [!NOTE]\n> and continue.\n",
+				["Please read [!NOTE] and continue."],
 			],
 			[
-				"marker preceded by text, body starts with formatting",
-				"> Please read [!NOTE] **carefully**.\n",
-				"> Please read \\[!NOTE] **carefully**.\n",
+				"the alert type is not one GitHub supports",
+				"> [!DANGER]\n> Body text.\n",
+				["[!DANGER] Body text."],
 			],
+			["the marker is not in a blockquote", "[!NOTE]\nBody text.\n", ["[!NOTE] Body text."]],
 			[
-				"marker with body already on its line",
-				"> [!NOTE] Body on the marker line.\n",
-				"> \\[!NOTE] Body on the marker line.\n",
-			],
-			["unsupported alert type", "> [!DANGER]\n> Body text.\n", "> \\[!DANGER] Body text.\n"],
-			["marker outside a blockquote", "[!NOTE]\nBody text.\n", "\\[!NOTE] Body text.\n"],
-		];
-
-		for (const [name, input, expected] of cases) {
-			it(name, () => {
-				assert.equal(process(input), expected);
-			});
-		}
-	});
-
-	it("does not split a marker that has no body, because that is not an alert", () => {
-		assert.equal(process("> [!NOTE]\n"), "> \\[!NOTE]\n");
-	});
-
-	it("keeps an alert whose body is separated by a blank line", () => {
-		// GitHub still renders this as an alert. The marker and body are separate paragraphs, so there is no soft break
-		// between them to lose in the first place.
-		assert.equal(process("> [!NOTE]\n>\n> Body text.\n"), "> \\[!NOTE]\n>\n> Body text.\n");
-	});
-
-	describe("does not treat a marker as an alert where GitHub would not", () => {
-		const cases: [name: string, input: string, expected: string][] = [
-			[
-				"inside a nested blockquote",
+				"the blockquote is nested inside another",
 				"> > [!NOTE]\n> > Body text.\n",
-				"> > \\[!NOTE] Body text.\n",
+				["[!NOTE] Body text."],
 			],
 			[
-				"in a paragraph other than the first",
+				"the marker is in a paragraph other than the first",
 				"> Intro.\n>\n> [!NOTE]\n> Body text.\n",
-				"> Intro.\n>\n> \\[!NOTE] Body text.\n",
+				["Intro.", "[!NOTE] Body text."],
 			],
 		];
 
 		for (const [name, input, expected] of cases) {
 			it(name, () => {
-				assert.equal(process(input), expected);
+				assert.deepEqual(strippedText(input), expected);
 			});
 		}
 	});
 
-	it("leaves an ordinary blockquote alone apart from collapsing its soft breaks", () => {
-		assert.equal(
-			process("> Regular quote with **bold**.\n> A second line.\n"),
-			"> Regular quote with **bold**. A second line.\n",
-		);
+	describe("leaves the text as it is when there is no line break to act on", () => {
+		it("a marker written inline with its body, which GitHub does not treat as an alert", () => {
+			assert.deepEqual(strippedText("> [!NOTE] Body on the marker line.\n"), [
+				"[!NOTE] Body on the marker line.",
+			]);
+		});
+
+		it("a marker with no body, which GitHub does not treat as an alert", () => {
+			assert.deepEqual(strippedText("> [!NOTE]\n"), ["[!NOTE]"]);
+		});
+
+		it("an alert whose body is a separate paragraph", () => {
+			// GitHub still renders this as an alert, and the marker and body are separate paragraphs, so there is no
+			// soft break between them in the first place.
+			assert.deepEqual(strippedText("> [!NOTE]\n>\n> Body text.\n"), [
+				"[!NOTE]",
+				"Body text.",
+			]);
+		});
+	});
+
+	it("collapses soft breaks in an ordinary blockquote", () => {
+		assert.deepEqual(strippedText("> Regular quote with **bold**.\n> A second line.\n"), [
+			"Regular quote with ",
+			"bold",
+			". A second line.",
+		]);
+	});
+
+	describe("serializes back to markdown that GitHub still renders as an alert", () => {
+		// remark-stringify escapes a leading `[` as `\[` on any text, so that re-parsing cannot mistake `[text]` for a
+		// link reference. It does that with no plugins loaded, and to ordinary prose brackets alike, and GitHub renders
+		// the escaped marker as an alert regardless. The escape below is therefore expected, and is not something
+		// `stripSoftBreaks` introduces.
+		it("keeps the marker on its own line", () => {
+			assert.equal(
+				strippedMarkdown("> [!NOTE]\n> Line one.\n> Line two.\n"),
+				"> \\[!NOTE]\n> Line one. Line two.\n",
+			);
+		});
+
+		it("keeps the marker on its own line when the body starts with formatting", () => {
+			assert.equal(
+				strippedMarkdown("> [!NOTE]\n> **Bold** and more.\n"),
+				"> \\[!NOTE]\n> **Bold** and more.\n",
+			);
+		});
+
+		it("does not give a marker in ordinary prose a line of its own", () => {
+			assert.equal(
+				strippedMarkdown("> Please read [!NOTE]\n> and continue.\n"),
+				"> Please read \\[!NOTE] and continue.\n",
+			);
+		});
 	});
 });

--- a/build-tools/packages/build-cli/src/test/library/markdown.test.ts
+++ b/build-tools/packages/build-cli/src/test/library/markdown.test.ts
@@ -25,26 +25,23 @@ function process(markdown: string): string {
 const alertTypes = ["NOTE", "TIP", "IMPORTANT", "WARNING", "CAUTION"] as const;
 
 /**
- * These tests describe what GitHub actually does, rather than what the current implementation does. Every expectation
- * below was verified by rendering the markdown through GitHub's own renderer (`POST /markdown`) and checking whether
- * the result carried a `markdown-alert` class.
+ * GitHub renders a blockquote as an alert only when all of the following hold:
  *
- * The rules that came out of that exercise:
+ * - The blockquote's first paragraph begins with a `[!TYPE]` marker, where the type is one of NOTE, TIP, IMPORTANT,
+ * WARNING or CAUTION. The type is matched case-insensitively, so `[!note]` and `[!Note]` are alerts too.
+ * - The marker is the very first thing in the blockquote. Text in front of it means the blockquote is ordinary prose.
+ * - The marker is alone on its line. Body content on the marker's line means the blockquote is ordinary prose.
+ * - The alert has a body. A marker on its own is just a blockquote.
+ * - The blockquote is at the top level of the document, because alerts do not nest inside other elements.
  *
- * 1. An alert is a blockquote whose first paragraph begins with a `[!TYPE]` marker.
- * 2. The marker must be the very first thing in the blockquote. Text in front of it means it is not an alert.
- * 3. The marker must be alone on its line. Body content on the marker's line means it is not an alert.
- * 4. Matching is case-insensitive: `[!note]` and `[!Note]` are alerts just like `[!NOTE]`.
- * 5. Only NOTE, TIP, IMPORTANT, WARNING and CAUTION are alert types.
- * 6. An alert needs a body. A marker on its own is just a blockquote.
- * 7. Trailing whitespace after the marker is fine, as is a blank line between the marker and the body.
- * 8. A backslash-escaped marker (`\[!NOTE]`) still renders as an alert, so the escaping that remark-stringify applies
- * on output is harmless.
- * 9. Nested blockquotes are not alerts, and neither is a marker outside a blockquote.
+ * Trailing whitespace after the marker is allowed, as is a blank line between the marker and the body. A
+ * backslash-escaped marker (`\[!NOTE]`) still renders as an alert, so the escaping that remark-stringify applies on
+ * output does not affect any of this.
  *
  * `stripSoftBreaks` collapses single line breaks, which would otherwise pull the body up onto the marker's line and
- * break rule 3. So the contract under test is: markdown that GitHub renders as an alert must still be rendered as an
- * alert afterwards, and markdown that is not an alert must not be rewritten into something that looks like one.
+ * stop the alert from rendering. The contract these tests cover is therefore twofold: markdown that GitHub renders as
+ * an alert must still render as one afterwards, and markdown that GitHub does not render as an alert must not be
+ * rewritten into something that looks like one.
  */
 describe("stripSoftBreaks and GitHub alerts", () => {
 	describe("keeps the marker on its own line for every alert type", () => {


### PR DESCRIPTION
## Description

`stripSoftBreaks` prepares release notes for GitHub Releases by collapsing single line breaks. GitHub alerts (`> [!NOTE]`) only render when the marker is alone on its line, so the plugin collapsed every line break and then tried to put the marker's line break back with a regular expression.

That cannot work. Once the break is gone, these two are identical:

```md
> [!NOTE]
> Body text.

> [!NOTE] Body text.
```

Only the first is an alert. The regex had no way to tell them apart, and the surrounding rules were guesses about GitHub's behaviour rather than a description of it.

This replaces the collapse-then-restore approach. Alert blockquotes are now identified structurally *before* any line break is removed, and the marker's line break is simply never collapsed. The structural check mirrors GitHub's own rules: the marker must begin the blockquote's first paragraph, must be alone on its line, must have a body, and must not be nested inside another element.

`ADMONITION_REGEX` is removed, replaced by a single `ALERT_MARKER_REGEX` used by that check.

### Defects fixed

Each was found by a spec-driven test that failed against `main`, and each is verified against GitHub's own renderer:

| Input | Before | After |
| ----- | ------ | ----- |
| `> [!note]` + body | marker collapsed onto the body line, alert lost | renders as an alert |
| `> [!NOTE]` + `**bold**` body | marker collapsed onto the body line, alert lost | renders as an alert |
| `> Please read [!NOTE] and continue.` | split across two lines, mangling the sentence | left alone |
| `> [!NOTE] Body on the marker line.` | rewritten into an alert GitHub does not render | left alone |

The first two produced broken alerts in published release notes. The third silently altered author prose. The fourth invented an alert the author did not write.

### How the expectations were established

Rather than reasoning about GitHub's behaviour, every rule was measured by rendering markdown through GitHub's own renderer (`POST /markdown`) and checking whether the result carried a `markdown-alert` class. That produced the rule list documented at the top of the test file, including two rules that contradict reasonable-sounding assumptions:

- Alert type matching is **case-insensitive**. `> [!note]` is a real alert. The previous implementation only matched upper case.
- A backslash-escaped marker (`\[!NOTE]`, which is what remark-stringify emits) **still renders as an alert**, as does a marker separated from its body by a blank line. Both appear in committed files such as `RELEASE_NOTES/2.33.0.md`, and both are fine.

### Testing

27 new tests in `src/test/library/markdown.test.ts`, written from GitHub's behaviour rather than from the implementation. Against `main` 14 of them fail; all 27 pass with this change.

The output of the fixed code was then fed back through GitHub's renderer to confirm it really does produce alerts, rather than only satisfying the new tests.

Across the full `build-cli` suite the failure count is unchanged from a baseline run of the same commit without these changes. `tsc`, `eslint` and `biome` are clean.

[AB#15064](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/15064)

## Reviewer Guidance

The review process is outlined in [the pull request guidelines](../docs/content/Contributing/PR-Guidelines.md#guidelines).

Draft, pending a maintainer's view on three behaviour changes that go beyond fixing broken alerts.

- **`> [!NOTE] Body on the marker line.` is no longer rewritten.** GitHub does not render it as an alert, so this change preserves what the author wrote. The previous behaviour converted it into an alert. If release notes rely on that normalisation, this is the line to push back on.
- **Blockquote prose containing a marker is no longer split.** `> Please read [!NOTE] and continue.` used to gain a line break mid-sentence. I believe that was always wrong, but it does change output for any release note that mentions a marker in passing.
- **Case-insensitive matching widens what counts as an alert.** This matches GitHub, but it means `> [!note]` now keeps its line break where previously it did not.
