### PR TITLE
fix(container-runtime): classify malformed runtime op JSON as data corruption

### DIFF
--- a/packages/runtime/container-runtime/src/opLifecycle/opSerialization.ts
+++ b/packages/runtime/container-runtime/src/opLifecycle/opSerialization.ts
@@ -12,6 +12,11 @@ import {
 	isFluidHandle,
 	toFluidHandleInternal,
 } from "@fluidframework/runtime-utils/internal";
+import {
+	DataCorruptionError,
+	extractSafePropertiesFromMessage,
+	wrapError,
+} from "@fluidframework/telemetry-utils/internal";
 
 import type { LocalContainerRuntimeMessage } from "../messageTypes.js";
 
@@ -28,7 +33,20 @@ export function ensureContentsDeserialized(mutableMessage: ISequencedDocumentMes
 	// This should become unconditional once Loader LTS reaches 2.4 or later.
 	// There will be a long time of needing both cases, until LTS advances to that point.
 	if (typeof mutableMessage.contents === "string" && mutableMessage.contents !== "") {
-		mutableMessage.contents = JSON.parse(mutableMessage.contents);
+		let deserializedContents: unknown;
+		try {
+			deserializedContents = JSON.parse(mutableMessage.contents);
+		} catch (error) {
+			throw wrapError(
+				error,
+				(message) =>
+					new DataCorruptionError(message, {
+						dataProcessingCodepath: "ensureContentsDeserialized",
+						...extractSafePropertiesFromMessage(mutableMessage),
+					}),
+			);
+		}
+		mutableMessage.contents = deserializedContents;
 	}
 }
 

--- a/packages/runtime/container-runtime/src/test/opLifecycle/opSerialization.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/opSerialization.spec.ts
@@ -5,9 +5,11 @@
 
 import { strict as assert } from "node:assert";
 
+import { FluidErrorTypes } from "@fluidframework/core-interfaces/internal";
 import type { ISequencedDocumentMessage } from "@fluidframework/driver-definitions/internal";
 import { MessageType } from "@fluidframework/driver-definitions/internal";
 import { encodeHandleForSerialization } from "@fluidframework/runtime-utils/internal";
+import type { IFluidErrorBase } from "@fluidframework/telemetry-utils/internal";
 import { MockHandle } from "@fluidframework/test-runtime-utils/internal";
 
 import {
@@ -51,6 +53,39 @@ describe("opSerialization", () => {
 			ensureContentsDeserialized(message as ISequencedDocumentMessage);
 
 			assert.strictEqual(message.contents, "");
+		});
+
+		it("should classify malformed JSON as data corruption", () => {
+			const malformedContents = '{"key":"value",}';
+			const parseError = (() => {
+				try {
+					JSON.parse(malformedContents);
+				} catch (error) {
+					assert(error instanceof Error);
+					return error;
+				}
+				assert.fail("JSON.parse should throw");
+			})();
+			const message: Partial<ISequencedDocumentMessage> = {
+				sequenceNumber: 42,
+				contents: malformedContents,
+			};
+
+			assert.throws(
+				() => ensureContentsDeserialized(message as ISequencedDocumentMessage),
+				(error: IFluidErrorBase) => {
+					assert.strictEqual(error.errorType, FluidErrorTypes.dataCorruptionError);
+					assert.strictEqual(error.message, parseError.message);
+
+					const props = error.getTelemetryProperties();
+					assert.strictEqual(
+						props.dataProcessingCodepath,
+						"ensureContentsDeserialized",
+					);
+					assert.strictEqual(props.messageSequenceNumber, message.sequenceNumber);
+					return true;
+				},
+			);
 		});
 	});
 

--- a/packages/runtime/container-runtime/src/test/opLifecycle/opSerialization.spec.ts
+++ b/packages/runtime/container-runtime/src/test/opLifecycle/opSerialization.spec.ts
@@ -78,10 +78,7 @@ describe("opSerialization", () => {
 					assert.strictEqual(error.message, parseError.message);
 
 					const props = error.getTelemetryProperties();
-					assert.strictEqual(
-						props.dataProcessingCodepath,
-						"ensureContentsDeserialized",
-					);
+					assert.strictEqual(props.dataProcessingCodepath, "ensureContentsDeserialized");
 					assert.strictEqual(props.messageSequenceNumber, message.sequenceNumber);
 					return true;
 				},


### PR DESCRIPTION
## Description

Classifies `JSON.parse` failures while deserializing sequenced runtime-op contents as `DataCorruptionError` instead of allowing DeltaManager to wrap them as generic data-processing failures.

The original parser message and stack are preserved, while the error gains the container-runtime codepath and standard safe sequenced-message telemetry. A focused unit test covers the classification, preserved parser message, codepath, and sequence number.

## Reviewer Guidance

The review process is outlined in [the pull request guidelines](../docs/content/Contributing/PR-Guidelines.md#guidelines).

Please focus on whether malformed sequenced runtime-op JSON is correctly classified at the narrowest parse boundary.

[AB#82853](https://dev.azure.com/fluidframework/235294da-091d-4c29-84fc-cdfc3d90890b/_workitems/edit/82853)