### PR TITLE
test(container-runtime): add version mark integration coverage

### DIFF
--- a/packages/runtime/container-runtime/src/versionMarks/DEV.md
+++ b/packages/runtime/container-runtime/src/versionMarks/DEV.md
@@ -526,6 +526,8 @@ moment tracking flips on may be missed, which is harmless: an app's own captured
 - `src/test/containerRuntime.spec.ts` covers the complete context `fetchOps` -> historical unpack -> resolver path
   (including system/server-op filtering and abort-after-match), plus the ordering guarantee that failed inbound
   validation does not notify listeners.
+- `packages/test/test-end-to-end-tests/src/test/versionMarks.spec.ts` covers real-container capture and resolution for a
+  normal pending edit, plus multi-batch staging commit where the post mark resolves to the final staged batch.
 
 ## Future work
 
@@ -550,8 +552,9 @@ known sequence number and exercise loading. They do not create that sequence num
    inbound/history pipelines recover the same effective batch identity.
 1. **Pending and retention outcomes:** Resolve before the batch sequences and observe `pending`; when the test
    environment can deterministically trim the target ops, verify the same stored locator becomes `unresolvable`.
-1. **Offline and staging lifecycles:** Cover stash/rehydration plus staging commit and discard once those capture
-   contracts are finalized.
+1. **Offline and staging lifecycles:** Cover stash/rehydration and define and test the behavior of marks captured for
+   staged changes that are later discarded. Multi-batch staging commit is covered by
+   `packages/test/test-end-to-end-tests/src/test/versionMarks.spec.ts`.
 1. **Repeated capture and multiple pending batches:** Capture twice while the same batch remains unacknowledged, then
    capture after a second local batch is flushed. Verify each mark identifies the latest batch whose state it includes
    and that changing remote sequence numbers between captures does not produce an invalid lower bound.
@@ -748,8 +751,9 @@ Suggested test coverage:
    capture flushes the op into `PendingStateManager` and returns that exact batch's ID rather than a mocked ID.
 1. **Unsafe contexts:** Call capture during inbound processing and inside `orderSequentially`; verify `notCaptured` with
    `reason: "unsafeToFlush"`, no flush, and no container closure. Also verify a later retry succeeds.
-1. **Staging commit and discard:** Capture staged edits and verify nothing is sent immediately. Verify that commit
-   preserves the captured ID through resubmit and resolution, and define and test the result after discard.
+1. **Staging discard:** Define and test the result of capturing a mark for staged edits that are later discarded.
+   Staging commit preservation and resolution are covered by
+   `packages/test/test-end-to-end-tests/src/test/versionMarks.spec.ts`.
 1. **Offline rehydration:** Capture while disconnected, stash and rehydrate, resubmit from the new client, and resolve
    using the original ID. This also covers end-to-end preservation and stamping of the batch identity through
    pending-state rehydration, beyond the existing unit tests for explicit original `batchId` metadata.

--- a/packages/runtime/container-runtime/src/versionMarks/DEV.md
+++ b/packages/runtime/container-runtime/src/versionMarks/DEV.md
@@ -527,7 +527,8 @@ moment tracking flips on may be missed, which is harmless: an app's own captured
   (including system/server-op filtering and abort-after-match), plus the ordering guarantee that failed inbound
   validation does not notify listeners.
 - `packages/test/test-end-to-end-tests/src/test/versionMarks.spec.ts` covers real-container capture and resolution for a
-  normal pending edit, plus multi-batch staging commit where the post mark resolves to the final staged batch.
+  normal pending edit, live `onBatchSequenced` notification, a pending pre-edit mark when staging begins with
+  unacknowledged changes, and multi-batch staging commit where the post mark resolves to the final staged batch.
 
 ## Future work
 

--- a/packages/test/test-end-to-end-tests/src/test/versionMarks.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/versionMarks.spec.ts
@@ -1,0 +1,120 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+
+import { describeCompat } from "@fluid-private/test-version-utils";
+import type { ContainerRuntime } from "@fluidframework/container-runtime/internal";
+import {
+	getContainerEntryPointBackCompat,
+	type ITestFluidObject,
+	type ITestObjectProvider,
+	waitForContainerConnection,
+} from "@fluidframework/test-utils/internal";
+
+describeCompat("Version marks", "NoCompat", function (getTestObjectProvider) {
+	let provider: ITestObjectProvider;
+
+	before(function () {
+		provider = getTestObjectProvider();
+		if (provider.driver.type !== "local") {
+			this.skip();
+		}
+	});
+
+	const createTestContext = async () => {
+		const container = await provider.makeTestContainer({
+			runtimeOptions: { enableGroupedBatching: true },
+		});
+		const dataObject = await getContainerEntryPointBackCompat<ITestFluidObject>(container);
+		const containerRuntime = dataObject.context.containerRuntime as ContainerRuntime;
+
+		dataObject.root.set("bootstrap", true);
+		await waitForContainerConnection(container);
+		await provider.ensureSynchronized();
+
+		return { containerRuntime, sharedMap: dataObject.root };
+	};
+
+	it("resolves a mark captured after a normal edit", async () => {
+		const { containerRuntime, sharedMap } = await createTestContext();
+		const sequenceNumberBeforeEdit = containerRuntime.deltaManager.lastSequenceNumber;
+
+		sharedMap.set("normalEdit", true);
+		const mark = containerRuntime.versionMarkResolver.sealAndCaptureVersionMark();
+		assert(mark.kind === "pending", "the unacknowledged edit should produce a pending mark");
+
+		await provider.ensureSynchronized();
+
+		const resolved = await containerRuntime.versionMarkResolver.resolve(
+			mark.batchId,
+			mark.sequenceNumberLowerBound,
+		);
+		assert(
+			resolved.kind === "resolved",
+			"the mark should resolve after the edit is sequenced",
+		);
+		assert(
+			resolved.sequenceNumber > sequenceNumberBeforeEdit,
+			"the mark should resolve after the state captured before the edit",
+		);
+		assert.equal(sharedMap.get("normalEdit"), true);
+	});
+
+	it("resolves a staged mark to the final staged batch", async () => {
+		const { containerRuntime, sharedMap } = await createTestContext();
+		const stageControls = containerRuntime.enterStagingMode();
+
+		const preMark = containerRuntime.versionMarkResolver.sealAndCaptureVersionMark();
+		assert(
+			preMark.kind === "resolved",
+			"a mark captured before any staged edits should resolve immediately",
+		);
+		assert.equal(
+			preMark.sequenceNumber,
+			containerRuntime.deltaManager.lastSequenceNumber,
+			"the pre-edit mark should sit before the staged edits",
+		);
+
+		sharedMap.set("batchA", true);
+		const batchAMark = containerRuntime.versionMarkResolver.sealAndCaptureVersionMark();
+		assert(batchAMark.kind === "pending", "batch A should produce a pending mark");
+
+		sharedMap.set("batchB", true);
+		const postMark = containerRuntime.versionMarkResolver.sealAndCaptureVersionMark();
+		assert(
+			postMark.kind === "pending",
+			"the final staged batch should produce a pending mark",
+		);
+		assert.notEqual(
+			batchAMark.batchId,
+			postMark.batchId,
+			"the post-edit mark should identify the final staged batch",
+		);
+
+		stageControls.commitChanges();
+		await provider.ensureSynchronized();
+
+		const [resolvedA, resolvedPost] = await Promise.all([
+			containerRuntime.versionMarkResolver.resolve(
+				batchAMark.batchId,
+				batchAMark.sequenceNumberLowerBound,
+			),
+			containerRuntime.versionMarkResolver.resolve(
+				postMark.batchId,
+				postMark.sequenceNumberLowerBound,
+			),
+		]);
+		assert(resolvedA.kind === "resolved", "batch A's mark should resolve after commit");
+		assert(resolvedPost.kind === "resolved", "the post-edit mark should resolve after commit");
+		assert(
+			resolvedA.sequenceNumber < resolvedPost.sequenceNumber,
+			"the post-edit mark should resolve at the final staged batch",
+		);
+
+		assert.equal(sharedMap.get("batchA"), true);
+		assert.equal(sharedMap.get("batchB"), true);
+	});
+});

--- a/packages/test/test-end-to-end-tests/src/test/versionMarks.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/versionMarks.spec.ts
@@ -38,15 +38,22 @@ describeCompat("Version marks", "NoCompat", function (getTestObjectProvider) {
 		return { containerRuntime, sharedMap: dataObject.root };
 	};
 
-	it("resolves a mark captured after a normal edit", async () => {
+	it("resolves a pending mark after its batch is sequenced", async () => {
 		const { containerRuntime, sharedMap } = await createTestContext();
 		const sequenceNumberBeforeEdit = containerRuntime.deltaManager.lastSequenceNumber;
+		const sequencedBatches = new Map<string, number>();
+		const unsubscribe = containerRuntime.versionMarkResolver.onBatchSequenced(
+			(batchId, sequenceNumber) => {
+				sequencedBatches.set(batchId, sequenceNumber);
+			},
+		);
 
 		sharedMap.set("normalEdit", true);
 		const mark = containerRuntime.versionMarkResolver.sealAndCaptureVersionMark();
 		assert(mark.kind === "pending", "the unacknowledged edit should produce a pending mark");
 
 		await provider.ensureSynchronized();
+		unsubscribe();
 
 		const resolved = await containerRuntime.versionMarkResolver.resolve(
 			mark.batchId,
@@ -60,7 +67,38 @@ describeCompat("Version marks", "NoCompat", function (getTestObjectProvider) {
 			resolved.sequenceNumber > sequenceNumberBeforeEdit,
 			"the mark should resolve after the state captured before the edit",
 		);
+		assert.equal(
+			sequencedBatches.get(mark.batchId),
+			resolved.sequenceNumber,
+			"the live sequencing notification should identify the resolved batch",
+		);
 		assert.equal(sharedMap.get("normalEdit"), true);
+	});
+
+	it("resolves a pending pre-edit mark after entering staging mode", async () => {
+		const { containerRuntime, sharedMap } = await createTestContext();
+
+		sharedMap.set("beforeStaging", true);
+		const stageControls = containerRuntime.enterStagingMode();
+
+		const preMark = containerRuntime.versionMarkResolver.sealAndCaptureVersionMark();
+		assert(
+			preMark.kind === "pending",
+			"the unacknowledged pre-staging edit should produce a pending mark",
+		);
+
+		stageControls.commitChanges();
+		await provider.ensureSynchronized();
+
+		const resolved = await containerRuntime.versionMarkResolver.resolve(
+			preMark.batchId,
+			preMark.sequenceNumberLowerBound,
+		);
+		assert(
+			resolved.kind === "resolved",
+			"the pre-staging mark should resolve after its batch is sequenced",
+		);
+		assert.equal(sharedMap.get("beforeStaging"), true);
 	});
 
 	it("resolves a staged mark to the final staged batch", async () => {


### PR DESCRIPTION
## Description

Adds real-container integration coverage for the version-mark resolver.

This was motivated by [Office-Bohemia PR 5631638](https://office.visualstudio.com/OC/_git/office-bohemia/pullrequest/5631638), which uses ContainerRuntime staging to capture a pre-edit mark, apply NitL page edits, capture a post-edit mark, and commit the staged changes.

The new tests validate:

- A mark captured after a normal pending edit resolves once that edit is sequenced.
- A mark captured before staged edits resolves to the pre-edit sequence.
- A staging session can contain multiple operation batches.
- The post-edit mark identifies and resolves to the final staged batch.
- All staged edits remain after commit.

The version-mark DEV.md test map and remaining end-to-end coverage list have also been updated. Historical resolution, point-in-time loading, offline rehydration, retention behavior, and staging-discard behavior remain separate future coverage.

This PR only adds tests and documentation. It does not change runtime behavior or public APIs.

## Reviewer Guidance

The staged test captures an intermediate mark after the first staged edit. Each call to `sealAndCaptureVersionMark()` seals the current operation batch, so the intermediate and post-edit marks identify distinct staged batches. Resolving both marks after commit verifies that the post-edit mark corresponds to the later, final staged batch.

The intermediate mark is only a test probe and is not part of the intended application flow.

Validated with the local driver:

- Version-mark integration suite: 2 passing
- Existing staging-mode suite: 96 passing, with 6 expected compatibility skips
- Test TypeScript compilation, Biome, and ESLint passed