### PR TITLE
fix(container-runtime): Rebase all Outbox batches before flushing any

### DIFF
--- a/.changeset/brave-pianos-hammer.md
+++ b/.changeset/brave-pianos-hammer.md
@@ -1,0 +1,9 @@
+---
+"@fluidframework/container-runtime": minor
+"__section": fix
+---
+Fixed a container error when ops are added to a different batch while rebasing
+
+When a batch contains ops that were created while another op was being processed, the batch is "rebased" by resubmitting its ops one at a time. Resubmitting an op could add ops to a different batch than the one being rebased (for example, resubmitting a blob attach op can generate a document schema change op). Those ops were left behind when the flush completed, which closed the container with a `0x3cf` assert.
+
+All batches that require rebasing are now rebased before any batch is flushed, so ops generated during a rebase are always flushed, and blob attach ops are still sent before the ops that reference them.

--- a/packages/runtime/container-runtime/src/opLifecycle/batchManager.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/batchManager.ts
@@ -70,10 +70,20 @@ export function getEffectiveBatchId(
  */
 export class BatchManager {
 	private pendingBatch: LocalBatchMessage[] = [];
-	private hasReentrantOps = false;
+	private _hasReentrantOps = false;
 
 	public get length(): number {
 		return this.pendingBatch.length;
+	}
+
+	/**
+	 * Whether any of the messages currently pending in this batch were submitted from a reentrant context
+	 * (i.e. submitted while another op was being processed). Such a batch must be rebased before being flushed.
+	 *
+	 * @remarks Reset when the batch is popped via {@link BatchManager.popBatch}.
+	 */
+	public get hasReentrantOps(): boolean {
+		return this._hasReentrantOps;
 	}
 
 	public get sequenceNumbers(): BatchSequenceNumbers {
@@ -103,7 +113,7 @@ export class BatchManager {
 		reentrant: boolean,
 		currentClientSequenceNumber?: number,
 	): void {
-		this.hasReentrantOps = this.hasReentrantOps || reentrant;
+		this._hasReentrantOps = this._hasReentrantOps || reentrant;
 
 		if (this.pendingBatch.length === 0) {
 			this.clientSequenceNumber = currentClientSequenceNumber;
@@ -125,13 +135,13 @@ export class BatchManager {
 		const batch: LocalBatch = {
 			messages: this.pendingBatch,
 			referenceSequenceNumber: this.referenceSequenceNumber,
-			hasReentrantOps: this.hasReentrantOps,
+			hasReentrantOps: this._hasReentrantOps,
 			staged: this.pendingBatch[0].staged,
 		};
 
 		this.pendingBatch = [];
 		this.clientSequenceNumber = undefined;
-		this.hasReentrantOps = false;
+		this._hasReentrantOps = false;
 
 		return batch;
 	}
@@ -141,10 +151,14 @@ export class BatchManager {
 	 */
 	public checkpoint(): IBatchCheckpoint {
 		const startSequenceNumber = this.clientSequenceNumber;
+		const startHasReentrantOps = this._hasReentrantOps;
 		const startPoint = this.pendingBatch.length;
 		return {
 			rollback: (process: (message: LocalBatchMessage) => void) => {
 				this.clientSequenceNumber = startSequenceNumber;
+				// Any reentrant ops pushed after the checkpoint are being rolled back, so restore the flag as well.
+				// Otherwise it could remain set for a batch which no longer contains any reentrant ops.
+				this._hasReentrantOps = startHasReentrantOps;
 				const rollbackOpsLifo = this.pendingBatch.splice(startPoint).reverse();
 				for (const message of rollbackOpsLifo) {
 					process(message);

--- a/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/outbox.ts
@@ -356,6 +356,13 @@ export class Outbox {
 	}
 
 	private flushAll(resubmitInfo?: BatchResubmitInfo): void {
+		// Rebasing must happen before *any* batch is flushed. Rebasing resubmits ops one-by-one, and
+		// resubmitting an op can add new ops to *any* BatchManager, not just the one being rebased
+		// (e.g. resubmitting a BlobAttach op can generate a DocumentSchemaChange op in the main batch).
+		// If we flushed as we went, ops landing in an already-flushed BatchManager would be stranded in
+		// the Outbox (ADO:39273), and blobAttach ops could end up sequenced after the ops referencing them.
+		this.rebaseAllIfNeeded(resubmitInfo);
+
 		const allBatchesEmpty = this.blobAttachBatch.empty && this.mainBatch.empty;
 		if (allBatchesEmpty) {
 			// If we're resubmitting with a batchId and all batches are empty, we need to flush an empty batch.
@@ -422,22 +429,12 @@ export class Outbox {
 		const groupingEnabled =
 			!batchManager.options.disableGroupedBatching &&
 			this.params.groupingManager.groupedBatchingEnabled();
-		if (rawBatch.hasReentrantOps === true) {
-			assert(
-				resubmitInfo === undefined,
-				0xcf2 /* Re-submitting a batch with reentrant ops is not supported */,
-			);
-			assert(!this.rebasing, 0x6fa /* A rebased batch should never have reentrant ops */);
-			// Rebase the current batch (resubmit the ops one-by-one) and then reinvoke flushInternal.
-			// If a batch contains reentrant ops (ops created as a result from processing another op)
-			// it needs to be rebased so that we can ensure consistent reference sequence numbers
-			// and eventual consistency at the DDS level.
-			// Note: Since this is happening in the same turn the ops were originally created with,
-			// and they haven't gone to PendingStateManager yet, we can just let them respect
-			// ContainerRuntime.inStagingMode.  So we do not plumb local 'staged' variable through here.
-			this.rebase(rawBatch, batchManager);
-			return;
-		}
+
+		// Rebasing happens up front in flushAll, so by the time we get here no batch may contain reentrant ops.
+		assert(
+			rawBatch.hasReentrantOps !== true,
+			0x6fa /* A rebased batch should never have reentrant ops */,
+		);
 
 		// Did we disconnect? (i.e. is shouldSend false?)
 		// If so, do nothing, as pending state manager will resubmit it correctly on reconnect.
@@ -474,15 +471,63 @@ export class Outbox {
 	}
 
 	/**
+	 * Rebases every batch which contains reentrant ops (ops created as a result of processing another op).
+	 * A batch containing such ops must be rebased so that we can ensure consistent reference sequence
+	 * numbers and eventual consistency at the DDS level.
+	 *
+	 * @remarks
+	 * All batches which need rebasing are popped *before* any op is resubmitted. Resubmitting an op can add
+	 * new ops to any BatchManager, and those newly generated ops must not be swept into another batch's
+	 * rebase (they are brand new, so they need no rebasing, and some op types are intentionally dropped
+	 * rather than resubmitted).
+	 *
+	 * @param resubmitInfo - Key information when flushing a resubmitted batch. Undefined means this is not resubmit.
+	 */
+	private rebaseAllIfNeeded(resubmitInfo?: BatchResubmitInfo): void {
+		const blobAttachNeedsRebase =
+			!this.blobAttachBatch.empty && this.blobAttachBatch.hasReentrantOps;
+		const mainNeedsRebase = !this.mainBatch.empty && this.mainBatch.hasReentrantOps;
+		if (!blobAttachNeedsRebase && !mainNeedsRebase) {
+			return;
+		}
+
+		assert(
+			resubmitInfo === undefined,
+			0xcf2 /* Re-submitting a batch with reentrant ops is not supported */,
+		);
+		assert(!this.rebasing, 0x6fb /* Reentrancy */);
+
+		// Pop everything that needs rebasing before resubmitting any op (see remarks above).
+		const batchesToRebase = [
+			blobAttachNeedsRebase ? this.blobAttachBatch.popBatch() : undefined,
+			mainNeedsRebase ? this.mainBatch.popBatch() : undefined,
+		];
+
+		// Note: Since this is happening in the same turn the ops were originally created with,
+		// and they haven't gone to PendingStateManager yet, we can just let them respect
+		// ContainerRuntime.inStagingMode. So we do not plumb the batches' 'staged' value through here.
+		this.rebasing = true;
+		try {
+			for (const rawBatch of batchesToRebase) {
+				if (rawBatch !== undefined) {
+					this.rebase(rawBatch);
+				}
+			}
+		} finally {
+			this.rebasing = false;
+		}
+	}
+
+	/**
 	 * Rebases a batch. All the ops in the batch are resubmitted to the runtime and
-	 * they will end up back in the same batch manager they were flushed from and subsequently flushed.
+	 * they will end up back in the Outbox (typically in the same batch manager they were popped from)
+	 * to be flushed once all rebasing is complete.
 	 *
 	 * @param rawBatch - the batch to be rebased
 	 */
-	private rebase(rawBatch: LocalBatch, batchManager: BatchManager): void {
-		assert(!this.rebasing, 0x6fb /* Reentrancy */);
+	private rebase(rawBatch: LocalBatch): void {
+		assert(this.rebasing, "Must be rebasing");
 
-		this.rebasing = true;
 		const squash = false;
 		for (const message of rawBatch.messages) {
 			this.params.reSubmit(
@@ -506,9 +551,6 @@ export class Outbox {
 			);
 			this.batchRebasesToReport--;
 		}
-
-		this.flushInternal(batchManager);
-		this.rebasing = false;
 	}
 
 	private isContextReentrant(): boolean {

--- a/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts
@@ -241,6 +241,11 @@ describe("Outbox", () => {
 		opGroupingConfig?: OpGroupingManagerConfig;
 		immediateMode?: boolean;
 		generateIdAllocationOp?: () => LocalBatchMessage | undefined;
+		/**
+		 * Override for the reSubmit callback. The default just counts the resubmitted ops.
+		 * Note that implementations should still increment `state.opsResubmitted`.
+		 */
+		reSubmit?: (message: PendingMessageResubmitData) => void;
 	}) => {
 		const { submitFn, submitBatchFn, deltaManager } = params.context;
 
@@ -268,9 +273,11 @@ describe("Outbox", () => {
 				mockLogger,
 			),
 			getCurrentSequenceNumbers: () => currentSeqNumbers,
-			reSubmit: (message: PendingMessageResubmitData) => {
-				state.opsResubmitted++;
-			},
+			reSubmit:
+				params.reSubmit ??
+				((message: PendingMessageResubmitData) => {
+					state.opsResubmitted++;
+				}),
 			opReentrancy: () => state.isReentrant,
 			generateIdAllocationOp: params.generateIdAllocationOp ?? (() => undefined),
 		});
@@ -1061,6 +1068,27 @@ describe("Outbox", () => {
 			validateCounts(0, 0, 2);
 		});
 
+		it("both batches have reentrant ops", () => {
+			// Both batch managers must be rebased, and neither may be left behind in the Outbox.
+			const outbox = getOutbox({
+				context: getMockContext(),
+				opGroupingConfig: {
+					groupedBatchingEnabled: true,
+				},
+			});
+
+			state.isReentrant = true;
+			outbox.submit(createMessage(ContainerMessageType.FluidDataStoreOp, "0"));
+			outbox.submitBlobAttach(createMessage(ContainerMessageType.BlobAttach, "1"));
+			outbox.submit(createMessage(ContainerMessageType.FluidDataStoreOp, "2"));
+			state.isReentrant = false;
+
+			outbox.flush();
+
+			validateCounts(0, 0, 3);
+			assert.strictEqual(outbox.isEmpty, true, "Outbox must be empty after flush");
+		});
+
 		it("non-reentrant blobAttach ops do not trigger rebase", () => {
 			const outbox = getOutbox({
 				context: getMockContext(),
@@ -1098,6 +1126,121 @@ describe("Outbox", () => {
 			assert.throws(
 				() => outbox.flush({ batchId: "batchId", staged: false }),
 				(e: Error) => e.message === "0xcf2",
+			);
+		});
+
+		/**
+		 * Converts the data handed to the reSubmit callback back into a message which can be
+		 * submitted to the Outbox, mimicking what ContainerRuntime.reSubmit does for most op types.
+		 */
+		const toResubmittedMessage = ({
+			runtimeOp,
+			localOpMetadata,
+			opMetadata,
+		}: PendingMessageResubmitData): LocalBatchMessage => ({
+			runtimeOp,
+			localOpMetadata,
+			metadata: opMetadata,
+			referenceSequenceNumber: Number.POSITIVE_INFINITY,
+		});
+
+		it("ops added to a different batch manager while rebasing are still flushed", () => {
+			// ADO:39273 - Resubmitting an op while rebasing can add ops to a *different* BatchManager than
+			// the one being rebased (e.g. resubmitting a main batch op can generate a BlobAttach op).
+			// Those ops must not be left behind in the Outbox, otherwise ContainerRuntime.flush's
+			// `assert(this.outbox.isEmpty, 0x3cf)` fires and the container is closed.
+			const outboxRef: { current?: Outbox } = {};
+			let blobAttachGenerated = false;
+			const outbox = getOutbox({
+				context: getMockContext(),
+				opGroupingConfig: {
+					groupedBatchingEnabled: true,
+				},
+				reSubmit: (resubmitData: PendingMessageResubmitData) => {
+					state.opsResubmitted++;
+					if (!blobAttachGenerated) {
+						blobAttachGenerated = true;
+						outboxRef.current?.submitBlobAttach(
+							createMessage(ContainerMessageType.BlobAttach, "blob"),
+						);
+					}
+					outboxRef.current?.submit(toResubmittedMessage(resubmitData));
+				},
+			});
+			outboxRef.current = outbox;
+
+			state.isReentrant = true;
+			outbox.submit(createMessage(ContainerMessageType.FluidDataStoreOp, "0"));
+			outbox.submit(createMessage(ContainerMessageType.FluidDataStoreOp, "1"));
+			state.isReentrant = false;
+
+			outbox.flush();
+
+			assert.strictEqual(state.opsResubmitted, 2, "unexpected opsResubmitted");
+			assert.strictEqual(
+				outbox.isEmpty,
+				true,
+				"Outbox must be empty after flush (otherwise ContainerRuntime asserts 0x3cf)",
+			);
+			assert.strictEqual(
+				state.batchesSubmitted.length,
+				2,
+				"expected a blobAttach batch and a main batch",
+			);
+			assert.strictEqual(
+				state.batchesSubmitted[0].messages[0].contents?.includes(`"blob"`),
+				true,
+				"the blobAttach batch must be sent before the main batch",
+			);
+		});
+
+		it("ops generated while rebasing one batch are not swept into another batch's rebase", () => {
+			// Resubmitting a blobAttach op can generate a brand new main batch op (e.g. a
+			// DocumentSchemaChange). Since it's brand new it needs no rebasing, and some op types are
+			// intentionally dropped rather than resubmitted, so it must not be fed through reSubmit as
+			// part of the main batch's rebase - it must simply be flushed.
+			const outboxRef: { current?: Outbox } = {};
+			let schemaOpGenerated = false;
+			const resubmittedContents: unknown[] = [];
+			const outbox = getOutbox({
+				context: getMockContext(),
+				opGroupingConfig: {
+					groupedBatchingEnabled: true,
+				},
+				reSubmit: (resubmitData: PendingMessageResubmitData) => {
+					state.opsResubmitted++;
+					resubmittedContents.push(resubmitData.runtimeOp.contents);
+					if (resubmitData.runtimeOp.type === ContainerMessageType.BlobAttach) {
+						if (!schemaOpGenerated) {
+							schemaOpGenerated = true;
+							outboxRef.current?.submit(
+								createMessage(ContainerMessageType.DocumentSchemaChange, "generated"),
+							);
+						}
+						outboxRef.current?.submitBlobAttach(toResubmittedMessage(resubmitData));
+					} else {
+						outboxRef.current?.submit(toResubmittedMessage(resubmitData));
+					}
+				},
+			});
+			outboxRef.current = outbox;
+
+			state.isReentrant = true;
+			outbox.submitBlobAttach(createMessage(ContainerMessageType.BlobAttach, "blob"));
+			outbox.submit(createMessage(ContainerMessageType.FluidDataStoreOp, "main"));
+			state.isReentrant = false;
+
+			outbox.flush();
+
+			assert.deepStrictEqual(
+				resubmittedContents,
+				["blob", "main"],
+				"only the originally reentrant ops may be rebased",
+			);
+			assert.strictEqual(outbox.isEmpty, true, "Outbox must be empty after flush");
+			assert.ok(
+				state.pendingOpContents.some((pending) => pending.runtimeOp?.contents === "generated"),
+				"the op generated during rebase must be flushed",
 			);
 		});
 


### PR DESCRIPTION
## Description

`Outbox.rebase` only flushed the batch manager it was rebasing, not both. Resubmitting an op can generate a *new* op that lands in the **other** batch manager (e.g. resubmitting a `mainBatch` op can generate a `BlobAttach` op into `blobAttachBatch`; resubmitting that `BlobAttach` op can in turn generate a `DocumentSchemaChange` op back into `mainBatch`). Because only the batch being rebased was flushed, the other batch manager could be left non-empty, tripping `assert(this.outbox.isEmpty, 0x3cf)` in `ContainerRuntime.flush`.

The naive fix suggested in the work item (having `rebase` call `flushAll()` at the end) was considered and rejected: if *both* batch managers simultaneously contain reentrant ops, this causes a nested `flushAll()` call, which trips `assert(!this.rebasing, 0x6fa)` — turning a working scenario into a container-closing failure.

A second candidate (sequentially rebase-then-flush each batch manager in turn) was also considered and rejected: an op generated while rebasing the first batch manager (e.g. a `DocumentSchemaChange`) could land in the *second* batch manager's still-unpopped op list and get erroneously swept into that batch's rebase — and since some op types like `DocumentSchemaChange` are intentionally dropped rather than resubmitted during rebase, the op would be silently lost.

### Fix

Restructured `Outbox.flushAll` to snapshot ("pop") **all** batch managers that have reentrant ops *before* resubmitting any of them. Newly generated ops during resubmission land in the outbox's live (already-emptied) batch managers, so they get flushed normally afterward and are never swept into another batch's rebase snapshot. `flushInternal`'s rebase/recursion logic was removed since rebasing all batches now happens up front via the new `rebaseAllIfNeeded`. `BatchManager.hasReentrantOps` is now exposed via a getter, and `checkpoint()` rollback restores the flag correctly.

### Reviewer guidance

- Core logic change: `packages/runtime/container-runtime/src/opLifecycle/outbox.ts` (`rebaseAllIfNeeded`, `flushAll`, `flushInternal`).
- Supporting change: `packages/runtime/container-runtime/src/opLifecycle/batchManager.ts` (`hasReentrantOps` getter, checkpoint/rollback fix).
- New regression tests in `packages/runtime/container-runtime/src/test/opLifecycle/outbox.spec.ts` cover: ops landing in the other batch during rebase are still flushed; ops generated during one batch's rebase are not swept into another batch's rebase; both batches having reentrant ops simultaneously.
- Full `container-runtime` mocha suite (1065 tests), eslint, biome, `flub check policy`, and API report regeneration all pass with no diffs.

## Breaking Changes

None. No public API surface changes.

[AB#39273](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/39273)
