### PR TITLE
fix(build-cli): parallelize tarball publish preflight

### DIFF
--- a/build-tools/packages/build-cli/src/commands/publish/tarballs.ts
+++ b/build-tools/packages/build-cli/src/commands/publish/tarballs.ts
@@ -22,56 +22,67 @@ import { readLines } from "../../library/text.js";
  */
 export interface TarballMetadata {
 	/**
-	 * The npm package name.
+	 * The npm package name (for example `@fluidframework/core-utils`).
 	 */
-	name: string;
+	readonly name: string;
 
 	/**
-	 * The package version.
+	 * The package version (for example `2.0.0`).
 	 */
-	version: string;
+	readonly version: string;
 
 	/**
-	 * The absolute path to the tarball.
+	 * The absolute path to the tarball on disk.
 	 */
-	filePath: string;
+	readonly filePath: string;
 
 	/**
-	 * The tarball file name.
+	 * The tarball file name (for example `fluidframework-core-utils-2.0.0.tgz`).
 	 */
-	fileName: string;
+	readonly fileName: string;
 }
 
 const publishPreflightConcurrency = 10;
 
 /**
- * Hooks and options used by {@link publishTarballsInOrder}.
+ * Hooks and options used by {@link publishTarballsInOrder} to orchestrate tarball publishing.
  */
 export interface PublishTarballsOptions {
 	/**
 	 * Number of times to retry a failed publish after the first attempt.
+	 * Must be greater than or equal to 0.
 	 */
-	retry: number;
+	readonly retry: number;
 
 	/**
-	 * Checks whether a package version is already published.
+	 * Checks whether a package version is already available in the registry.
+	 *
+	 * @param tarball - The tarball metadata to check.
+	 * @returns `true` if the version exists in the registry; otherwise `false`.
 	 */
-	isPublished: (tarball: TarballMetadata) => Promise<boolean>;
+	readonly isPublished: (tarball: TarballMetadata) => Promise<boolean>;
 
 	/**
-	 * Publishes one tarball.
+	 * Publishes one tarball to the registry.
+	 *
+	 * @param tarball - The tarball to publish.
+	 * @returns The resulting {@link PublishStatus}.
 	 */
-	publish: (tarball: TarballMetadata) => Promise<PublishStatus>;
+	readonly publish: (tarball: TarballMetadata) => Promise<PublishStatus>;
 
 	/**
-	 * Called immediately before each publish attempt.
+	 * Optional callback invoked immediately before each publish attempt.
+	 *
+	 * @param tarball - The tarball being attempted.
+	 * @param attempt - The 1-based attempt number (1 for initial attempt, 2 for first retry, etc.).
 	 */
-	onPublishAttempt?: (tarball: TarballMetadata, attempt: number) => void;
+	readonly onPublishAttempt?: (tarball: TarballMetadata, attempt: number) => void;
 
 	/**
-	 * Maximum number of initial registry preflight checks to run at the same time.
+	 * Maximum number of initial registry preflight checks to execute concurrently.
+	 * Defaults to `10` when omitted.
 	 */
-	preflightConcurrency?: number;
+	readonly preflightConcurrency?: number;
 }
 
 /**
@@ -81,17 +92,17 @@ export interface PublishTarballResult {
 	/**
 	 * The final publish status for the tarball.
 	 */
-	status: PublishStatus;
+	readonly status: PublishStatus;
 
 	/**
-	 * The tarball that was processed.
+	 * The tarball metadata that was processed.
 	 */
-	tarball: TarballMetadata;
+	readonly tarball: TarballMetadata;
 
 	/**
-	 * The number of publish attempts made.
+	 * The total number of publish attempts made (0 if skipped via preflight check).
 	 */
-	tryCount: number;
+	readonly tryCount: number;
 }
 
 /**
@@ -237,10 +248,13 @@ export default class PublishTarballCommand extends BaseCommand<typeof PublishTar
 }
 
 /**
- * Reads package.json from a gzipped tarball.
+ * Reads and parses `package.json` from a gzipped tarball archive.
  *
- * Implementation from
+ * Implementation adapted from
  * https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/3729bc2a3ca2ef7dda5c22fef81f89e1abe5dacf/packages/core/src/createPackage.ts#L296
+ *
+ * @param tarballPath - Absolute path to the `.tgz` tarball file.
+ * @returns Parsed `package.json` object.
  */
 async function extractPackageJsonFromTarball(
 	tarballPath: string,
@@ -260,12 +274,25 @@ async function extractPackageJsonFromTarball(
 }
 
 /**
- * Final status for a tarball publish operation.
+ * Final outcome of a tarball publish operation.
+ *
+ * - `"SuccessfullyPublished"`: The package was published to the registry in this run.
+ * - `"AlreadyPublished"`: The package version already existed in the registry and was skipped.
+ * - `"Error"`: An error occurred and could not be resolved within the retry budget.
  */
 export type PublishStatus = "SuccessfullyPublished" | "AlreadyPublished" | "Error";
 
 /**
- * Resolves the ordered, deduplicated list of tarballs to publish.
+ * Resolves and deduplicates the list of tarballs to publish based on an ordered list of names.
+ *
+ * Retains only the first occurrence of each lookup key so duplicate entries in the order file
+ * are published only once while preserving the original relative order.
+ *
+ * @param packageOrder - Ordered list of package names or tarball file names from the order file.
+ * @param tarballMetadata - Map of tarball lookup names to metadata.
+ * @param orderFileIsTarballs - Whether `packageOrder` contains tarball file names rather than package names.
+ * @returns Ordered, deduplicated array of tarball metadata to publish.
+ * @throws `Error` if any entry in `packageOrder` does not have matching tarball metadata.
  */
 export function getTarballsToPublish(
 	packageOrder: readonly string[],
@@ -289,7 +316,20 @@ export function getTarballsToPublish(
 }
 
 /**
- * Runs publish orchestration for a set of already ordered tarballs.
+ * Executes publish orchestration for a list of tarballs.
+ *
+ * Runs initial registry preflight checks concurrently up to `options.preflightConcurrency`
+ * (default 10) to determine which packages are already published, then publishes unpublished
+ * packages sequentially in the provided dependency order.
+ *
+ * If a publish attempt fails, the registry is checked again to recover from lost responses
+ * or concurrent publication. If a tarball exhausts retries with an unrecoverable error,
+ * publishing stops immediately to avoid publishing downstream packages with broken dependencies.
+ *
+ * @param tarballs - Ordered list of tarballs to publish.
+ * @param options - Configuration and callbacks for publishing and retries.
+ * @returns Array of publish results corresponding to each attempted tarball up to first fatal error.
+ * @throws `RangeError` if `options.retry` is negative.
  */
 export async function publishTarballsInOrder(
 	tarballs: readonly TarballMetadata[],
@@ -350,6 +390,14 @@ export async function publishTarballsInOrder(
 	return results;
 }
 
+/**
+ * Invokes `npm publish` for a single tarball archive.
+ *
+ * @param tarball - Tarball metadata including file path and name.
+ * @param log - Logger instance for recording verbose output and errors.
+ * @param publishArgs - Additional CLI arguments to pass to `npm publish`.
+ * @returns Status indicating whether publication succeeded or resulted in an error.
+ */
 async function publishTarball(
 	tarball: TarballMetadata,
 	log: Logger,
@@ -377,6 +425,13 @@ async function publishTarball(
 	return "SuccessfullyPublished";
 }
 
+/**
+ * Queries the package registry to determine if a specific version of a package is already published.
+ *
+ * @param tarball - Tarball metadata containing the package name and version.
+ * @param log - Logger instance for debug output.
+ * @returns `true` if the version is found in the registry; otherwise `false`.
+ */
 async function isTarballPublished(tarball: TarballMetadata, log: Logger): Promise<boolean> {
 	try {
 		const publishedVersion = await latestVersion(tarball.name, {
@@ -390,6 +445,15 @@ async function isTarballPublished(tarball: TarballMetadata, log: Logger): Promis
 	}
 }
 
+/**
+ * Logs details about a failed publish attempt and returns an error status.
+ *
+ * @param log - Logger instance.
+ * @param name - Package name that failed to publish.
+ * @param message - Primary error message or stderr output.
+ * @param stack - Optional stack trace.
+ * @returns Always returns `"Error"`.
+ */
 function handlePublishError(
 	log: Logger,
 	name: string,

--- a/build-tools/packages/build-cli/src/commands/publish/tarballs.ts
+++ b/build-tools/packages/build-cli/src/commands/publish/tarballs.ts
@@ -328,7 +328,7 @@ export async function publishTarballsInOrder(
 			// eslint-disable-next-line no-await-in-loop
 			status = await publish(tarball);
 			tryCount++;
-			if (status === "SuccessfullyPublished") {
+			if (status !== "Error") {
 				break;
 			}
 

--- a/build-tools/packages/build-cli/src/commands/publish/tarballs.ts
+++ b/build-tools/packages/build-cli/src/commands/publish/tarballs.ts
@@ -42,6 +42,9 @@ export interface TarballMetadata {
 	readonly fileName: string;
 }
 
+/**
+ * Default maximum number of initial registry preflight checks to execute concurrently.
+ */
 const publishPreflightConcurrency = 10;
 
 /**

--- a/build-tools/packages/build-cli/src/commands/publish/tarballs.ts
+++ b/build-tools/packages/build-cli/src/commands/publish/tarballs.ts
@@ -62,6 +62,7 @@ export default class PublishTarballCommand extends BaseCommand<typeof PublishTar
 		retry: Flags.integer({
 			description: `Number of times to retry publishing a package that fails to publish.`,
 			default: 0,
+			min: 0,
 		}),
 		dryRun: Flags.boolean({
 			aliases: ["dry-run"],
@@ -122,13 +123,17 @@ export default class PublishTarballCommand extends BaseCommand<typeof PublishTar
 		await Promise.all(mapPromises);
 
 		const tarballsToPublish: TarballMetadata[] = [];
+		const seenTarballs = new Set<string>();
 		for (const entry of packageOrder) {
 			const lookupEntry = orderFileIsTarballs ? entry : getTarballName(entry);
 			const toPublish = tarballMetadata.get(lookupEntry);
 			if (toPublish === undefined) {
 				this.error(`No tarball found matching '${entry}'`, { exit: 1 });
 			}
-			tarballsToPublish.push(toPublish);
+			if (!seenTarballs.has(lookupEntry)) {
+				seenTarballs.add(lookupEntry);
+				tarballsToPublish.push(toPublish);
+			}
 		}
 
 		// The registry check is independent for every package, unlike publishing which must remain

--- a/build-tools/packages/build-cli/src/commands/publish/tarballs.ts
+++ b/build-tools/packages/build-cli/src/commands/publish/tarballs.ts
@@ -9,6 +9,7 @@ import { gunzipSync } from "node:zlib";
 import { untar } from "@andrewbranch/untar.js";
 import type { Logger, PackageJson } from "@fluidframework/build-tools";
 import { Flags } from "@oclif/core";
+import async from "async";
 import execa from "execa";
 import globby from "globby";
 import latestVersion from "latest-version";
@@ -22,6 +23,8 @@ interface TarballMetadata {
 	filePath: string;
 	fileName: string;
 }
+
+const publishPreflightConcurrency = 10;
 
 /**
  * Publishes a tarball to the package registry unless the version is already published.
@@ -118,26 +121,50 @@ export default class PublishTarballCommand extends BaseCommand<typeof PublishTar
 		}
 		await Promise.all(mapPromises);
 
+		const tarballsToPublish: TarballMetadata[] = [];
 		for (const entry of packageOrder) {
 			const lookupEntry = orderFileIsTarballs ? entry : getTarballName(entry);
 			const toPublish = tarballMetadata.get(lookupEntry);
 			if (toPublish === undefined) {
 				this.error(`No tarball found matching '${entry}'`, { exit: 1 });
 			}
+			tarballsToPublish.push(toPublish);
+		}
 
+		// The registry check is independent for every package, unlike publishing which must remain
+		// dependency-ordered. Bound the concurrent requests to avoid overwhelming the registry.
+		// eslint-disable-next-line import-x/no-named-as-default-member -- async.mapLimit is the idiomatic usage
+		const alreadyPublished = await async.mapLimit(
+			tarballsToPublish,
+			publishPreflightConcurrency,
+			async (tarball: TarballMetadata) => isTarballPublished(tarball, this.logger),
+		);
+
+		for (const [index, toPublish] of tarballsToPublish.entries()) {
 			let tryCount = 0;
-			let status: PublishStatus;
+			let status: PublishStatus = alreadyPublished[index]
+				? "AlreadyPublished"
+				: "SuccessfullyPublished";
 
-			do {
+			while (status !== "AlreadyPublished" && tryCount <= retry) {
 				this.info(`Publishing ${toPublish.fileName}, attempt ${tryCount + 1}`);
 				// We publish one package at a time, in order, and we don't continue until the current package is successfully
 				// published. This ensures that no packages are published to npm without their dependencies first being
 				// published. Note that despite publishing in order, npm itself may still make packages available in a different
 				// order - but we have no control over that.
 				// eslint-disable-next-line no-await-in-loop
-				status = await publishTarball(toPublish, this.logger, publishArgs);
+				status = await publishTarball(
+					toPublish,
+					this.logger,
+					publishArgs,
+					// Re-check on retries so a successful upload with a lost response is not reported as a failure.
+					tryCount > 0,
+				);
 				tryCount++;
-			} while (status === "Error" && tryCount <= retry);
+				if (status === "SuccessfullyPublished") {
+					break;
+				}
+			}
 
 			switch (status) {
 				case "AlreadyPublished": {
@@ -194,17 +221,10 @@ async function publishTarball(
 	tarball: TarballMetadata,
 	log: Logger,
 	publishArgs: string[],
+	checkIfPublished: boolean,
 ): Promise<PublishStatus> {
-	try {
-		const publishedVersion = await latestVersion(tarball.name, {
-			version: tarball.version,
-		});
-		if (publishedVersion !== "" && publishedVersion !== undefined) {
-			return "AlreadyPublished";
-		}
-	} catch (error) {
-		// Assume package or version is not published, so just continue and try to publish
-		log.verbose(`Version appears unpublished; expected error: ${error}`);
+	if (checkIfPublished && (await isTarballPublished(tarball, log))) {
+		return "AlreadyPublished";
 	}
 
 	const args = ["publish", tarball.fileName, "--access", "public"];
@@ -227,6 +247,19 @@ async function publishTarball(
 	}
 
 	return "SuccessfullyPublished";
+}
+
+async function isTarballPublished(tarball: TarballMetadata, log: Logger): Promise<boolean> {
+	try {
+		const publishedVersion = await latestVersion(tarball.name, {
+			version: tarball.version,
+		});
+		return publishedVersion !== "" && publishedVersion !== undefined;
+	} catch (error) {
+		// Assume package or version is not published, so just continue and try to publish.
+		log.verbose(`Version appears unpublished; expected error: ${error}`);
+		return false;
+	}
 }
 
 function handlePublishError(

--- a/build-tools/packages/build-cli/src/commands/publish/tarballs.ts
+++ b/build-tools/packages/build-cli/src/commands/publish/tarballs.ts
@@ -17,14 +17,82 @@ import { BaseCommand } from "../../library/commands/base.js";
 import { getTarballName } from "../../library/package.js";
 import { readLines } from "../../library/text.js";
 
-interface TarballMetadata {
+/**
+ * Package metadata extracted from a tarball before publishing.
+ */
+export interface TarballMetadata {
+	/**
+	 * The npm package name.
+	 */
 	name: string;
+
+	/**
+	 * The package version.
+	 */
 	version: string;
+
+	/**
+	 * The absolute path to the tarball.
+	 */
 	filePath: string;
+
+	/**
+	 * The tarball file name.
+	 */
 	fileName: string;
 }
 
 const publishPreflightConcurrency = 10;
+
+/**
+ * Hooks and options used by {@link publishTarballsInOrder}.
+ */
+export interface PublishTarballsOptions {
+	/**
+	 * Number of times to retry a failed publish after the first attempt.
+	 */
+	retry: number;
+
+	/**
+	 * Checks whether a package version is already published.
+	 */
+	isPublished: (tarball: TarballMetadata) => Promise<boolean>;
+
+	/**
+	 * Publishes one tarball.
+	 */
+	publish: (tarball: TarballMetadata) => Promise<PublishStatus>;
+
+	/**
+	 * Called immediately before each publish attempt.
+	 */
+	onPublishAttempt?: (tarball: TarballMetadata, attempt: number) => void;
+
+	/**
+	 * Maximum number of initial registry preflight checks to run at the same time.
+	 */
+	preflightConcurrency?: number;
+}
+
+/**
+ * Result for one tarball processed by {@link publishTarballsInOrder}.
+ */
+export interface PublishTarballResult {
+	/**
+	 * The final publish status for the tarball.
+	 */
+	status: PublishStatus;
+
+	/**
+	 * The tarball that was processed.
+	 */
+	tarball: TarballMetadata;
+
+	/**
+	 * The number of publish attempts made.
+	 */
+	tryCount: number;
+}
 
 /**
  * Publishes a tarball to the package registry unless the version is already published.
@@ -122,55 +190,26 @@ export default class PublishTarballCommand extends BaseCommand<typeof PublishTar
 		}
 		await Promise.all(mapPromises);
 
-		const tarballsToPublish: TarballMetadata[] = [];
-		const seenTarballs = new Set<string>();
-		for (const entry of packageOrder) {
-			const lookupEntry = orderFileIsTarballs ? entry : getTarballName(entry);
-			const toPublish = tarballMetadata.get(lookupEntry);
-			if (toPublish === undefined) {
-				this.error(`No tarball found matching '${entry}'`, { exit: 1 });
-			}
-			if (!seenTarballs.has(lookupEntry)) {
-				seenTarballs.add(lookupEntry);
-				tarballsToPublish.push(toPublish);
-			}
+		let tarballsToPublish: TarballMetadata[];
+		try {
+			tarballsToPublish = getTarballsToPublish(
+				packageOrder,
+				tarballMetadata,
+				orderFileIsTarballs,
+			);
+		} catch (error) {
+			this.error((error as Error).message, { exit: 1 });
 		}
 
-		// The registry check is independent for every package, unlike publishing which must remain
-		// dependency-ordered. Bound the concurrent requests to avoid overwhelming the registry.
-		// eslint-disable-next-line import-x/no-named-as-default-member -- async.mapLimit is the idiomatic usage
-		const alreadyPublished = await async.mapLimit(
-			tarballsToPublish,
-			publishPreflightConcurrency,
-			async (tarball: TarballMetadata) => isTarballPublished(tarball, this.logger),
-		);
+		const results = await publishTarballsInOrder(tarballsToPublish, {
+			retry,
+			isPublished: async (tarball) => isTarballPublished(tarball, this.logger),
+			publish: async (tarball) => publishTarball(tarball, this.logger, publishArgs),
+			onPublishAttempt: (tarball, attempt) =>
+				this.info(`Publishing ${tarball.fileName}, attempt ${attempt}`),
+		});
 
-		for (const [index, toPublish] of tarballsToPublish.entries()) {
-			let tryCount = 0;
-			let status: PublishStatus = alreadyPublished[index]
-				? "AlreadyPublished"
-				: "SuccessfullyPublished";
-
-			while (status !== "AlreadyPublished" && tryCount <= retry) {
-				this.info(`Publishing ${toPublish.fileName}, attempt ${tryCount + 1}`);
-				// We publish one package at a time, in order, and we don't continue until the current package is successfully
-				// published. This ensures that no packages are published to npm without their dependencies first being
-				// published. Note that despite publishing in order, npm itself may still make packages available in a different
-				// order - but we have no control over that.
-				// eslint-disable-next-line no-await-in-loop
-				status = await publishTarball(
-					toPublish,
-					this.logger,
-					publishArgs,
-					// Re-check on retries so a successful upload with a lost response is not reported as a failure.
-					tryCount > 0,
-				);
-				tryCount++;
-				if (status === "SuccessfullyPublished") {
-					break;
-				}
-			}
-
+		for (const { status, tarball: toPublish, tryCount } of results) {
 			switch (status) {
 				case "AlreadyPublished": {
 					this.info(`Already published ${toPublish.fileName}, skipping`);
@@ -220,18 +259,99 @@ async function extractPackageJsonFromTarball(
 	return packageJson;
 }
 
-type PublishStatus = "SuccessfullyPublished" | "AlreadyPublished" | "Error";
+/**
+ * Final status for a tarball publish operation.
+ */
+export type PublishStatus = "SuccessfullyPublished" | "AlreadyPublished" | "Error";
+
+/**
+ * Resolves the ordered, deduplicated list of tarballs to publish.
+ */
+export function getTarballsToPublish(
+	packageOrder: readonly string[],
+	tarballMetadata: ReadonlyMap<string, TarballMetadata>,
+	orderFileIsTarballs: boolean,
+): TarballMetadata[] {
+	const tarballsToPublish: TarballMetadata[] = [];
+	const seenTarballs = new Set<string>();
+	for (const entry of packageOrder) {
+		const lookupEntry = orderFileIsTarballs ? entry : getTarballName(entry);
+		const toPublish = tarballMetadata.get(lookupEntry);
+		if (toPublish === undefined) {
+			throw new Error(`No tarball found matching '${entry}'`);
+		}
+		if (!seenTarballs.has(lookupEntry)) {
+			seenTarballs.add(lookupEntry);
+			tarballsToPublish.push(toPublish);
+		}
+	}
+	return tarballsToPublish;
+}
+
+/**
+ * Runs publish orchestration for a set of already ordered tarballs.
+ */
+export async function publishTarballsInOrder(
+	tarballs: readonly TarballMetadata[],
+	options: PublishTarballsOptions,
+): Promise<PublishTarballResult[]> {
+	const { isPublished, onPublishAttempt, preflightConcurrency, publish, retry } = options;
+	if (retry < 0) {
+		throw new RangeError(`retry must be greater than or equal to 0`);
+	}
+
+	// The registry check is independent for every package, unlike publishing which must remain
+	// dependency-ordered. Bound the concurrent requests to avoid overwhelming the registry.
+	// eslint-disable-next-line import-x/no-named-as-default-member -- async.mapLimit is the idiomatic usage
+	const alreadyPublished = await async.mapLimit(
+		[...tarballs],
+		preflightConcurrency ?? publishPreflightConcurrency,
+		async (tarball: TarballMetadata) => isPublished(tarball),
+	);
+	const results: PublishTarballResult[] = [];
+
+	for (const [index, tarball] of tarballs.entries()) {
+		if (alreadyPublished[index]) {
+			results.push({ status: "AlreadyPublished", tarball, tryCount: 0 });
+			continue;
+		}
+
+		let tryCount = 0;
+		let status: PublishStatus = "Error";
+
+		while (tryCount <= retry) {
+			onPublishAttempt?.(tarball, tryCount + 1);
+			// We publish one package at a time, in order, and we don't continue until the current package is successfully
+			// published. This ensures that no packages are published to npm without their dependencies first being
+			// published. Note that despite publishing in order, npm itself may still make packages available in a different
+			// order - but we have no control over that.
+			// eslint-disable-next-line no-await-in-loop
+			status = await publish(tarball);
+			tryCount++;
+			if (status === "SuccessfullyPublished") {
+				break;
+			}
+
+			// A package may become available after the upfront preflight has completed, either because
+			// a concurrent publisher won the race or because this publish succeeded but lost its response.
+			// eslint-disable-next-line no-await-in-loop
+			if (await isPublished(tarball)) {
+				status = "AlreadyPublished";
+				break;
+			}
+		}
+
+		results.push({ status, tarball, tryCount });
+	}
+
+	return results;
+}
 
 async function publishTarball(
 	tarball: TarballMetadata,
 	log: Logger,
 	publishArgs: string[],
-	checkIfPublished: boolean,
 ): Promise<PublishStatus> {
-	if (checkIfPublished && (await isTarballPublished(tarball, log))) {
-		return "AlreadyPublished";
-	}
-
 	const args = ["publish", tarball.fileName, "--access", "public"];
 	if (publishArgs !== undefined) {
 		args.push(...publishArgs);

--- a/build-tools/packages/build-cli/src/commands/publish/tarballs.ts
+++ b/build-tools/packages/build-cli/src/commands/publish/tarballs.ts
@@ -342,6 +342,9 @@ export async function publishTarballsInOrder(
 		}
 
 		results.push({ status, tarball, tryCount });
+		if (status === "Error") {
+			break;
+		}
 	}
 
 	return results;

--- a/build-tools/packages/build-cli/src/test/commands/publish/tarballs.test.ts
+++ b/build-tools/packages/build-cli/src/test/commands/publish/tarballs.test.ts
@@ -1,0 +1,204 @@
+/*!
+ * Copyright (c) Microsoft Corporation and contributors. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { setTimeout as delay } from "node:timers/promises";
+import { expect } from "chai";
+import { describe, it } from "mocha";
+
+import PublishTarballCommand, {
+	getTarballsToPublish,
+	publishTarballsInOrder,
+	type TarballMetadata,
+} from "../../../commands/publish/tarballs.js";
+
+interface Deferred<T> {
+	promise: Promise<T>;
+	resolve: (value: T) => void;
+}
+
+function createTarball(name: string): TarballMetadata {
+	return {
+		name,
+		version: "1.0.0",
+		filePath: `${name}.tgz`,
+		fileName: `${name}.tgz`,
+	};
+}
+
+function createDeferred<T>(): Deferred<T> {
+	let resolve: (value: T) => void = () => {
+		throw new Error("Deferred promise was resolved before initialization");
+	};
+	const promise = new Promise<T>((innerResolve) => {
+		resolve = innerResolve;
+	});
+	return { promise, resolve };
+}
+
+async function waitFor(condition: () => boolean): Promise<void> {
+	for (let index = 0; index < 100; index++) {
+		if (condition()) {
+			return;
+		}
+		await delay(0);
+	}
+	throw new Error("Timed out waiting for test condition");
+}
+
+describe("publish tarballs", () => {
+	describe("getTarballsToPublish", () => {
+		it("uses the first occurrence of duplicate order entries", () => {
+			const first = createTarball("first");
+			const second = createTarball("second");
+			const metadata = new Map([
+				[first.fileName, first],
+				[second.fileName, second],
+			]);
+
+			expect(
+				getTarballsToPublish(
+					[second.fileName, first.fileName, second.fileName],
+					metadata,
+					true,
+				),
+			).to.deep.equal([second, first]);
+		});
+
+		it("rejects order entries without matching tarballs", () => {
+			expect(() => getTarballsToPublish(["missing.tgz"], new Map(), true)).to.throw(
+				"No tarball found matching 'missing.tgz'",
+			);
+		});
+	});
+
+	describe("publishTarballsInOrder", () => {
+		it("bounds concurrent preflight checks and preserves publish order", async () => {
+			const tarballs = [createTarball("first"), createTarball("second"), createTarball("third")];
+			const preflightChecks: string[] = [];
+			const publishOrder: string[] = [];
+			const preflightDeferreds = new Map<string, Deferred<boolean>>();
+			let activePreflightChecks = 0;
+			let maxActivePreflightChecks = 0;
+
+			const result = publishTarballsInOrder(tarballs, {
+				retry: 0,
+				preflightConcurrency: 2,
+				isPublished: async (tarball) => {
+					activePreflightChecks++;
+					maxActivePreflightChecks = Math.max(maxActivePreflightChecks, activePreflightChecks);
+					preflightChecks.push(tarball.name);
+					const deferred = createDeferred<boolean>();
+					preflightDeferreds.set(tarball.name, deferred);
+					try {
+						return await deferred.promise;
+					} finally {
+						activePreflightChecks--;
+					}
+				},
+				publish: async (tarball) => {
+					publishOrder.push(tarball.name);
+					return "SuccessfullyPublished";
+				},
+			});
+
+			await waitFor(() => preflightChecks.length === 2);
+			expect(maxActivePreflightChecks).to.equal(2);
+			expect(publishOrder).to.deep.equal([]);
+
+			preflightDeferreds.get("second")?.resolve(false);
+			await waitFor(() => preflightChecks.length === 3);
+			preflightDeferreds.get("first")?.resolve(false);
+			preflightDeferreds.get("third")?.resolve(false);
+
+			await result;
+
+			expect(maxActivePreflightChecks).to.equal(2);
+			expect(preflightChecks).to.deep.equal(["first", "second", "third"]);
+			expect(publishOrder).to.deep.equal(["first", "second", "third"]);
+		});
+
+		it("skips packages reported as already published during preflight", async () => {
+			const first = createTarball("first");
+			const second = createTarball("second");
+			const publishedPackages = new Set([first.name]);
+			const publishOrder: string[] = [];
+
+			const results = await publishTarballsInOrder([first, second], {
+				retry: 0,
+				isPublished: async (tarball) => publishedPackages.has(tarball.name),
+				publish: async (tarball) => {
+					publishOrder.push(tarball.name);
+					return "SuccessfullyPublished";
+				},
+			});
+
+			expect(publishOrder).to.deep.equal([second.name]);
+			expect(results.map((result) => result.status)).to.deep.equal([
+				"AlreadyPublished",
+				"SuccessfullyPublished",
+			]);
+		});
+
+		it("treats a failed publish as already published when the version appears afterward", async () => {
+			const tarball = createTarball("tarball");
+			let publishedCheckCount = 0;
+
+			const [result] = await publishTarballsInOrder([tarball], {
+				retry: 0,
+				isPublished: async () => {
+					publishedCheckCount++;
+					return publishedCheckCount > 1;
+				},
+				publish: async () => "Error",
+			});
+
+			expect(result).to.deep.equal({
+				status: "AlreadyPublished",
+				tarball,
+				tryCount: 1,
+			});
+		});
+
+		it("retries until exhaustion", async () => {
+			const tarball = createTarball("tarball");
+			let publishAttemptCount = 0;
+
+			const [result] = await publishTarballsInOrder([tarball], {
+				retry: 2,
+				isPublished: async () => false,
+				publish: async () => {
+					publishAttemptCount++;
+					return "Error";
+				},
+			});
+
+			expect(publishAttemptCount).to.equal(3);
+			expect(result).to.deep.equal({
+				status: "Error",
+				tarball,
+				tryCount: 3,
+			});
+		});
+
+		it("rejects negative retry counts", async () => {
+			let error: unknown;
+			try {
+				await publishTarballsInOrder([createTarball("tarball")], {
+					retry: -1,
+					isPublished: async () => false,
+					publish: async () => "SuccessfullyPublished",
+				});
+			} catch (caught) {
+				error = caught;
+			}
+
+			expect(error).to.be.instanceOf(RangeError);
+		});
+	});
+
+	it("rejects negative retry counts when parsing command flags", () => {
+		expect(PublishTarballCommand.flags.retry).to.include({ min: 0 });
+	});
+});

--- a/build-tools/packages/build-cli/src/test/commands/publish/tarballs.test.ts
+++ b/build-tools/packages/build-cli/src/test/commands/publish/tarballs.test.ts
@@ -14,8 +14,8 @@ import PublishTarballCommand, {
 } from "../../../commands/publish/tarballs.js";
 
 interface Deferred<T> {
-	promise: Promise<T>;
-	resolve: (value: T) => void;
+	readonly promise: Promise<T>;
+	readonly resolve: (value: T) => void;
 }
 
 function createTarball(name: string): TarballMetadata {

--- a/build-tools/packages/build-cli/src/test/commands/publish/tarballs.test.ts
+++ b/build-tools/packages/build-cli/src/test/commands/publish/tarballs.test.ts
@@ -165,6 +165,27 @@ describe("publish tarballs", () => {
 			});
 		});
 
+		it("does not retry when publishing reports an already published tarball", async () => {
+			const tarball = createTarball("tarball");
+			let publishAttemptCount = 0;
+
+			const [result] = await publishTarballsInOrder([tarball], {
+				retry: 2,
+				isPublished: async () => false,
+				publish: async () => {
+					publishAttemptCount++;
+					return "AlreadyPublished";
+				},
+			});
+
+			expect(publishAttemptCount).to.equal(1);
+			expect(result).to.deep.equal({
+				status: "AlreadyPublished",
+				tarball,
+				tryCount: 1,
+			});
+		});
+
 		it("retries until exhaustion", async () => {
 			const tarball = createTarball("tarball");
 			let publishAttemptCount = 0;

--- a/build-tools/packages/build-cli/src/test/commands/publish/tarballs.test.ts
+++ b/build-tools/packages/build-cli/src/test/commands/publish/tarballs.test.ts
@@ -75,7 +75,11 @@ describe("publish tarballs", () => {
 
 	describe("publishTarballsInOrder", () => {
 		it("bounds concurrent preflight checks and preserves publish order", async () => {
-			const tarballs = [createTarball("first"), createTarball("second"), createTarball("third")];
+			const tarballs = [
+				createTarball("first"),
+				createTarball("second"),
+				createTarball("third"),
+			];
 			const preflightChecks: string[] = [];
 			const publishOrder: string[] = [];
 			const preflightDeferreds = new Map<string, Deferred<boolean>>();
@@ -180,6 +184,24 @@ describe("publish tarballs", () => {
 				tarball,
 				tryCount: 3,
 			});
+		});
+
+		it("stops publishing after the first exhausted error", async () => {
+			const first = createTarball("first");
+			const second = createTarball("second");
+			const publishOrder: string[] = [];
+
+			const results = await publishTarballsInOrder([first, second], {
+				retry: 0,
+				isPublished: async () => false,
+				publish: async (tarball) => {
+					publishOrder.push(tarball.name);
+					return "Error";
+				},
+			});
+
+			expect(publishOrder).to.deep.equal([first.name]);
+			expect(results).to.deep.equal([{ status: "Error", tarball: first, tryCount: 1 }]);
 		});
 
 		it("rejects negative retry counts", async () => {


### PR DESCRIPTION
## Description

`ff_publishing` invokes `flub publish tarballs` for internal-feed publishing. Each tarball previously performed a serial registry lookup before publishing, adding registry round-trip time for every package.

Run initial version checks with a bounded concurrency of 10 while preserving serial, dependency-ordered `npm publish` calls. Retry attempts still re-check the registry so a successful upload with a lost response is treated as already published.

[AB#21577](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/21577)

## Reviewer Guidance

The review process is outlined in [the pull request guidelines](../docs/content/Contributing/PR-Guidelines.md#guidelines).