### PR TITLE
🤖 Fix SharedTree inverse identities across multiple commits

### DIFF
--- a/.changeset/big-mangos-learn.md
+++ b/.changeset/big-mangos-learn.md
@@ -1,0 +1,12 @@
+---
+"@fluidframework/tree": minor
+"fluid-framework": minor
+"__section": tree
+---
+
+Fix reverting multi-commit sequence changes
+
+Reverting a revision with `TreeViewAlpha.revertTo()` now allocates distinct identifiers when undoing array edits from multiple commits.
+This prevents identifier collisions during reversion and subsequent undo or redo, including histories with concurrent moves and nested edits.
+Inversion also handles moves fragmented by many concurrent insertions without recursive stack growth.
+Rollback behavior and the stored change format are unchanged.

--- a/packages/dds/tree/src/feature-libraries/sequence-field/invert.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/invert.ts
@@ -5,8 +5,12 @@
 
 import { assert, unreachableCase, fail } from "@fluidframework/core-utils/internal";
 
-import type { RevisionTag } from "../../core/index.js";
-import { type IdAllocator, type Mutable, hasSingle } from "../../util/index.js";
+import {
+	type ChangesetLocalId,
+	type RevisionTag,
+	offsetChangeAtomId,
+} from "../../core/index.js";
+import { type IdAllocator, type Mutable, brand, hasSingle } from "../../util/index.js";
 import {
 	type CrossFieldManager,
 	CrossFieldTarget,
@@ -43,6 +47,13 @@ import {
 	withNodeChange,
 } from "./utils.js";
 
+interface InverseMoveId {
+	readonly oldId: ChangesetLocalId;
+	readonly newId: ChangesetLocalId;
+}
+
+type InverseCrossFieldData = NodeId | InverseMoveId;
+
 /**
  * Inverts a given changeset.
  * @param change - The changeset to produce the inverse of.
@@ -65,22 +76,26 @@ export function invert(
 	return invertMarkList(
 		change,
 		isRollback,
-		crossFieldManager as CrossFieldManager<NodeId>,
+		crossFieldManager as CrossFieldManager<InverseCrossFieldData>,
 		revision,
+		genId,
 	);
 }
 
 function invertMarkList(
 	markList: MarkList,
 	isRollback: boolean,
-	crossFieldManager: CrossFieldManager<NodeId>,
+	crossFieldManager: CrossFieldManager<InverseCrossFieldData>,
 	revision: RevisionTag | undefined,
+	genId: IdAllocator,
 ): MarkList {
 	const inverseMarkList = new MarkListFactory();
 
 	for (const mark of markList) {
-		const inverseMarks = invertMark(mark, isRollback, crossFieldManager, revision);
-		inverseMarkList.push(...inverseMarks);
+		const inverseMarks = invertMark(mark, isRollback, crossFieldManager, revision, genId);
+		for (const inverseMark of inverseMarks) {
+			inverseMarkList.pushContent(inverseMark);
+		}
 	}
 
 	return inverseMarkList.list;
@@ -89,8 +104,9 @@ function invertMarkList(
 function invertMark(
 	mark: Mark,
 	isRollback: boolean,
-	crossFieldManager: CrossFieldManager<NodeId>,
+	crossFieldManager: CrossFieldManager<InverseCrossFieldData>,
 	revision: RevisionTag | undefined,
+	genId: IdAllocator,
 ): Mark[] {
 	if (!isImpactful(mark)) {
 		const inputId = getInputCellId(mark);
@@ -112,7 +128,10 @@ function invertMark(
 				// This means it should be safe to always restore the input cell ID (as opposed to only doing it on rollbacks).
 				// Despite that, we still only do it on rollback for the sake of consistency: once a cell has been assigned an ID,
 				// the only way for that cell to be assigned that ID again is if it is rolled back to that state.
-				idOverride: isRollback ? inputId : { localId: inputId.localId },
+				// This reference can flow into a later composition, so its revision must be explicit.
+				idOverride: isRollback
+					? inputId
+					: { localId: brand(genId.allocate(mark.count)), revision },
 			};
 			return [withNodeChange(inverse, mark.changes)];
 		}
@@ -120,11 +139,14 @@ function invertMark(
 			assert(mark.revision !== undefined, 0x5a1 /* Unable to revert to undefined revision */);
 			const outputId = getOutputCellId(mark);
 			const inputId = getInputCellId(mark);
+			const inverseId: ChangesetLocalId = isRollback
+				? mark.id
+				: brand(genId.allocate(mark.count));
 			let inverse: Mutable<Mark>;
 			if (inputId === undefined) {
 				inverse = {
 					type: "Insert",
-					id: mark.id,
+					id: inverseId,
 					cellId: outputId,
 					count: mark.count,
 					revision,
@@ -132,7 +154,7 @@ function invertMark(
 			} else {
 				inverse = {
 					type: "Remove",
-					id: mark.id,
+					id: inverseId,
 					cellId: outputId,
 					count: mark.count,
 					revision,
@@ -149,7 +171,7 @@ function invertMark(
 			const removeMark: Mutable<CellMark<Remove>> = {
 				type: "Remove",
 				count: mark.count,
-				id: inputId.localId,
+				id: isRollback ? inputId.localId : brand(genId.allocate(mark.count)),
 				revision,
 			};
 
@@ -161,6 +183,17 @@ function invertMark(
 			return [inverse];
 		}
 		case "MoveOut": {
+			const ids = isRollback ? undefined : getInverseMoveIds(mark, genId, crossFieldManager);
+			if (ids !== undefined && ids.length < mark.count) {
+				return splitAndInvert(
+					mark,
+					ids.length,
+					isRollback,
+					crossFieldManager,
+					revision,
+					genId,
+				);
+			}
 			if (mark.changes !== undefined) {
 				assert(mark.count === 1, 0x6ed /* Mark with changes can only target a single cell */);
 
@@ -182,13 +215,13 @@ function invertMark(
 
 			const moveIn: MoveIn = {
 				type: "MoveIn",
-				id: mark.id,
+				id: ids?.id ?? mark.id,
 				revision,
 			};
 
 			if (mark.finalEndpoint !== undefined) {
 				moveIn.finalEndpoint = {
-					localId: mark.finalEndpoint.localId,
+					localId: ids?.finalEndpoint ?? mark.finalEndpoint.localId,
 					revision,
 				};
 			}
@@ -197,7 +230,7 @@ function invertMark(
 			if (inputId !== undefined) {
 				const detach: Mutable<Detach> = {
 					type: "Remove",
-					id: mark.id,
+					id: ids?.id ?? mark.id,
 					revision,
 				};
 				if (isRollback) {
@@ -212,11 +245,22 @@ function invertMark(
 			return [{ ...effect, count: mark.count, cellId }];
 		}
 		case "MoveIn": {
+			const ids = isRollback ? undefined : getInverseMoveIds(mark, genId, crossFieldManager);
+			if (ids !== undefined && ids.length < mark.count) {
+				return splitAndInvert(
+					mark,
+					ids.length,
+					isRollback,
+					crossFieldManager,
+					revision,
+					genId,
+				);
+			}
 			const inputId = getInputCellId(mark);
 			assert(inputId !== undefined, 0x89e /* Active move-ins should target empty cells */);
 			const invertedMark: Mutable<CellMark<MoveOut>> = {
 				type: "MoveOut",
-				id: mark.id,
+				id: ids?.id ?? mark.id,
 				count: mark.count,
 				revision,
 			};
@@ -227,11 +271,15 @@ function invertMark(
 
 			if (mark.finalEndpoint) {
 				invertedMark.finalEndpoint = {
-					localId: mark.finalEndpoint.localId,
+					localId: ids?.finalEndpoint ?? mark.finalEndpoint.localId,
 					revision,
 				};
 			}
-			return applyMovedChanges(invertedMark, mark.revision, crossFieldManager);
+			return applyMovedChanges(
+				invertedMark,
+				{ revision: mark.revision, localId: mark.id },
+				crossFieldManager,
+			);
 		}
 		case "AttachAndDetach": {
 			const attach: Mark = {
@@ -249,8 +297,20 @@ function invertMark(
 				changes: mark.changes,
 				...mark.detach,
 			};
-			const attachInverses = invertMark(attach, isRollback, crossFieldManager, revision);
-			const detachInverses = invertMark(detach, isRollback, crossFieldManager, revision);
+			const attachInverses = invertMark(
+				attach,
+				isRollback,
+				crossFieldManager,
+				revision,
+				genId,
+			);
+			const detachInverses = invertMark(
+				detach,
+				isRollback,
+				crossFieldManager,
+				revision,
+				genId,
+			);
 
 			if (detachInverses.length === 0) {
 				return attachInverses;
@@ -309,30 +369,126 @@ function invertMark(
 	}
 }
 
+function splitAndInvert(
+	mark: CellMark<MoveIn | MoveOut>,
+	length: number,
+	isRollback: boolean,
+	manager: CrossFieldManager<InverseCrossFieldData>,
+	revision: RevisionTag | undefined,
+	genId: IdAllocator,
+): Mark[] {
+	const [first, second] = splitMark(mark, length);
+	const pending = [second, first];
+	const result: Mark[] = [];
+	for (let fragment = pending.pop(); fragment !== undefined; fragment = pending.pop()) {
+		const ids = isRollback ? undefined : getInverseMoveIds(fragment, genId, manager);
+		if (ids !== undefined && ids.length < fragment.count) {
+			const [head, tail] = splitMark(fragment, ids.length);
+			pending.push(tail, head);
+			continue;
+		}
+		for (const inverse of invertMark(fragment, isRollback, manager, revision, genId)) {
+			result.push(inverse);
+		}
+	}
+	return result;
+}
+
+function getInverseMoveIds(
+	mark: CellMark<MoveIn | MoveOut>,
+	genId: IdAllocator,
+	manager: CrossFieldManager<InverseCrossFieldData>,
+): { id: ChangesetLocalId; finalEndpoint?: ChangesetLocalId; length: number } {
+	const own = getInverseMoveId(
+		{ revision: mark.revision, localId: mark.id },
+		mark.count,
+		genId,
+		manager,
+	);
+	const endpoint =
+		mark.finalEndpoint === undefined
+			? undefined
+			: getInverseMoveId(mark.finalEndpoint, mark.count, genId, manager);
+	return {
+		id: own.id,
+		finalEndpoint: endpoint?.id,
+		length: Math.min(own.length, endpoint?.length ?? own.length),
+	};
+}
+
+function getInverseMoveId(
+	original: CellId,
+	count: number,
+	genId: IdAllocator,
+	manager: CrossFieldManager<InverseCrossFieldData>,
+): { id: ChangesetLocalId; length: number } {
+	// Destination carries moved node changes. Source shares remapped IDs across move
+	// endpoints and amended field passes within this inversion.
+	const entry = manager.get(
+		CrossFieldTarget.Source,
+		original.revision,
+		original.localId,
+		count,
+		false,
+	);
+	if (entry.value === undefined) {
+		const id: ChangesetLocalId = brand(genId.allocate(entry.length));
+		manager.set(
+			CrossFieldTarget.Source,
+			original.revision,
+			original.localId,
+			entry.length,
+			{ oldId: original.localId, newId: id },
+			false,
+		);
+		return { id, length: entry.length };
+	}
+	assert("oldId" in entry.value, "Expected inverse move ID mapping");
+	return {
+		id: brand(entry.value.newId + original.localId - entry.value.oldId),
+		length: entry.length,
+	};
+}
+
 function applyMovedChanges(
 	mark: CellMark<MoveOut>,
-	revision: RevisionTag | undefined,
-	manager: CrossFieldManager<NodeId>,
+	originalId: CellId,
+	manager: CrossFieldManager<InverseCrossFieldData>,
 ): Mark[] {
-	// Although this is a source mark, we query the destination because this was a destination mark during the original invert pass.
-	const entry = manager.get(CrossFieldTarget.Destination, revision, mark.id, mark.count, true);
+	const result: Mark[] = [];
+	let remaining = mark;
+	let remainingOriginalId = originalId;
+	for (;;) {
+		// Query by the original endpoint, not its newly allocated inverse ID.
+		const entry = manager.get(
+			CrossFieldTarget.Destination,
+			remainingOriginalId.revision,
+			remainingOriginalId.localId,
+			remaining.count,
+			true,
+		);
+		const nodeChange = entry.value;
+		assert(nodeChange === undefined || "localId" in nodeChange, "Expected moved node change");
 
-	if (entry.length < mark.count) {
-		const [mark1, mark2] = splitMark(mark, entry.length);
-		const mark1WithChanges =
-			entry.value === undefined
-				? mark1
-				: withNodeChange<CellMark<MoveOut>, MoveOut>(mark1, entry.value);
-
-		return [mark1WithChanges, ...applyMovedChanges(mark2, revision, manager)];
+		if (entry.length < remaining.count) {
+			const [head, tail] = splitMark(remaining, entry.length);
+			result.push(
+				nodeChange === undefined
+					? head
+					: withNodeChange<CellMark<MoveOut>, MoveOut>(head, nodeChange),
+			);
+			remaining = tail;
+			remainingOriginalId = offsetChangeAtomId(remainingOriginalId, entry.length);
+			continue;
+		}
+		if (nodeChange === undefined) {
+			result.push(remaining);
+		} else {
+			manager.onMoveIn(nodeChange);
+			result.push(withNodeChange<CellMark<MoveOut>, MoveOut>(remaining, nodeChange));
+		}
+		return result;
 	}
-
-	if (entry.value !== undefined) {
-		manager.onMoveIn(entry.value);
-		return [withNodeChange<CellMark<MoveOut>, MoveOut>(mark, entry.value)];
-	}
-
-	return [mark];
 }
 
 function invertNodeChangeOrSkip(

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/invert.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/invert.test.ts
@@ -41,6 +41,174 @@ function invert(change: Changeset, tag: RevisionTag = tag1): Changeset {
 
 export function testInvert(): void {
 	describe("Invert", () => {
+		describe("non-rollback IDs", () => {
+			it("allocates disjoint detach ranges for inserts from different revisions", () => {
+				const input = [
+					Mark.insert(2, { revision: tag1, localId: brand(0) }),
+					Mark.insert(3, { revision: tag2, localId: brand(0) }),
+				];
+				const actual = invertChange(tagChangeInline(input, tag1), tagForInvert, false);
+				assertChangesetsEqual(actual, [Mark.remove(5, brand(0), { revision: tagForInvert })]);
+			});
+
+			it("qualifies freshly allocated rename references", () => {
+				const input = [
+					Mark.rename(
+						2,
+						{ revision: tag1, localId: brand(10) },
+						{ revision: tag2, localId: brand(20) },
+					),
+				];
+				const actual = invertChange(tagChangeInline(input, tag1), tagForInvert, false);
+				assertChangesetsEqual(actual, [
+					Mark.rename(
+						2,
+						{ revision: tag2, localId: brand(20) },
+						{ revision: tagForInvert, localId: brand(0) },
+					),
+				]);
+			});
+
+			it("keeps move pairs distinct when their original local IDs overlap", () => {
+				const input = [
+					Mark.moveOut(2, { revision: tag1, localId: brand(0) }),
+					Mark.moveOut(2, { revision: tag2, localId: brand(0) }),
+					Mark.moveIn(2, { revision: tag1, localId: brand(0) }),
+					Mark.moveIn(2, { revision: tag2, localId: brand(0) }),
+				];
+				const actual = invertChange(tagChangeInline(input, tag1), tagForInvert, false);
+				assertChangesetsEqual(actual, [
+					Mark.returnTo(
+						2,
+						brand(0),
+						{ revision: tag1, localId: brand(0) },
+						{ revision: tagForInvert },
+					),
+					Mark.returnTo(
+						2,
+						brand(2),
+						{ revision: tag2, localId: brand(0) },
+						{ revision: tagForInvert },
+					),
+					Mark.moveOut(4, brand(0), { revision: tagForInvert }),
+				]);
+			});
+
+			it("remaps final endpoints without losing moved child changes", () => {
+				const input = [
+					Mark.moveOut(1, brand(10), {
+						changes: childChange1,
+						finalEndpoint: { revision: tag2, localId: brand(20) },
+					}),
+					Mark.rename(
+						1,
+						{ revision: tag1, localId: brand(11) },
+						{ revision: tag2, localId: brand(20) },
+					),
+					Mark.moveIn(
+						1,
+						{ revision: tag2, localId: brand(20) },
+						{
+							finalEndpoint: { revision: tag1, localId: brand(10) },
+						},
+					),
+				];
+				const actual = invertChange(tagChangeInline(input, tag1), tagForInvert, false);
+				assertChangesetsEqual(actual, [
+					Mark.returnTo(
+						1,
+						brand(0),
+						{ revision: tag1, localId: brand(10) },
+						{
+							revision: tagForInvert,
+							finalEndpoint: { revision: tagForInvert, localId: brand(1) },
+						},
+					),
+					Mark.rename(
+						1,
+						{ revision: tag2, localId: brand(20) },
+						{ revision: tagForInvert, localId: brand(2) },
+					),
+					Mark.moveOut(1, brand(1), {
+						revision: tagForInvert,
+						finalEndpoint: { revision: tagForInvert, localId: brand(0) },
+						changes: { ...childChange1, revision: tag1 },
+					}),
+				]);
+			});
+
+			it("splits a destination at noncontiguous inverse ID ranges", () => {
+				const input = [
+					Mark.moveOut(1, brand(10)),
+					Mark.insert(1, brand(20)),
+					Mark.moveOut(1, brand(11)),
+					Mark.skip(1),
+					Mark.moveIn(2, brand(10)),
+				];
+				const actual = invertChange(tagChangeInline(input, tag1), tagForInvert, false);
+				assertChangesetsEqual(actual, [
+					Mark.returnTo(
+						1,
+						brand(0),
+						{ revision: tag1, localId: brand(10) },
+						{ revision: tagForInvert },
+					),
+					Mark.remove(1, brand(1), { revision: tagForInvert }),
+					Mark.returnTo(
+						1,
+						brand(2),
+						{ revision: tag1, localId: brand(11) },
+						{ revision: tagForInvert },
+					),
+					Mark.skip(1),
+					Mark.moveOut(1, brand(0), { revision: tagForInvert }),
+					Mark.moveOut(1, brand(2), { revision: tagForInvert }),
+				]);
+			});
+
+			it("preserves range offsets and moved changes when the destination is visited first", () => {
+				const input = [
+					Mark.moveIn(3, brand(10)),
+					Mark.skip(1),
+					Mark.moveOut(1, brand(10)),
+					Mark.skip(1),
+					Mark.moveOut(1, brand(11), { changes: childChange1 }),
+					Mark.skip(1),
+					Mark.moveOut(1, brand(12)),
+				];
+				const actual = invertChange(tagChangeInline(input, tag1), tagForInvert, false);
+				assertChangesetsEqual(actual, [
+					Mark.moveOut(1, brand(0), { revision: tagForInvert }),
+					Mark.moveOut(1, brand(1), {
+						revision: tagForInvert,
+						changes: { ...childChange1, revision: tag1 },
+					}),
+					Mark.moveOut(1, brand(2), { revision: tagForInvert }),
+					Mark.skip(1),
+					Mark.returnTo(
+						1,
+						brand(0),
+						{ revision: tag1, localId: brand(10) },
+						{ revision: tagForInvert },
+					),
+					Mark.skip(1),
+					Mark.returnTo(
+						1,
+						brand(1),
+						{ revision: tag1, localId: brand(11) },
+						{ revision: tagForInvert },
+					),
+					Mark.skip(1),
+					Mark.returnTo(
+						1,
+						brand(2),
+						{ revision: tag1, localId: brand(12) },
+						{ revision: tagForInvert },
+					),
+				]);
+			});
+		});
+
 		it("no changes", () => {
 			const input: Changeset = [];
 			const expected: Changeset = [];

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/utils.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/utils.ts
@@ -482,27 +482,15 @@ export function testInvert(
 ): Changeset {
 	deepFreeze(change.change);
 	const table = newCrossFieldTable();
-	let inverted = invert(
-		change.change,
-		isRollback,
-		// Sequence fields should not generate IDs during invert
-		fakeIdAllocator,
-		revision,
-		table,
-	);
+	// Rollback inversion must not allocate IDs.
+	const genId = isRollback ? fakeIdAllocator : idAllocatorFromMaxId();
+	let inverted = invert(change.change, isRollback, genId, revision, table);
 
 	if (table.isInvalidated) {
 		table.isInvalidated = false;
 		table.srcQueries.clear();
 		table.dstQueries.clear();
-		inverted = invert(
-			change.change,
-			isRollback,
-			// Sequence fields should not generate IDs during invert
-			fakeIdAllocator,
-			revision,
-			table,
-		);
+		inverted = invert(change.change, isRollback, genId, revision, table);
 	}
 
 	return inverted;

--- a/packages/dds/tree/src/test/simple-tree/api/revertTo.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/revertTo.spec.ts
@@ -1,0 +1,228 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "node:assert";
+
+import { RevertibleStatus, type Revertible } from "../../../core/index.js";
+import {
+	SchemaFactory,
+	TreeViewConfiguration,
+	type TreeViewAlpha,
+} from "../../../simple-tree/index.js";
+import { getView } from "../../utils.js";
+
+const schema = new SchemaFactory("revertTo-sequences");
+class Item extends schema.object("Item", { id: schema.number, v: schema.number }) {}
+class Items extends schema.array("Items", Item) {}
+class Root extends schema.object("Root", { a: Items, b: Items, c: Items }) {}
+
+function initialContent() {
+	return {
+		a: [0, 1, 2, 3, 4].map((id) => ({ id, v: id })),
+		b: [5, 6, 7].map((id) => ({ id, v: id })),
+		c: [],
+	};
+}
+
+function content(view: TreeViewAlpha<typeof Root>) {
+	const copy = (items: Items) => items.map(({ id, v }) => ({ id, v }));
+	return { a: copy(view.root.a), b: copy(view.root.b), c: copy(view.root.c) };
+}
+
+function setup() {
+	const view = getView(new TreeViewConfiguration({ schema: Root }));
+	view.initialize(initialContent());
+	const target = view.branchHistory.getHead()?.revision;
+	assert(target !== undefined);
+	const handles: Revertible[] = [];
+	const forks: TreeViewAlpha<typeof Root>[] = [];
+	let latest: Revertible | undefined;
+	const unsubscribe = view.events.on("changed", (_, getRevertible) => {
+		if (getRevertible !== undefined) {
+			latest = getRevertible();
+			handles.push(latest);
+		}
+	});
+	return {
+		view,
+		target,
+		fork() {
+			const fork = view.fork();
+			forks.push(fork);
+			return fork;
+		},
+		revertLatest() {
+			assert(latest !== undefined, "Expected a synchronously captured revertible");
+			latest.revert();
+		},
+		dispose() {
+			unsubscribe();
+			for (const handle of handles) {
+				if (handle.status !== RevertibleStatus.Disposed) {
+					handle.dispose();
+				}
+			}
+			for (const fork of forks) {
+				fork.dispose();
+			}
+			view.dispose();
+		},
+	};
+}
+
+function assertRestoreRoundTrip(fixture: ReturnType<typeof setup>) {
+	const { view, target } = fixture;
+	const before = content(view);
+	const historyLength = view.branchHistory.length;
+	view.revertTo(target);
+	assert.deepEqual(content(view), initialContent());
+	assert.equal(view.branchHistory.length, historyLength + 1);
+	fixture.revertLatest();
+	assert.deepEqual(content(view), before);
+	assert.equal(view.branchHistory.length, historyLength + 2);
+	fixture.revertLatest();
+	assert.deepEqual(content(view), initialContent());
+	assert.equal(view.branchHistory.length, historyLength + 3);
+}
+
+function editBeforeRepeatedRestore(view: TreeViewAlpha<typeof Root>) {
+	view.runTransaction(() => {
+		view.root.c.insertAt(0, { id: 100, v: 0 }, { id: 101, v: 0 });
+	});
+	view.runTransaction(() => {
+		view.root.a.insertAt(3, { id: 102, v: 0 });
+	});
+	view.runTransaction(() => {
+		view.root.a.insertAt(0, { id: 103, v: 0 }, { id: 104, v: 0 }, { id: 105, v: 0 });
+	});
+	// Preserve the no-op transaction: Undo must use the actual latest changed-event factory.
+	view.runTransaction(() => {
+		view.root.c.moveRangeToIndex(0, 0, 2, view.root.c);
+	});
+}
+
+function editPeer(view: TreeViewAlpha<typeof Root>) {
+	view.runTransaction(() => {
+		view.root.a.moveRangeToIndex(0, 0, 2, view.root.c);
+	});
+	view.runTransaction(() => {
+		view.root.b[1].v = 106;
+	});
+}
+
+function interleaveInsertions(view: TreeViewAlpha<typeof Root>, count: number) {
+	view.runTransaction(() => {
+		for (let index = count - 1; index > 0; index--) {
+			view.root.a.insertAt(index, { id: count + index, v: 0 });
+		}
+	});
+}
+
+describe("revertTo sequence changes", () => {
+	let fixture: ReturnType<typeof setup>;
+	beforeEach(() => {
+		fixture = setup();
+	});
+	afterEach(() => {
+		fixture.dispose();
+	});
+
+	it("restores consecutive insertion commits", () => {
+		fixture.view.runTransaction(() => {
+			fixture.view.root.c.insertAtEnd({ id: 100, v: 0 });
+		});
+		fixture.view.runTransaction(() => {
+			fixture.view.root.c.insertAtEnd({ id: 101, v: 0 });
+		});
+		assertRestoreRoundTrip(fixture);
+	});
+
+	it("restores consecutive removal commits", () => {
+		fixture.view.root.a.removeRange(1, 3);
+		fixture.view.root.a.removeAt(0);
+		assertRestoreRoundTrip(fixture);
+	});
+
+	it("restores chained cross-field moves with nested edits", () => {
+		const { root } = fixture.view;
+		root.b.moveRangeToIndex(1, 1, 4, root.a);
+		root.c.moveRangeToIndex(0, 2, 4, root.b);
+		root.c[1].v = 100;
+		assertRestoreRoundTrip(fixture);
+	});
+
+	it("restores replaced roots with scalar edits", () => {
+		fixture.view.root = { a: [], b: [], c: [{ id: 100, v: 0 }] };
+		fixture.view.root.c[0].v = 101;
+		fixture.view.root = { a: [{ id: 102, v: 0 }], b: [], c: [] };
+		assertRestoreRoundTrip(fixture);
+	});
+
+	it("preserves rollback identities before restoring later edits", () => {
+		fixture.view.runTransaction(() => {
+			fixture.view.root.c.moveRangeToIndex(0, 1, 4, fixture.view.root.a);
+			fixture.view.root.c.removeAt(0);
+			return { rollback: true, value: undefined };
+		});
+		assert.deepEqual(content(fixture.view), initialContent());
+		fixture.view.root.c.insertAtEnd({ id: 100, v: 0 });
+		fixture.view.root.a.removeAt(2);
+		assertRestoreRoundTrip(fixture);
+	});
+
+	for (const restoreFirst of [true, false]) {
+		it(`restores again after Undo and peer edits (${restoreFirst ? "restore" : "peer"} merged first)`, () => {
+			const { view, target } = fixture;
+			editBeforeRepeatedRestore(view);
+			fixture.revertLatest();
+			const prepared = fixture.fork();
+			prepared.revertTo(target);
+			const peer = fixture.fork();
+			editPeer(peer);
+			view.merge(restoreFirst ? prepared : peer, false);
+			view.merge(restoreFirst ? peer : prepared, false);
+			peer.rebaseOnto(view);
+			assert.deepEqual(content(peer), content(view));
+			assertRestoreRoundTrip(fixture);
+		});
+	}
+
+	it("restores again after peer edits without an initial Undo", () => {
+		const { view, target } = fixture;
+		editBeforeRepeatedRestore(view);
+		const prepared = fixture.fork();
+		prepared.revertTo(target);
+		const peer = fixture.fork();
+		editPeer(peer);
+		view.merge(prepared, false);
+		view.merge(peer, false);
+		peer.rebaseOnto(view);
+		assert.deepEqual(content(peer), content(view));
+		assertRestoreRoundTrip(fixture);
+	});
+
+	it("restores a move fragmented by thousands of concurrent insertions", function () {
+		this.timeout(30_000);
+		const { view } = fixture;
+		const source = Array.from({ length: 4000 }, (_, id) => ({ id, v: id }));
+		view.root = { a: source, b: [], c: [] };
+		const moving = fixture.fork();
+		moving.root.c.moveRangeToIndex(0, 0, 4000, moving.root.a);
+		interleaveInsertions(view, 4000);
+		const target = view.branchHistory.getHead()?.revision;
+		assert(target !== undefined);
+		const expected = content(view);
+		view.merge(moving, false);
+		const moved = content(view);
+		assert.deepEqual(moved.c, source);
+		assert.equal(moved.a.length, 3999);
+		view.revertTo(target);
+		assert.deepEqual(content(view), expected);
+		fixture.revertLatest();
+		assert.deepEqual(content(view), moved);
+		fixture.revertLatest();
+		assert.deepEqual(content(view), expected);
+	});
+});


### PR DESCRIPTION
🤖 Fix `TreeViewAlpha.revertTo()` for histories containing sequence edits from multiple commits.

## Description

Sequence inversion reused revision-local identifiers when composing multiple original revisions into one inverse revision. Two valid original IDs such as `(A, 0)` and `(B, 0)` could become the same inverse detach ID and trigger `0x7ce`.

- Allocate fresh identifiers for non-rollback inverse inserts, removes, and renames.
- Remap revision-qualified move ranges and both endpoints consistently across fields and amended passes, while looking up moved child changes using their original IDs.
- Qualify fresh Rename references with the inverse revision, covering the reproduced Undo/Restore/peer/repeated-Restore `0x695` history.
- Process fragmented ranges iteratively and avoid unbounded argument spreads.

Rollback identities, schemas, the stored change format, and existing assertions are unchanged. `ComposeQueue` is not modified.

## Reproduction and regression coverage

The smallest failure is two separate insertion transactions followed by `revertTo()` to the revision before them. Added coverage also exercises chained moves and nested edits, root replacement, prior native Undo followed by Restore and peer changes, both merge orders, repeated Restore, and a 4,000-node move fragmented by concurrent insertions.

The public API tests use actual captured native revertibles, compare full document state through Undo/Redo, and assert one new history commit per operation.

## Validation

- Tree `build:test:esm` and `lint` task graphs passed through `fluid-build`.
- Focused sequence-field, simple-tree API, reversion, shared-tree Undo, checkout, and custom metadata suites: **3,791 passing; 48 existing pending**.
- Fifteen new focused regressions; targeted ESLint, Biome, and diff checks passed.
- Includes changesets for `@fluidframework/tree` and `fluid-framework`.

## Reviewer guidance

Please review the cross-field ID-map lifetime, paired/final endpoint range mapping, and the distinction between fresh normal inverses and identity-preserving rollback. This draft targets `main`; any backport or patch release is a separate maintainer decision.