### PR TITLE
docs(odsp-driver): add changeset for Node 24 compatibility fix

### DIFF
--- a/.changeset/fix-pooled-snapshot-buffers.md
+++ b/.changeset/fix-pooled-snapshot-buffers.md
@@ -1,0 +1,9 @@
+---
+"@fluidframework/odsp-driver": minor
+"__section": fix
+---
+Fix compact snapshot loading with pooled Node.js buffers
+
+Compact snapshots can now be loaded when their binary data is represented by a `Uint8Array` view
+with a non-zero `byteOffset`. This prevents container load failures in Node.js 24.18 and later,
+where the larger buffer pool causes more file reads to return pooled buffer views.


### PR DESCRIPTION
## Description

Adds the missing changeset for the compact snapshot parsing fix in [PR #28194](https://github.com/microsoft/FluidFramework/pull/28194).

Although the implementation change is internal, it fixes a consumer-visible compatibility issue where valid compact snapshots could fail to load with pooled buffers returned by Node.js 24.18 and later.