### PR TITLE
Fix(tree): Fix bug in revertTo

### DIFF
--- a/.changeset/fast-sites-warn.md
+++ b/.changeset/fast-sites-warn.md
@@ -1,0 +1,9 @@
+---
+"@fluidframework/tree": minor
+"fluid-framework": minor
+"__section": tree
+---
+Fix a bug in revertTo
+
+Fixes a bug in [`UntypedTreeViewAlpha.revertTo`](https://fluidframework.com/docs/api/tree/untypedtreeviewalpha-interface#revertto-methodsignature) which could trigger assert codes `0x7ce`, `0x8a1`, `0x695`, and possibly others.
+This bug is not known to cause document corruption.

--- a/packages/dds/tree/src/core/index.ts
+++ b/packages/dds/tree/src/core/index.ts
@@ -220,6 +220,7 @@ export {
 	taggedAtomId,
 	taggedOptAtomId,
 	offsetChangeAtomId,
+	offsetChangesetLocalId,
 	StableIdSchema,
 	subtractChangeAtomIds,
 	replaceChange,

--- a/packages/dds/tree/src/core/rebase/index.ts
+++ b/packages/dds/tree/src/core/rebase/index.ts
@@ -33,6 +33,7 @@ export {
 	taggedAtomId,
 	taggedOptAtomId,
 	offsetChangeAtomId,
+	offsetChangesetLocalId,
 	StableIdSchema,
 	subtractChangeAtomIds,
 	type ChangeAtomIdRangeMap,

--- a/packages/dds/tree/src/core/rebase/types.ts
+++ b/packages/dds/tree/src/core/rebase/types.ts
@@ -129,7 +129,14 @@ export function taggedOptAtomId(
 }
 
 export function offsetChangeAtomId<T extends ChangeAtomId>(id: T, offset: number): T {
-	return { ...id, localId: brand(id.localId + offset) };
+	return { ...id, localId: offsetChangesetLocalId(id.localId, offset) };
+}
+
+export function offsetChangesetLocalId(
+	value: ChangesetLocalId,
+	offset: number,
+): ChangesetLocalId {
+	return brand(value + offset);
 }
 
 // #region These comparison functions are used instead of e.g. `compareNumbers` as a performance optimization

--- a/packages/dds/tree/src/core/rebase/types.ts
+++ b/packages/dds/tree/src/core/rebase/types.ts
@@ -132,6 +132,12 @@ export function offsetChangeAtomId<T extends ChangeAtomId>(id: T, offset: number
 	return { ...id, localId: offsetChangesetLocalId(id.localId, offset) };
 }
 
+/**
+ * Offsets a changeset local ID by the specified amount.
+ * @param value - The original changeset local ID.
+ * @param offset - The amount by which to offset the local ID.
+ * @returns The offset changeset local ID.
+ */
 export function offsetChangesetLocalId(
 	value: ChangesetLocalId,
 	offset: number,

--- a/packages/dds/tree/src/feature-libraries/index.ts
+++ b/packages/dds/tree/src/feature-libraries/index.ts
@@ -95,6 +95,7 @@ export {
 	type FieldKindConfiguration,
 	type FieldKindConfigurationEntry,
 	isNeverTree,
+	DefaultAtomIdAliasAllocator,
 	DefaultRevisionReplacer,
 	ModularChangeFormatVersion,
 	minimizeModularChangeset,

--- a/packages/dds/tree/src/feature-libraries/modular-schema/defaultAtomIdAliasAllocator.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/defaultAtomIdAliasAllocator.ts
@@ -18,13 +18,16 @@ export class DefaultAtomIdAliasAllocator implements AtomIdAliasAllocator {
 	 * Mapping from original revision tag to the offset that should be applied to local IDs from that revision.
 	 */
 	private readonly offsets: Map<
-		RevisionTag,
+		RevisionTag | undefined,
 		{ readonly offset: number; readonly originalMaxLocalId: ChangesetLocalId }
 	> = new Map();
 
 	private readonly allocator: IdAllocator = idAllocatorFromMaxId();
 
-	public reserve(originalRevision: RevisionTag, originalMaxLocalId: ChangesetLocalId): void {
+	public reserve(
+		originalRevision: RevisionTag | undefined,
+		originalMaxLocalId: ChangesetLocalId,
+	): void {
 		const current = this.offsets.get(originalRevision);
 		if (current === undefined) {
 			const offset =
@@ -41,7 +44,7 @@ export class DefaultAtomIdAliasAllocator implements AtomIdAliasAllocator {
 	}
 
 	public getAlias(
-		originalRevision: RevisionTag,
+		originalRevision: RevisionTag | undefined,
 		originalLocalId: ChangesetLocalId,
 	): ChangesetLocalId {
 		const current = this.offsets.get(originalRevision);

--- a/packages/dds/tree/src/feature-libraries/modular-schema/defaultAtomIdAliasAllocator.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/defaultAtomIdAliasAllocator.ts
@@ -1,0 +1,65 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { assert, fail } from "@fluidframework/core-utils/internal";
+
+import {
+	offsetChangesetLocalId,
+	type ChangesetLocalId,
+	type RevisionTag,
+} from "../../core/index.js";
+import { brand, type IdAllocator, idAllocatorFromMaxId } from "../../util/index.js";
+import type { AtomIdAliasAllocator } from "./fieldChangeHandler.js";
+
+export class DefaultAtomIdAliasAllocator implements AtomIdAliasAllocator {
+	/**
+	 * Mapping from original revision tag to the offset that should be applied to local IDs from that revision.
+	 */
+	private readonly offsets: Map<
+		RevisionTag,
+		{ readonly offset: number; readonly originalMaxLocalId: ChangesetLocalId }
+	> = new Map();
+
+	private readonly allocator: IdAllocator = idAllocatorFromMaxId();
+
+	public reserve(originalRevision: RevisionTag, originalMaxLocalId: ChangesetLocalId): void {
+		const current = this.offsets.get(originalRevision);
+		if (current === undefined) {
+			const offset =
+				originalMaxLocalId < 0
+					? this.allocator.getMaxId()
+					: this.allocator.allocate(originalMaxLocalId + 1);
+			this.offsets.set(originalRevision, { offset, originalMaxLocalId });
+		} else {
+			assert(
+				originalMaxLocalId === current.originalMaxLocalId,
+				"Inconsistent original max local ID for the same revision",
+			);
+		}
+	}
+
+	public getAlias(
+		originalRevision: RevisionTag,
+		originalLocalId: ChangesetLocalId,
+	): ChangesetLocalId {
+		const current = this.offsets.get(originalRevision);
+		if (current === undefined) {
+			fail("No alias reserved for the given revision");
+		}
+		assert(
+			originalLocalId <= current.originalMaxLocalId,
+			"Original local ID exceeds the reserved count for the given revision",
+		);
+		return offsetChangesetLocalId(originalLocalId, current.offset);
+	}
+
+	public getMaxId = (): ChangesetLocalId => {
+		return brand(this.allocator.getMaxId());
+	};
+
+	public allocate = (count?: number): ChangesetLocalId => {
+		return brand(this.allocator.allocate(count));
+	};
+}

--- a/packages/dds/tree/src/feature-libraries/modular-schema/defaultAtomIdAliasAllocator.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/defaultAtomIdAliasAllocator.ts
@@ -13,6 +13,9 @@ import {
 import { brand, type IdAllocator, idAllocatorFromMaxId } from "../../util/index.js";
 import type { AtomIdAliasAllocator } from "./fieldChangeHandler.js";
 
+/**
+ * Default implementation of the {@link AtomIdAliasAllocator} interface.
+ */
 export class DefaultAtomIdAliasAllocator implements AtomIdAliasAllocator {
 	/**
 	 * Mapping from original revision tag to the offset that should be applied to local IDs from that revision.

--- a/packages/dds/tree/src/feature-libraries/modular-schema/defaultRevisionReplacer.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/defaultRevisionReplacer.ts
@@ -8,6 +8,7 @@ import { assert, fail } from "@fluidframework/core-utils/internal";
 import {
 	newChangeAtomIdRangeMap,
 	offsetChangeAtomId,
+	offsetChangesetLocalId,
 	type ChangeAtomId,
 	type ChangeAtomIdRangeMap,
 	type ChangesetLocalId,
@@ -21,9 +22,6 @@ import {
 	type RangeMap,
 	type Mutable,
 } from "../../util/index.js";
-
-const offsetChangesetLocalId = (value: ChangesetLocalId, offset: number): ChangesetLocalId =>
-	brand(value + offset);
 
 export class DefaultRevisionReplacer implements RevisionReplacer {
 	/**

--- a/packages/dds/tree/src/feature-libraries/modular-schema/fieldChangeHandler.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/fieldChangeHandler.ts
@@ -7,6 +7,7 @@ import type { ICodecFamily, JsonCodecPart } from "../../codec/index.js";
 import type {
 	ChangeAtomId,
 	ChangeEncodingContext,
+	ChangesetLocalId,
 	DeltaDetachedNodeChanges,
 	DeltaDetachedNodeId,
 	DeltaDetachedNodeRename,
@@ -150,7 +151,7 @@ export interface FieldChangeRebaser<TChangeset> {
 	invert(
 		change: TChangeset,
 		isRollback: boolean,
-		genId: IdAllocator,
+		genId: AtomIdAliasAllocator,
 		revision: RevisionTag | undefined,
 		crossFieldManager: CrossFieldManager,
 		revisionMetadata: RevisionMetadataSource,
@@ -377,4 +378,19 @@ export interface FieldChangeEncodingContext {
 export interface FieldChangeDecodingContext {
 	readonly baseContext: ChangeEncodingContext;
 	decodeNode(encodedNode: EncodedNodeChangeset): NodeId;
+}
+
+/**
+ * Allocates and manages aliases for local IDs within different revisions.
+ */
+export interface AtomIdAliasAllocator extends IdAllocator<ChangesetLocalId> {
+	/**
+	 * Reserves a contiguous block of IDs for the given original revision up to the specified maximum local ID.
+	 * Can be called multiple times for the same revision (later calls have no effect), but the maximum local ID must be consistent.
+	 */
+	reserve(originalRevision: RevisionTag, originalMaxLocalId: ChangesetLocalId): void;
+	/**
+	 * @returns The alias for the given original local ID within the specified revision.
+	 */
+	getAlias(originalRevision: RevisionTag, originalLocalId: ChangesetLocalId): ChangesetLocalId;
 }

--- a/packages/dds/tree/src/feature-libraries/modular-schema/fieldChangeHandler.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/fieldChangeHandler.ts
@@ -388,9 +388,15 @@ export interface AtomIdAliasAllocator extends IdAllocator<ChangesetLocalId> {
 	 * Reserves a contiguous block of IDs for the given original revision up to the specified maximum local ID.
 	 * Can be called multiple times for the same revision (later calls have no effect), but the maximum local ID must be consistent.
 	 */
-	reserve(originalRevision: RevisionTag, originalMaxLocalId: ChangesetLocalId): void;
+	reserve(
+		originalRevision: RevisionTag | undefined,
+		originalMaxLocalId: ChangesetLocalId,
+	): void;
 	/**
 	 * @returns The alias for the given original local ID within the specified revision.
 	 */
-	getAlias(originalRevision: RevisionTag, originalLocalId: ChangesetLocalId): ChangesetLocalId;
+	getAlias(
+		originalRevision: RevisionTag | undefined,
+		originalLocalId: ChangesetLocalId,
+	): ChangesetLocalId;
 }

--- a/packages/dds/tree/src/feature-libraries/modular-schema/fieldChangeHandler.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/fieldChangeHandler.ts
@@ -386,7 +386,7 @@ export interface FieldChangeDecodingContext {
 export interface AtomIdAliasAllocator extends IdAllocator<ChangesetLocalId> {
 	/**
 	 * Reserves a contiguous block of IDs for the given original revision up to the specified maximum local ID.
-	 * Can be called multiple times for the same revision (later calls have no effect), but the maximum local ID must be consistent.
+	 * Can be called multiple times for the same revision (later calls have no effect), but the maximum local ID must be consistent across calls.
 	 */
 	reserve(
 		originalRevision: RevisionTag | undefined,

--- a/packages/dds/tree/src/feature-libraries/modular-schema/index.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/index.ts
@@ -41,6 +41,7 @@ export {
 	type FieldChangeDecodingContext,
 	type FieldChangeRebaser,
 	type FieldEditor,
+	type AtomIdAliasAllocator,
 	type NodeChangeComposer,
 	type NodeChangeInverter,
 	type NodeChangeRebaser,
@@ -90,3 +91,4 @@ export type {
 } from "./fieldKindConfiguration.js";
 export { DefaultRevisionReplacer } from "./defaultRevisionReplacer.js";
 export { minimizeModularChangeset } from "./minimizeModularChange.js";
+export { DefaultAtomIdAliasAllocator } from "./defaultAtomIdAliasAllocator.js";

--- a/packages/dds/tree/src/feature-libraries/modular-schema/invert.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/invert.ts
@@ -87,8 +87,8 @@ export function invertModularChange(
 	const { revInfos: oldRevInfos } = getRevInfoFromTaggedChanges([change]);
 	const revisionMetadata = revisionMetadataSourceFromInfo(oldRevInfos);
 
-	for (const { revision } of oldRevInfos) {
-		if (change.change.maxId !== undefined) {
+	if (change.change.maxId !== undefined) {
+		for (const { revision } of oldRevInfos) {
 			genId.reserve(revision, change.change.maxId);
 		}
 	}

--- a/packages/dds/tree/src/feature-libraries/modular-schema/invert.ts
+++ b/packages/dds/tree/src/feature-libraries/modular-schema/invert.ts
@@ -15,7 +15,7 @@ import {
 	type TaggedChange,
 	type TreeChunk,
 } from "../../core/index.js";
-import { brand, idAllocatorFromMaxId, type IdAllocator } from "../../util/index.js";
+import { brand } from "../../util/index.js";
 import { newChangeAtomIdBTree, type ChangeAtomIdBTree } from "../changeAtomIdBTree.js";
 import type {
 	FieldChange,
@@ -39,7 +39,8 @@ import {
 } from "./modularChangeUtils.js";
 import type { CrossFieldTarget } from "./crossFieldQueries.js";
 import type { FlexFieldKind } from "./fieldKind.js";
-import { NodeAttachState } from "./fieldChangeHandler.js";
+import { NodeAttachState, type AtomIdAliasAllocator } from "./fieldChangeHandler.js";
+import { DefaultAtomIdAliasAllocator } from "./defaultAtomIdAliasAllocator.js";
 
 /**
  * @param change - The change to invert.
@@ -77,7 +78,7 @@ export function invertModularChange(
 		});
 	}
 
-	const genId: IdAllocator = idAllocatorFromMaxId(change.change.maxId ?? -1);
+	const genId = new DefaultAtomIdAliasAllocator();
 
 	const crossFieldTable: InvertTable = {
 		...newCrossFieldTable<FieldChange>(),
@@ -85,6 +86,12 @@ export function invertModularChange(
 	};
 	const { revInfos: oldRevInfos } = getRevInfoFromTaggedChanges([change]);
 	const revisionMetadata = revisionMetadataSourceFromInfo(oldRevInfos);
+
+	for (const { revision } of oldRevInfos) {
+		if (change.change.maxId !== undefined) {
+			genId.reserve(revision, change.change.maxId);
+		}
+	}
 
 	const invertedFields = invertFieldMap(
 		change.change.fieldChanges,
@@ -172,7 +179,7 @@ function invertFieldMap(
 	changes: FieldChangeMap,
 	parentId: NodeId | undefined,
 	isRollback: boolean,
-	genId: IdAllocator,
+	genId: AtomIdAliasAllocator,
 	crossFieldTable: InvertTable,
 	revisionMetadata: RevisionMetadataSource,
 	revisionForInvert: RevisionTag,
@@ -211,7 +218,7 @@ function invertNodeChange(
 	change: NodeChangeset,
 	id: NodeId,
 	isRollback: boolean,
-	genId: IdAllocator,
+	genId: AtomIdAliasAllocator,
 	crossFieldTable: InvertTable,
 	revisionMetadata: RevisionMetadataSource,
 	revisionForInvert: RevisionTag,

--- a/packages/dds/tree/src/feature-libraries/sequence-field/invert.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/invert.ts
@@ -5,7 +5,11 @@
 
 import { assert, unreachableCase, fail } from "@fluidframework/core-utils/internal";
 
-import type { RevisionTag } from "../../core/index.js";
+import {
+	offsetChangesetLocalId,
+	type ChangesetLocalId,
+	type RevisionTag,
+} from "../../core/index.js";
 import { type Mutable, hasSingle } from "../../util/index.js";
 import {
 	type AtomIdAliasAllocator,
@@ -106,19 +110,23 @@ function invertMark(
 			return [mark];
 		}
 		case "Rename": {
-			const inputId = getInputCellId(mark);
-			assert(inputId !== undefined, 0x9f5 /* Rename mark must have cell ID */);
-			const inverse: Mutable<CellMark<Rename>> = {
-				type: "Rename",
-				count: mark.count,
-				cellId: mark.idOverride,
-				// Unlike a remove or move-out, which follow a node, there is no way for this mark to assign the original input cell ID to another cell.
-				// This means it should be safe to always restore the input cell ID (as opposed to only doing it on rollbacks).
-				// Despite that, we still only do it on rollback for the sake of consistency: once a cell has been assigned an ID,
-				// the only way for that cell to be assigned that ID again is if it is rolled back to that state.
-				idOverride: isRollback ? inputId : { localId: inputId.localId },
-			};
-			return [withNodeChange(inverse, mark.changes)];
+			if (isRollback) {
+				const inputId = getInputCellId(mark);
+				assert(inputId !== undefined, 0x9f5 /* Rename mark must have cell ID */);
+				const inverse: Mutable<CellMark<Rename>> = {
+					type: "Rename",
+					count: mark.count,
+					cellId: mark.idOverride,
+					// Unlike a remove or move-out, which follow a node, there is no way for this mark to assign the original input cell ID to another cell.
+					// This means it should be safe to always restore the input cell ID (as opposed to only doing it on rollbacks).
+					// Despite that, we still only do it on rollback for the sake of consistency: once a cell has been assigned an ID,
+					// the only way for that cell to be assigned that ID again is if it is rolled back to that state.
+					idOverride: inputId,
+				};
+				return [withNodeChange(inverse, mark.changes)];
+			} else {
+				return [withNodeChange({ count: mark.count, cellId: mark.idOverride }, mark.changes)];
+			}
 		}
 		case "Remove": {
 			assert(mark.revision !== undefined, 0x5a1 /* Unable to revert to undefined revision */);
@@ -192,7 +200,7 @@ function invertMark(
 
 			if (mark.finalEndpoint !== undefined) {
 				moveIn.finalEndpoint = {
-					localId: genId.getAlias(mark.revision, mark.finalEndpoint.localId),
+					localId: genId.getAlias(mark.finalEndpoint.revision, mark.finalEndpoint.localId),
 					revision,
 				};
 			}
@@ -231,11 +239,11 @@ function invertMark(
 
 			if (mark.finalEndpoint) {
 				invertedMark.finalEndpoint = {
-					localId: genId.getAlias(mark.revision, mark.finalEndpoint.localId),
+					localId: genId.getAlias(mark.finalEndpoint.revision, mark.finalEndpoint.localId),
 					revision,
 				};
 			}
-			return applyMovedChanges(invertedMark, mark.revision, crossFieldManager);
+			return applyMovedChanges(invertedMark, mark.revision, mark.id, crossFieldManager);
 		}
 		case "AttachAndDetach": {
 			const attach: Mark = {
@@ -326,29 +334,44 @@ function invertMark(
 }
 
 function applyMovedChanges(
-	mark: CellMark<MoveOut>,
-	revision: RevisionTag | undefined,
+	invertedMark: CellMark<MoveOut>,
+	originalRevision: RevisionTag | undefined,
+	originalId: ChangesetLocalId,
 	manager: CrossFieldManager<NodeId>,
 ): Mark[] {
 	// Although this is a source mark, we query the destination because this was a destination mark during the original invert pass.
-	const entry = manager.get(CrossFieldTarget.Destination, revision, mark.id, mark.count, true);
+	const entry = manager.get(
+		CrossFieldTarget.Destination,
+		originalRevision,
+		originalId,
+		invertedMark.count,
+		true,
+	);
 
-	if (entry.length < mark.count) {
-		const [mark1, mark2] = splitMark(mark, entry.length);
+	if (entry.length < invertedMark.count) {
+		const [mark1, mark2] = splitMark(invertedMark, entry.length);
 		const mark1WithChanges =
 			entry.value === undefined
 				? mark1
 				: withNodeChange<CellMark<MoveOut>, MoveOut>(mark1, entry.value);
 
-		return [mark1WithChanges, ...applyMovedChanges(mark2, revision, manager)];
+		return [
+			mark1WithChanges,
+			...applyMovedChanges(
+				mark2,
+				originalRevision,
+				offsetChangesetLocalId(originalId, mark1.count),
+				manager,
+			),
+		];
 	}
 
 	if (entry.value !== undefined) {
 		manager.onMoveIn(entry.value);
-		return [withNodeChange<CellMark<MoveOut>, MoveOut>(mark, entry.value)];
+		return [withNodeChange<CellMark<MoveOut>, MoveOut>(invertedMark, entry.value)];
 	}
 
-	return [mark];
+	return [invertedMark];
 }
 
 function invertNodeChangeOrSkip(

--- a/packages/dds/tree/src/feature-libraries/sequence-field/invert.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/invert.ts
@@ -6,8 +6,9 @@
 import { assert, unreachableCase, fail } from "@fluidframework/core-utils/internal";
 
 import type { RevisionTag } from "../../core/index.js";
-import { type IdAllocator, type Mutable, hasSingle } from "../../util/index.js";
+import { type Mutable, hasSingle } from "../../util/index.js";
 import {
+	type AtomIdAliasAllocator,
 	type CrossFieldManager,
 	CrossFieldTarget,
 	type NodeId,
@@ -58,7 +59,7 @@ import {
 export function invert(
 	change: Changeset,
 	isRollback: boolean,
-	genId: IdAllocator,
+	genId: AtomIdAliasAllocator,
 	revision: RevisionTag | undefined,
 	crossFieldManager: CrossFieldManager,
 ): Changeset {
@@ -66,6 +67,7 @@ export function invert(
 		change,
 		isRollback,
 		crossFieldManager as CrossFieldManager<NodeId>,
+		genId,
 		revision,
 	);
 }
@@ -74,12 +76,13 @@ function invertMarkList(
 	markList: MarkList,
 	isRollback: boolean,
 	crossFieldManager: CrossFieldManager<NodeId>,
+	genId: AtomIdAliasAllocator,
 	revision: RevisionTag | undefined,
 ): MarkList {
 	const inverseMarkList = new MarkListFactory();
 
 	for (const mark of markList) {
-		const inverseMarks = invertMark(mark, isRollback, crossFieldManager, revision);
+		const inverseMarks = invertMark(mark, isRollback, crossFieldManager, genId, revision);
 		inverseMarkList.push(...inverseMarks);
 	}
 
@@ -90,6 +93,7 @@ function invertMark(
 	mark: Mark,
 	isRollback: boolean,
 	crossFieldManager: CrossFieldManager<NodeId>,
+	genId: AtomIdAliasAllocator,
 	revision: RevisionTag | undefined,
 ): Mark[] {
 	if (!isImpactful(mark)) {
@@ -124,7 +128,7 @@ function invertMark(
 			if (inputId === undefined) {
 				inverse = {
 					type: "Insert",
-					id: mark.id,
+					id: genId.getAlias(mark.revision, mark.id),
 					cellId: outputId,
 					count: mark.count,
 					revision,
@@ -132,7 +136,7 @@ function invertMark(
 			} else {
 				inverse = {
 					type: "Remove",
-					id: mark.id,
+					id: genId.getAlias(mark.revision, mark.id),
 					cellId: outputId,
 					count: mark.count,
 					revision,
@@ -149,7 +153,7 @@ function invertMark(
 			const removeMark: Mutable<CellMark<Remove>> = {
 				type: "Remove",
 				count: mark.count,
-				id: inputId.localId,
+				id: genId.getAlias(inputId.revision, inputId.localId),
 				revision,
 			};
 
@@ -182,13 +186,13 @@ function invertMark(
 
 			const moveIn: MoveIn = {
 				type: "MoveIn",
-				id: mark.id,
+				id: genId.getAlias(mark.revision, mark.id),
 				revision,
 			};
 
 			if (mark.finalEndpoint !== undefined) {
 				moveIn.finalEndpoint = {
-					localId: mark.finalEndpoint.localId,
+					localId: genId.getAlias(mark.revision, mark.finalEndpoint.localId),
 					revision,
 				};
 			}
@@ -197,7 +201,7 @@ function invertMark(
 			if (inputId !== undefined) {
 				const detach: Mutable<Detach> = {
 					type: "Remove",
-					id: mark.id,
+					id: genId.getAlias(mark.revision, mark.id),
 					revision,
 				};
 				if (isRollback) {
@@ -216,7 +220,7 @@ function invertMark(
 			assert(inputId !== undefined, 0x89e /* Active move-ins should target empty cells */);
 			const invertedMark: Mutable<CellMark<MoveOut>> = {
 				type: "MoveOut",
-				id: mark.id,
+				id: genId.getAlias(mark.revision, mark.id),
 				count: mark.count,
 				revision,
 			};
@@ -227,7 +231,7 @@ function invertMark(
 
 			if (mark.finalEndpoint) {
 				invertedMark.finalEndpoint = {
-					localId: mark.finalEndpoint.localId,
+					localId: genId.getAlias(mark.revision, mark.finalEndpoint.localId),
 					revision,
 				};
 			}
@@ -249,8 +253,20 @@ function invertMark(
 				changes: mark.changes,
 				...mark.detach,
 			};
-			const attachInverses = invertMark(attach, isRollback, crossFieldManager, revision);
-			const detachInverses = invertMark(detach, isRollback, crossFieldManager, revision);
+			const attachInverses = invertMark(
+				attach,
+				isRollback,
+				crossFieldManager,
+				genId,
+				revision,
+			);
+			const detachInverses = invertMark(
+				detach,
+				isRollback,
+				crossFieldManager,
+				genId,
+				revision,
+			);
 
 			if (detachInverses.length === 0) {
 				return attachInverses;

--- a/packages/dds/tree/src/feature-libraries/sequence-field/invert.ts
+++ b/packages/dds/tree/src/feature-libraries/sequence-field/invert.ts
@@ -161,7 +161,7 @@ function invertMark(
 			const removeMark: Mutable<CellMark<Remove>> = {
 				type: "Remove",
 				count: mark.count,
-				id: genId.getAlias(inputId.revision, inputId.localId),
+				id: genId.getAlias(mark.revision, mark.id),
 				revision,
 			};
 

--- a/packages/dds/tree/src/test/feature-libraries/default-field-kinds/defaultFieldKinds.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/default-field-kinds/defaultFieldKinds.spec.ts
@@ -18,6 +18,7 @@ import type {
 } from "../../../feature-libraries/index.js";
 import {
 	allowsMultiplicitySuperset,
+	DefaultAtomIdAliasAllocator,
 	type NodeId,
 	rebaseRevisionMetadataFromInfo,
 	// eslint-disable-next-line import-x/no-internal-modules
@@ -30,7 +31,7 @@ import {
 	requiredFieldEditor,
 	// eslint-disable-next-line import-x/no-internal-modules
 } from "../../../feature-libraries/optional-field/requiredField.js";
-import { brand, fakeIdAllocator, idAllocatorFromMaxId } from "../../../util/index.js";
+import { brand, fakeIdAllocator } from "../../../util/index.js";
 import { TestNodeId } from "../../testNodeId.js";
 import { defaultRevisionMetadataFromChanges, mintRevisionTag } from "../../utils.js";
 import {
@@ -245,7 +246,7 @@ describe("defaultFieldKinds", () => {
 			const inverted = fieldHandler.rebaser.invert(
 				taggedChange.change,
 				true,
-				idAllocatorFromMaxId(),
+				new DefaultAtomIdAliasAllocator(),
 				mintRevisionTag(),
 				failCrossFieldManager,
 				defaultRevisionMetadataFromChanges([taggedChange]),

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/defaultAtomIdAliasAllocator.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/defaultAtomIdAliasAllocator.spec.ts
@@ -1,0 +1,121 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "node:assert";
+
+import type { ChangesetLocalId, RevisionTag } from "../../../core/index.js";
+
+import { brand } from "../../../util/index.js";
+import { DefaultAtomIdAliasAllocator } from "../../../feature-libraries/index.js";
+
+describe("DefaultAtomIdAliasAllocator", () => {
+	const revA: RevisionTag = "RevA" as RevisionTag;
+	const revB: RevisionTag = "RevB" as RevisionTag;
+	const revC: RevisionTag = "RevC" as RevisionTag;
+	const noLocalId = brand<ChangesetLocalId>(-1);
+	const localId0 = brand<ChangesetLocalId>(0);
+	const localId1 = brand<ChangesetLocalId>(1);
+	const localId2 = brand<ChangesetLocalId>(2);
+
+	function assertContiguous(aliases: number[]) {
+		for (let i = 1; i < aliases.length; i++) {
+			assert.strictEqual(aliases[i], aliases[i - 1] + 1);
+		}
+	}
+
+	function assertUnique(aliases: number[]) {
+		const seen = new Set<number>();
+		for (const alias of aliases) {
+			assert(!seen.has(alias), `Alias ${alias} is not unique`);
+			seen.add(alias);
+		}
+	}
+	const permutations = [
+		[revA, revB, revC],
+		[revA, revC, revB],
+		[revB, revA, revC],
+		[revB, revC, revA],
+		[revC, revA, revB],
+		[revC, revB, revA],
+	];
+
+	const maxIdPerRevision: Map<RevisionTag, ChangesetLocalId> = new Map([
+		[revA, localId2],
+		[revB, localId0],
+		[revC, localId1],
+	]);
+
+	const testModifiers = [
+		{ testRevisionsWithoutIds: false, testExtraAllocations: false },
+		{ testRevisionsWithoutIds: true, testExtraAllocations: false },
+		{ testRevisionsWithoutIds: false, testExtraAllocations: true },
+		{ testRevisionsWithoutIds: true, testExtraAllocations: true },
+	];
+
+	const extraBlockSize = 100;
+
+	for (const testModifier of testModifiers) {
+		describe(`should correctly reserve and return aliases ${JSON.stringify(testModifier)}`, () => {
+			for (const reserveOrder of permutations) {
+				it(`order: ${reserveOrder.join(", ")}`, () => {
+					const allocator = new DefaultAtomIdAliasAllocator();
+
+					const extras: number[] = [];
+
+					for (const revision of reserveOrder) {
+						allocator.reserve(
+							revision,
+							maxIdPerRevision.get(revision) ?? assert.fail("Missing max ID for revision"),
+						);
+						// Test that revisions with no reserved local IDs are handled correctly
+						if (testModifier.testRevisionsWithoutIds) {
+							allocator.reserve(`${revision}-no-ID` as RevisionTag, noLocalId);
+						}
+						// Test that extra ID can be allocated
+						if (testModifier.testExtraAllocations) {
+							extras.push(allocator.allocate(extraBlockSize));
+						}
+					}
+
+					const aliasA0 = allocator.getAlias(revA, localId0);
+					const aliasA1 = allocator.getAlias(revA, localId1);
+					const aliasA2 = allocator.getAlias(revA, localId2);
+					assertContiguous([aliasA0, aliasA1, aliasA2]);
+
+					const aliasB0 = allocator.getAlias(revB, localId0);
+
+					const aliasC0 = allocator.getAlias(revC, localId0);
+					const aliasC1 = allocator.getAlias(revC, localId1);
+					assertContiguous([aliasC0, aliasC1]);
+
+					const allAliases = [aliasA0, aliasA1, aliasA2, aliasB0, aliasC0, aliasC1];
+					assertUnique(allAliases);
+
+					if (testModifier.testExtraAllocations) {
+						assertUnique(extras);
+						for (const extra of extras) {
+							for (const alias of allAliases) {
+								assert(alias < extra || alias >= extra + extraBlockSize);
+							}
+						}
+					}
+
+					// Check that the aliases remain consistent
+					assert.equal(allocator.getAlias(revA, localId0), aliasA0);
+					assert.equal(allocator.getAlias(revA, localId1), aliasA1);
+					assert.equal(allocator.getAlias(revA, localId2), aliasA2);
+					assert.equal(allocator.getAlias(revB, localId0), aliasB0);
+					assert.equal(allocator.getAlias(revC, localId0), aliasC0);
+					assert.equal(allocator.getAlias(revC, localId1), aliasC1);
+
+					assert.equal(
+						allocator.getMaxId(),
+						5 + (testModifier.testExtraAllocations ? extraBlockSize * 3 : 0),
+					);
+				});
+			}
+		});
+	}
+});

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/defaultAtomIdAliasAllocator.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/defaultAtomIdAliasAllocator.spec.ts
@@ -13,7 +13,7 @@ import { DefaultAtomIdAliasAllocator } from "../../../feature-libraries/index.js
 describe("DefaultAtomIdAliasAllocator", () => {
 	const revA: RevisionTag = "RevA" as RevisionTag;
 	const revB: RevisionTag = "RevB" as RevisionTag;
-	const revC: RevisionTag = "RevC" as RevisionTag;
+	const revC = undefined;
 	const noLocalId = brand<ChangesetLocalId>(-1);
 	const localId0 = brand<ChangesetLocalId>(0);
 	const localId1 = brand<ChangesetLocalId>(1);
@@ -41,7 +41,7 @@ describe("DefaultAtomIdAliasAllocator", () => {
 		[revC, revB, revA],
 	];
 
-	const maxIdPerRevision: Map<RevisionTag, ChangesetLocalId> = new Map([
+	const maxIdPerRevision: Map<RevisionTag | undefined, ChangesetLocalId> = new Map([
 		[revA, localId2],
 		[revB, localId0],
 		[revC, localId1],

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/genericFieldKind.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/genericFieldKind.spec.ts
@@ -20,7 +20,7 @@ import {
 	DefaultAtomIdAliasAllocator,
 	// eslint-disable-next-line import-x/no-internal-modules
 } from "../../../feature-libraries/modular-schema/index.js";
-import { fakeIdAllocator, brand, idAllocatorFromMaxId } from "../../../util/index.js";
+import { fakeIdAllocator, brand } from "../../../util/index.js";
 import { TestChange } from "../../testChange.js";
 import { TestNodeId } from "../../testNodeId.js";
 import {

--- a/packages/dds/tree/src/test/feature-libraries/modular-schema/genericFieldKind.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/modular-schema/genericFieldKind.spec.ts
@@ -17,6 +17,7 @@ import {
 	type NodeId,
 	type RebaseRevisionMetadata,
 	genericChangeHandler,
+	DefaultAtomIdAliasAllocator,
 	// eslint-disable-next-line import-x/no-internal-modules
 } from "../../../feature-libraries/modular-schema/index.js";
 import { fakeIdAllocator, brand, idAllocatorFromMaxId } from "../../../util/index.js";
@@ -172,7 +173,7 @@ describe("GenericField", () => {
 		const actual = genericChangeHandler.rebaser.invert(
 			forward,
 			true,
-			idAllocatorFromMaxId(),
+			new DefaultAtomIdAliasAllocator(),
 			mintRevisionTag(),
 			crossFieldManager,
 			defaultRevisionMetadataFromChanges([]),

--- a/packages/dds/tree/src/test/feature-libraries/optional-field/optionalChangeRebaser.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/optional-field/optionalChangeRebaser.test.ts
@@ -22,6 +22,7 @@ import {
 } from "../../../core/index.js";
 import type { CrossFieldManager } from "../../../feature-libraries/index.js";
 import {
+	DefaultAtomIdAliasAllocator,
 	DefaultRevisionReplacer,
 	type FieldChangeDelta,
 	type NodeChangeComposer,
@@ -165,7 +166,7 @@ function invert(
 	const inverted = optionalChangeRebaser.invert(
 		change.change,
 		isRollback,
-		idAllocatorFromMaxId(),
+		new DefaultAtomIdAliasAllocator(),
 		revision,
 		failCrossFieldManager,
 		defaultRevisionMetadataFromChanges([change]),

--- a/packages/dds/tree/src/test/feature-libraries/optional-field/optionalField.spec.ts
+++ b/packages/dds/tree/src/test/feature-libraries/optional-field/optionalField.spec.ts
@@ -14,10 +14,11 @@ import {
 	makeDetachedNodeId,
 	tagChange,
 } from "../../../core/index.js";
-import type {
-	CrossFieldManager,
-	NodeId,
-	RelevantRemovedRootsFromChild,
+import {
+	DefaultAtomIdAliasAllocator,
+	type CrossFieldManager,
+	type NodeId,
+	type RelevantRemovedRootsFromChild,
 } from "../../../feature-libraries/index.js";
 import type {
 	ChildChangeInfo,
@@ -41,12 +42,7 @@ import type {
 	OptionalChangeset,
 	// eslint-disable-next-line import-x/no-internal-modules
 } from "../../../feature-libraries/optional-field/optionalFieldChangeTypes.js";
-import {
-	brand,
-	fakeIdAllocator,
-	idAllocatorFromMaxId,
-	type RangeQueryResult,
-} from "../../../util/index.js";
+import { brand, fakeIdAllocator, type RangeQueryResult } from "../../../util/index.js";
 import { TestChange } from "../../testChange.js";
 import { TestNodeId } from "../../testNodeId.js";
 import {
@@ -351,7 +347,7 @@ describe("optionalField", () => {
 				return optionalChangeRebaser.invert(
 					change.change,
 					false,
-					idAllocatorFromMaxId(),
+					new DefaultAtomIdAliasAllocator(),
 					mintRevisionTag(),
 					failCrossFieldManager,
 					defaultRevisionMetadataFromChanges([change]),
@@ -361,7 +357,7 @@ describe("optionalField", () => {
 				return optionalChangeRebaser.invert(
 					change.change,
 					true,
-					idAllocatorFromMaxId(),
+					new DefaultAtomIdAliasAllocator(),
 					mintRevisionTag(),
 					failCrossFieldManager,
 					defaultRevisionMetadataFromChanges([change]),
@@ -542,7 +538,7 @@ describe("optionalField", () => {
 					optionalChangeRebaser.invert(
 						deletion.change,
 						false,
-						idAllocatorFromMaxId(),
+						new DefaultAtomIdAliasAllocator(),
 						tag2,
 						failCrossFieldManager,
 						defaultRevisionMetadataFromChanges([deletion]),
@@ -816,7 +812,7 @@ describe("optionalField", () => {
 				const restore = optionalChangeRebaser.invert(
 					clear.change,
 					false,
-					idAllocatorFromMaxId(),
+					new DefaultAtomIdAliasAllocator(),
 					mintRevisionTag(),
 					failCrossFieldManager,
 					defaultRevisionMetadataFromChanges([clear]),
@@ -882,7 +878,7 @@ describe("optionalField", () => {
 					optionalChangeRebaser.invert(
 						clear.change,
 						false,
-						idAllocatorFromMaxId(),
+						new DefaultAtomIdAliasAllocator(),
 						mintRevisionTag(),
 						failCrossFieldManager,
 						defaultRevisionMetadataFromChanges([clear]),

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/invert.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/invert.test.ts
@@ -77,7 +77,7 @@ export function testInvert(): void {
 		it("insert => remove", () => {
 			const cellId: CellId = { revision: tag1, localId: brand(0) };
 			const input = Change.insert(0, 2, tag1, cellId);
-			const actual = invert(input, tag2);
+			const actual = invert(input);
 			const expected = [
 				Mark.remove(2, brand(0), { idOverride: cellId, revision: tagForInvert }),
 			];
@@ -137,13 +137,9 @@ export function testInvert(): void {
 
 		it("active revive => remove", () => {
 			const cellId: CellId = { revision: tag1, localId: brand(0) };
-			const input = Change.revive(0, 2, cellId, tag1);
+			const input = Change.revive(0, 2, cellId, tag2);
 			const expected: Changeset = [
-				Mark.remove(
-					2,
-					{ localId: brand(0), revision: tag2 },
-					{ idOverride: cellId, revision: tagForInvert },
-				),
+				Mark.remove(2, { localId: brand(0), revision: tagForInvert }, { idOverride: cellId }),
 			];
 			const actual = invert(input, tag2);
 			assertChangesetsEqual(actual, expected);

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceChangeRebaser.test.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/sequenceChangeRebaser.test.ts
@@ -297,12 +297,12 @@ export function testRebaserAxioms(): void {
 
 		// Hand-crafted version of the above tests to add coverage for returns
 		it("Return ↷ [Return, Return⁻¹] === Return", () => {
-			const move: SF.Changeset = Mark.move(1, { revision: tag0, localId: brand(0) });
-			const r: SF.Changeset = testInvert(tagChange(move, tag0), tag3, false);
-			const base1 = tagChange(r, tag1);
+			const move = tagChange(Mark.move(1, { revision: tag0, localId: brand(0) }), tag0);
+			const r = tagChange(testInvert(move, tag3, false), tag3);
+			const base1 = tagChange(testInvert(move, tag1, false), tag1);
 			const base2 = tagChange(testInvert(base1, tag2, true), tag2);
-			const actual = rebaseOverChanges(tagChange(r, tag3), [base1, base2]);
-			assertChangesetsEqual(actual.change, r);
+			const actual = rebaseOverChanges(r, [base1, base2]);
+			assertChangesetsEqual(actual.change, r.change);
 		});
 
 		/**

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/utils.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/utils.ts
@@ -88,7 +88,6 @@ import {
 	type IdAllocator,
 	type Mutable,
 	brand,
-	fakeIdAllocator,
 	getOrAddEmptyToMap,
 	idAllocatorFromMaxId,
 	setInNestedMap,

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/utils.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/utils.ts
@@ -477,20 +477,20 @@ export function invertDeep(
 
 export function testInvert(
 	change: TaggedChange<Changeset>,
-	revision: RevisionTag | undefined,
+	inverseRevision: RevisionTag | undefined,
 	isRollback = true,
 ): Changeset {
 	deepFreeze(change.change);
 	const table = newCrossFieldTable();
 	const genId = new DefaultAtomIdAliasAllocator();
-	genId.reserve(revision, brand(Number.MAX_SAFE_INTEGER));
-	let inverted = invert(change.change, isRollback, genId, revision, table);
+	genId.reserve(change.revision, brand(Number.MAX_SAFE_INTEGER));
+	let inverted = invert(change.change, isRollback, genId, inverseRevision, table);
 
 	if (table.isInvalidated) {
 		table.isInvalidated = false;
 		table.srcQueries.clear();
 		table.dstQueries.clear();
-		inverted = invert(change.change, isRollback, genId, revision, table);
+		inverted = invert(change.change, isRollback, genId, inverseRevision, table);
 	}
 
 	return inverted;

--- a/packages/dds/tree/src/test/feature-libraries/sequence-field/utils.ts
+++ b/packages/dds/tree/src/test/feature-libraries/sequence-field/utils.ts
@@ -29,6 +29,7 @@ import {
 	type CrossFieldManager,
 	type CrossFieldQuerySet,
 	CrossFieldTarget,
+	DefaultAtomIdAliasAllocator,
 	type FieldChangeDelta,
 	type NodeId,
 	type RebaseRevisionMetadata,
@@ -482,27 +483,15 @@ export function testInvert(
 ): Changeset {
 	deepFreeze(change.change);
 	const table = newCrossFieldTable();
-	let inverted = invert(
-		change.change,
-		isRollback,
-		// Sequence fields should not generate IDs during invert
-		fakeIdAllocator,
-		revision,
-		table,
-	);
+	const genId = new DefaultAtomIdAliasAllocator();
+	genId.reserve(revision, brand(Number.MAX_SAFE_INTEGER));
+	let inverted = invert(change.change, isRollback, genId, revision, table);
 
 	if (table.isInvalidated) {
 		table.isInvalidated = false;
 		table.srcQueries.clear();
 		table.dstQueries.clear();
-		inverted = invert(
-			change.change,
-			isRollback,
-			// Sequence fields should not generate IDs during invert
-			fakeIdAllocator,
-			revision,
-			table,
-		);
+		inverted = invert(change.change, isRollback, genId, revision, table);
 	}
 
 	return inverted;

--- a/packages/dds/tree/src/test/shared-tree/fuzz/composeVsIndividual.fuzz.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/composeVsIndividual.fuzz.spec.ts
@@ -70,11 +70,11 @@ const fuzzComposedVsIndividualReducer = combineReducers<Operation, BranchedTreeF
 			"Transactions are simulated manually in these tests and should not be generated.",
 		);
 	},
-	undoRedo: (state, { operation }) => {
-		const tree = state.main ?? assert.fail();
-		assert(isRevertibleSharedTreeView(tree.checkout));
-		applyUndoRedoEdit(tree.checkout.undoStack, tree.checkout.redoStack, operation);
-		return state;
+	undoRedo: () => {
+		assert.fail("Revert operations are not expected in these tests.");
+	},
+	revertTo: () => {
+		assert.fail("RevertTo operations are not expected in these tests.");
 	},
 	synchronizeTrees: (state) => {
 		applySynchronizationOp(state);

--- a/packages/dds/tree/src/test/shared-tree/fuzz/composeVsIndividual.fuzz.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/composeVsIndividual.fuzz.spec.ts
@@ -33,13 +33,8 @@ import {
 	applyConstraint,
 	applyFieldEdit,
 	applySynchronizationOp,
-	applyUndoRedoEdit,
 } from "./fuzzEditReducers.js";
-import {
-	createOnCreate,
-	deterministicIdCompressorFactory,
-	isRevertibleSharedTreeView,
-} from "./fuzzUtils.js";
+import { createOnCreate, deterministicIdCompressorFactory } from "./fuzzUtils.js";
 import type { Operation } from "./operationTypes.js";
 
 /**

--- a/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditGenerators.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditGenerators.ts
@@ -29,7 +29,7 @@ import { type DownPath, toDownPath } from "../../../feature-libraries/index.js";
 import { Tree, type ITreePrivate } from "../../../shared-tree/index.js";
 // eslint-disable-next-line import-x/no-internal-modules
 import type { SchematizingSimpleTreeView } from "../../../shared-tree/schematizingTreeView.js";
-import { getInnerNode } from "../../../simple-tree/index.js";
+import { getInnerNode, type CommitRevision } from "../../../simple-tree/index.js";
 import {
 	SchemaFactory,
 	TreeViewConfiguration,
@@ -67,6 +67,7 @@ import {
 	GeneratedFuzzValueType,
 	type NodeRange,
 	type ForkMergeOperation,
+	type RevertTo,
 } from "./operationTypes.js";
 
 export type FuzzView = SchematizingSimpleTreeView<typeof fuzzFieldSchema> & {
@@ -276,6 +277,7 @@ export interface EditGeneratorOpWeights {
 	nodeConstraint: number;
 	fork: number;
 	merge: number;
+	revertTo: number;
 }
 const defaultEditGeneratorOpWeights: EditGeneratorOpWeights = {
 	set: 0,
@@ -295,6 +297,7 @@ const defaultEditGeneratorOpWeights: EditGeneratorOpWeights = {
 	nodeConstraint: 0,
 	fork: 0,
 	merge: 0,
+	revertTo: 0,
 };
 
 export interface EditGeneratorOptions {
@@ -672,6 +675,21 @@ export const makeUndoRedoEditGenerator = (
 	]);
 };
 
+export const revertToGenerator = (state: FuzzTestState): RevertTo => {
+	const allRevisions: CommitRevision[] = [];
+	const head = viewFromState(state).branchHistory.getHead();
+	for (
+		let revisionMetadata = head;
+		revisionMetadata !== undefined;
+		revisionMetadata = revisionMetadata.getParent()
+	) {
+		allRevisions.push(revisionMetadata.revision);
+	}
+	assert(allRevisions.length > 0, "No revisions available to revert to.");
+	const revision = state.random.pick(allRevisions);
+	return { type: "revertTo", revision };
+};
+
 export const makeConstraintEditGenerator = (
 	opWeightsArg: Partial<EditGeneratorOpWeights>,
 ): Generator<Constraint, FuzzTestState> => {
@@ -723,6 +741,7 @@ export function makeOpGenerator(
 		start,
 		undo,
 		redo,
+		revertTo,
 		fieldSelection,
 		schema,
 		synchronizeTrees,
@@ -751,6 +770,17 @@ export function makeOpGenerator(
 						type: "synchronizeTrees",
 					}),
 					synchronizeTrees,
+				],
+				[
+					() => revertToGenerator,
+					revertTo,
+					(state: FuzzTestState) => {
+						const view = viewFromState(state);
+						return (
+							view.checkout.transaction.size === 0 &&
+							view.branchHistory.getHead() !== undefined
+						);
+					},
 				],
 				[() => schemaEditGenerator, schema],
 				[

--- a/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditReducers.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/fuzzEditReducers.ts
@@ -86,6 +86,10 @@ const syncFuzzReducer = combineReducers<
 		assert(isRevertibleSharedTreeView(view));
 		applyUndoRedoEdit(view.undoStack, view.redoStack, operation);
 	},
+	revertTo: (state, { revision }) => {
+		const view = viewFromState(state).checkout;
+		view.revertTo(revision);
+	},
 	synchronizeTrees: (state) => {
 		applySynchronizationOp(state);
 	},

--- a/packages/dds/tree/src/test/shared-tree/fuzz/operationTypes.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/operationTypes.ts
@@ -7,6 +7,7 @@ import type { IFluidHandle } from "@fluidframework/core-interfaces";
 
 import type { FieldKey } from "../../../core/index.js";
 import type { DownPath } from "../../../feature-libraries/index.js";
+import type { CommitRevision } from "../../../simple-tree/index.js";
 
 export type Operation = TreeOperation | Synchronize;
 
@@ -14,6 +15,7 @@ export type TreeOperation =
 	| TreeEdit
 	| TransactionBoundary
 	| UndoRedo
+	| RevertTo
 	| SchemaChange
 	| Constraint
 	| ForkMergeOperation;
@@ -42,6 +44,12 @@ export interface TransactionBoundary {
 export interface UndoRedo {
 	type: "undoRedo";
 	operation: "undo" | "redo";
+}
+
+export interface RevertTo {
+	type: "revertTo";
+	/** The revision to revert the tree to. */
+	revision: CommitRevision;
 }
 
 export interface SchemaChange {

--- a/packages/dds/tree/src/test/shared-tree/fuzz/revertTo.fuzz.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/revertTo.fuzz.spec.ts
@@ -28,8 +28,8 @@ import {
 } from "./fuzzUtils.js";
 import type { Operation } from "./operationTypes.js";
 
-const runsPerBatch = 200;
-const opsPerRun = 5;
+const runsPerBatch = 20;
+const opsPerRun = 50;
 
 const weights: Partial<EditGeneratorOpWeights> = {
 	fieldSelection: { optional: 0, required: 0, sequence: 1, recurse: 1 },
@@ -60,9 +60,6 @@ describe("Fuzz - revertTo", () => {
 		numberOfClients: 3,
 		defaultTestCount: runsPerBatch,
 		saveFailures: {
-			directory: failureDirectory,
-		},
-		saveSuccesses: {
 			directory: failureDirectory,
 		},
 		clientJoinOptions: {

--- a/packages/dds/tree/src/test/shared-tree/fuzz/revertTo.fuzz.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/revertTo.fuzz.spec.ts
@@ -1,0 +1,81 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { type AsyncGenerator, takeAsync } from "@fluid-private/stochastic-test-utils";
+import {
+	type DDSFuzzModel,
+	type DDSFuzzSuiteOptions,
+	type DDSFuzzTestState,
+	createDDSFuzzSuite,
+} from "@fluid-private/test-dds-utils";
+
+import { ForestTypeExpensiveDebug } from "../../../shared-tree/index.js";
+import { SharedTreeTestFactory, validateFuzzTreeConsistency } from "../../utils.js";
+
+import {
+	type EditGeneratorOpWeights,
+	type FuzzTestState,
+	makeOpGenerator,
+} from "./fuzzEditGenerators.js";
+import { fuzzReducer } from "./fuzzEditReducers.js";
+import {
+	createOnCreate,
+	deterministicIdCompressorFactory,
+	failureDirectory,
+	populatedInitialState,
+} from "./fuzzUtils.js";
+import type { Operation } from "./operationTypes.js";
+
+const runsPerBatch = 20;
+const opsPerRun = 50;
+
+const weights: Partial<EditGeneratorOpWeights> = {
+	fieldSelection: { optional: 0, required: 0, sequence: 1, recurse: 1 },
+	crossFieldMove: 6,
+	start: 1,
+	commit: 5,
+	revertTo: 10,
+};
+
+describe("Fuzz - revertTo", () => {
+	const generatorFactory = (): AsyncGenerator<Operation, FuzzTestState> =>
+		takeAsync(opsPerRun, makeOpGenerator(weights));
+
+	const model: DDSFuzzModel<
+		SharedTreeTestFactory,
+		Operation,
+		DDSFuzzTestState<SharedTreeTestFactory>
+	> = {
+		workloadName: "revert to random past revision",
+		factory: new SharedTreeTestFactory(createOnCreate(populatedInitialState), undefined, {
+			forest: ForestTypeExpensiveDebug,
+		}),
+		generatorFactory,
+		reducer: fuzzReducer,
+		validateConsistency: validateFuzzTreeConsistency,
+	};
+	const options: Partial<DDSFuzzSuiteOptions> = {
+		numberOfClients: 3,
+		defaultTestCount: runsPerBatch,
+		saveFailures: {
+			directory: failureDirectory,
+		},
+		saveSuccesses: {
+			directory: failureDirectory,
+		},
+		clientJoinOptions: {
+			clientAddProbability: 0.1,
+			maxNumberOfClients: 3,
+		},
+		detachedStartOptions: {
+			numOpsBeforeAttach: 5,
+			// AB#43127: fully allowing rehydrate after attach is currently not supported in tests (but should be in prod) due to limitations in the test mocks.
+			attachingBeforeRehydrateDisable: true,
+		},
+		reconnectProbability: 0.1,
+		idCompressorFactory: deterministicIdCompressorFactory(0xdeadbeef),
+	};
+	createDDSFuzzSuite(model, options);
+});

--- a/packages/dds/tree/src/test/shared-tree/fuzz/revertTo.fuzz.spec.ts
+++ b/packages/dds/tree/src/test/shared-tree/fuzz/revertTo.fuzz.spec.ts
@@ -28,8 +28,8 @@ import {
 } from "./fuzzUtils.js";
 import type { Operation } from "./operationTypes.js";
 
-const runsPerBatch = 20;
-const opsPerRun = 50;
+const runsPerBatch = 200;
+const opsPerRun = 5;
 
 const weights: Partial<EditGeneratorOpWeights> = {
 	fieldSelection: { optional: 0, required: 0, sequence: 1, recurse: 1 },
@@ -76,6 +76,7 @@ describe("Fuzz - revertTo", () => {
 		},
 		reconnectProbability: 0.1,
 		idCompressorFactory: deterministicIdCompressorFactory(0xdeadbeef),
+		skipMinimization: true,
 	};
 	createDDSFuzzSuite(model, options);
 });

--- a/packages/dds/tree/src/test/simple-tree/api/tree.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/tree.spec.ts
@@ -623,17 +623,25 @@ describe("simple-tree tree", () => {
 	describe("revertTo", () => {
 		it("restores the state of the given revision with a new commit", () => {
 			// Setup
-			const config = new TreeViewConfiguration({ schema: schema.number });
+			const config = new TreeViewConfiguration({ schema: StringArray });
 			const view = getView(config);
-			view.initialize(1);
+			view.initialize([]);
 
 			const revision1 = view.branchHistory.getHead()?.revision;
 			assert(revision1 !== undefined, "revision should be defined");
-			view.root = 2;
+			// Test with some changes made outside of a transaction
+			view.root.insertAtEnd("A");
 			const revision2 = view.branchHistory.getHead()?.revision;
 			assert(revision2 !== undefined, "revision should be defined");
-			view.root = 3;
-			view.root = 4;
+			// Test with some changes made in a transaction
+			view.runTransaction(() => {
+				view.root.insertAtEnd("B");
+			});
+			view.runTransaction(() => {
+				view.root.insertAtEnd("C");
+			});
+			const revision4 = view.branchHistory.getHead()?.revision;
+			assert(revision4 !== undefined, "revision should be defined");
 
 			// Consistency check
 			assert.equal(view.branchHistory.length, 4);
@@ -645,22 +653,29 @@ describe("simple-tree tree", () => {
 			assert(revision5 !== undefined, "revision should be defined");
 
 			// Verify
-			assert.equal(view.root, 2);
+			assert.equal([...view.root], ["A"]);
 			assert.equal(view.branchHistory.length, 5);
 
 			// Act
 			view.revertTo(revision1);
 
 			// Verify
-			assert.equal(view.root, 1);
+			assert.equal([...view.root], []);
 			assert.equal(view.branchHistory.length, 6);
 
 			// Act
 			view.revertTo(revision5);
 
 			// Verify
-			assert.equal(view.root, 2);
+			assert.equal([...view.root], ["A"]);
 			assert.equal(view.branchHistory.length, 7);
+
+			// Act
+			view.revertTo(revision4);
+
+			// Verify
+			assert.equal([...view.root], ["A", "B", "C"]);
+			assert.equal(view.branchHistory.length, 8);
 		});
 
 		it("is a no-op when given the revision of the head commit", () => {

--- a/packages/dds/tree/src/test/simple-tree/api/tree.spec.ts
+++ b/packages/dds/tree/src/test/simple-tree/api/tree.spec.ts
@@ -653,28 +653,28 @@ describe("simple-tree tree", () => {
 			assert(revision5 !== undefined, "revision should be defined");
 
 			// Verify
-			assert.equal([...view.root], ["A"]);
+			assert.deepEqual([...view.root], ["A"]);
 			assert.equal(view.branchHistory.length, 5);
 
 			// Act
 			view.revertTo(revision1);
 
 			// Verify
-			assert.equal([...view.root], []);
+			assert.deepEqual([...view.root], []);
 			assert.equal(view.branchHistory.length, 6);
 
 			// Act
 			view.revertTo(revision5);
 
 			// Verify
-			assert.equal([...view.root], ["A"]);
+			assert.deepEqual([...view.root], ["A"]);
 			assert.equal(view.branchHistory.length, 7);
 
 			// Act
 			view.revertTo(revision4);
 
 			// Verify
-			assert.equal([...view.root], ["A", "B", "C"]);
+			assert.deepEqual([...view.root], ["A", "B", "C"]);
 			assert.equal(view.branchHistory.length, 8);
 		});
 


### PR DESCRIPTION
## Description

Fixes a bug in `UntypedTreeViewAlpha.revertTo` that could lead to the following assert codes: `0x7ce`, `0x8a1`, `0x695`.

The core issue was that our implementation of `invert` did not support inverting a composite (non-squashed) changeset. Specifically, the invert logic in sequence field would generate the same change atom ID in the inverse for multiple input change atom IDs which only differed by their revision.

## Breaking Changes

None
