### PR TITLE
fix(odsp-driver): bypass live snapshot caches for point-in-time loads

### DIFF
--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -284,6 +284,7 @@ export class OdspDocumentStorageService extends OdspDocumentStorageServiceBase {
 						hostSnapshotOptions,
 						snapshotFetchOptions.loadingGroupIds,
 						snapshotFetchOptions.scenarioName,
+						true,
 					);
 					method = "networkOnly";
 				} else {
@@ -355,6 +356,7 @@ export class OdspDocumentStorageService extends OdspDocumentStorageServiceBase {
 							hostSnapshotOptions,
 							snapshotFetchOptions.loadingGroupIds,
 							snapshotFetchOptions.scenarioName,
+							false,
 						);
 
 						// Ensure that failures on both paths are ignored initially.
@@ -412,6 +414,7 @@ export class OdspDocumentStorageService extends OdspDocumentStorageServiceBase {
 								hostSnapshotOptions,
 								snapshotFetchOptions.loadingGroupIds,
 								snapshotFetchOptions.scenarioName,
+								false,
 							);
 						}
 					}
@@ -553,11 +556,13 @@ export class OdspDocumentStorageService extends OdspDocumentStorageServiceBase {
 		hostSnapshotOptions: ISnapshotOptions | undefined,
 		loadingGroupIds: string[] | undefined,
 		scenarioName?: string,
+		avoidPrefetchSnapshotCache: boolean = false,
 	): Promise<ISnapshot | IPrefetchSnapshotContents> {
 		return this.fetchSnapshotFromNetworkCore(
 			hostSnapshotOptions,
 			loadingGroupIds,
 			scenarioName,
+			avoidPrefetchSnapshotCache,
 		).catch((error) => {
 			// Issue #5895:
 			// If we are offline, this error is retryable. But that means that RetriableDocumentStorageService
@@ -576,10 +581,13 @@ export class OdspDocumentStorageService extends OdspDocumentStorageServiceBase {
 		hostSnapshotOptions: ISnapshotOptions | undefined,
 		loadingGroupIds: string[] | undefined,
 		scenarioName?: string,
+		avoidPrefetchSnapshotCache: boolean = false,
 	): Promise<ISnapshot | IPrefetchSnapshotContents> {
-		// Don't look into cache, if the host specifically tells us so. Also, if request is
-		// for initial snapshot, don't consult the prefetch cache.
-		if (!this.hostPolicy.avoidPrefetchSnapshotCache && this.firstSnapshotFetchCall) {
+		if (
+			!avoidPrefetchSnapshotCache &&
+			!this.hostPolicy.avoidPrefetchSnapshotCache &&
+			this.firstSnapshotFetchCall
+		) {
 			const prefetchCacheKey = getKeyForCacheEntry(
 				createCacheSnapshotKey(
 					this.odspResolvedUrl,

--- a/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
+++ b/packages/drivers/odsp-driver/src/odspDocumentStorageManager.ts
@@ -284,7 +284,7 @@ export class OdspDocumentStorageService extends OdspDocumentStorageServiceBase {
 						hostSnapshotOptions,
 						snapshotFetchOptions.loadingGroupIds,
 						snapshotFetchOptions.scenarioName,
-						true,
+						true /* avoidPrefetchSnapshotCache */,
 					);
 					method = "networkOnly";
 				} else {
@@ -356,7 +356,7 @@ export class OdspDocumentStorageService extends OdspDocumentStorageServiceBase {
 							hostSnapshotOptions,
 							snapshotFetchOptions.loadingGroupIds,
 							snapshotFetchOptions.scenarioName,
-							false,
+							false /* avoidPrefetchSnapshotCache */,
 						);
 
 						// Ensure that failures on both paths are ignored initially.
@@ -414,7 +414,7 @@ export class OdspDocumentStorageService extends OdspDocumentStorageServiceBase {
 								hostSnapshotOptions,
 								snapshotFetchOptions.loadingGroupIds,
 								snapshotFetchOptions.scenarioName,
-								false,
+								false /* avoidPrefetchSnapshotCache */,
 							);
 						}
 					}

--- a/packages/drivers/odsp-driver/src/odspVersionManager/DEV.md
+++ b/packages/drivers/odsp-driver/src/odspVersionManager/DEV.md
@@ -571,7 +571,10 @@ The injected implementation:
    document services: a **recoverable** one bound to that base version (its storage is the base
    snapshot) and a **live** one (its delta storage supplies the ops to replay). Both are created via
    `createDocumentServiceCore` with a **single shared** `EpochTracker` (the same one the version
-   manager reads through) — this is the structural lineage guard; see the next question.
+   manager reads through) — this is the structural lineage guard; see the next question. The
+   point-in-time storage wrapper forces the recoverable service's initial snapshot read to bypass
+   the persistent latest-snapshot cache so the selected base cannot be replaced by a newer cached
+   snapshot.
 3. Return an `OdspPointInTimeDocumentService` composing the two.
 
 It lives in this package rather than a generic wrapping driver (e.g. `@fluidframework/replay-driver`)

--- a/packages/drivers/odsp-driver/src/odspVersionManager/DEV.md
+++ b/packages/drivers/odsp-driver/src/odspVersionManager/DEV.md
@@ -573,8 +573,9 @@ The injected implementation:
    `createDocumentServiceCore` with a **single shared** `EpochTracker` (the same one the version
    manager reads through) — this is the structural lineage guard; see the next question. The
    point-in-time storage wrapper forces the recoverable service's initial snapshot read to bypass
-   the persistent latest-snapshot cache so the selected base cannot be replaced by a newer cached
-   snapshot.
+   both the persistent latest-snapshot cache and the in-memory snapshot-prefetch cache so the
+   selected base cannot be replaced by a newer cached live snapshot. Both loader snapshot paths
+   (`getSnapshot` and the legacy `getVersions` + `getSnapshotTree` path) apply this rule.
 3. Return an `OdspPointInTimeDocumentService` composing the two.
 
 It lives in this package rather than a generic wrapping driver (e.g. `@fluidframework/replay-driver`)

--- a/packages/drivers/odsp-driver/src/pointInTimeDriver/odspPointInTimeDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/pointInTimeDriver/odspPointInTimeDocumentService.ts
@@ -31,6 +31,7 @@ class PointInTimeDocumentStorageService extends DocumentStorageServiceProxy {
 	}
 
 	public override async getVersions(
+		// eslint-disable-next-line @rushstack/no-new-null -- IDocumentStorageService is a legacy API that requires null.
 		versionId: string | null,
 		count: number,
 		scenarioName?: string,

--- a/packages/drivers/odsp-driver/src/pointInTimeDriver/odspPointInTimeDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/pointInTimeDriver/odspPointInTimeDocumentService.ts
@@ -20,6 +20,10 @@ import {
 } from "@fluidframework/driver-definitions/internal";
 import { DocumentStorageServiceProxy } from "@fluidframework/driver-utils/internal";
 
+/**
+ * Forces point-in-time snapshot reads to bypass caches while forwarding all other storage operations
+ * to the selected historical document service.
+ */
 class PointInTimeDocumentStorageService extends DocumentStorageServiceProxy {
 	public override async getSnapshot(
 		snapshotFetchOptions?: ISnapshotFetchOptions,

--- a/packages/drivers/odsp-driver/src/pointInTimeDriver/odspPointInTimeDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/pointInTimeDriver/odspPointInTimeDocumentService.ts
@@ -4,16 +4,31 @@
  */
 
 import { TypedEventEmitter } from "@fluid-internal/client-utils";
-import type {
-	IClient,
-	IDocumentDeltaConnection,
-	IDocumentDeltaStorageService,
-	IDocumentService,
-	IDocumentServiceEvents,
-	IDocumentServicePolicies,
-	IDocumentStorageService,
-	IResolvedUrl,
+import {
+	FetchSource,
+	type IClient,
+	type IDocumentDeltaConnection,
+	type IDocumentDeltaStorageService,
+	type IDocumentService,
+	type IDocumentServiceEvents,
+	type IDocumentServicePolicies,
+	type IDocumentStorageService,
+	type IResolvedUrl,
+	type ISnapshot,
+	type ISnapshotFetchOptions,
 } from "@fluidframework/driver-definitions/internal";
+import { DocumentStorageServiceProxy } from "@fluidframework/driver-utils/internal";
+
+class PointInTimeDocumentStorageService extends DocumentStorageServiceProxy {
+	public override async getSnapshot(
+		snapshotFetchOptions?: ISnapshotFetchOptions,
+	): Promise<ISnapshot> {
+		return super.getSnapshot({
+			...snapshotFetchOptions,
+			fetchSource: FetchSource.noCache,
+		});
+	}
+}
 
 /**
  * A read-only document service that materializes a document at a target sequence number by combining
@@ -64,7 +79,8 @@ export class OdspPointInTimeDocumentService
 	}
 
 	public async connectToStorage(): Promise<IDocumentStorageService> {
-		return this.recoverableDocumentService.connectToStorage();
+		const storage = await this.recoverableDocumentService.connectToStorage();
+		return new PointInTimeDocumentStorageService(storage);
 	}
 
 	public async connectToDeltaStorage(): Promise<IDocumentDeltaStorageService> {

--- a/packages/drivers/odsp-driver/src/pointInTimeDriver/odspPointInTimeDocumentService.ts
+++ b/packages/drivers/odsp-driver/src/pointInTimeDriver/odspPointInTimeDocumentService.ts
@@ -16,6 +16,7 @@ import {
 	type IResolvedUrl,
 	type ISnapshot,
 	type ISnapshotFetchOptions,
+	type IVersion,
 } from "@fluidframework/driver-definitions/internal";
 import { DocumentStorageServiceProxy } from "@fluidframework/driver-utils/internal";
 
@@ -27,6 +28,14 @@ class PointInTimeDocumentStorageService extends DocumentStorageServiceProxy {
 			...snapshotFetchOptions,
 			fetchSource: FetchSource.noCache,
 		});
+	}
+
+	public override async getVersions(
+		versionId: string | null,
+		count: number,
+		scenarioName?: string,
+	): Promise<IVersion[]> {
+		return super.getVersions(versionId, count, scenarioName, FetchSource.noCache);
 	}
 }
 

--- a/packages/drivers/odsp-driver/src/test/odspPointInTimeDocumentService.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspPointInTimeDocumentService.spec.ts
@@ -6,15 +6,18 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
 import { strict as assert } from "node:assert";
 
-import type {
-	IClient,
-	IDocumentDeltaStorageService,
-	IDocumentService,
-	IDocumentStorageService,
-	IResolvedUrl,
-	ISequencedDocumentMessage,
-	IStream,
-	IStreamResult,
+import {
+	FetchSource,
+	type IClient,
+	type IDocumentDeltaStorageService,
+	type IDocumentService,
+	type IDocumentStorageService,
+	type IResolvedUrl,
+	type ISequencedDocumentMessage,
+	type ISnapshot,
+	type ISnapshotFetchOptions,
+	type IStream,
+	type IStreamResult,
 } from "@fluidframework/driver-definitions/internal";
 
 // eslint-disable-next-line import-x/no-internal-modules
@@ -109,7 +112,21 @@ class FakeLiveDocumentService {
 class FakeRecoverableDocumentService {
 	public disposeCount = 0;
 	public connectToStorageCount = 0;
-	public readonly storage = {} as IDocumentStorageService;
+	public snapshotFetchOptions: ISnapshotFetchOptions | undefined;
+	public readonly snapshot = {
+		snapshotTree: { blobs: {}, trees: {} },
+		blobContents: new Map(),
+		ops: [],
+		sequenceNumber: 0,
+		latestSequenceNumber: 0,
+		snapshotFormatV: 1,
+	} satisfies ISnapshot;
+	public readonly storage = {
+		getSnapshot: async (snapshotFetchOptions?: ISnapshotFetchOptions) => {
+			this.snapshotFetchOptions = snapshotFetchOptions;
+			return this.snapshot;
+		},
+	} as IDocumentStorageService;
 
 	public async connectToStorage(): Promise<IDocumentStorageService> {
 		this.connectToStorageCount++;
@@ -207,10 +224,15 @@ describe("OdspPointInTimeDocumentService", () => {
 			assert.equal(service.policies?.storageOnly, true);
 		});
 
-		it("serves storage from the recoverable (snapshot) document service", async () => {
+		it("serves the recoverable snapshot without consulting the persistent cache", async () => {
 			const { service, recoverable } = makeService(100, streamFromBatches([]));
 			const storage = await service.connectToStorage();
-			assert.equal(storage, recoverable.storage);
+			const snapshot = await storage.getSnapshot?.({ scenarioName: "point-in-time-test" });
+			assert.equal(snapshot, recoverable.snapshot);
+			assert.deepEqual(recoverable.snapshotFetchOptions, {
+				scenarioName: "point-in-time-test",
+				fetchSource: FetchSource.noCache,
+			});
 			assert.equal(recoverable.connectToStorageCount, 1);
 		});
 

--- a/packages/drivers/odsp-driver/src/test/odspPointInTimeDocumentService.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspPointInTimeDocumentService.spec.ts
@@ -129,6 +129,7 @@ class FakeRecoverableDocumentService {
 			return this.snapshot;
 		},
 		getVersions: async (
+			// eslint-disable-next-line @rushstack/no-new-null -- IDocumentStorageService is a legacy API that requires null.
 			_versionId: string | null,
 			_count: number,
 			_scenarioName?: string,

--- a/packages/drivers/odsp-driver/src/test/odspPointInTimeDocumentService.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/odspPointInTimeDocumentService.spec.ts
@@ -18,6 +18,7 @@ import {
 	type ISnapshotFetchOptions,
 	type IStream,
 	type IStreamResult,
+	type IVersion,
 } from "@fluidframework/driver-definitions/internal";
 
 // eslint-disable-next-line import-x/no-internal-modules
@@ -113,6 +114,7 @@ class FakeRecoverableDocumentService {
 	public disposeCount = 0;
 	public connectToStorageCount = 0;
 	public snapshotFetchOptions: ISnapshotFetchOptions | undefined;
+	public versionsFetchSource: FetchSource | undefined;
 	public readonly snapshot = {
 		snapshotTree: { blobs: {}, trees: {} },
 		blobContents: new Map(),
@@ -126,7 +128,31 @@ class FakeRecoverableDocumentService {
 			this.snapshotFetchOptions = snapshotFetchOptions;
 			return this.snapshot;
 		},
-	} as IDocumentStorageService;
+		getVersions: async (
+			_versionId: string | null,
+			_count: number,
+			_scenarioName?: string,
+			fetchSource?: FetchSource,
+		): Promise<IVersion[]> => {
+			this.versionsFetchSource = fetchSource;
+			return [{ id: "version", treeId: undefined! }];
+		},
+		getSnapshotTree: async () => null,
+		createBlob: async () => {
+			throw new Error("createBlob should not be used by the point-in-time service");
+		},
+		readBlob: async () => {
+			throw new Error("readBlob should not be used by this test");
+		},
+		uploadSummaryWithContext: async () => {
+			throw new Error(
+				"uploadSummaryWithContext should not be used by the point-in-time service",
+			);
+		},
+		downloadSummary: async () => {
+			throw new Error("downloadSummary should not be used by the point-in-time service");
+		},
+	} satisfies IDocumentStorageService;
 
 	public async connectToStorage(): Promise<IDocumentStorageService> {
 		this.connectToStorageCount++;
@@ -224,7 +250,7 @@ describe("OdspPointInTimeDocumentService", () => {
 			assert.equal(service.policies?.storageOnly, true);
 		});
 
-		it("serves the recoverable snapshot without consulting the persistent cache", async () => {
+		it("serves the recoverable snapshot without consulting snapshot caches", async () => {
 			const { service, recoverable } = makeService(100, streamFromBatches([]));
 			const storage = await service.connectToStorage();
 			const snapshot = await storage.getSnapshot?.({ scenarioName: "point-in-time-test" });
@@ -234,6 +260,13 @@ describe("OdspPointInTimeDocumentService", () => {
 				fetchSource: FetchSource.noCache,
 			});
 			assert.equal(recoverable.connectToStorageCount, 1);
+		});
+
+		it("bypasses caches when the loader uses the getVersions snapshot path", async () => {
+			const { service, recoverable } = makeService(100, streamFromBatches([]));
+			const storage = await service.connectToStorage();
+			await storage.getVersions(null, 1, "point-in-time-test");
+			assert.equal(recoverable.versionsFetchSource, FetchSource.noCache);
 		});
 
 		it("refuses connectToDeltaStream (the service is storage-only)", async () => {

--- a/packages/drivers/odsp-driver/src/test/prefetchSnapshotTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/prefetchSnapshotTests.spec.ts
@@ -224,6 +224,51 @@ describe("Tests for prefetching snapshot", () => {
 			);
 		});
 
+		it("noCache bypasses a prefetched snapshot", async () => {
+			await mockFetchSingle(
+				async () =>
+					prefetchLatestSnapshot(
+						resolved,
+						async (_options) => "token",
+						localCache,
+						true,
+						mockLogger,
+						undefined,
+						false,
+						undefined,
+						undefined,
+						odspDocumentServiceFactory,
+					),
+				async () =>
+					createResponse(
+						{ "x-fluid-epoch": "epoch1", "content-type": "application/json" },
+						odspSnapshot,
+						200,
+					),
+			);
+
+			const networkSnapshot: IOdspSnapshot = {
+				...odspSnapshot,
+				id: "network-id",
+				trees: [{ ...odspSnapshot.trees[0], id: "network-id" }],
+			};
+			const version = await mockFetchSingle(
+				async () => service.getVersions(null, 1, undefined, FetchSource.noCache),
+				async () =>
+					createResponse(
+						{ "x-fluid-epoch": "epoch1", "content-type": "application/json" },
+						networkSnapshot,
+						200,
+					),
+			);
+
+			assert.deepStrictEqual(
+				version,
+				[{ id: "network-id", treeId: undefined! }],
+				"noCache should return the network snapshot rather than the prefetched snapshot",
+			);
+		});
+
 		it("prefetching snapshot should result in snapshot source as network if both cache and prefetch throws", async () => {
 			// overwriting get() to make cache fetch throw
 			localCache.get = async (): Promise<void> => {

--- a/packages/loader/container-loader/src/pointInTime/DEV.md
+++ b/packages/loader/container-loader/src/pointInTime/DEV.md
@@ -45,6 +45,8 @@ The result is a historical view with these invariants:
 3. `PointInTimeDocumentServiceFactory` adapts that capability to the normal `createDocumentService` call used by container loading, preserving the requested target sequence number.
 4. The driver creates a point-in-time document service:
    - storage serves a recoverable snapshot whose sequence number is at or before the target;
+   - the initial snapshot read bypasses the persistent latest-snapshot cache so it cannot replace
+     the selected recoverable snapshot with a newer snapshot;
    - delta storage serves the live document's retained ops, bounded so replay cannot pass the target;
    - the service is storage-only, preventing a live delta-stream connection.
 5. `loadContainerPaused` loads the selected snapshot with automatic op processing disabled and forces the container into read-only mode.

--- a/packages/loader/container-loader/src/pointInTime/DEV.md
+++ b/packages/loader/container-loader/src/pointInTime/DEV.md
@@ -45,8 +45,8 @@ The result is a historical view with these invariants:
 3. `PointInTimeDocumentServiceFactory` adapts that capability to the normal `createDocumentService` call used by container loading, preserving the requested target sequence number.
 4. The driver creates a point-in-time document service:
    - storage serves a recoverable snapshot whose sequence number is at or before the target;
-   - the initial snapshot read bypasses the persistent latest-snapshot cache so it cannot replace
-     the selected recoverable snapshot with a newer snapshot;
+   - the initial snapshot read bypasses persistent and in-memory prefetched snapshot caches so they
+     cannot replace the selected recoverable snapshot with a newer snapshot;
    - delta storage serves the live document's retained ops, bounded so replay cannot pass the target;
    - the service is storage-only, preventing a live delta-stream connection.
 5. `loadContainerPaused` loads the selected snapshot with automatic op processing disabled and forces the container into read-only mode.
@@ -239,7 +239,9 @@ ODSP unit coverage exercises base selection, no-base failures, version URL resol
 Real-service ODSP coverage lives under [`packages/test/test-end-to-end-tests/src/test/pointInTime/`](../../../../test/test-end-to-end-tests/src/test/pointInTime/):
 
 - `loadToSequenceNumber.spec.ts` covers exact version boundaries, replay to a mid-stream target, and distinct historical targets.
-- `loadSuccess.spec.ts` covers the earliest recoverable state, deterministic repeated loads, a frozen read-only result, and deep-history replay.
+- `loadSuccess.spec.ts` covers the earliest recoverable state, deterministic repeated loads, a
+  first historical load with a newer live snapshot already in persistent cache, a frozen read-only
+  result, and deep-history replay.
 - `epochMismatch.spec.ts` and `loadFailure.spec.ts` cover lineage changes, unavailable ops, malformed targets, and cancellation during replay.
 - `odspVersionApi.spec.ts` verifies the real-service version-history test setup.
 - `pointInTimeTestUtils.ts` supplies the shared counter runtime, summarizer, version-snapshot helpers, and point-in-time load wrapper.
@@ -253,7 +255,10 @@ The following loading behaviors are covered by unit or integration tests, inferr
 1. **Boundary targets:** Load sequence number `0` and the current live tip. Existing successful tests use a non-zero recoverable point and advance the document past the target before loading.
 2. **Complex runtime op representations:** Load across grouped, compressed, and chunked batches, including a large payload that genuinely uses the chunk-reassembly path. The current `SharedCounter` scenarios generate small operations. This is separate from delta-fetch page batching below.
 3. **Attachment and blob state:** Create an attachment or blob-backed handle after the base snapshot, load to a target after its attach op, and verify the historical container can read the expected content.
-4. **Cache and load isolation:** Run concurrent loads to different targets, then perform a normal live load with the same factory credentials. Verify each historical view remains pinned to its own target and no historical snapshot leaks through shared or persisted caches.
+4. **Cache and load isolation:** A first historical load with a newer live snapshot already in the
+   same persistent cache is covered. Still run concurrent loads to different targets, then perform a
+   normal live load with the same factory credentials. Verify each historical view remains pinned to
+   its own target and no historical snapshot leaks through shared or persisted caches.
 5. **Cancellation entry and propagation:** Pass an already-aborted signal and verify no storage work begins. During replay, propagate cancellation through the delta-storage fetch rather than only rejecting the loader's wait promise, and verify retries and network reads stop promptly. The existing cancellation test aborts only after replay has begun and observes that storage retries can continue racing teardown.
 6. **Read-only enforcement:** Attempt a DDS mutation and call `connect()` on the returned historical container, then verify no op is submitted, no live connection is established, and the view does not advance. Existing coverage checks the exposed read-only and disconnected state without attempting either action.
 7. **Mid-load lineage change:** Trigger a file restore after base-version discovery but before or during live-op replay and verify the shared `EpochTracker` rejects the mixed lineage. Existing epoch tests restore before the point-in-time load starts.

--- a/packages/test/test-end-to-end-tests/src/test/pointInTime/loadSuccess.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/pointInTime/loadSuccess.spec.ts
@@ -156,9 +156,7 @@ describeCompat(
 			);
 		});
 
-		it("loads the target on the first attempt when the persisted cache contains a newer live snapshot", async function (this: Mocha.Context) {
-			this.timeout(120_000);
-
+		it("loads the target on the first attempt when the persisted cache contains a newer live snapshot", async () => {
 			const ctx = await createPointInTimeTestContext(suite, apis, { withSummarizer: true });
 			const { container, dataObject, incrementAndSync, snapVersion } = ctx;
 

--- a/packages/test/test-end-to-end-tests/src/test/pointInTime/loadSuccess.spec.ts
+++ b/packages/test/test-end-to-end-tests/src/test/pointInTime/loadSuccess.spec.ts
@@ -12,6 +12,7 @@
  *
  * - loading at the earliest recoverable point (the oldest, not just a middle, version),
  * - determinism: loading the same target twice yields identical materialized state,
+ * - first-load correctness when a newer live snapshot is already present in persistent cache,
  * - the returned container's contract: a disconnected, read-only, still-open historical view pinned
  *   exactly at the target sequence number (never advancing to the live tip), and
  * - correctness across a deep history: many versions between the base and the live tip still replay
@@ -28,8 +29,11 @@ import { describeCompat } from "@fluid-private/test-version-utils";
 import type { IContainer } from "@fluidframework/container-definitions/internal";
 import { ConnectionState } from "@fluidframework/container-loader";
 
+import { TestPersistedCache } from "../../testPersistedCache.js";
+
 import {
 	createPointInTimeTestContext,
+	loadLiveContainerWithPersistedCache,
 	loadPointInTimeContainer,
 	setupPointInTimeSuite,
 	type IPointInTimeTestObject,
@@ -149,6 +153,57 @@ describeCompat(
 				second.value,
 				first.value,
 				"loading the same target twice must yield identical state",
+			);
+		});
+
+		it("loads the target on the first attempt when the persisted cache contains a newer live snapshot", async function (this: Mocha.Context) {
+			this.timeout(120_000);
+
+			const ctx = await createPointInTimeTestContext(suite, apis, { withSummarizer: true });
+			const { container, dataObject, incrementAndSync, snapVersion } = ctx;
+
+			await incrementAndSync(2);
+			await snapVersion("base");
+			await incrementAndSync(2);
+			const targetSequenceNumber = container.deltaManager.lastSequenceNumber;
+			const expectedValue = dataObject.value;
+
+			await incrementAndSync(3);
+			await snapVersion("newer-live-snapshot");
+
+			const persistedCache = new TestPersistedCache();
+			const liveContainer = await loadLiveContainerWithPersistedCache(
+				suite.provider(),
+				suite.runtimeFactory(),
+				suite.tracker,
+				ctx.documentId,
+				persistedCache,
+			);
+			assert(
+				liveContainer.deltaManager.initialSequenceNumber > targetSequenceNumber,
+				"the warmed live snapshot must be newer than the historical target",
+			);
+
+			const historicalContainer = await loadPointInTimeContainer(
+				suite.provider(),
+				suite.runtimeFactory(),
+				ctx.documentId,
+				targetSequenceNumber,
+				undefined,
+				undefined,
+				persistedCache,
+			);
+			const historicalObject =
+				(await historicalContainer.getEntryPoint()) as IPointInTimeTestObject;
+			assert.strictEqual(
+				historicalContainer.deltaManager.lastSequenceNumber,
+				targetSequenceNumber,
+				"the first historical load should stop exactly at the target",
+			);
+			assert.strictEqual(
+				historicalObject.value,
+				expectedValue,
+				"the first historical load should ignore the newer cached live state",
 			);
 		});
 

--- a/packages/test/test-end-to-end-tests/src/test/pointInTime/pointInTimeTestUtils.ts
+++ b/packages/test/test-end-to-end-tests/src/test/pointInTime/pointInTimeTestUtils.ts
@@ -29,6 +29,7 @@ import { loadContainerToSequenceNumber } from "@fluidframework/container-loader/
 import type { ISummarizer } from "@fluidframework/container-runtime/internal";
 import type { IFluidHandle, ITelemetryBaseLogger } from "@fluidframework/core-interfaces";
 import type { ISharedCounter } from "@fluidframework/counter/internal";
+import type { IPersistedCache } from "@fluidframework/driver-definitions/internal";
 import {
 	defaultTestOldestSupportedClient,
 	type ITestObjectProvider,
@@ -153,9 +154,13 @@ export async function loadPointInTimeContainer(
 	loadToSequenceNumber: number,
 	signal?: AbortSignal,
 	logger?: ITelemetryBaseLogger,
+	persistedCache?: IPersistedCache,
 ): Promise<IContainer> {
 	assert(provider.driver.type === "odsp", "Point-in-time load requires the odsp driver");
 	const odspDriver = provider.driver as OdspTestDriver;
+	if (persistedCache !== undefined) {
+		odspDriver.setPersistedCache(persistedCache);
+	}
 	const documentServiceFactory = odspDriver.createPointInTimeDocumentServiceFactory();
 	const url = await provider.driver.createContainerUrl(documentId);
 	const codeDetails: IFluidCodeDetails = provider.defaultCodeDetails;
@@ -168,6 +173,32 @@ export async function loadPointInTimeContainer(
 		logger: logger ?? provider.logger,
 		signal,
 	});
+}
+
+/**
+ * Load the live document through a supplied persisted cache so a later point-in-time load can
+ * verify that a newer cached live snapshot is not used as its recoverable historical base.
+ */
+export async function loadLiveContainerWithPersistedCache(
+	provider: ITestObjectProvider,
+	runtimeFactory: IRuntimeFactory,
+	tracker: LoaderContainerTracker,
+	documentId: string,
+	persistedCache: IPersistedCache,
+): Promise<IContainer> {
+	assert(provider.driver.type === "odsp", "Point-in-time load requires the odsp driver");
+	const odspDriver = provider.driver as OdspTestDriver;
+	odspDriver.setPersistedCache(persistedCache);
+	const loader = createLoader(
+		[[provider.defaultCodeDetails, runtimeFactory]],
+		odspDriver.createDocumentServiceFactory(),
+		provider.urlResolver,
+		provider.logger,
+	);
+	const url = await provider.driver.createContainerUrl(documentId);
+	const container = await loader.resolve({ url });
+	tracker.addContainer(container);
+	return container;
 }
 
 /**


### PR DESCRIPTION
## Description

Fixes a transient failure when loading an ODSP document at an exact historical sequence number.

Point-in-time loading first selects the newest sealed ODSP file version whose snapshot sequence number is at or before the requested target. That version-selection logic was working correctly. However, when the selected historical document service connected to storage, snapshot retrieval could still consume a snapshot cached by a normal live-document load.

Two cache paths could return the wrong snapshot:

- The legacy loader path uses `getVersions()` followed by `getSnapshotTree()`. The point-in-time storage proxy previously forced `FetchSource.noCache` only for `getSnapshot()`, so this path could still read from persisted cache.
- Even with `FetchSource.noCache`, ODSP's network-fetch path could consume `snapshotPrefetchResultCache`, which may contain a prefetched snapshot for the newer live document.

If the returned snapshot's sequence number was greater than the requested mark, Fluid could not replay backward and failed with:

> Cannot satisfy request to pause the container at the specified sequence number. Most recent snapshot is newer than the specified sequence number.

The failure appeared transient because the in-memory prefetch entry is consumed during the first attempt. Loading the same mark again could therefore fetch the correct historical snapshot and succeed.

This change ensures point-in-time snapshot retrieval bypasses live snapshot caches throughout the load:

- Forces `FetchSource.noCache` through both `getSnapshot()` and the legacy `getVersions()` path.
- Prevents `FetchSource.noCache` requests from consuming `snapshotPrefetchResultCache`.
- Preserves the existing version-selection behavior: choose the newest sealed ODSP file version whose resolved sequence is at or before the target, then replay operations forward to the exact requested sequence.
- Retains the loader's newer-snapshot error as a final invariant guard rather than normal control flow.
- Documents the point-in-time cache-isolation requirements in the ODSP driver and container loader development documentation.

Regression coverage includes:

- Verifying both point-in-time snapshot APIs forward `FetchSource.noCache`.
- Verifying a no-cache request returns the network snapshot instead of a different prefetched snapshot.
- A real-service ODSP scenario that advances and summarizes a document, adds a shared persisted cache with the newer live snapshot, and verifies that the first historical load materializes the older requested state.

The change was also tested manually in Loop App ([integrate pipeline](https://dev.azure.com/office/OC/_build/results?buildId=55071071&view=logs&j=d6956aff-6d69-59bd-8123-278d693cd42a&t=91276d92-09c9-5d2b-eaf4-534f342fd19c)). Version marks loaded successfully, and the newer-snapshot error was no longer observed.

## Reviewer Guidance

The review process is outlined in [the pull request guidelines](../docs/content/Contributing/PR-Guidelines.md#guidelines).

Please focus on the interaction between `FetchSource.noCache` and `snapshotPrefetchResultCache`, and confirm that bypassing the prefetch cache only for explicit no-cache requests preserves normal live-load prefetch behavior.

The real-service regression test requires ODSP credentials and is intended to exercise the first-load behavior with a warmed newer live snapshot.

Followup: https://dev.azure.com/fluidframework/internal/_workitems/edit/83259
