### PR TITLE
[release/3.0] fix(odsp-driver): remove invalid byteOffset === 0 assumption 

### DIFF
--- a/.changeset/fix-pooled-snapshot-buffers.md
+++ b/.changeset/fix-pooled-snapshot-buffers.md
@@ -1,0 +1,9 @@
+---
+"@fluidframework/odsp-driver": minor
+"__section": fix
+---
+Fix compact snapshot loading with pooled Node.js buffers
+
+Compact snapshots can now be loaded when their binary data is represented by a `Uint8Array` view
+with a non-zero `byteOffset`. This prevents container load failures in Node.js 24.18 and later,
+where the larger buffer pool causes more file reads to return pooled buffer views.

--- a/packages/drivers/odsp-driver/src/test/zipItDataRepresentationTests.spec.ts
+++ b/packages/drivers/odsp-driver/src/test/zipItDataRepresentationTests.spec.ts
@@ -120,6 +120,23 @@ describe("Tree Representation tests", () => {
 		validate(2 + 5);
 	});
 
+	it("loads from a Uint8Array with a non-zero byte offset", () => {
+		builder.addString("first");
+		builder.addBlob(createLongBuffer(3));
+
+		const serialized = builder.serialize();
+		const backingBuffer = new Uint8Array(serialized.length + 2);
+		backingBuffer.set(serialized, 1);
+		const offsetBuffer = backingBuffer.subarray(1, serialized.length + 1);
+		assert.notStrictEqual(offsetBuffer.byteOffset, 0, "Test buffer should have a byte offset");
+
+		const builder2 = TreeBuilder.load(
+			new ReadBuffer(offsetBuffer),
+			logger.toTelemetryLogger(),
+		).builder;
+		compareNodes(builder, builder2);
+	});
+
 	it("small const string", async () => {
 		builder.addDictionaryString("first");
 		validate(8 + 2);

--- a/packages/drivers/odsp-driver/src/zipItDataRepresentationUtils.ts
+++ b/packages/drivers/odsp-driver/src/zipItDataRepresentationUtils.ts
@@ -541,7 +541,6 @@ export class NodeCore {
 
 		length = 0;
 		const input = buffer.buffer;
-		assert(input.byteOffset === 0, 0x3e8 /* code below assumes no offset */);
 
 		for (const el of stringsToResolve) {
 			for (let it = el.startPos; it < el.endPos; it++) {


### PR DESCRIPTION
Backport for the ODSP compact snapshot parser fix to support non-zero-offset buffers exposed by Node 24.18+.
PR for same change into main: #28194 (root cause and validation)
