### PR TITLE
Cleanup test trees

### DIFF
--- a/packages/dds/tree/src/test/simple-tree/api/getSimpleSchema.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/getSimpleSchema.spec.ts
@@ -32,7 +32,7 @@ import { transformSimpleSchema } from "../../../simple-tree/toStoredSchema.js";
 import type { Mutable } from "../../../util/index.js";
 import { ajvValidator } from "../../codec/index.js";
 import { takeJsonSnapshot, useSnapshotDirectory } from "../../snapshots/index.js";
-import { HasUnknownOptionalFields } from "../../testTrees.js";
+import { AllowsUnknownOptionalFields } from "../../testTrees.js";
 
 const simpleString: SimpleLeafNodeSchema<SchemaType.View> = {
 	leafKind: ValueSchema.String,
@@ -660,7 +660,7 @@ describe("getSimpleSchema", () => {
 	});
 
 	describe("With allowUnknownOptionalFields in object schema", () => {
-		const schema = HasUnknownOptionalFields;
+		const schema = AllowsUnknownOptionalFields;
 
 		it("Should preserve allowUnknownOptionalFields when converting to SimpleTreeSchema", () => {
 			const expected: SimpleTreeSchema = {

--- a/packages/dds/tree/src/test/simple-tree/api/schemaFromSimple.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/schemaFromSimple.spec.ts
@@ -19,7 +19,7 @@ import {
 	SchemaUpgrade,
 } from "../../../simple-tree/index.js";
 import { testTreeSchema } from "../../cursorTestSuite.js";
-import { HasUnknownOptionalFields, testSimpleTrees } from "../../testTrees.js";
+import { AllowsUnknownOptionalFields, testSimpleTrees } from "../../testTrees.js";
 
 describe("schemaFromSimple", () => {
 	function roundtrip(root: ImplicitFieldSchema): void {
@@ -84,7 +84,7 @@ describe("schemaFromSimple", () => {
 
 	describe("compatibility fields", () => {
 		it("handles allowUnknownOptionalFields = true", () => {
-			const root = HasUnknownOptionalFields;
+			const root = AllowsUnknownOptionalFields;
 			const simpleSchema = getSimpleSchema(root);
 			const simpleObjectSchema = simpleSchema.definitions.get(
 				"test.hasUnknownOptionalFields",

--- a/packages/dds/tree/src/test/simple-tree/api/schemaFromSimple.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/schemaFromSimple.spec.ts
@@ -64,8 +64,16 @@ describe("schemaFromSimple", () => {
 			roundtrip(SchemaFactory.number);
 		});
 
+		const stagedOptionalTestCases = new Set([
+			"HasStagedOptionalFieldBeforeUpdate",
+			"Staged optional in root",
+			"NestedStagedOptional with no upgrades",
+		]);
+
 		for (const testSchema of testSimpleTrees) {
-			it(testSchema.name, () => {
+			// TODO: AB#82814: Fix simple schema conversion for staged optional fields and enable these cases.
+			const test = stagedOptionalTestCases.has(testSchema.name) ? it.skip : it;
+			test(testSchema.name, () => {
 				roundtrip(testSchema.schema);
 			});
 		}

--- a/packages/dds/tree/src/test/simple-tree/api/snapshotCompatibilityChecker.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/snapshotCompatibilityChecker.spec.ts
@@ -34,7 +34,7 @@ import {
 	numberSchema,
 	allowUnused,
 } from "../../../simple-tree/index.js";
-import { testDocuments } from "../../testTrees.js";
+import { testSchema } from "../../testTrees.js";
 import { testSrcPath } from "../../testSrcPath.cjs";
 import { inMemorySnapshotFileSystem } from "../../utils.js";
 
@@ -64,16 +64,12 @@ describe("snapshotCompatibilityChecker", () => {
 	describe("parse and snapshot preserve test schemas", () => {
 		// TODO:AB#82814: Fix compatibility logic and enable these staged optional cases, which are currently skipped below.
 		const stagedOptionalTestCases = new Set([
-			"HasStagedOptionalFieldBeforeUpdate",
-			"HasStagedOptionalFieldAfterUpdate",
-			"Staged optional in root",
-			"Staged optional empty root",
-			"NestedStagedOptional with no upgrades",
-			"NestedStagedOptional with one upgrade",
-			"NestedStagedOptional with all upgrades",
+			"hasStagedOptionalField",
+			"stagedOptionalRoot",
+			"nestedStagedOptional",
 		]);
 
-		for (const testCase of testDocuments) {
+		for (const testCase of testSchema) {
 			// TODO:AB#82814: Fix compatibility logic and enable the staged optional cases.
 			const test = stagedOptionalTestCases.has(testCase.name) ? it.skip : it;
 			test(testCase.name, () => {

--- a/packages/dds/tree/src/test/simple-tree/api/storedSchema.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/storedSchema.spec.ts
@@ -14,7 +14,7 @@ import {
 } from "../../../simple-tree/api/storedSchema.js";
 import { TreeViewConfigurationAlpha, type SchemaUpgrade } from "../../../simple-tree/index.js";
 import { takeJsonSnapshot, useSnapshotDirectory } from "../../snapshots/index.js";
-import { testDocuments } from "../../testTrees.js";
+import { getStagedSchemaUpgrades, testDocuments } from "../../testTrees.js";
 
 describe("simple-tree storedSchema", () => {
 	describe("test-schema", () => {
@@ -40,7 +40,7 @@ describe("simple-tree storedSchema", () => {
 					FluidClientVersion.v2_0,
 					() => false,
 				);
-				if (test.hasStagedSchema) {
+				if (getStagedSchemaUpgrades(test.schema).size > 0) {
 					assert.notDeepEqual(withoutStaged, persisted);
 					takeJsonSnapshot(withoutStaged, " - without staged");
 				} else {
@@ -51,7 +51,7 @@ describe("simple-tree storedSchema", () => {
 
 			// These tests assert that extractPersistedSchema gives the same result as the stored schema.
 			// This is not always the case if there are staged schema. As the details of such cases are tested elsewhere, its fine to filter them out here.
-			if (!test.hasStagedSchema) {
+			if (getStagedSchemaUpgrades(test.schema).size === 0) {
 				// comparePersistedSchema is a trivial wrapper around functionality that is tested elsewhere,
 				// but might as will give it a simple smoke test for the various test schema.
 				it(`comparePersistedSchema to self ${test.name} - schema v1`, () => {

--- a/packages/dds/tree/src/test/simple-tree/toStoredSchema.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/toStoredSchema.spec.ts
@@ -44,6 +44,7 @@ import {
 } from "../../simple-tree/toStoredSchema.js";
 import { brand } from "../../util/index.js";
 import {
+	getStagedSchemaUpgrades,
 	HasStagedAllowedTypes,
 	HasStagedAllowedTypesAfterUpdate,
 	HasStagedOptionalField,
@@ -141,7 +142,7 @@ describe("toStoredSchema", () => {
 						// The restrictive case, used for initial schemas and upgrades, does not include any staged schema features.
 						// The permissive case, used for unhydrated trees, includes all staged schema features.
 						// They should be equal if and only if there are no staged schema features.
-						if (testCase.hasStagedSchema) {
+						if (getStagedSchemaUpgrades(testCase.schema).size > 0) {
 							assert.notDeepEqual(restrictive, permissive);
 						} else {
 							assert.deepEqual(restrictive, permissive);
@@ -189,7 +190,7 @@ describe("toStoredSchema", () => {
 						const simpleFromRestrictive = exportSimpleSchema(restrictive);
 						const simpleFromPermissive = exportSimpleSchema(permissive);
 
-						if (testCase.hasStagedSchema) {
+						if (getStagedSchemaUpgrades(testCase.schema).size > 0) {
 							assert.notDeepEqual(simpleFromRestrictive, simpleFromPermissive);
 						} else {
 							assert.deepEqual(simpleFromRestrictive, simpleFromPermissive);

--- a/packages/dds/tree/src/test/snapshots/output/chunked-forest-schema-compressed/V1/HasStagedAllowedTypesBeforeUpdate.json
+++ b/packages/dds/tree/src/test/snapshots/output/chunked-forest-schema-compressed/V1/HasStagedAllowedTypesBeforeUpdate.json
@@ -1,0 +1,30 @@
+{
+  "version": 2,
+  "identifiers": [],
+  "shapes": [
+    {
+      "c": {
+        "type": "test.hasStagedAllowedTypes",
+        "value": false,
+        "fields": [
+          [
+            "x",
+            1
+          ]
+        ]
+      }
+    },
+    {
+      "c": {
+        "type": "com.fluidframework.leaf.number",
+        "value": true
+      }
+    }
+  ],
+  "data": [
+    [
+      0,
+      5
+    ]
+  ]
+}

--- a/packages/dds/tree/src/test/snapshots/output/chunked-forest-schema-compressed/V1/HasStagedOptionalFieldBeforeUpdate.json
+++ b/packages/dds/tree/src/test/snapshots/output/chunked-forest-schema-compressed/V1/HasStagedOptionalFieldBeforeUpdate.json
@@ -1,0 +1,30 @@
+{
+  "version": 2,
+  "identifiers": [],
+  "shapes": [
+    {
+      "c": {
+        "type": "test.hasStagedOptionalField",
+        "value": false,
+        "fields": [
+          [
+            "x",
+            1
+          ]
+        ]
+      }
+    },
+    {
+      "c": {
+        "type": "com.fluidframework.leaf.number",
+        "value": true
+      }
+    }
+  ],
+  "data": [
+    [
+      0,
+      5
+    ]
+  ]
+}

--- a/packages/dds/tree/src/test/snapshots/output/chunked-forest-schema-compressed/V1/NestedMultiStage with no upgrades.json
+++ b/packages/dds/tree/src/test/snapshots/output/chunked-forest-schema-compressed/V1/NestedMultiStage with no upgrades.json
@@ -1,0 +1,46 @@
+{
+  "version": 2,
+  "identifiers": [],
+  "shapes": [
+    {
+      "c": {
+        "type": "com.fluidframework.leaf.null",
+        "value": [
+          null
+        ]
+      }
+    },
+    {
+      "c": {
+        "type": "test.NestedMultiStage",
+        "value": false,
+        "fields": [
+          [
+            "a",
+            2
+          ],
+          [
+            "b",
+            0
+          ],
+          [
+            "c",
+            0
+          ]
+        ]
+      }
+    },
+    {
+      "a": 3
+    },
+    {
+      "d": 0
+    }
+  ],
+  "data": [
+    [
+      1,
+      0
+    ]
+  ]
+}

--- a/packages/dds/tree/src/test/snapshots/output/chunked-forest-schema-compressed/V1/NestedStagedOptional with no upgrades.json
+++ b/packages/dds/tree/src/test/snapshots/output/chunked-forest-schema-compressed/V1/NestedStagedOptional with no upgrades.json
@@ -1,0 +1,41 @@
+{
+  "version": 2,
+  "identifiers": [],
+  "shapes": [
+    {
+      "c": {
+        "type": "test.NestedStagedOptional",
+        "value": false,
+        "fields": [
+          [
+            "a",
+            1
+          ],
+          [
+            "b",
+            2
+          ]
+        ]
+      }
+    },
+    {
+      "c": {
+        "type": "com.fluidframework.leaf.number",
+        "value": true
+      }
+    },
+    {
+      "c": {
+        "type": "com.fluidframework.leaf.string",
+        "value": true
+      }
+    }
+  ],
+  "data": [
+    [
+      0,
+      5,
+      "text"
+    ]
+  ]
+}

--- a/packages/dds/tree/src/test/snapshots/output/chunked-forest-schema-compressed/V1/Staged in root.json
+++ b/packages/dds/tree/src/test/snapshots/output/chunked-forest-schema-compressed/V1/Staged in root.json
@@ -1,0 +1,18 @@
+{
+  "version": 2,
+  "identifiers": [],
+  "shapes": [
+    {
+      "c": {
+        "type": "com.fluidframework.leaf.number",
+        "value": true
+      }
+    }
+  ],
+  "data": [
+    [
+      0,
+      5
+    ]
+  ]
+}

--- a/packages/dds/tree/src/test/snapshots/output/chunked-forest-schema-compressed/V1/Staged optional in root.json
+++ b/packages/dds/tree/src/test/snapshots/output/chunked-forest-schema-compressed/V1/Staged optional in root.json
@@ -1,0 +1,18 @@
+{
+  "version": 2,
+  "identifiers": [],
+  "shapes": [
+    {
+      "c": {
+        "type": "com.fluidframework.leaf.number",
+        "value": true
+      }
+    }
+  ],
+  "data": [
+    [
+      0,
+      5
+    ]
+  ]
+}

--- a/packages/dds/tree/src/test/snapshots/output/chunked-forest-schema-compressed/V1/allowsUnknownOptionalFields.json
+++ b/packages/dds/tree/src/test/snapshots/output/chunked-forest-schema-compressed/V1/allowsUnknownOptionalFields.json
@@ -1,0 +1,17 @@
+{
+  "version": 2,
+  "identifiers": [],
+  "shapes": [
+    {
+      "c": {
+        "type": "test.hasUnknownOptionalFields",
+        "value": false
+      }
+    }
+  ],
+  "data": [
+    [
+      0
+    ]
+  ]
+}

--- a/packages/dds/tree/src/test/snapshots/output/chunked-forest-schema-compressed/V1/mapWithStaged.json
+++ b/packages/dds/tree/src/test/snapshots/output/chunked-forest-schema-compressed/V1/mapWithStaged.json
@@ -1,0 +1,28 @@
+{
+  "version": 2,
+  "identifiers": [],
+  "shapes": [
+    {
+      "c": {
+        "type": "test.MapWithStaged",
+        "value": false,
+        "extraFields": 1
+      }
+    },
+    {
+      "a": 2
+    },
+    {
+      "c": {
+        "type": "com.fluidframework.leaf.number",
+        "value": true
+      }
+    }
+  ],
+  "data": [
+    [
+      0,
+      []
+    ]
+  ]
+}

--- a/packages/dds/tree/src/test/snapshots/output/chunked-forest-schema-compressed/V2/HasStagedAllowedTypesBeforeUpdate.json
+++ b/packages/dds/tree/src/test/snapshots/output/chunked-forest-schema-compressed/V2/HasStagedAllowedTypesBeforeUpdate.json
@@ -1,0 +1,30 @@
+{
+  "version": 2,
+  "identifiers": [],
+  "shapes": [
+    {
+      "c": {
+        "type": "test.hasStagedAllowedTypes",
+        "value": false,
+        "fields": [
+          [
+            "x",
+            1
+          ]
+        ]
+      }
+    },
+    {
+      "c": {
+        "type": "com.fluidframework.leaf.number",
+        "value": true
+      }
+    }
+  ],
+  "data": [
+    [
+      0,
+      5
+    ]
+  ]
+}

--- a/packages/dds/tree/src/test/snapshots/output/chunked-forest-schema-compressed/V2/HasStagedOptionalFieldBeforeUpdate.json
+++ b/packages/dds/tree/src/test/snapshots/output/chunked-forest-schema-compressed/V2/HasStagedOptionalFieldBeforeUpdate.json
@@ -1,0 +1,30 @@
+{
+  "version": 2,
+  "identifiers": [],
+  "shapes": [
+    {
+      "c": {
+        "type": "test.hasStagedOptionalField",
+        "value": false,
+        "fields": [
+          [
+            "x",
+            1
+          ]
+        ]
+      }
+    },
+    {
+      "c": {
+        "type": "com.fluidframework.leaf.number",
+        "value": true
+      }
+    }
+  ],
+  "data": [
+    [
+      0,
+      5
+    ]
+  ]
+}

--- a/packages/dds/tree/src/test/snapshots/output/chunked-forest-schema-compressed/V2/NestedMultiStage with no upgrades.json
+++ b/packages/dds/tree/src/test/snapshots/output/chunked-forest-schema-compressed/V2/NestedMultiStage with no upgrades.json
@@ -1,0 +1,46 @@
+{
+  "version": 2,
+  "identifiers": [],
+  "shapes": [
+    {
+      "c": {
+        "type": "com.fluidframework.leaf.null",
+        "value": [
+          null
+        ]
+      }
+    },
+    {
+      "c": {
+        "type": "test.NestedMultiStage",
+        "value": false,
+        "fields": [
+          [
+            "a",
+            2
+          ],
+          [
+            "b",
+            0
+          ],
+          [
+            "c",
+            0
+          ]
+        ]
+      }
+    },
+    {
+      "a": 3
+    },
+    {
+      "d": 0
+    }
+  ],
+  "data": [
+    [
+      1,
+      0
+    ]
+  ]
+}

--- a/packages/dds/tree/src/test/snapshots/output/chunked-forest-schema-compressed/V2/NestedStagedOptional with no upgrades.json
+++ b/packages/dds/tree/src/test/snapshots/output/chunked-forest-schema-compressed/V2/NestedStagedOptional with no upgrades.json
@@ -1,0 +1,41 @@
+{
+  "version": 2,
+  "identifiers": [],
+  "shapes": [
+    {
+      "c": {
+        "type": "test.NestedStagedOptional",
+        "value": false,
+        "fields": [
+          [
+            "a",
+            1
+          ],
+          [
+            "b",
+            2
+          ]
+        ]
+      }
+    },
+    {
+      "c": {
+        "type": "com.fluidframework.leaf.number",
+        "value": true
+      }
+    },
+    {
+      "c": {
+        "type": "com.fluidframework.leaf.string",
+        "value": true
+      }
+    }
+  ],
+  "data": [
+    [
+      0,
+      5,
+      "text"
+    ]
+  ]
+}

--- a/packages/dds/tree/src/test/snapshots/output/chunked-forest-schema-compressed/V2/Staged in root.json
+++ b/packages/dds/tree/src/test/snapshots/output/chunked-forest-schema-compressed/V2/Staged in root.json
@@ -1,0 +1,18 @@
+{
+  "version": 2,
+  "identifiers": [],
+  "shapes": [
+    {
+      "c": {
+        "type": "com.fluidframework.leaf.number",
+        "value": true
+      }
+    }
+  ],
+  "data": [
+    [
+      0,
+      5
+    ]
+  ]
+}

--- a/packages/dds/tree/src/test/snapshots/output/chunked-forest-schema-compressed/V2/Staged optional in root.json
+++ b/packages/dds/tree/src/test/snapshots/output/chunked-forest-schema-compressed/V2/Staged optional in root.json
@@ -1,0 +1,18 @@
+{
+  "version": 2,
+  "identifiers": [],
+  "shapes": [
+    {
+      "c": {
+        "type": "com.fluidframework.leaf.number",
+        "value": true
+      }
+    }
+  ],
+  "data": [
+    [
+      0,
+      5
+    ]
+  ]
+}

--- a/packages/dds/tree/src/test/snapshots/output/chunked-forest-schema-compressed/V2/allowsUnknownOptionalFields.json
+++ b/packages/dds/tree/src/test/snapshots/output/chunked-forest-schema-compressed/V2/allowsUnknownOptionalFields.json
@@ -1,0 +1,17 @@
+{
+  "version": 2,
+  "identifiers": [],
+  "shapes": [
+    {
+      "c": {
+        "type": "test.hasUnknownOptionalFields",
+        "value": false
+      }
+    }
+  ],
+  "data": [
+    [
+      0
+    ]
+  ]
+}

--- a/packages/dds/tree/src/test/snapshots/output/chunked-forest-schema-compressed/V2/mapWithStaged.json
+++ b/packages/dds/tree/src/test/snapshots/output/chunked-forest-schema-compressed/V2/mapWithStaged.json
@@ -1,0 +1,28 @@
+{
+  "version": 2,
+  "identifiers": [],
+  "shapes": [
+    {
+      "c": {
+        "type": "test.MapWithStaged",
+        "value": false,
+        "extraFields": 1
+      }
+    },
+    {
+      "a": 2
+    },
+    {
+      "c": {
+        "type": "com.fluidframework.leaf.number",
+        "value": true
+      }
+    }
+  ],
+  "data": [
+    [
+      0,
+      []
+    ]
+  ]
+}

--- a/packages/dds/tree/src/test/snapshots/output/schema-files/HasStagedAllowedTypesBeforeUpdate - schema v1.json
+++ b/packages/dds/tree/src/test/snapshots/output/schema-files/HasStagedAllowedTypesBeforeUpdate - schema v1.json
@@ -1,0 +1,24 @@
+{
+  "version": 1,
+  "nodes": {
+    "com.fluidframework.leaf.number": {
+      "leaf": 0
+    },
+    "test.hasStagedAllowedTypes": {
+      "object": {
+        "x": {
+          "kind": "Value",
+          "types": [
+            "com.fluidframework.leaf.number"
+          ]
+        }
+      }
+    }
+  },
+  "root": {
+    "kind": "Value",
+    "types": [
+      "test.hasStagedAllowedTypes"
+    ]
+  }
+}

--- a/packages/dds/tree/src/test/snapshots/output/schema-files/HasStagedAllowedTypesBeforeUpdate - schema v2.json
+++ b/packages/dds/tree/src/test/snapshots/output/schema-files/HasStagedAllowedTypesBeforeUpdate - schema v2.json
@@ -1,0 +1,28 @@
+{
+  "version": 2,
+  "nodes": {
+    "com.fluidframework.leaf.number": {
+      "kind": {
+        "leaf": 0
+      }
+    },
+    "test.hasStagedAllowedTypes": {
+      "kind": {
+        "object": {
+          "x": {
+            "kind": "Value",
+            "types": [
+              "com.fluidframework.leaf.number"
+            ]
+          }
+        }
+      }
+    }
+  },
+  "root": {
+    "kind": "Value",
+    "types": [
+      "test.hasStagedAllowedTypes"
+    ]
+  }
+}

--- a/packages/dds/tree/src/test/snapshots/output/schema-files/HasStagedOptionalFieldBeforeUpdate - schema v1.json
+++ b/packages/dds/tree/src/test/snapshots/output/schema-files/HasStagedOptionalFieldBeforeUpdate - schema v1.json
@@ -1,0 +1,24 @@
+{
+  "version": 1,
+  "nodes": {
+    "com.fluidframework.leaf.number": {
+      "leaf": 0
+    },
+    "test.hasStagedOptionalField": {
+      "object": {
+        "x": {
+          "kind": "Value",
+          "types": [
+            "com.fluidframework.leaf.number"
+          ]
+        }
+      }
+    }
+  },
+  "root": {
+    "kind": "Value",
+    "types": [
+      "test.hasStagedOptionalField"
+    ]
+  }
+}

--- a/packages/dds/tree/src/test/snapshots/output/schema-files/HasStagedOptionalFieldBeforeUpdate - schema v2.json
+++ b/packages/dds/tree/src/test/snapshots/output/schema-files/HasStagedOptionalFieldBeforeUpdate - schema v2.json
@@ -1,0 +1,28 @@
+{
+  "version": 2,
+  "nodes": {
+    "com.fluidframework.leaf.number": {
+      "kind": {
+        "leaf": 0
+      }
+    },
+    "test.hasStagedOptionalField": {
+      "kind": {
+        "object": {
+          "x": {
+            "kind": "Value",
+            "types": [
+              "com.fluidframework.leaf.number"
+            ]
+          }
+        }
+      }
+    }
+  },
+  "root": {
+    "kind": "Value",
+    "types": [
+      "test.hasStagedOptionalField"
+    ]
+  }
+}

--- a/packages/dds/tree/src/test/snapshots/output/schema-files/NestedMultiStage with no upgrades - schema v1.json
+++ b/packages/dds/tree/src/test/snapshots/output/schema-files/NestedMultiStage with no upgrades - schema v1.json
@@ -1,0 +1,34 @@
+{
+  "version": 1,
+  "nodes": {
+    "com.fluidframework.leaf.null": {
+      "leaf": 4
+    },
+    "test.NestedMultiStage": {
+      "object": {
+        "a": {
+          "kind": "Optional",
+          "types": []
+        },
+        "b": {
+          "kind": "Value",
+          "types": [
+            "com.fluidframework.leaf.null"
+          ]
+        },
+        "c": {
+          "kind": "Value",
+          "types": [
+            "com.fluidframework.leaf.null"
+          ]
+        }
+      }
+    }
+  },
+  "root": {
+    "kind": "Value",
+    "types": [
+      "test.NestedMultiStage"
+    ]
+  }
+}

--- a/packages/dds/tree/src/test/snapshots/output/schema-files/NestedMultiStage with no upgrades - schema v2.json
+++ b/packages/dds/tree/src/test/snapshots/output/schema-files/NestedMultiStage with no upgrades - schema v2.json
@@ -1,0 +1,38 @@
+{
+  "version": 2,
+  "nodes": {
+    "com.fluidframework.leaf.null": {
+      "kind": {
+        "leaf": 4
+      }
+    },
+    "test.NestedMultiStage": {
+      "kind": {
+        "object": {
+          "a": {
+            "kind": "Optional",
+            "types": []
+          },
+          "b": {
+            "kind": "Value",
+            "types": [
+              "com.fluidframework.leaf.null"
+            ]
+          },
+          "c": {
+            "kind": "Value",
+            "types": [
+              "com.fluidframework.leaf.null"
+            ]
+          }
+        }
+      }
+    }
+  },
+  "root": {
+    "kind": "Value",
+    "types": [
+      "test.NestedMultiStage"
+    ]
+  }
+}

--- a/packages/dds/tree/src/test/snapshots/output/schema-files/NestedStagedOptional with no upgrades - schema v1.json
+++ b/packages/dds/tree/src/test/snapshots/output/schema-files/NestedStagedOptional with no upgrades - schema v1.json
@@ -1,0 +1,33 @@
+{
+  "version": 1,
+  "nodes": {
+    "com.fluidframework.leaf.number": {
+      "leaf": 0
+    },
+    "com.fluidframework.leaf.string": {
+      "leaf": 1
+    },
+    "test.NestedStagedOptional": {
+      "object": {
+        "a": {
+          "kind": "Value",
+          "types": [
+            "com.fluidframework.leaf.number"
+          ]
+        },
+        "b": {
+          "kind": "Value",
+          "types": [
+            "com.fluidframework.leaf.string"
+          ]
+        }
+      }
+    }
+  },
+  "root": {
+    "kind": "Value",
+    "types": [
+      "test.NestedStagedOptional"
+    ]
+  }
+}

--- a/packages/dds/tree/src/test/snapshots/output/schema-files/NestedStagedOptional with no upgrades - schema v2.json
+++ b/packages/dds/tree/src/test/snapshots/output/schema-files/NestedStagedOptional with no upgrades - schema v2.json
@@ -1,0 +1,39 @@
+{
+  "version": 2,
+  "nodes": {
+    "com.fluidframework.leaf.number": {
+      "kind": {
+        "leaf": 0
+      }
+    },
+    "com.fluidframework.leaf.string": {
+      "kind": {
+        "leaf": 1
+      }
+    },
+    "test.NestedStagedOptional": {
+      "kind": {
+        "object": {
+          "a": {
+            "kind": "Value",
+            "types": [
+              "com.fluidframework.leaf.number"
+            ]
+          },
+          "b": {
+            "kind": "Value",
+            "types": [
+              "com.fluidframework.leaf.string"
+            ]
+          }
+        }
+      }
+    }
+  },
+  "root": {
+    "kind": "Value",
+    "types": [
+      "test.NestedStagedOptional"
+    ]
+  }
+}

--- a/packages/dds/tree/src/test/snapshots/output/schema-files/Staged in root - schema v1.json
+++ b/packages/dds/tree/src/test/snapshots/output/schema-files/Staged in root - schema v1.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "nodes": {
+    "com.fluidframework.leaf.number": {
+      "leaf": 0
+    }
+  },
+  "root": {
+    "kind": "Value",
+    "types": [
+      "com.fluidframework.leaf.number"
+    ]
+  }
+}

--- a/packages/dds/tree/src/test/snapshots/output/schema-files/Staged in root - schema v2.json
+++ b/packages/dds/tree/src/test/snapshots/output/schema-files/Staged in root - schema v2.json
@@ -1,0 +1,16 @@
+{
+  "version": 2,
+  "nodes": {
+    "com.fluidframework.leaf.number": {
+      "kind": {
+        "leaf": 0
+      }
+    }
+  },
+  "root": {
+    "kind": "Value",
+    "types": [
+      "com.fluidframework.leaf.number"
+    ]
+  }
+}

--- a/packages/dds/tree/src/test/snapshots/output/schema-files/Staged optional in root - schema v1.json
+++ b/packages/dds/tree/src/test/snapshots/output/schema-files/Staged optional in root - schema v1.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "nodes": {
+    "com.fluidframework.leaf.number": {
+      "leaf": 0
+    }
+  },
+  "root": {
+    "kind": "Value",
+    "types": [
+      "com.fluidframework.leaf.number"
+    ]
+  }
+}

--- a/packages/dds/tree/src/test/snapshots/output/schema-files/Staged optional in root - schema v2.json
+++ b/packages/dds/tree/src/test/snapshots/output/schema-files/Staged optional in root - schema v2.json
@@ -1,0 +1,16 @@
+{
+  "version": 2,
+  "nodes": {
+    "com.fluidframework.leaf.number": {
+      "kind": {
+        "leaf": 0
+      }
+    }
+  },
+  "root": {
+    "kind": "Value",
+    "types": [
+      "com.fluidframework.leaf.number"
+    ]
+  }
+}

--- a/packages/dds/tree/src/test/snapshots/output/schema-files/allowsUnknownOptionalFields - schema v1.json
+++ b/packages/dds/tree/src/test/snapshots/output/schema-files/allowsUnknownOptionalFields - schema v1.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "nodes": {
+    "test.hasUnknownOptionalFields": {
+      "object": {}
+    }
+  },
+  "root": {
+    "kind": "Value",
+    "types": [
+      "test.hasUnknownOptionalFields"
+    ]
+  }
+}

--- a/packages/dds/tree/src/test/snapshots/output/schema-files/allowsUnknownOptionalFields - schema v2.json
+++ b/packages/dds/tree/src/test/snapshots/output/schema-files/allowsUnknownOptionalFields - schema v2.json
@@ -1,0 +1,16 @@
+{
+  "version": 2,
+  "nodes": {
+    "test.hasUnknownOptionalFields": {
+      "kind": {
+        "object": {}
+      }
+    }
+  },
+  "root": {
+    "kind": "Value",
+    "types": [
+      "test.hasUnknownOptionalFields"
+    ]
+  }
+}

--- a/packages/dds/tree/src/test/snapshots/output/schema-files/mapWithStaged - schema v1.json
+++ b/packages/dds/tree/src/test/snapshots/output/schema-files/mapWithStaged - schema v1.json
@@ -1,0 +1,22 @@
+{
+  "version": 1,
+  "nodes": {
+    "com.fluidframework.leaf.number": {
+      "leaf": 0
+    },
+    "test.MapWithStaged": {
+      "map": {
+        "kind": "Optional",
+        "types": [
+          "com.fluidframework.leaf.number"
+        ]
+      }
+    }
+  },
+  "root": {
+    "kind": "Value",
+    "types": [
+      "test.MapWithStaged"
+    ]
+  }
+}

--- a/packages/dds/tree/src/test/snapshots/output/schema-files/mapWithStaged - schema v2.json
+++ b/packages/dds/tree/src/test/snapshots/output/schema-files/mapWithStaged - schema v2.json
@@ -1,0 +1,26 @@
+{
+  "version": 2,
+  "nodes": {
+    "com.fluidframework.leaf.number": {
+      "kind": {
+        "leaf": 0
+      }
+    },
+    "test.MapWithStaged": {
+      "kind": {
+        "map": {
+          "kind": "Optional",
+          "types": [
+            "com.fluidframework.leaf.number"
+          ]
+        }
+      }
+    }
+  },
+  "root": {
+    "kind": "Value",
+    "types": [
+      "test.MapWithStaged"
+    ]
+  }
+}

--- a/packages/dds/tree/src/test/snapshots/output/simple-tree-storedSchema/allowsUnknownOptionalFields - schema v1.json
+++ b/packages/dds/tree/src/test/snapshots/output/simple-tree-storedSchema/allowsUnknownOptionalFields - schema v1.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "nodes": {
+    "test.hasUnknownOptionalFields": {
+      "object": {}
+    }
+  },
+  "root": {
+    "kind": "Value",
+    "types": [
+      "test.hasUnknownOptionalFields"
+    ]
+  }
+}

--- a/packages/dds/tree/src/test/snapshots/output/simple-tree-storedSchema/mapWithStaged - schema v1 - without staged.json
+++ b/packages/dds/tree/src/test/snapshots/output/simple-tree-storedSchema/mapWithStaged - schema v1 - without staged.json
@@ -1,0 +1,22 @@
+{
+  "version": 1,
+  "nodes": {
+    "com.fluidframework.leaf.number": {
+      "leaf": 0
+    },
+    "test.MapWithStaged": {
+      "map": {
+        "kind": "Optional",
+        "types": [
+          "com.fluidframework.leaf.number"
+        ]
+      }
+    }
+  },
+  "root": {
+    "kind": "Value",
+    "types": [
+      "test.MapWithStaged"
+    ]
+  }
+}

--- a/packages/dds/tree/src/test/snapshots/output/simple-tree-storedSchema/mapWithStaged - schema v1.json
+++ b/packages/dds/tree/src/test/snapshots/output/simple-tree-storedSchema/mapWithStaged - schema v1.json
@@ -1,0 +1,26 @@
+{
+  "version": 1,
+  "nodes": {
+    "com.fluidframework.leaf.number": {
+      "leaf": 0
+    },
+    "com.fluidframework.leaf.string": {
+      "leaf": 1
+    },
+    "test.MapWithStaged": {
+      "map": {
+        "kind": "Optional",
+        "types": [
+          "com.fluidframework.leaf.number",
+          "com.fluidframework.leaf.string"
+        ]
+      }
+    }
+  },
+  "root": {
+    "kind": "Value",
+    "types": [
+      "test.MapWithStaged"
+    ]
+  }
+}

--- a/packages/dds/tree/src/test/testTrees.spec.ts
+++ b/packages/dds/tree/src/test/testTrees.spec.ts
@@ -1,0 +1,75 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "node:assert";
+import { isDeepStrictEqual } from "node:util";
+
+import {
+	StagedSchemaUpgradePolicy,
+	toStoredSchema,
+	type SchemaUpgrade,
+} from "../simple-tree/index.js";
+
+import { getStagedSchemaUpgrades, testSchema, testSimpleTrees } from "./testTrees.js";
+import { compareSets } from "../util/index.js";
+
+describe("test tree catalogs", () => {
+	it("includes the schema for every simple tree", () => {
+		const schemas = new Set(testSchema.map((testCase) => testCase.schema));
+		// Check for duplicate schemas in the testSchema array.
+		assert.equal(schemas.size, testSchema.length);
+
+		for (const tree of testSimpleTrees) {
+			assert(schemas.has(tree.schema), `Missing testSchema entry for tree '${tree.name}'`);
+		}
+	});
+
+	// Currently we expect every schema to have at least one test tree.
+	// If we ever add schema which can't have any valid trees
+	// (like a recursive required field, or required field with no allowed types), this test will need to be updated to exclude those cases.
+	it("includes at least one simple tree for every schema", () => {
+		const treeSchemas = new Set(testSimpleTrees.map((tree) => tree.schema));
+
+		for (const testCase of testSchema) {
+			assert(
+				treeSchemas.has(testCase.schema),
+				`Missing testSimpleTrees entry for schema '${testCase.name}'`,
+			);
+		}
+	});
+
+	describe("getStagedSchemaUpgrades on test schema", () => {
+		for (const testCase of testSchema) {
+			it(testCase.name, () => {
+				// Validate getStagedSchemaUpgrades against toStoredSchema.
+				const upgrades = getStagedSchemaUpgrades(testCase.schema);
+				const upgradesFromToStoredSchema = new Set<SchemaUpgrade>();
+				toStoredSchema(testCase.schema, {
+					includeStaged(upgrade) {
+						upgradesFromToStoredSchema.add(upgrade);
+						return true;
+					},
+					includeStagedOptional(upgrade) {
+						upgradesFromToStoredSchema.add(upgrade);
+						return true;
+					},
+				});
+				assert(compareSets({ a: upgrades, b: upgradesFromToStoredSchema }));
+
+				// Sanity check: Convert the schema to stored schema using different staged schema policies and compare the results.
+				const restrictive = toStoredSchema(
+					testCase.schema,
+					StagedSchemaUpgradePolicy.restrictive,
+				);
+				const permissive = toStoredSchema(
+					testCase.schema,
+					StagedSchemaUpgradePolicy.permissive,
+				);
+				const convertedHasStagedSchema = !isDeepStrictEqual(restrictive, permissive);
+				assert.equal(upgrades.size > 0, convertedHasStagedSchema);
+			});
+		}
+	});
+});

--- a/packages/dds/tree/src/test/testTrees.ts
+++ b/packages/dds/tree/src/test/testTrees.ts
@@ -73,21 +73,23 @@ import { fieldCursorFromInsertable, testIdCompressor } from "./utils.js";
 
 interface NamedCase {
 	/**
-	 * A descriptive name to descrive what is special about this configuration, used in test names.
+	 * A descriptive name for what is special about this configuration, used in test names.
 	 */
 	readonly name: string;
 }
 
 /**
- * A schema paired with an in-schema tree for it, which is expressable using our user facing (aka "simple-tree") APi surface.
+ * A schema paired with an in-schema tree that can be expressed using the user-facing (aka "simple-tree") API surface.
  */
 interface TestSimpleTreeSchema extends NamedCase {
+	/** The view schema for the test case. */
 	readonly schema: ImplicitFieldSchema;
+	/** Whether the schema permits ambiguous content. */
 	readonly ambiguous: boolean;
 }
 
 /**
- * A schema paired with an in-schema tree for it, which is expressable using our user facing (aka "simple-tree") APi surface.
+ * A schema paired with an in-schema tree that can be expressed using the user-facing (aka "simple-tree") API surface.
  */
 interface TestSimpleTree extends TestSimpleTreeSchema {
 	/**
@@ -99,9 +101,10 @@ interface TestSimpleTree extends TestSimpleTreeSchema {
 /**
  * A more flexible generalization of {@link TestSimpleTree}, which operates at a lower abstraction level (matching flex-tree).
  *
- * This can customize field kinds used in the tree, and use any expressable/persistable stored schema and tree content, regardless of if it can current be producied using the user facing APIs.
- * This is valuable for testing implementations on cases which cannot be easily represented using the user facing APIs,
- * as well as simple more directly testing specific aspects of the lower level implementation (glass box testing).
+ * This can customize field kinds used in the tree and use any expressible, persistable stored schema and tree content,
+ * regardless of whether it can currently be produced using the user-facing APIs.
+ * This is valuable for testing cases that cannot be easily represented using the user-facing APIs,
+ * as well as for directly testing specific aspects of the lower-level implementation (glass-box testing).
  */
 interface TestTree extends NamedCase {
 	readonly schemaData: TreeStoredSchema;
@@ -112,10 +115,10 @@ interface TestTree extends NamedCase {
 /**
  * Content for a test document, which can have a different stored schema than just toStoredSchema(schema).
  *
- * This gets its "root" from {@link TestTree.treeFactory} not {@link TestSimpleTree.root}
- * so its possible to express documents which which have contewnt unknown to the ViewSchema (for now just unknown optional fields).
+ * This gets its "root" from {@link TestTree.treeFactory}, not {@link TestSimpleTree.root},
+ * so it is possible to express documents that have content unknown to the view schema (for now, just unknown optional fields).
  *
- * This addational flexiability ovver {@link TestSimpleTree} is require for testing forwards compat scenerions.
+ * This additional flexibility over {@link TestSimpleTree} is required for testing forward-compatibility scenarios.
  */
 export interface TestDocument extends TestTree, Omit<TestSimpleTree, "root"> {
 	/**
@@ -165,18 +168,10 @@ export function visitFieldSchema(
 	schema: ImplicitFieldSchema,
 	callback: (field: FieldSchemaAlpha) => void,
 ): void {
-	const stagedSchemaUpgrades = new Set<SchemaUpgrade>();
 	const root = normalizeFieldSchema(schema);
 	callback(root);
 
 	walkFieldSchema(root, {
-		allowedTypes: ({ types }) => {
-			for (const type of types) {
-				if (type.metadata.stagedSchemaUpgrade) {
-					stagedSchemaUpgrades.add(type.metadata.stagedSchemaUpgrade);
-				}
-			}
-		},
 		node: (nodeSchema) => {
 			if (nodeSchema instanceof ObjectNodeSchema) {
 				for (const field of nodeSchema.fields.values()) {
@@ -232,6 +227,7 @@ export class HasRenamedField extends factory.object("hasRenamedField", {
 	field: factory.required(Minimal, { key: "stored-name" }),
 }) {}
 
+/** Exercises persisted descriptions on an object and one of its fields. */
 export class HasDescriptions extends factory.object(
 	"hasDescriptions",
 	{
@@ -240,6 +236,7 @@ export class HasDescriptions extends factory.object(
 	{ metadata: { description: "root object" } },
 ) {}
 
+/** Exercises all supported persisted metadata and unknown optional fields together. */
 export class HasAllMetadata extends factory.object(
 	"hasDescriptions",
 	{
@@ -259,9 +256,11 @@ const hasAllMetadataRootSchema = SchemaFactoryAlpha.optional(HasAllMetadata, {
 	metadata: { description: "root field", custom: "root field custom" },
 });
 
+/** Exercises ambiguity between two structurally identical object types. */
 export class HasAmbiguousField extends factory.object("hasAmbiguousField", {
 	field: [Minimal, Minimal2],
 }) {}
+
 export class HasNumericValueField extends factory.object("hasNumericValueField", {
 	field: factory.number,
 }) {}
@@ -333,6 +332,29 @@ class MapWithStaged extends factory.mapAlpha(
 		SchemaFactoryAlpha.number,
 		SchemaFactoryAlpha.staged(SchemaFactoryAlpha.string),
 	]),
+) {}
+
+/** Allows unknown optional fields so older views can tolerate fields added by newer views. */
+export class AllowsUnknownOptionalFields extends factory.objectAlpha(
+	"hasUnknownOptionalFields",
+	{},
+	{
+		allowUnknownOptionalFields: true,
+	},
+) {}
+
+/** Adds representative fields that can be unknown to {@link AllowsUnknownOptionalFields}. */
+export class AllowsUnknownOptionalFieldsV2 extends factory.objectRecursive(
+	"hasUnknownOptionalFields",
+	{
+		recursive: factory.optionalRecursive([() => AllowsUnknownOptionalFieldsV2]),
+		minimal: factory.optional(Minimal),
+		hasMinimalValueField: factory.optional(HasMinimalValueField),
+		leaf: factory.optional(SchemaFactoryAlpha.string),
+	},
+	{
+		allowUnknownOptionalFields: true,
+	},
 ) {}
 
 class ArrayWithStaged extends factory.arrayAlpha(
@@ -411,7 +433,13 @@ export const testSchema: readonly TestSimpleTreeSchema[] = [
 	{ name: "numericMap", schema: NumericMap, ambiguous: false },
 	{ name: "numericRecord", schema: NumericRecord, ambiguous: false },
 	{ name: "recursiveType", schema: RecursiveType, ambiguous: false },
+	{
+		name: "allowsUnknownOptionalFields",
+		schema: AllowsUnknownOptionalFields,
+		ambiguous: false,
+	},
 	{ name: "hasStagedAllowedTypes", schema: HasStagedAllowedTypes, ambiguous: false },
+	{ name: "mapWithStaged", schema: MapWithStaged, ambiguous: false },
 	{ name: "stagedAllowedTypesRoot", schema: stagedAllowedTypesRoot, ambiguous: false },
 	{ name: "hasStagedOptionalField", schema: HasStagedOptionalField, ambiguous: false },
 	{ name: "stagedOptionalRoot", schema: stagedOptionalRoot, ambiguous: false },
@@ -422,10 +450,10 @@ export const testSchema: readonly TestSimpleTreeSchema[] = [
 /**
  * Simple-tree-compatible trees.
  *
- * Can be used used to exercise APIs which accept insertable content,
+ * Can be used to exercise APIs which accept insertable content,
  * or which process the trees constructed from that content.
  *
- * Add a at least one representative here whenever adding a schema to {@link testSchema}.
+ * Add at least one representative here whenever adding a schema to {@link testSchema}.
  */
 export const testSimpleTrees: readonly TestSimpleTree[] = [
 	testSimpleTree("empty", emptySchema, undefined),
@@ -466,7 +494,9 @@ export const testSimpleTrees: readonly TestSimpleTree[] = [
 			field: new RecursiveType({ field: new RecursiveType({ field: new RecursiveType({}) }) }),
 		}),
 	),
+	testSimpleTree("allowsUnknownOptionalFields", AllowsUnknownOptionalFields, {}),
 	testSimpleTree("HasStagedAllowedTypesBeforeUpdate", HasStagedAllowedTypes, { x: 5 }, false),
+	testSimpleTree("mapWithStaged", MapWithStaged, {}),
 	testSimpleTree("Staged in root", stagedAllowedTypesRoot, 5, false),
 	testSimpleTree(
 		"HasStagedOptionalFieldBeforeUpdate",
@@ -569,27 +599,6 @@ export const testTrees: readonly TestTree[] = [
 	),
 ];
 
-export class HasUnknownOptionalFields extends factory.objectAlpha(
-	"hasUnknownOptionalFields",
-	{},
-	{
-		allowUnknownOptionalFields: true,
-	},
-) {}
-
-export class HasUnknownOptionalFieldsV2 extends factory.objectRecursive(
-	"hasUnknownOptionalFields",
-	{
-		recursive: factory.optionalRecursive([() => HasUnknownOptionalFieldsV2]),
-		minimal: factory.optional(Minimal),
-		hasMinimalValueField: factory.optional(HasMinimalValueField),
-		leaf: factory.optional(SchemaFactoryAlpha.string),
-	},
-	{
-		allowUnknownOptionalFields: true,
-	},
-) {}
-
 export class HasStagedAllowedTypesAfterUpdate extends factory.objectAlpha(
 	"hasStagedAllowedTypes",
 	{
@@ -637,28 +646,28 @@ export const testDocuments: readonly TestDocument[] = [
 	{
 		ambiguous: false,
 		name: "AllowsUnknownOptionalFields",
-		schema: HasUnknownOptionalFields,
+		schema: AllowsUnknownOptionalFields,
 		hasUnknownOptionalFieldSchema: true,
 		// Unknown optional fields are allowed but empty in this document.
 		policy: defaultSchemaPolicy,
-		schemaData: toInitialSchema(HasUnknownOptionalFieldsV2),
+		schemaData: toInitialSchema(AllowsUnknownOptionalFieldsV2),
 		treeFactory: () =>
-			jsonableTreeFromFieldCursor(fieldCursorFromInsertable(HasUnknownOptionalFields, {})),
+			jsonableTreeFromFieldCursor(fieldCursorFromInsertable(AllowsUnknownOptionalFields, {})),
 	},
 	{
 		ambiguous: false,
 		name: "HasUnknownOptionalFields",
-		schema: HasUnknownOptionalFields,
+		schema: AllowsUnknownOptionalFields,
 		hasUnknownOptionalFields: true,
 		hasUnknownOptionalFieldSchema: true,
 		policy: defaultSchemaPolicy,
-		schemaData: toInitialSchema(HasUnknownOptionalFieldsV2),
+		schemaData: toInitialSchema(AllowsUnknownOptionalFieldsV2),
 		treeFactory: () =>
 			jsonableTreeFromFieldCursor(
 				fieldCursorFromInsertable(
-					HasUnknownOptionalFieldsV2,
-					new HasUnknownOptionalFieldsV2({
-						recursive: new HasUnknownOptionalFieldsV2({ leaf: "nested leaf" }),
+					AllowsUnknownOptionalFieldsV2,
+					new AllowsUnknownOptionalFieldsV2({
+						recursive: new AllowsUnknownOptionalFieldsV2({ leaf: "nested leaf" }),
 						minimal: {},
 						hasMinimalValueField: { field: {} },
 						leaf: "leaf",

--- a/packages/dds/tree/src/test/testTrees.ts
+++ b/packages/dds/tree/src/test/testTrees.ts
@@ -236,7 +236,13 @@ export class HasDescriptions extends factory.object(
 	{ metadata: { description: "root object" } },
 ) {}
 
-/** Exercises all supported persisted metadata and unknown optional fields together. */
+/**
+ * A node schema configured with all metadata options.
+ *
+ * @remarks
+ * Used to validate metadata handling in schema-focused tests.
+ * Use {@link hasAllMetadataRootSchema} when testing a root field schema.
+ */
 export class HasAllMetadata extends factory.object(
 	"hasDescriptions",
 	{
@@ -251,7 +257,13 @@ export class HasAllMetadata extends factory.object(
 	},
 ) {}
 
-const hasAllMetadataRootSchema = SchemaFactoryAlpha.optional(HasAllMetadata, {
+/**
+ * A root field schema configured with all metadata options.
+ * @remarks
+ * Root fields receive special handling in several code paths,
+ * so this is used to validate that their metadata is preserved correctly.
+ */
+export const hasAllMetadataRootSchema = SchemaFactoryAlpha.optional(HasAllMetadata, {
 	key: "unused root key",
 	metadata: { description: "root field", custom: "root field custom" },
 });

--- a/packages/dds/tree/src/test/testTrees.ts
+++ b/packages/dds/tree/src/test/testTrees.ts
@@ -42,7 +42,7 @@ import {
 	type ForestOptions,
 } from "../shared-tree/index.js";
 // eslint-disable-next-line import-x/no-internal-modules
-import { isLazy } from "../simple-tree/core/index.js";
+import { isLazy, type SchemaUpgrade } from "../simple-tree/core/index.js";
 import {
 	numberSchema,
 	SchemaFactoryAlpha,
@@ -60,6 +60,10 @@ import {
 	toInitialSchema,
 	StagedSchemaUpgradePolicy,
 	type TreeViewConfiguration,
+	type FieldSchemaAlpha,
+	normalizeFieldSchema,
+	walkFieldSchema,
+	ObjectNodeSchema,
 } from "../simple-tree/index.js";
 import { brand, Breakable } from "../util/index.js";
 
@@ -67,18 +71,39 @@ import { brand, Breakable } from "../util/index.js";
 import { fieldJsonCursor } from "./json/jsonCursor.js";
 import { fieldCursorFromInsertable, testIdCompressor } from "./utils.js";
 
-interface TestSimpleTree {
+interface NamedCase {
+	/**
+	 * A descriptive name to descrive what is special about this configuration, used in test names.
+	 */
 	readonly name: string;
+}
+
+/**
+ * A schema paired with an in-schema tree for it, which is expressable using our user facing (aka "simple-tree") APi surface.
+ */
+interface TestSimpleTreeSchema extends NamedCase {
 	readonly schema: ImplicitFieldSchema;
+	readonly ambiguous: boolean;
+}
+
+/**
+ * A schema paired with an in-schema tree for it, which is expressable using our user facing (aka "simple-tree") APi surface.
+ */
+interface TestSimpleTree extends TestSimpleTreeSchema {
 	/**
 	 * InsertableTreeFieldFromImplicitField<TSchema>
 	 */
 	root(): InsertableField<UnsafeUnknownSchema>;
-	readonly ambiguous: boolean;
 }
 
-interface TestTree {
-	readonly name: string;
+/**
+ * A more flexible generalization of {@link TestSimpleTree}, which operates at a lower abstraction level (matching flex-tree).
+ *
+ * This can customize field kinds used in the tree, and use any expressable/persistable stored schema and tree content, regardless of if it can current be producied using the user facing APIs.
+ * This is valuable for testing implementations on cases which cannot be easily represented using the user facing APIs,
+ * as well as simple more directly testing specific aspects of the lower level implementation (glass box testing).
+ */
+interface TestTree extends NamedCase {
 	readonly schemaData: TreeStoredSchema;
 	readonly policy: FullSchemaPolicy;
 	readonly treeFactory: (idCompressor?: IIdCompressor) => JsonableTree[];
@@ -86,6 +111,11 @@ interface TestTree {
 
 /**
  * Content for a test document, which can have a different stored schema than just toStoredSchema(schema).
+ *
+ * This gets its "root" from {@link TestTree.treeFactory} not {@link TestSimpleTree.root}
+ * so its possible to express documents which which have contewnt unknown to the ViewSchema (for now just unknown optional fields).
+ *
+ * This addational flexiability ovver {@link TestSimpleTree} is require for testing forwards compat scenerions.
  */
 export interface TestDocument extends TestTree, Omit<TestSimpleTree, "root"> {
 	/**
@@ -99,16 +129,62 @@ export interface TestDocument extends TestTree, Omit<TestSimpleTree, "root"> {
 	readonly hasUnknownOptionalFieldSchema?: true;
 
 	/**
-	 * True if and only if the document had staged schema features.
-	 */
-	readonly hasStagedSchema?: true;
-
-	/**
 	 * True if and only if the document content requires staged schema features.
 	 *
 	 * For this to be the case, the stored schema must also have had staged schema features included.
 	 */
 	readonly requiresStagedSchema?: true;
+}
+
+/**
+ * Returns the set of staged schema upgrades found within the provided schema (deeply).
+ *
+ * @param schema - The field schema to deeply inspect for staged schema upgrades.
+ */
+export function getStagedSchemaUpgrades(schema: ImplicitFieldSchema): Set<SchemaUpgrade> {
+	const stagedSchemaUpgrades = new Set<SchemaUpgrade>();
+	function processFieldSchema(field: FieldSchemaAlpha): void {
+		if (field.isStagedOptional !== false) {
+			stagedSchemaUpgrades.add(field.isStagedOptional);
+		}
+	}
+	visitFieldSchema(schema, processFieldSchema);
+	walkFieldSchema(schema, {
+		allowedTypes: ({ types }) => {
+			for (const type of types) {
+				if (type.metadata.stagedSchemaUpgrade) {
+					stagedSchemaUpgrades.add(type.metadata.stagedSchemaUpgrade);
+				}
+			}
+		},
+	});
+	return stagedSchemaUpgrades;
+}
+
+export function visitFieldSchema(
+	schema: ImplicitFieldSchema,
+	callback: (field: FieldSchemaAlpha) => void,
+): void {
+	const stagedSchemaUpgrades = new Set<SchemaUpgrade>();
+	const root = normalizeFieldSchema(schema);
+	callback(root);
+
+	walkFieldSchema(root, {
+		allowedTypes: ({ types }) => {
+			for (const type of types) {
+				if (type.metadata.stagedSchemaUpgrade) {
+					stagedSchemaUpgrades.add(type.metadata.stagedSchemaUpgrade);
+				}
+			}
+		},
+		node: (nodeSchema) => {
+			if (nodeSchema instanceof ObjectNodeSchema) {
+				for (const field of nodeSchema.fields.values()) {
+					callback(field);
+				}
+			}
+		},
+	});
 }
 
 function testSimpleTree<const TSchema extends ImplicitFieldSchema>(
@@ -146,6 +222,7 @@ function test(name: string, schemaData: TreeStoredSchema, data: JsonableTree[]):
 }
 
 const factory = new SchemaFactoryAlpha("test");
+const emptySchema = factory.optional([]);
 export class Minimal extends factory.objectAlpha("minimal", {}) {}
 export class Minimal2 extends factory.object("minimal2", {}) {}
 export class HasMinimalValueField extends factory.object("hasMinimalValueField", {
@@ -177,6 +254,11 @@ export class HasAllMetadata extends factory.object(
 	},
 ) {}
 
+const hasAllMetadataRootSchema = SchemaFactoryAlpha.optional(HasAllMetadata, {
+	key: "unused root key",
+	metadata: { description: "root field", custom: "root field custom" },
+});
+
 export class HasAmbiguousField extends factory.object("hasAmbiguousField", {
 	field: [Minimal, Minimal2],
 }) {}
@@ -194,6 +276,7 @@ export class HasIdentifierField extends factory.object("hasIdentifierField", {
 }) {}
 
 const numberSet: TreeTypeSet = new Set([brand(numberSchema.identifier)]);
+/** A lower-level stored schema used to test all supported field kinds. */
 export const allTheFields = new ObjectNodeStoredSchema(
 	new Map([
 		[
@@ -233,6 +316,67 @@ export class RecursiveType extends factory.objectRecursive("recursiveType", {
 	type _check = ValidateRecursiveSchema<typeof RecursiveType>;
 }
 
+export class HasStagedAllowedTypes extends factory.objectAlpha("hasStagedAllowedTypes", {
+	x: SchemaFactoryAlpha.types([
+		SchemaFactoryAlpha.number,
+		SchemaFactoryAlpha.staged(SchemaFactoryAlpha.string),
+	]),
+}) {}
+
+export class HasStagedOptionalField extends factory.objectAlpha("hasStagedOptionalField", {
+	x: SchemaFactoryAlpha.stagedOptional(SchemaFactoryAlpha.number),
+}) {}
+
+class MapWithStaged extends factory.mapAlpha(
+	"MapWithStaged",
+	SchemaFactoryAlpha.types([
+		SchemaFactoryAlpha.number,
+		SchemaFactoryAlpha.staged(SchemaFactoryAlpha.string),
+	]),
+) {}
+
+class ArrayWithStaged extends factory.arrayAlpha(
+	"ArrayWithStaged",
+	SchemaFactoryAlpha.types([
+		SchemaFactoryAlpha.number,
+		SchemaFactoryAlpha.staged(SchemaFactoryAlpha.string),
+	]),
+) {}
+
+const stagedAllowedTypesRoot = SchemaFactoryAlpha.types([
+	SchemaFactoryAlpha.number,
+	SchemaFactoryAlpha.staged(SchemaFactoryAlpha.string),
+]);
+const stagedOptionalRoot = SchemaFactoryAlpha.stagedOptional(SchemaFactoryAlpha.number);
+const optionalRoot = SchemaFactoryAlpha.optional(SchemaFactoryAlpha.number);
+const stagedOptionalA = SchemaFactoryAlpha.stagedOptional(SchemaFactoryAlpha.number);
+const stagedOptionalB = SchemaFactoryAlpha.stagedOptional(SchemaFactoryAlpha.string);
+
+class NestedStagedOptional extends factory.object("NestedStagedOptional", {
+	a: stagedOptionalA,
+	b: stagedOptionalB,
+}) {}
+
+const multiStageCUpgrade = SchemaFactoryAlpha.staged(ArrayWithStaged);
+
+class NestedMultiStage extends factory.object("NestedMultiStage", {
+	a: SchemaFactoryAlpha.optional(
+		SchemaFactoryAlpha.types([SchemaFactoryAlpha.staged(SchemaFactoryAlpha.number)]),
+	),
+	b: SchemaFactoryAlpha.required(
+		SchemaFactoryAlpha.types([
+			SchemaFactoryAlpha.staged({
+				type: () => MapWithStaged,
+				metadata: {},
+			}),
+			SchemaFactoryAlpha.null,
+		]),
+	),
+	c: SchemaFactoryAlpha.required(
+		SchemaFactoryAlpha.types([multiStageCUpgrade, SchemaFactoryAlpha.null]),
+	),
+}) {}
+
 const allTheFieldsName: TreeNodeSchemaIdentifier = brand("test.allTheFields");
 
 const library = {
@@ -243,8 +387,48 @@ const library = {
 	]),
 } satisfies Partial<TreeStoredSchema>;
 
+/**
+ * Named simple-tree schemas used by schema-focused test suites.
+ *
+ * Each schema must have at least one matching entry in {@link testSimpleTrees}.
+ */
+export const testSchema: readonly TestSimpleTreeSchema[] = [
+	{ name: "empty", schema: emptySchema, ambiguous: false },
+	{ name: "null", schema: factory.null, ambiguous: false },
+	{ name: "minimal", schema: Minimal, ambiguous: false },
+	{ name: "number", schema: schemaStatics.number, ambiguous: false },
+	{ name: "handle", schema: factory.handle, ambiguous: false },
+	{ name: "boolean", schema: factory.boolean, ambiguous: false },
+	{ name: "hasMinimalValueField", schema: HasMinimalValueField, ambiguous: false },
+	{ name: "hasRenamedField", schema: HasRenamedField, ambiguous: false },
+	{ name: "hasAmbiguousField", schema: HasAmbiguousField, ambiguous: true },
+	{ name: "hasDescriptions", schema: HasDescriptions, ambiguous: false },
+	{ name: "hasAllMetadata", schema: HasAllMetadata, ambiguous: false },
+	{ name: "hasAllMetadataRootField", schema: hasAllMetadataRootSchema, ambiguous: false },
+	{ name: "hasNumericValueField", schema: HasNumericValueField, ambiguous: false },
+	{ name: "hasPolymorphicValueField", schema: HasPolymorphicValueField, ambiguous: false },
+	{ name: "hasOptionalField", schema: HasOptionalField, ambiguous: false },
+	{ name: "numericMap", schema: NumericMap, ambiguous: false },
+	{ name: "numericRecord", schema: NumericRecord, ambiguous: false },
+	{ name: "recursiveType", schema: RecursiveType, ambiguous: false },
+	{ name: "hasStagedAllowedTypes", schema: HasStagedAllowedTypes, ambiguous: false },
+	{ name: "stagedAllowedTypesRoot", schema: stagedAllowedTypesRoot, ambiguous: false },
+	{ name: "hasStagedOptionalField", schema: HasStagedOptionalField, ambiguous: false },
+	{ name: "stagedOptionalRoot", schema: stagedOptionalRoot, ambiguous: false },
+	{ name: "nestedStagedOptional", schema: NestedStagedOptional, ambiguous: false },
+	{ name: "nestedMultiStage", schema: NestedMultiStage, ambiguous: false },
+];
+
+/**
+ * Simple-tree-compatible trees.
+ *
+ * Can be used used to exercise APIs which accept insertable content,
+ * or which process the trees constructed from that content.
+ *
+ * Add a at least one representative here whenever adding a schema to {@link testSchema}.
+ */
 export const testSimpleTrees: readonly TestSimpleTree[] = [
-	testSimpleTree("empty", factory.optional([]), undefined),
+	testSimpleTree("empty", emptySchema, undefined),
 	testSimpleTree("null", factory.null, null),
 	testSimpleTree("minimal", Minimal, {}),
 	testSimpleTree("numeric", factory.number, 5),
@@ -261,14 +445,7 @@ export const testSimpleTrees: readonly TestSimpleTree[] = [
 	),
 	testSimpleTree("hasDescriptions", HasDescriptions, { field: {} }),
 	testSimpleTree("hasAllMetadata", HasAllMetadata, { field: {} }),
-	testSimpleTree(
-		"hasAllMetadataRootField",
-		SchemaFactoryAlpha.optional(HasAllMetadata, {
-			key: "unused root key",
-			metadata: { description: "root field", custom: "root field custom" },
-		}),
-		{ field: {} },
-	),
+	testSimpleTree("hasAllMetadataRootField", hasAllMetadataRootSchema, { field: {} }),
 	testSimpleTree("hasNumericValueField", HasNumericValueField, { field: 5 }),
 	testSimpleTree("hasPolymorphicValueField", HasPolymorphicValueField, { field: 5 }),
 	testSimpleTree("hasOptionalField-empty", HasOptionalField, {}),
@@ -289,8 +466,33 @@ export const testSimpleTrees: readonly TestSimpleTree[] = [
 			field: new RecursiveType({ field: new RecursiveType({ field: new RecursiveType({}) }) }),
 		}),
 	),
+	testSimpleTree("HasStagedAllowedTypesBeforeUpdate", HasStagedAllowedTypes, { x: 5 }, false),
+	testSimpleTree("Staged in root", stagedAllowedTypesRoot, 5, false),
+	testSimpleTree(
+		"HasStagedOptionalFieldBeforeUpdate",
+		HasStagedOptionalField,
+		{ x: 5 },
+		false,
+	),
+	testSimpleTree("Staged optional in root", stagedOptionalRoot, 5, false),
+	testSimpleTree(
+		"NestedStagedOptional with no upgrades",
+		NestedStagedOptional,
+		{ a: 5, b: "text" },
+		false,
+	),
+	testSimpleTree(
+		"NestedMultiStage with no upgrades",
+		NestedMultiStage,
+		{ b: null, c: null },
+		false,
+	),
 ];
 
+/**
+ * Stored-schema trees used by lower-level tree tests.
+ * Prefer adding cases to {@link testSimpleTrees}; add custom cases here only when simple-tree cannot express them.
+ */
 export const testTrees: readonly TestTree[] = [
 	...testSimpleTrees.map(convertSimpleTreeTest),
 	test(
@@ -327,7 +529,6 @@ export const testTrees: readonly TestTree[] = [
 		},
 		policy: defaultSchemaPolicy,
 	},
-
 	test(
 		"allTheFields-minimal",
 		{
@@ -389,23 +590,12 @@ export class HasUnknownOptionalFieldsV2 extends factory.objectRecursive(
 	},
 ) {}
 
-export class HasStagedAllowedTypes extends factory.objectAlpha("hasStagedAllowedTypes", {
-	x: SchemaFactoryAlpha.types([
-		SchemaFactoryAlpha.number,
-		SchemaFactoryAlpha.staged(SchemaFactoryAlpha.string),
-	]),
-}) {}
-
 export class HasStagedAllowedTypesAfterUpdate extends factory.objectAlpha(
 	"hasStagedAllowedTypes",
 	{
 		x: [SchemaFactoryAlpha.number, SchemaFactoryAlpha.string],
 	},
 ) {}
-
-export class HasStagedOptionalField extends factory.objectAlpha("hasStagedOptionalField", {
-	x: SchemaFactoryAlpha.stagedOptional(SchemaFactoryAlpha.number),
-}) {}
 
 export class HasStagedOptionalFieldAfterUpdate extends factory.objectAlpha(
 	"hasStagedOptionalField",
@@ -414,63 +604,21 @@ export class HasStagedOptionalFieldAfterUpdate extends factory.objectAlpha(
 	},
 ) {}
 
-class MapWithStaged extends factory.mapAlpha(
-	"MapWithStaged",
-	SchemaFactoryAlpha.types([
-		SchemaFactoryAlpha.number,
-		SchemaFactoryAlpha.staged(SchemaFactoryAlpha.string),
-	]),
-) {}
-
-class ArrayWithStaged extends factory.arrayAlpha(
-	"ArrayWithStaged",
-	SchemaFactoryAlpha.types([
-		SchemaFactoryAlpha.number,
-		SchemaFactoryAlpha.staged(SchemaFactoryAlpha.string),
-	]),
-) {}
-
-const stagedOptionalRoot = SchemaFactoryAlpha.stagedOptional(SchemaFactoryAlpha.number);
-const optionalRoot = SchemaFactoryAlpha.optional(SchemaFactoryAlpha.number);
-const stagedOptionalA = SchemaFactoryAlpha.stagedOptional(SchemaFactoryAlpha.number);
-const stagedOptionalB = SchemaFactoryAlpha.stagedOptional(SchemaFactoryAlpha.string);
-
-class NestedStagedOptional extends factory.object("NestedStagedOptional", {
-	a: stagedOptionalA,
-	b: stagedOptionalB,
-}) {}
-
-const multiStageCUpgrade = SchemaFactoryAlpha.staged(ArrayWithStaged);
-
-class NestedMultiStage extends factory.object("NestedMultiStage", {
-	a: SchemaFactoryAlpha.optional(
-		SchemaFactoryAlpha.types([SchemaFactoryAlpha.staged(SchemaFactoryAlpha.number)]),
-	),
-	b: SchemaFactoryAlpha.required(
-		SchemaFactoryAlpha.types([
-			SchemaFactoryAlpha.staged({
-				type: () => MapWithStaged,
-				metadata: {},
-			}),
-			SchemaFactoryAlpha.null,
-		]),
-	),
-	c: SchemaFactoryAlpha.required(
-		SchemaFactoryAlpha.types([multiStageCUpgrade, SchemaFactoryAlpha.null]),
-	),
-}) {}
-
 // TODO: AB#45711: add recursive staged schema tests documents
 
 /**
  * Collection of {@link TestDocument|TestDocuments}.
- *
+ * @remarks
  * Use these test documents to test import and export APIs.
  *
  * Can be used to test schema evolution related features where view and stored schema can diverge.
  * Includes for example documents with unknown optional fields;
  *
  * Includes documents with staged schema features both before and after the stored schema update.
+ *
+ * @privateRemarks
+ * When possible, add test cases to {@link testSimpleTrees} instead of this collection:
+ * such cases are automatically included here as well.
  */
 export const testDocuments: readonly TestDocument[] = [
 	...testSimpleTrees.map(
@@ -520,19 +668,8 @@ export const testDocuments: readonly TestDocument[] = [
 	},
 	{
 		ambiguous: false,
-		name: "HasStagedAllowedTypesBeforeUpdate",
-		schema: HasStagedAllowedTypes,
-		hasStagedSchema: true,
-		policy: defaultSchemaPolicy,
-		schemaData: toInitialSchema(HasStagedAllowedTypes),
-		treeFactory: () =>
-			jsonableTreeFromFieldCursor(fieldCursorFromInsertable(HasStagedAllowedTypes, { x: 5 })),
-	},
-	{
-		ambiguous: false,
 		name: "HasStagedAllowedTypesAfterUpdate",
 		schema: HasStagedAllowedTypes,
-		hasStagedSchema: true,
 		requiresStagedSchema: true,
 		policy: defaultSchemaPolicy,
 		schemaData: toInitialSchema(HasStagedAllowedTypesAfterUpdate),
@@ -543,25 +680,8 @@ export const testDocuments: readonly TestDocument[] = [
 	},
 	{
 		ambiguous: false,
-		name: "Staged in root",
-		schema: SchemaFactoryAlpha.types([
-			SchemaFactoryAlpha.number,
-			SchemaFactoryAlpha.staged(SchemaFactoryAlpha.string),
-		]),
-		hasStagedSchema: true,
-		policy: defaultSchemaPolicy,
-		schemaData: toInitialSchema(SchemaFactoryAlpha.number),
-		treeFactory: () =>
-			jsonableTreeFromFieldCursor(fieldCursorFromInsertable(SchemaFactoryAlpha.number, 5)),
-	},
-	{
-		ambiguous: false,
 		name: "Staged node in root",
-		schema: SchemaFactoryAlpha.types([
-			SchemaFactoryAlpha.number,
-			SchemaFactoryAlpha.staged(SchemaFactoryAlpha.string),
-		]),
-		hasStagedSchema: true,
+		schema: stagedAllowedTypesRoot,
 		requiresStagedSchema: true,
 		policy: defaultSchemaPolicy,
 		schemaData: toInitialSchema(
@@ -576,7 +696,6 @@ export const testDocuments: readonly TestDocument[] = [
 		ambiguous: false,
 		name: "Staged in map",
 		schema: MapWithStaged,
-		hasStagedSchema: true,
 		requiresStagedSchema: true,
 		policy: defaultSchemaPolicy,
 		schemaData: toStoredSchema(MapWithStaged, StagedSchemaUpgradePolicy.permissive),
@@ -585,19 +704,8 @@ export const testDocuments: readonly TestDocument[] = [
 	},
 	{
 		ambiguous: false,
-		name: "HasStagedOptionalFieldBeforeUpdate",
-		schema: HasStagedOptionalField,
-		hasStagedSchema: true,
-		policy: defaultSchemaPolicy,
-		schemaData: toInitialSchema(HasStagedOptionalField),
-		treeFactory: () =>
-			jsonableTreeFromFieldCursor(fieldCursorFromInsertable(HasStagedOptionalField, { x: 5 })),
-	},
-	{
-		ambiguous: false,
 		name: "HasStagedOptionalFieldAfterUpdate",
 		schema: HasStagedOptionalField,
-		hasStagedSchema: true,
 		requiresStagedSchema: true,
 		policy: defaultSchemaPolicy,
 		schemaData: toInitialSchema(HasStagedOptionalFieldAfterUpdate),
@@ -606,19 +714,8 @@ export const testDocuments: readonly TestDocument[] = [
 	},
 	{
 		ambiguous: false,
-		name: "Staged optional in root",
-		schema: stagedOptionalRoot,
-		hasStagedSchema: true,
-		policy: defaultSchemaPolicy,
-		schemaData: toInitialSchema(stagedOptionalRoot),
-		treeFactory: () =>
-			jsonableTreeFromFieldCursor(fieldCursorFromInsertable(stagedOptionalRoot, 5)),
-	},
-	{
-		ambiguous: false,
 		name: "Staged optional empty root",
 		schema: stagedOptionalRoot,
-		hasStagedSchema: true,
 		requiresStagedSchema: true,
 		policy: defaultSchemaPolicy,
 		schemaData: toInitialSchema(optionalRoot),
@@ -627,21 +724,8 @@ export const testDocuments: readonly TestDocument[] = [
 	},
 	{
 		ambiguous: false,
-		name: "NestedStagedOptional with no upgrades",
-		schema: NestedStagedOptional,
-		hasStagedSchema: true,
-		policy: defaultSchemaPolicy,
-		schemaData: toStoredSchema(NestedStagedOptional, StagedSchemaUpgradePolicy.restrictive),
-		treeFactory: () =>
-			jsonableTreeFromFieldCursor(
-				fieldCursorFromInsertable(NestedStagedOptional, { a: 5, b: "text" }),
-			),
-	},
-	{
-		ambiguous: false,
 		name: "NestedStagedOptional with one upgrade",
 		schema: NestedStagedOptional,
-		hasStagedSchema: true,
 		requiresStagedSchema: true,
 		policy: defaultSchemaPolicy,
 		schemaData: toStoredSchema(NestedStagedOptional, {
@@ -657,7 +741,6 @@ export const testDocuments: readonly TestDocument[] = [
 		ambiguous: false,
 		name: "NestedStagedOptional with all upgrades",
 		schema: NestedStagedOptional,
-		hasStagedSchema: true,
 		requiresStagedSchema: true,
 		policy: defaultSchemaPolicy,
 		schemaData: toStoredSchema(NestedStagedOptional, StagedSchemaUpgradePolicy.permissive),
@@ -666,21 +749,8 @@ export const testDocuments: readonly TestDocument[] = [
 	},
 	{
 		ambiguous: false,
-		name: "NestedMultiStage with no upgrades",
-		schema: NestedMultiStage,
-		hasStagedSchema: true,
-		policy: defaultSchemaPolicy,
-		schemaData: toStoredSchema(NestedMultiStage, StagedSchemaUpgradePolicy.restrictive),
-		treeFactory: () =>
-			jsonableTreeFromFieldCursor(
-				fieldCursorFromInsertable(NestedMultiStage, { b: null, c: null }),
-			),
-	},
-	{
-		ambiguous: false,
 		name: "NestedMultiStage with one upgrade",
 		schema: NestedMultiStage,
-		hasStagedSchema: true,
 		requiresStagedSchema: true,
 		policy: defaultSchemaPolicy,
 		schemaData: toStoredSchema(NestedMultiStage, {
@@ -696,7 +766,6 @@ export const testDocuments: readonly TestDocument[] = [
 		ambiguous: false,
 		name: "NestedMultiStage with all upgrades",
 		schema: NestedMultiStage,
-		hasStagedSchema: true,
 		requiresStagedSchema: true,
 		policy: defaultSchemaPolicy,
 		schemaData: toStoredSchema(NestedMultiStage, StagedSchemaUpgradePolicy.permissive),
@@ -707,6 +776,7 @@ export const testDocuments: readonly TestDocument[] = [
 	},
 ];
 
+/** Creates an independent view initialized with a {@link TestDocument}'s stored schema and content. */
 export function testDocumentIndependentView(
 	document: Pick<TestDocument, "schema" | "treeFactory" | "schemaData" | "ambiguous">,
 ): SchematizingSimpleTreeView<UnsafeUnknownSchema> {


### PR DESCRIPTION
## Description

Cleanup test trees and test schema.

Ensures tests for schema avoid duplication for different unused trees by just testing the schema directly, and ensure we have test trees where possible and not just test documents.

## Reviewer Guidance

The review process is outlined in [the pull request guidelines](../docs/content/Contributing/PR-Guidelines.md#guidelines).
